### PR TITLE
Background WebContent Processes should fully suspend behind runtime flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -912,6 +912,18 @@ ServiceWorkersUserGestureEnabled:
     WebCore:
       default: true
 
+ShouldTakeSuspendedAssertions:
+  type: bool
+  humanReadableName: "Take WebKit:Suspended assertions on background web content processes"
+  humanReadableDescription: "Take WebKit:Suspended assertions on background web content processes"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 ShowModalDialogEnabled:
   type: bool
   humanReadableName: "Legacy showModalDialog() API"

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -88,7 +88,7 @@ struct WKAppPrivacyReportTestingData {
 - (void)_processDidResumeForTesting;
 @property (nonatomic, readonly) BOOL _hasServiceWorkerBackgroundActivityForTesting;
 @property (nonatomic, readonly) BOOL _hasServiceWorkerForegroundActivityForTesting;
-- (void)_setAssertionTypeForTesting:(int)type;
+- (void)_setThrottleStateForTesting:(int)type;
 
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -220,12 +220,12 @@
         _page->process().sendProcessDidResume(WebKit::ProcessThrottlerClient::ResumeReason::ForegroundActivity);
 }
 
-- (void)_setAssertionTypeForTesting:(int)value
+- (void)_setThrottleStateForTesting:(int)value
 {
     if (!_page)
         return;
 
-    _page->process().setAssertionTypeForTesting(static_cast<WebKit::ProcessAssertionType>(value));
+    _page->process().setThrottleStateForTesting(static_cast<WebKit::ProcessThrottleState>(value));
 }
 
 - (BOOL)_hasServiceWorkerBackgroundActivityForTesting

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -28,6 +28,7 @@
 
 #include "Logging.h"
 #include "ProcessThrottlerClient.h"
+#include <optional>
 #include <wtf/CompletionHandler.h>
 #include <wtf/text/TextStream.h>
 
@@ -63,7 +64,7 @@ bool ProcessThrottler::addActivity(ForegroundActivity& activity)
     }
 
     m_foregroundActivities.add(&activity);
-    updateAssertionIfNeeded();
+    updateThrottleStateIfNeeded();
     return true;
 }
 
@@ -77,7 +78,7 @@ bool ProcessThrottler::addActivity(BackgroundActivity& activity)
     }
 
     m_backgroundActivities.add(&activity);
-    updateAssertionIfNeeded();
+    updateThrottleStateIfNeeded();
     return true;
 }
 
@@ -85,14 +86,14 @@ void ProcessThrottler::removeActivity(ForegroundActivity& activity)
 {
     ASSERT(isMainRunLoop());
     m_foregroundActivities.remove(&activity);
-    updateAssertionIfNeeded();
+    updateThrottleStateIfNeeded();
 }
 
 void ProcessThrottler::removeActivity(BackgroundActivity& activity)
 {
     ASSERT(isMainRunLoop());
     m_backgroundActivities.remove(&activity);
-    updateAssertionIfNeeded();
+    updateThrottleStateIfNeeded();
 }
 
 void ProcessThrottler::invalidateAllActivities()
@@ -106,18 +107,18 @@ void ProcessThrottler::invalidateAllActivities()
     PROCESSTHROTTLER_RELEASE_LOG("invalidateAllActivities: END");
 }
     
-ProcessAssertionType ProcessThrottler::expectedAssertionType()
+ProcessThrottleState ProcessThrottler::expectedThrottleState()
 {
     if (!m_foregroundActivities.isEmpty())
-        return ProcessAssertionType::Foreground;
+        return ProcessThrottleState::Foreground;
     if (!m_backgroundActivities.isEmpty())
-        return ProcessAssertionType::Background;
-    return ProcessAssertionType::Suspended;
+        return ProcessThrottleState::Background;
+    return ProcessThrottleState::Suspended;
 }
     
-void ProcessThrottler::updateAssertionTypeNow()
+void ProcessThrottler::updateThrottleStateNow()
 {
-    setAssertionType(expectedAssertionType());
+    setThrottleState(expectedThrottleState());
 }
 
 String ProcessThrottler::assertionName(ProcessAssertionType type) const
@@ -142,12 +143,35 @@ String ProcessThrottler::assertionName(ProcessAssertionType type) const
     return makeString(m_process.clientName(), " ", typeString, " Assertion");
 }
 
-void ProcessThrottler::setAssertionType(ProcessAssertionType newType)
+std::optional<ProcessAssertionType> ProcessThrottler::assertionTypeForState(ProcessThrottleState state)
 {
+    switch (state) {
+    case ProcessThrottleState::Foreground:
+        return ProcessAssertionType::Foreground;
+    case ProcessThrottleState::Background:
+        return ProcessAssertionType::Background;
+    case ProcessThrottleState::Suspended:
+        return m_shouldTakeSuspendedAssertion ? std::optional(ProcessAssertionType::Suspended) : std::nullopt;
+    }
+}
+
+void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
+{
+    m_state = newState;
+    m_process.didChangeThrottleState(newState);
+
+    ProcessAssertionType newType;
+    if (auto assertionType = assertionTypeForState(newState))
+        newType = assertionType.value();
+    else {
+        m_assertion = nullptr;
+        return;
+    }
+
     if (m_assertion && m_assertion->isValid() && m_assertion->type() == newType)
         return;
 
-    PROCESSTHROTTLER_RELEASE_LOG("setAssertionType: Updating process assertion type to %u (foregroundActivities=%u, backgroundActivities=%u)", newType, m_foregroundActivities.size(), m_backgroundActivities.size());
+    PROCESSTHROTTLER_RELEASE_LOG("setThrottleState: Updating process assertion type to %u (foregroundActivities=%u, backgroundActivities=%u)", newType, m_foregroundActivities.size(), m_backgroundActivities.size());
 
     // Keep the previous assertion active until the new assertion is taken asynchronously.
     auto previousAssertion = std::exchange(m_assertion, nullptr);
@@ -165,35 +189,34 @@ void ProcessThrottler::setAssertionType(ProcessAssertionType newType)
         if (weakThis)
             weakThis->assertionWasInvalidated();
     });
-    m_process.didSetAssertionType(newType);
 }
     
-void ProcessThrottler::updateAssertionIfNeeded()
+void ProcessThrottler::updateThrottleStateIfNeeded()
 {
-    if (!m_assertion)
+    if (!m_processIdentifier)
         return;
 
     if (shouldBeRunnable()) {
-        if (m_assertion->type() == ProcessAssertionType::Suspended || m_pendingRequestToSuspendID) {
-            if (m_assertion->type() == ProcessAssertionType::Suspended)
-                PROCESSTHROTTLER_RELEASE_LOG("updateAssertionIfNeeded: sending ProcessDidResume IPC because the process was suspended");
+        if (m_state == ProcessThrottleState::Suspended || m_pendingRequestToSuspendID) {
+            if (m_state == ProcessThrottleState::Suspended)
+                PROCESSTHROTTLER_RELEASE_LOG("updateThrottleStateIfNeeded: sending ProcessDidResume IPC because the process was suspended");
             else
-                PROCESSTHROTTLER_RELEASE_LOG("updateAssertionIfNeeded: sending ProcessDidResume IPC because the WebProcess is still processing request to suspend=%" PRIu64, *m_pendingRequestToSuspendID);
-            m_process.sendProcessDidResume(expectedAssertionType() == ProcessAssertionType::Foreground ? ProcessThrottlerClient::ResumeReason::ForegroundActivity : ProcessThrottlerClient::ResumeReason::BackgroundActivity);
+                PROCESSTHROTTLER_RELEASE_LOG("updateThrottleStateIfNeeded: sending ProcessDidResume IPC because the WebProcess is still processing request to suspend=%" PRIu64, *m_pendingRequestToSuspendID);
+            m_process.sendProcessDidResume(expectedThrottleState() == ProcessThrottleState::Foreground ? ProcessThrottlerClient::ResumeReason::ForegroundActivity : ProcessThrottlerClient::ResumeReason::BackgroundActivity);
             clearPendingRequestToSuspend();
         }
     } else {
         // If the process is currently runnable but will be suspended then first give it a chance to complete what it was doing
         // and clean up - move it to the background and send it a message to notify. Schedule a timeout so it can't stay running
         // in the background for too long.
-        if (m_assertion->type() != ProcessAssertionType::Suspended) {
+        if (m_state != ProcessThrottleState::Suspended) {
             m_prepareToSuspendTimeoutTimer.startOneShot(processSuspensionTimeout);
             sendPrepareToSuspendIPC(IsSuspensionImminent::No);
             return;
         }
     }
 
-    updateAssertionTypeNow();
+    updateThrottleStateNow();
 }
 
 void ProcessThrottler::didConnectToProcess(ProcessID pid)
@@ -202,7 +225,7 @@ void ProcessThrottler::didConnectToProcess(ProcessID pid)
     RELEASE_ASSERT(!m_assertion);
 
     m_processIdentifier = pid;
-    setAssertionType(expectedAssertionType());
+    updateThrottleStateNow();
     RELEASE_ASSERT(m_assertion);
 }
     
@@ -210,7 +233,7 @@ void ProcessThrottler::prepareToSuspendTimeoutTimerFired()
 {
     PROCESSTHROTTLER_RELEASE_LOG("prepareToSuspendTimeoutTimerFired: Updating process assertion to allow suspension");
     RELEASE_ASSERT(m_pendingRequestToSuspendID);
-    updateAssertionTypeNow();
+    updateThrottleStateNow();
 }
     
 void ProcessThrottler::processReadyToSuspend()
@@ -220,8 +243,8 @@ void ProcessThrottler::processReadyToSuspend()
     RELEASE_ASSERT(m_pendingRequestToSuspendID);
     clearPendingRequestToSuspend();
 
-    if (m_assertion->type() != ProcessAssertionType::Suspended)
-        updateAssertionTypeNow();
+    if (m_state != ProcessThrottleState::Suspended)
+        updateThrottleStateNow();
 }
 
 void ProcessThrottler::clearPendingRequestToSuspend()
@@ -246,7 +269,7 @@ void ProcessThrottler::sendPrepareToSuspendIPC(IsSuspensionImminent isSuspension
         });
     }
 
-    setAssertionType(isSuspensionImminent == IsSuspensionImminent::Yes ? ProcessAssertionType::Suspended : ProcessAssertionType::Background);
+    setThrottleState(isSuspensionImminent == IsSuspensionImminent::Yes ? ProcessThrottleState::Suspended : ProcessThrottleState::Background);
 }
 
 void ProcessThrottler::uiAssertionWillExpireImminently()
@@ -287,6 +310,11 @@ void ProcessThrottler::setAllowsActivities(bool allow)
 
     if (!allow)
         invalidateAllActivities();
+}
+
+void ProcessThrottler::setShouldTakeSuspendedAssertion(bool shouldTakeSuspendedAssertion)
+{
+    m_shouldTakeSuspendedAssertion = shouldTakeSuspendedAssertion;
 }
 
 ProcessThrottler::TimedActivity::TimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)

--- a/Source/WebKit/UIProcess/ProcessThrottlerClient.h
+++ b/Source/WebKit/UIProcess/ProcessThrottlerClient.h
@@ -26,11 +26,12 @@
 #ifndef ProcessThrottlerClient_h
 #define ProcessThrottlerClient_h
 
-#include "ProcessAssertion.h"
+#include <wtf/CompletionHandler.h>
 
 namespace WebKit {
 
 enum class IsSuspensionImminent : bool;
+enum class ProcessThrottleState : uint8_t;
 
 class ProcessThrottlerClient {
 public:
@@ -39,7 +40,7 @@ public:
     virtual void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) = 0;
     enum ResumeReason : bool { ForegroundActivity, BackgroundActivity };
     virtual void sendProcessDidResume(ResumeReason) = 0;
-    virtual void didSetAssertionType(ProcessAssertionType) { };
+    virtual void didChangeThrottleState(ProcessThrottleState) { };
     virtual ASCIILiteral clientName() const = 0;
 };
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1122,6 +1122,9 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     }
 #endif
 
+    bool shouldTakeSuspendedAssertions = page->preferences().shouldTakeSuspendedAssertions();
+    process->throttler().setShouldTakeSuspendedAssertion(shouldTakeSuspendedAssertions);
+
     return page;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -331,7 +331,7 @@ public:
     // ProcessThrottlerClient
     void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) final;
     void sendProcessDidResume(ResumeReason) final;
-    void didSetAssertionType(ProcessAssertionType) final;
+    void didChangeThrottleState(ProcessThrottleState) final;
     ASCIILiteral clientName() const final { return "WebProcess"_s; }
 
 #if PLATFORM(COCOA)
@@ -377,7 +377,7 @@ public:
     void startServiceWorkerBackgroundProcessing();
     void endServiceWorkerBackgroundProcessing();
 #endif
-    void setAssertionTypeForTesting(ProcessAssertionType type) { didSetAssertionType(type); }
+    void setThrottleStateForTesting(ProcessThrottleState state) { didChangeThrottleState(state); }
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     UserMediaCaptureManagerProxy* userMediaCaptureManagerProxy() { return m_userMediaCaptureManagerProxy.get(); }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -1749,15 +1749,15 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     [webView2 loadRequest:server.request()];
 
     auto webViewToUpdate = useSeparateServiceWorkerProcess == UseSeparateServiceWorkerProcess::Yes ? webView : webView2;
-    [webViewToUpdate _setAssertionTypeForTesting: 1];
+    [webViewToUpdate _setThrottleStateForTesting: 1];
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerForegroundActivityForTesting]; }));
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting]; }));
 
-    [webViewToUpdate _setAssertionTypeForTesting: 3];
+    [webViewToUpdate _setThrottleStateForTesting: 2];
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [webViewToUpdate _hasServiceWorkerForegroundActivityForTesting]; }));
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting]; }));
 
-    [webViewToUpdate _setAssertionTypeForTesting: 0];
+    [webViewToUpdate _setThrottleStateForTesting: 0];
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerForegroundActivityForTesting]; }));
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting]; }));
 
@@ -1765,19 +1765,19 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     webView = nullptr;
 
     // The service worker process should take activity based on webView2 process.
-    [webView2 _setAssertionTypeForTesting: 1];
+    [webView2 _setThrottleStateForTesting: 1];
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
-        [webView2 _setAssertionTypeForTesting:1];
+        [webView2 _setThrottleStateForTesting:1];
         return ![webView2 _hasServiceWorkerForegroundActivityForTesting] && [webView2 _hasServiceWorkerBackgroundActivityForTesting];
     }));
 
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
-        [webView2 _setAssertionTypeForTesting:3];
+        [webView2 _setThrottleStateForTesting:2];
         return [webView2 _hasServiceWorkerForegroundActivityForTesting] && ![webView2 _hasServiceWorkerBackgroundActivityForTesting];
     }));
 
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
-        [webView2 _setAssertionTypeForTesting:0];
+        [webView2 _setThrottleStateForTesting:0];
         return ![webView2 _hasServiceWorkerForegroundActivityForTesting] && ![webView2 _hasServiceWorkerBackgroundActivityForTesting];
     }));
 }


### PR DESCRIPTION
#### 4bd642c8073d7a9880db59403458169ccd72183e
<pre>
Background WebContent Processes should fully suspend behind runtime flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=246304">https://bugs.webkit.org/show_bug.cgi?id=246304</a>
rdar://101001791

Reviewed by Chris Dumez.

Add a runtime flag &quot;FullySuspendBackgroundTabs&quot; which allows
ProcessThrottler to drop all RunningBoard assertions and consequently
suspend the throttled background WebContent process.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setAssertionTypeForTesting:]):
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::addActivity):
(WebKit::ProcessThrottler::removeActivity):
(WebKit::ProcessThrottler::expectedThrottleState):
(WebKit::ProcessThrottler::updateThrottleStateNow):
(WebKit::ProcessThrottler::assertionTypeForState):
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::updateThrottleStateIfNeeded):
(WebKit::ProcessThrottler::didConnectToProcess):
(WebKit::ProcessThrottler::prepareToSuspendTimeoutTimerFired):
(WebKit::ProcessThrottler::processReadyToSuspend):
(WebKit::ProcessThrottler::sendPrepareToSuspendIPC):
(WebKit::ProcessThrottler::enableFullSuspension):
(WebKit::ProcessThrottler::expectedAssertionType): Deleted.
(WebKit::ProcessThrottler::updateAssertionTypeNow): Deleted.
(WebKit::ProcessThrottler::setAssertionType): Deleted.
(WebKit::ProcessThrottler::updateAssertionIfNeeded): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ProcessThrottlerClient.h:
(WebKit::ProcessThrottlerClient::didChangeThrottleState):
(WebKit::ProcessThrottlerClient::didSetAssertionType): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didChangeThrottleState):
(WebKit::WebProcessProxy::didSetAssertionType): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::setAssertionTypeForTesting):

Canonical link: <a href="https://commits.webkit.org/255498@main">https://commits.webkit.org/255498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58bbc7901b454831e741bf79d0977cd899cdc93f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102324 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1800 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30164 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84988 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98487 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1212 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79081 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28143 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82832 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71233 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /TestWTF:WTF_WorkQueue.DestroyDispatchedOnDispatchQueue (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36574 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16760 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78994 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17939 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27386 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40552 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81614 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37098 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18458 "Passed tests") | 
<!--EWS-Status-Bubble-End-->