### PR TITLE
Add initial support for screen orientation locking / unlocking

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6082,9 +6082,6 @@ js/ShadowRealm-iframe-sandboxed.html [ Pass Failure ]
 js/ShadowRealm-importValue.html [ Pass Failure ]
 js/ShadowRealm-worker.html [ Pass Failure ]
 
-# We don't support screen orientation locking yet, making these tests flaky.
-imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html [ Failure Pass ]
-
 # Old SVG+currentcolor tests are incorrect https://bugs.webkit.org/show_bug.cgi?id=245400
 imported/w3c/web-platform-tests/svg/import/color-prop-05-t-manual.svg [ Skip ]
 svg/W3C-SVG-1.1-SE/color-prop-05-t.svg [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Attempting to lock non-fully active documents results in a InvalidStateError promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'document.body.appendChild')"
-FAIL Attempting to unlock non-fully active documents results in a InvalidStateError promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'document.body.appendChild')"
-FAIL Making a document non-fully active while locking results in an AbortError promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'document.body.appendChild')"
+PASS Attempting to lock non-fully active documents results in a InvalidStateError
+PASS Attempting to unlock non-fully active documents results in a InvalidStateError
+PASS Making a document non-fully active while locking results in an AbortError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<body>
 <script>
   async function attachIFrame() {
     const iframe = document.createElement("iframe");
@@ -21,11 +22,13 @@
       ? "landscape"
       : "portrait";
 
+    const frameDOMException = iframe.contentWindow.DOMException;
     iframe.remove();
 
     await promise_rejects_dom(
       t,
       "InvalidStateError",
+      frameDOMException,
       orientation.lock(opposite)
     );
   }, "Attempting to lock non-fully active documents results in a InvalidStateError");
@@ -34,9 +37,10 @@
     const iframe = await attachIFrame();
     const { orientation } = iframe.contentWindow.screen;
 
+    const frameDOMException = iframe.contentWindow.DOMException;
     iframe.remove();
 
-    assert_throws_dom(t, "InvalidStateError", () => { orientation.unlock() });
+    assert_throws_dom("InvalidStateError", frameDOMException, () => { orientation.unlock() });
   }, "Attempting to unlock non-fully active documents results in a InvalidStateError");
 
   promise_test(async (t) => {
@@ -52,9 +56,11 @@
 
     const p = orientation.lock(opposite);
 
+    const frameDOMException = iframe.contentWindow.DOMException;
     iframe.remove();
 
-    await promise_rejects_dom(t, "AbortError", p);
-    assert_throws_dom(t, "InvalidStateError", () => { orientation.unlock() });
+    await promise_rejects_dom(t, "AbortError", frameDOMException, p);
+    assert_throws_dom("InvalidStateError", frameDOMException, () => { orientation.unlock() });
   }, "Making a document non-fully active while locking results in an AbortError");
 </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event.html
@@ -14,10 +14,10 @@ promise_test(async t => {
   await test_driver.bless("request full screen", () => {
     return document.documentElement.requestFullscreen();
   });
-  const type = screen.orientation.type.startsWith("portrait") ? "landscape" : "portrait";
+  const type = screen.orientation.type.startsWith("portrait") ? "portrait" : "landscape";
   screen.orientation.onchange = t.unreached_func("change event should not be fired");
   await screen.orientation.lock(type);
-  assert_equals(screen.orientation.type, type);
+  assert_true(screen.orientation.type.startsWith(type));
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 
 promise_test(async t => {
@@ -41,12 +41,14 @@ promise_test(async t => {
 
   for (const orientation of orientations) {
     // change event is fired before resolving promise by lock.
+    let lockPromise = screen.orientation.lock(orientation);
     const result = await Promise.race([
-      screen.orientation.lock(orientation),
+      lockPromise,
       orientationWatcher.wait_for('change'),
     ]);
-    assert_equals(result instanceof Event, "The event must be fired first.");
-    assert_equals(screen.orientation.type, orientation);
+    assert_true(result instanceof Event, "The event must be fired first.");
+    assert_true(screen.orientation.type.startsWith(orientation), "The orientation must match");
+    await lockPromise;
   }
 }, "Test that orientationchange event is fired when the orientation changes.");
 </script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL When performing a fragment navigation, the orientation must not change or unlock assert_unreached: change event must not fire Reached unreachable code
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The 'change' event must fire before the [[orientationPendingPromise]] is resolved.
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Test that screen.orientation.unlock() doesn't throw when there is no lock with fullscreen
+PASS Test that screen.orientation.unlock() doesn't throw when there is no lock
+PASS Test that screen.orientation.unlock() returns a void value
+PASS Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.
+PASS Test that screen.orientation.lock returns a pending promise.
+PASS Test that screen.orientation.lock() is actually async
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: Error while parsing the 'sandbox' attribute: 'allow-orientation
 
 
 FAIL Test without 'allow-orientation-lock' sandboxing directive assert_equals: screen.lockOrientation() throws a SecurityError expected "SecurityError" but got "error: TypeError Type error"
-FAIL Test with 'allow-orientation-lock' sandboxing directive assert_equals: screen.orientation lock to portrait-primary expected "portrait-primary" but got "error: NotSupportedError Screen orientation locking is not supported"
+PASS Test with 'allow-orientation-lock' sandboxing directive
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Re-locking orientation during event dispatch must reject existing orientationPendingPromise
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test that orientationchange event is not fired when the orientation does not change.
+PASS Test that orientationchange event is fired when the orientation changes.
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test subframes receive orientation change events
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -1,11 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: NotSupportedError: Screen orientation locking is not supported
-
-Harness Error (TIMEOUT), message = null
 
 PASS Test screen.orientation properties
 PASS Test screen.orientation default values.
-FAIL Test the orientations and associated angles promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+PASS Test the orientations and associated angles
 PASS Test that screen.orientation properties are not writable
 PASS Test that screen.orientation is always the same object
-TIMEOUT Test that screen.orientation values change if the orientation changes Test timed out
+PASS Test that screen.orientation values change if the orientation changes
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1773,6 +1773,9 @@ webkit.org/b/245010 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 
 webkit.org/b/245140 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Pass Failure ]
 
+# Mac does not support screen orientation locking, making this test flaky.
+imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html [ Failure Pass ]
+
 webkit.org/b/245727 [ Monterey ] imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker.html [ Failure ]
 
 webkit.org/b/245802 imported/w3c/web-platform-tests/permissions/permissions-cg.https.html [ Pass Failure ]

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1973,6 +1973,7 @@ platform/ReferrerPolicy.cpp
 platform/RemoteCommandListener.cpp
 platform/RuntimeApplicationChecks.cpp
 platform/SSLKeyGenerator.cpp
+platform/ScreenOrientationManager.cpp
 platform/ScreenOrientationProvider.cpp
 platform/ScrollAlignment.cpp
 platform/ScrollAnimation.cpp

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -44,11 +44,15 @@ public:
     static Ref<ScreenOrientation> create(Document*);
     ~ScreenOrientation();
 
+    using ScreenOrientationManager::Observer::weakPtrFactory;
+    using ScreenOrientationManager::Observer::WeakValueType;
+    using ScreenOrientationManager::Observer::WeakPtrImplType;
+
     using LockType = ScreenOrientationLockType;
     using Type = ScreenOrientationType;
 
     void lock(LockType, Ref<DeferredPromise>&&);
-    void unlock();
+    ExceptionOr<void> unlock();
     Type type() const;
     uint16_t angle() const;
 

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -36,6 +36,16 @@ enum class ScreenOrientationType : uint8_t {
     LandscapeSecondary
 };
 
+constexpr bool isPortait(ScreenOrientationType type)
+{
+    return type == ScreenOrientationType::PortraitPrimary || type == ScreenOrientationType::PortraitSecondary;
+}
+
+constexpr bool isLandscape(ScreenOrientationType type)
+{
+    return type == ScreenOrientationType::LandscapePrimary || type == ScreenOrientationType::LandscapeSecondary;
+}
+
 } // namespace WebCore
 
 namespace WTF {

--- a/Source/WebCore/platform/ScreenOrientationManager.cpp
+++ b/Source/WebCore/platform/ScreenOrientationManager.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScreenOrientationManager.h"
+
+#include "JSDOMPromiseDeferred.h"
+#include "ScreenOrientation.h"
+
+namespace WebCore {
+
+ScreenOrientationManager::ScreenOrientationManager() = default;
+
+ScreenOrientationManager::~ScreenOrientationManager() = default;
+
+void ScreenOrientationManager::setLockPromise(ScreenOrientation& requester, Ref<DeferredPromise>&& lockPromise)
+{
+    m_lockPromise = WTFMove(lockPromise);
+    m_lockRequester = requester;
+}
+
+ScreenOrientation* ScreenOrientationManager::lockRequester() const
+{
+    return m_lockRequester.get();
+}
+
+RefPtr<DeferredPromise> ScreenOrientationManager::takeLockPromise()
+{
+    m_lockRequester = nullptr;
+    return std::exchange(m_lockPromise, nullptr);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ScreenOrientationManager.h
+++ b/Source/WebCore/platform/ScreenOrientationManager.h
@@ -33,11 +33,13 @@
 
 namespace WebCore {
 
+class DeferredPromise;
 class Exception;
+class ScreenOrientation;
 
 class ScreenOrientationManager : public CanMakeWeakPtr<ScreenOrientationManager> {
 public:
-    virtual ~ScreenOrientationManager() { }
+    WEBCORE_EXPORT virtual ~ScreenOrientationManager();
 
     class Observer : public CanMakeWeakPtr<Observer> {
     public:
@@ -51,8 +53,16 @@ public:
     virtual void addObserver(Observer&) = 0;
     virtual void removeObserver(Observer&) = 0;
 
+    void setLockPromise(ScreenOrientation&, Ref<DeferredPromise>&&);
+    ScreenOrientation* lockRequester() const;
+    RefPtr<DeferredPromise> takeLockPromise();
+
 protected:
-    ScreenOrientationManager() = default;
+    WEBCORE_EXPORT ScreenOrientationManager();
+
+private:
+    RefPtr<DeferredPromise> m_lockPromise;
+    WeakPtr<ScreenOrientation> m_lockRequester;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -34,7 +34,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/ModalContainerTypes.h>
 #include <WebCore/PermissionState.h>
-#include <WebCore/ScreenOrientationLockType.h>
+#include <WebCore/ScreenOrientationType.h>
 #include <wtf/CompletionHandler.h>
 
 #if PLATFORM(COCOA)
@@ -140,8 +140,8 @@ public:
         completionHandler(currentQuota);
     }
 
-    virtual bool lockScreenOrientation(WebCore::ScreenOrientationLockType) { return false; }
-    virtual void unlockScreenOrientation() { }
+    virtual bool lockScreenOrientation(WebKit::WebPageProxy&, WebCore::ScreenOrientationType) { return false; }
+    virtual void unlockScreenOrientation(WebKit::WebPageProxy&) { }
 
     virtual bool needsFontAttributes() const { return false; }
     virtual void didChangeFontAttributes(const WebCore::FontAttributes&) { }

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -130,7 +130,7 @@ template<> struct ClientTraits<WKPagePolicyClientBase> {
 };
 
 template<> struct ClientTraits<WKPageUIClientBase> {
-    typedef std::tuple<WKPageUIClientV0, WKPageUIClientV1, WKPageUIClientV2, WKPageUIClientV3, WKPageUIClientV4, WKPageUIClientV5, WKPageUIClientV6, WKPageUIClientV7, WKPageUIClientV8, WKPageUIClientV9, WKPageUIClientV10, WKPageUIClientV11, WKPageUIClientV12, WKPageUIClientV13, WKPageUIClientV14, WKPageUIClientV15, WKPageUIClientV16, WKPageUIClientV17, WKPageUIClientV18> Versions;
+    typedef std::tuple<WKPageUIClientV0, WKPageUIClientV1, WKPageUIClientV2, WKPageUIClientV3, WKPageUIClientV4, WKPageUIClientV5, WKPageUIClientV6, WKPageUIClientV7, WKPageUIClientV8, WKPageUIClientV9, WKPageUIClientV10, WKPageUIClientV11, WKPageUIClientV12, WKPageUIClientV13, WKPageUIClientV14, WKPageUIClientV15, WKPageUIClientV16, WKPageUIClientV17, WKPageUIClientV18, WKPageUIClientV19> Versions;
 };
 
 #if ENABLE(CONTEXT_MENUS)
@@ -2189,6 +2189,37 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 return;
             }
             m_client.queryPermission(toAPI(API::String::create(permissionName).ptr()), toAPI(&origin), toAPI(QueryPermissionResultCallback::create(WTFMove(completionHandler)).ptr()));
+        }
+
+        static WKScreenOrientationType toWKScreenOrientationType(WebCore::ScreenOrientationType orientation)
+        {
+            switch (orientation) {
+            case WebCore::ScreenOrientationType::LandscapePrimary:
+                return kWKScreenOrientationTypeLandscapePrimary;
+            case WebCore::ScreenOrientationType::LandscapeSecondary:
+                return kWKScreenOrientationTypeLandscapeSecondary;
+            case WebCore::ScreenOrientationType::PortraitSecondary:
+                return kWKScreenOrientationTypePortraitSecondary;
+            case WebCore::ScreenOrientationType::PortraitPrimary:
+                return kWKScreenOrientationTypePortraitPrimary;
+            }
+            ASSERT_NOT_REACHED();
+            return kWKScreenOrientationTypePortraitPrimary;
+        }
+
+        bool lockScreenOrientation(WebPageProxy& page, WebCore::ScreenOrientationType orientation) final
+        {
+            if (!m_client.lockScreenOrientation)
+                return false;
+
+            m_client.lockScreenOrientation(toAPI(&page), toWKScreenOrientationType(orientation));
+            return true;
+        }
+
+        void unlockScreenOrientation(WebPageProxy& page) final
+        {
+            if (m_client.unlockScreenOrientation)
+                m_client.unlockScreenOrientation(toAPI(&page));
         }
     };
 

--- a/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageUIClient.h
@@ -69,6 +69,14 @@ enum {
 };
 typedef uint32_t WKResourceLimit;
 
+enum {
+    kWKScreenOrientationTypePortraitPrimary,
+    kWKScreenOrientationTypePortraitSecondary,
+    kWKScreenOrientationTypeLandscapePrimary,
+    kWKScreenOrientationTypeLandscapeSecondary,
+};
+typedef uint32_t WKScreenOrientationType;
+
 WK_EXPORT WKTypeID WKPageRunBeforeUnloadConfirmPanelResultListenerGetTypeID(void);
 WK_EXPORT void WKPageRunBeforeUnloadConfirmPanelResultListenerCall(WKPageRunBeforeUnloadConfirmPanelResultListenerRef listener, bool result);
 
@@ -140,6 +148,9 @@ typedef void (*WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback)(
 
 typedef void (*WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback)(WKPageRef page, WKSecurityOriginRef topOrigin, WKStringRef keySystem, WKMediaKeySystemPermissionCallbackRef callback);
 typedef void (*WKQueryPermissionCallback)(WKStringRef permissionName, WKSecurityOriginRef topOrigin, WKQueryPermissionResultCallbackRef callback);
+typedef void(*WKLockScreenOrientationCallback)(WKPageRef page, WKScreenOrientationType orientation);
+typedef void(*WKUnlockScreenOrientationCallback)(WKPageRef page);
+
 // Deprecated
 typedef WKPageRef (*WKPageCreateNewPageCallback_deprecatedForUseWithV0)(WKPageRef page, WKDictionaryRef features, WKEventModifiers modifiers, WKEventMouseButton mouseButton, const void* clientInfo);
 typedef void      (*WKPageMouseDidMoveOverElementCallback_deprecatedForUseWithV0)(WKPageRef page, WKEventModifiers modifiers, WKTypeRef userData, const void *clientInfo);
@@ -1815,6 +1826,129 @@ typedef struct WKPageUIClientV18 {
     // Version 18.
     WKQueryPermissionCallback                                           queryPermission;
 } WKPageUIClientV18;
+
+typedef struct WKPageUIClientV19 {
+    WKPageUIClientBase                                                  base;
+
+    // Version 0.
+    WKPageCreateNewPageCallback_deprecatedForUseWithV0                  createNewPage_deprecatedForUseWithV0;
+    WKPageUIClientCallback                                              showPage;
+    WKPageUIClientCallback                                              close;
+    WKPageTakeFocusCallback                                             takeFocus;
+    WKPageFocusCallback                                                 focus;
+    WKPageUnfocusCallback                                               unfocus;
+    WKPageRunJavaScriptAlertCallback_deprecatedForUseWithV0             runJavaScriptAlert_deprecatedForUseWithV0;
+    WKPageRunJavaScriptConfirmCallback_deprecatedForUseWithV0           runJavaScriptConfirm_deprecatedForUseWithV0;
+    WKPageRunJavaScriptPromptCallback_deprecatedForUseWithV0            runJavaScriptPrompt_deprecatedForUseWithV0;
+    WKPageSetStatusTextCallback                                         setStatusText;
+    WKPageMouseDidMoveOverElementCallback_deprecatedForUseWithV0        mouseDidMoveOverElement_deprecatedForUseWithV0;
+    WKPageMissingPluginButtonClickedCallback_deprecatedForUseWithV0     missingPluginButtonClicked_deprecatedForUseWithV0;
+    WKPageDidNotHandleKeyEventCallback                                  didNotHandleKeyEvent;
+    WKPageDidNotHandleWheelEventCallback                                didNotHandleWheelEvent;
+    WKPageGetToolbarsAreVisibleCallback                                 toolbarsAreVisible;
+    WKPageSetToolbarsAreVisibleCallback                                 setToolbarsAreVisible;
+    WKPageGetMenuBarIsVisibleCallback                                   menuBarIsVisible;
+    WKPageSetMenuBarIsVisibleCallback                                   setMenuBarIsVisible;
+    WKPageGetStatusBarIsVisibleCallback                                 statusBarIsVisible;
+    WKPageSetStatusBarIsVisibleCallback                                 setStatusBarIsVisible;
+    WKPageGetIsResizableCallback                                        isResizable;
+    WKPageSetIsResizableCallback                                        setIsResizable;
+    WKPageGetWindowFrameCallback                                        getWindowFrame;
+    WKPageSetWindowFrameCallback                                        setWindowFrame;
+    WKPageRunBeforeUnloadConfirmPanelCallback_deprecatedForUseWithV6    runBeforeUnloadConfirmPanel_deprecatedForUseWithV6;
+    WKPageUIClientCallback                                              didDraw;
+    WKPageUIClientCallback                                              pageDidScroll;
+    WKPageExceededDatabaseQuotaCallback                                 exceededDatabaseQuota;
+    WKPageRunOpenPanelCallback                                          runOpenPanel;
+    WKPageDecidePolicyForGeolocationPermissionRequestCallback           decidePolicyForGeolocationPermissionRequest;
+    WKPageHeaderHeightCallback                                          headerHeight;
+    WKPageFooterHeightCallback                                          footerHeight;
+    WKPageDrawHeaderCallback                                            drawHeader;
+    WKPageDrawFooterCallback                                            drawFooter;
+    WKPagePrintFrameCallback                                            printFrame;
+    WKPageUIClientCallback                                              runModal;
+    void*                                                               unused1; // Used to be didCompleteRubberBandForMainFrame
+    WKPageSaveDataToFileInDownloadsFolderCallback                       saveDataToFileInDownloadsFolder;
+    void*                                                               shouldInterruptJavaScript_unavailable;
+
+    // Version 1.
+    WKPageCreateNewPageCallback_deprecatedForUseWithV1                  createNewPage_deprecatedForUseWithV1;
+    WKPageMouseDidMoveOverElementCallback                               mouseDidMoveOverElement;
+    WKPageDecidePolicyForNotificationPermissionRequestCallback          decidePolicyForNotificationPermissionRequest;
+    WKPageUnavailablePluginButtonClickedCallback_deprecatedForUseWithV1 unavailablePluginButtonClicked_deprecatedForUseWithV1;
+
+    // Version 2.
+    WKPageShowColorPickerCallback                                       showColorPicker;
+    WKPageHideColorPickerCallback                                       hideColorPicker;
+    WKPageUnavailablePluginButtonClickedCallback                        unavailablePluginButtonClicked;
+
+    // Version 3.
+    WKPagePinnedStateDidChangeCallback                                  pinnedStateDidChange;
+
+    // Version 4.
+    void*                                                               unused2; // Used to be didBeginTrackingPotentialLongMousePress.
+    void*                                                               unused3; // Used to be didRecognizeLongMousePress.
+    void*                                                               unused4; // Used to be didCancelTrackingPotentialLongMousePress.
+    WKPageIsPlayingAudioDidChangeCallback                               isPlayingAudioDidChange;
+
+    // Version 5.
+    WKPageDecidePolicyForUserMediaPermissionRequestCallback             decidePolicyForUserMediaPermissionRequest;
+    WKPageDidClickAutoFillButtonCallback                                didClickAutoFillButton;
+    WKPageRunJavaScriptAlertCallback_deprecatedForUseWithV5             runJavaScriptAlert_deprecatedForUseWithV5;
+    WKPageRunJavaScriptConfirmCallback_deprecatedForUseWithV5           runJavaScriptConfirm_deprecatedForUseWithV5;
+    WKPageRunJavaScriptPromptCallback_deprecatedForUseWithV5            runJavaScriptPrompt_deprecatedForUseWithV5;
+    void*                                                               unused5; // Used to be mediaSessionMetadataDidChange.
+
+    // Version 6.
+    WKPageCreateNewPageCallback                                         createNewPage;
+    WKPageRunJavaScriptAlertCallback                                    runJavaScriptAlert;
+    WKPageRunJavaScriptConfirmCallback                                  runJavaScriptConfirm;
+    WKPageRunJavaScriptPromptCallback                                   runJavaScriptPrompt;
+    WKCheckUserMediaPermissionCallback                                  checkUserMediaPermissionForOrigin;
+
+    // Version 7.
+    WKPageRunBeforeUnloadConfirmPanelCallback                           runBeforeUnloadConfirmPanel;
+    WKFullscreenMayReturnToInlineCallback                               fullscreenMayReturnToInline;
+
+    // Version 8.
+    WKRequestPointerLockCallback                                        requestPointerLock;
+    WKDidLosePointerLockCallback                                        didLosePointerLock;
+
+    // Version 9.
+    WKHandleAutoplayEventCallback                                       handleAutoplayEvent;
+
+    // Version 10.
+    WKHasVideoInPictureInPictureDidChangeCallback                       hasVideoInPictureInPictureDidChange;
+    void*                                                               unused6; // Used to be didExceedBackgroundResourceLimitWhileInForeground
+
+    // Version 11.
+    WKPageDidResignInputElementStrongPasswordAppearanceCallback         didResignInputElementStrongPasswordAppearance;
+
+    // Version 12.
+    WKPageRequestStorageAccessConfirmCallback                           requestStorageAccessConfirm;
+
+    // Version 13.
+    WKPageShouldAllowDeviceOrientationAndMotionAccessCallback           shouldAllowDeviceOrientationAndMotionAccess;
+
+    // Version 14.
+    WKPageRunWebAuthenticationPanelCallback                             runWebAuthenticationPanel;
+
+    // Version 15.
+    WKPageDecidePolicyForSpeechRecognitionPermissionRequestCallback     decidePolicyForSpeechRecognitionPermissionRequest;
+
+    // Version 16.
+    WKPageDecidePolicyForMediaKeySystemPermissionRequestCallback        decidePolicyForMediaKeySystemPermissionRequest;
+
+    // Version 17.
+    WKPageRequestWebAuthenticationNoGestureCallback                     requestWebAuthenticationNoGesture;
+
+    // Version 18.
+    WKQueryPermissionCallback                                           queryPermission;
+
+    // Version 19.
+    WKLockScreenOrientationCallback                                     lockScreenOrientation;
+    WKUnlockScreenOrientationCallback                                   unlockScreenOrientation;
+} WKPageUIClientV19;
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -56,14 +56,11 @@
 @protocol UIDropSession;
 @protocol UIEditMenuInteractionAnimating;
 
-typedef NS_ENUM(NSInteger, _WKScreenOrientationLockType) {
-    _WKScreenOrientationLockTypeAny,
-    _WKScreenOrientationLockTypeLandscape,
-    _WKScreenOrientationLockTypeLandscapePrimary,
-    _WKScreenOrientationLockTypeLandscapeSecondary,
-    _WKScreenOrientationLockTypePortrait,
-    _WKScreenOrientationLockTypePortraitPrimary,
-    _WKScreenOrientationLockTypePortraitSecondary
+typedef NS_ENUM(NSInteger, _WKScreenOrientationType) {
+    _WKScreenOrientationTypePortraitPrimary,
+    _WKScreenOrientationTypePortraitSecondary,
+    _WKScreenOrientationTypeLandscapePrimary,
+    _WKScreenOrientationTypeLandscapeSecondary
 } WK_API_AVAILABLE(ios(WK_IOS_TBA));
 
 #else
@@ -268,7 +265,7 @@ struct UIEdgeInsets;
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDropSession:(id <UIDropSession>)session WK_API_AVAILABLE(ios(11.0));
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDragSession:(id <UIDragSession>)session WK_API_AVAILABLE(ios(11.0));
 
-- (void)_webViewLockScreenOrientation:(WKWebView *)webView lockType:(_WKScreenOrientationLockType)lockType WK_API_AVAILABLE(ios(WK_IOS_TBA));
+- (void)_webViewLockScreenOrientation:(WKWebView *)webView lockType:(_WKScreenOrientationType)lockType WK_API_AVAILABLE(ios(WK_IOS_TBA));
 - (void)_webViewUnlockScreenOrientation:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -250,6 +250,7 @@ struct PerWebProcessState {
     BOOL _haveSetUnobscuredSafeAreaInsets;
     BOOL _needsToPresentLockdownModeMessage;
     UIRectEdge _obscuredInsetEdgesAffectedBySafeArea;
+    UIInterfaceOrientationMask _supportedInterfaceOrientations;
 
     UIInterfaceOrientation _interfaceOrientationOverride;
     BOOL _overridesInterfaceOrientation;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -102,8 +102,8 @@ private:
         void runBeforeUnloadConfirmPanel(WebPageProxy&, const WTF::String&, WebFrameProxy*, FrameInfoData&&, Function<void(bool)>&& completionHandler) final;
         void exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, API::SecurityOrigin*, const WTF::String& databaseName, const WTF::String& displayName, unsigned long long currentQuota, unsigned long long currentOriginUsage, unsigned long long currentUsage, unsigned long long expectedUsage, Function<void(unsigned long long)>&& completionHandler) final;
         void reachedApplicationCacheOriginQuota(WebPageProxy*, const WebCore::SecurityOrigin&, uint64_t currentQuota, uint64_t totalBytesNeeded, Function<void(unsigned long long)>&& completionHandler) final;
-        bool lockScreenOrientation(WebCore::ScreenOrientationLockType) final;
-        void unlockScreenOrientation() final;
+        bool lockScreenOrientation(WebPageProxy&, WebCore::ScreenOrientationType) final;
+        void unlockScreenOrientation(WebPageProxy&) final;
         void didResignInputElementStrongPasswordAppearance(WebPageProxy&, API::Object*) final;
         bool takeFocus(WebPageProxy*, WKFocusDirection) final;
         void handleAutoplayEvent(WebPageProxy&, WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>) final;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -585,30 +585,23 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
 }
 
 #if PLATFORM(IOS)
-static _WKScreenOrientationLockType toWKScreenOrientationLockType(WebCore::ScreenOrientationLockType lockType)
+static _WKScreenOrientationType toWKScreenOrientationType(WebCore::ScreenOrientationType lockType)
 {
     switch (lockType) {
-    case WebCore::ScreenOrientationLockType::Natural:
-    case WebCore::ScreenOrientationLockType::Portrait:
+    case WebCore::ScreenOrientationType::PortraitSecondary:
+        return _WKScreenOrientationTypePortraitSecondary;
+    case WebCore::ScreenOrientationType::LandscapePrimary:
+        return _WKScreenOrientationTypeLandscapePrimary;
+    case WebCore::ScreenOrientationType::LandscapeSecondary:
+        return _WKScreenOrientationTypeLandscapeSecondary;
+    case WebCore::ScreenOrientationType::PortraitPrimary:
         break;
-    case WebCore::ScreenOrientationLockType::Any:
-        return _WKScreenOrientationLockTypeAny;
-    case WebCore::ScreenOrientationLockType::Landscape:
-        return _WKScreenOrientationLockTypeLandscape;
-    case WebCore::ScreenOrientationLockType::PortraitPrimary:
-        return _WKScreenOrientationLockTypePortraitPrimary;
-    case WebCore::ScreenOrientationLockType::PortraitSecondary:
-        return _WKScreenOrientationLockTypePortraitSecondary;
-    case WebCore::ScreenOrientationLockType::LandscapePrimary:
-        return _WKScreenOrientationLockTypeLandscapePrimary;
-    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
-        return _WKScreenOrientationLockTypeLandscapeSecondary;
     }
-    return _WKScreenOrientationLockTypePortrait;
+    return _WKScreenOrientationTypePortraitPrimary;
 }
 #endif
 
-bool UIDelegate::UIClient::lockScreenOrientation(WebCore::ScreenOrientationLockType lockType)
+bool UIDelegate::UIClient::lockScreenOrientation(WebPageProxy&, WebCore::ScreenOrientationType orientation)
 {
 #if PLATFORM(IOS)
     if (!m_uiDelegate)
@@ -619,15 +612,15 @@ bool UIDelegate::UIClient::lockScreenOrientation(WebCore::ScreenOrientationLockT
     if (!delegate)
         return false;
 
-    [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:m_uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationLockType(lockType)];
+    [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:m_uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationType(orientation)];
     return true;
 #else
-    UNUSED_PARAM(lockType);
+    UNUSED_PARAM(orientation);
     return false;
 #endif
 }
 
-void UIDelegate::UIClient::unlockScreenOrientation()
+void UIDelegate::UIClient::unlockScreenOrientation(WebPageProxy&)
 {
 #if PLATFORM(IOS)
     if (!m_uiDelegate)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5171,6 +5171,8 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
             if (privateClickMeasurement->destinationSite().matches(frame->url()) || privateClickMeasurement->isSKAdNetworkAttribution())
                 websiteDataStore().storePrivateClickMeasurement(*privateClickMeasurement);
         }
+        if (m_screenOrientationManager)
+            m_screenOrientationManager->unlockIfNecessary();
     }
     m_privateClickMeasurement.reset();
 
@@ -6253,6 +6255,9 @@ void WebPageProxy::didEnterFullscreen(PlaybackSessionContextIdentifier identifie
 
 void WebPageProxy::didExitFullscreen(PlaybackSessionContextIdentifier identifier)
 {
+    if (m_screenOrientationManager)
+        m_screenOrientationManager->unlockIfNecessary();
+
     m_uiClient->didExitFullscreen(this);
 
     if (m_currentFullscreenVideoSessionIdentifier == identifier) {
@@ -6274,6 +6279,9 @@ void WebPageProxy::didEnterFullscreen()
 
 void WebPageProxy::didExitFullscreen()
 {
+    if (m_screenOrientationManager)
+        m_screenOrientationManager->unlockIfNecessary();
+
     m_uiClient->didExitFullscreen(this);
 }
 

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -62,6 +62,8 @@ public:
     void setWindow(UIWindow *);
 #endif
 
+    void unlockIfNecessary();
+
 private:
     void platformInitialize();
     void platformDestroy();
@@ -82,6 +84,8 @@ private:
 
     WebPageProxy& m_page;
     Ref<WebCore::ScreenOrientationProvider> m_provider;
+    std::optional<WebCore::ScreenOrientationType> m_currentlyLockedOrientation;
+    CompletionHandler<void(std::optional<WebCore::Exception>&&)> m_currentLockRequest;
 };
 
 } // namespace WebKit

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -390,6 +390,11 @@ public:
 
     void handleQueryPermission(WKStringRef, WKSecurityOriginRef, WKQueryPermissionResultCallbackRef);
 
+#if PLATFORM(IOS)
+    void lockScreenOrientation(WKScreenOrientationType);
+    void unlockScreenOrientation();
+#endif
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;
@@ -451,6 +456,7 @@ private:
 
 #if PLATFORM(IOS_FAMILY)
     UIPasteboardConsistencyEnforcer *pasteboardConsistencyEnforcer();
+    void restorePortraitOrientationIfNeeded();
 #endif
 
     // WKContextInjectedBundleClient

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -71,6 +71,8 @@
 @property (nonatomic, readonly, getter=isInteractingWithFormControl) BOOL interactingWithFormControl;
 @property (nonatomic) _WKFocusStartsInputSessionPolicy focusStartsInputSessionPolicy;
 
+@property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientations;
+
 #endif
 
 @property (nonatomic, readonly, getter=isShowingContextMenu) BOOL showingContextMenu;

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -71,6 +71,7 @@ struct CustomMenuActionInfo {
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<UITapGestureRecognizer> _windowTapGestureRecognizer;
     BlockPtr<void()> _windowTapRecognizedCallback;
+    UIInterfaceOrientationMask _supportedInterfaceOrientations;
 #endif
 }
 
@@ -119,6 +120,7 @@ IGNORE_WARNINGS_END
         self.UIDelegate = self;
         self._inputDelegate = self;
         self.focusStartsInputSessionPolicy = _WKFocusStartsInputSessionPolicyAuto;
+        self.supportedInterfaceOrientations = UIInterfaceOrientationMaskAll;
 #endif
     }
     return self;
@@ -462,6 +464,16 @@ IGNORE_WARNINGS_END
 - (UIEdgeInsets)_safeAreaInsetsForFrame:(CGRect)frame inSuperview:(UIView *)view
 {
     return _overrideSafeAreaInsets;
+}
+
+- (void)setSupportedInterfaceOrientations:(UIInterfaceOrientationMask)orientations
+{
+    _supportedInterfaceOrientations = orientations;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    return _supportedInterfaceOrientations;
 }
 
 - (UIView *)contentView

--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -148,6 +148,13 @@ static CGRect viewRectForWindowRect(CGRect, PlatformWebView::WebViewSizingMode);
     return layoutMargins;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    if (TestRunnerWKWebView *view = WTR::TestController::singleton().mainWebView() ? WTR::TestController::singleton().mainWebView()->platformView() : nullptr)
+        return view.supportedInterfaceOrientations;
+    return UIInterfaceOrientationMaskAll;
+}
+
 - (void)viewWillTransitionToSize:(CGSize)toSize withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:toSize withTransitionCoordinator:coordinator];


### PR DESCRIPTION
#### 9a6f00e09dd1714190585288993b1edb9605b708
<pre>
Add initial support for screen orientation locking / unlocking
<a href="https://bugs.webkit.org/show_bug.cgi?id=246302">https://bugs.webkit.org/show_bug.cgi?id=246302</a>

Reviewed by Darin Adler.

Add initial support for screen orientation locking / unlocking:
- <a href="https://w3c.github.io/screen-orientation/#lock-method">https://w3c.github.io/screen-orientation/#lock-method</a>
- <a href="https://w3c.github.io/screen-orientation/#unlock-method">https://w3c.github.io/screen-orientation/#unlock-method</a>

Locking / Unlocking is now functional in layout tests on iOS simulator,
allowing us to run the WPT tests for this feature.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt: Added.
Rebaseline tests on iOS now that they are properly running.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
(WebCore::ScreenOrientation::unlock): Deleted.
(WebCore::ScreenOrientation::type const): Deleted.
(WebCore::ScreenOrientation::angle const): Deleted.
(WebCore::ScreenOrientation::visibilityStateChanged): Deleted.
(WebCore::ScreenOrientation::shouldListenForChangeNotification const): Deleted.
(WebCore::ScreenOrientation::screenOrientationDidChange): Deleted.
(WebCore::ScreenOrientation::activeDOMObjectName const): Deleted.
(WebCore::ScreenOrientation::suspend): Deleted.
(WebCore::ScreenOrientation::resume): Deleted.
(WebCore::ScreenOrientation::stop): Deleted.
(WebCore::ScreenOrientation::virtualHasPendingActivity const): Deleted.
(WebCore::ScreenOrientation::eventListenersDidChange): Deleted.
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/page/ScreenOrientationType.h:
(WebCore::screenOrientationIsPortait):
(WebCore::screenOrientationIsLandscape):
* Source/WebCore/platform/ScreenOrientationManager.cpp: Copied from Source/WebCore/platform/ios/Device.h.
(WebCore::ScreenOrientationManager::setLockPromise):
(WebCore::ScreenOrientationManager::takeLockPromise):
* Source/WebCore/platform/ScreenOrientationManager.h:
(WebCore::ScreenOrientationManager::~ScreenOrientationManager): Deleted.
* Source/WebCore/platform/ios/Device.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::lockScreenOrientation):
(API::UIClient::unlockScreenOrientation):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageUIClient):
* Source/WebKit/UIProcess/API/C/WKPageUIClient.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::toWKScreenOrientationType):
(WebKit::UIDelegate::UIClient::lockScreenOrientation):
(WebKit::UIDelegate::UIClient::unlockScreenOrientation):
(WebKit::toWKScreenOrientationLockType): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didExitFullscreen):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
(WebKit::resolveScreenOrientationLockType):
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::unlock):
(WebKit::WebScreenOrientationManagerProxy::screenOrientationDidChange):
(WebKit::WebScreenOrientationManagerProxy::unlockIfNecessary):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::lockScreenOrientationCallback):
(WTR::unlockScreenOrientationCallback):
(WTR::TestController::createWebViewWithOptions):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView initWithFrame:configuration:]):
(-[TestRunnerWKWebView setSupportedInterfaceOrientations:]):
(-[TestRunnerWKWebView supportedInterfaceOrientations]):
* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(-[PlatformWebViewController supportedInterfaceOrientations]):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:

(WTR::TestController::restorePortraitOrientationIfNeeded):
The previous way of restoring portrait orientation caused a UI rotation animation
which could lead to flakiness on the next test. To address the flakiness I now lock
to portrait and then unlock, which gets us in portrait mode without any animation.

(WTR::TestController::platformResetStateToConsistentValues):
(WTR::TestController::lockScreenOrientation):
(WTR::TestController::unlockScreenOrientation):
(WTR::restorePortraitOrientationIfNeeded): Deleted.
Add screen orientation locking / unlocking to WebKitTestRunner on iOS.

Canonical link: <a href="https://commits.webkit.org/255459@main">https://commits.webkit.org/255459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcb47f37aa75282d2babf714b248960439767ea1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92581 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102323 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1798 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30162 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98486 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1214 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79079 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28142 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36572 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34357 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3785 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40548 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40136 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37094 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->