### PR TITLE
Don't force CompletionHandlerCallThread::MainThread for async replies

### DIFF
--- a/Source/WTF/wtf/FunctionDispatcher.h
+++ b/Source/WTF/wtf/FunctionDispatcher.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Function.h>
+#include <wtf/ThreadSafetyAnalysis.h>
 
 namespace WTF {
 
@@ -42,6 +43,23 @@ protected:
     WTF_EXPORT_PRIVATE FunctionDispatcher();
 };
 
+class WTF_CAPABILITY("is current") SerialFunctionDispatcher : public FunctionDispatcher {
+public:
+#if ASSERT_ENABLED
+    WTF_EXPORT_PRIVATE virtual void assertIsCurrent() const = 0;
+#endif
+};
+
+inline void assertIsCurrent(const SerialFunctionDispatcher& queue) WTF_ASSERTS_ACQUIRED_CAPABILITY(queue)
+{
+#if ASSERT_ENABLED
+    queue.assertIsCurrent();
+#else
+    UNUSED_PARAM(queue);
+#endif
+}
+
 } // namespace WTF
 
 using WTF::FunctionDispatcher;
+using WTF::SerialFunctionDispatcher;

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -200,4 +200,11 @@ void RunLoop::threadWillExit()
     }
 }
 
+#if ASSERT_ENABLED
+void RunLoop::assertIsCurrent() const
+{
+    ASSERT(this == &current());
+}
+#endif
+
 } // namespace WTF

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -72,7 +72,7 @@ using RunLoopMode = unsigned;
 #define DefaultRunLoopMode 0
 #endif
 
-class WTF_CAPABILITY("is current") RunLoop final : public FunctionDispatcher, public ThreadSafeRefCounted<RunLoop> {
+class WTF_CAPABILITY("is current") RunLoop final : public SerialFunctionDispatcher, public ThreadSafeRefCounted<RunLoop> {
     WTF_MAKE_NONCOPYABLE(RunLoop);
 public:
     // Must be called from the main thread.
@@ -109,6 +109,10 @@ public:
     WTF_EXPORT_PRIVATE CycleResult static cycle(RunLoopMode = DefaultRunLoopMode);
 
     WTF_EXPORT_PRIVATE void threadWillExit();
+
+#if ASSERT_ENABLED
+    void assertIsCurrent() const final;
+#endif
 
 #if USE(GLIB_EVENT_LOOP)
     WTF_EXPORT_PRIVATE GMainContext* mainContext() const { return m_mainContext.get(); }

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -81,6 +81,20 @@ WorkerOrWorkletThread::~WorkerOrWorkletThread()
     workerOrWorkletThreads().remove(this);
 }
 
+void WorkerOrWorkletThread::dispatch(Function<void()>&& func)
+{
+    runLoop().postTask([func = WTFMove(func)](auto&) mutable {
+        func();
+    });
+}
+
+#if ASSERT_ENABLED
+void WorkerOrWorkletThread::assertIsCurrent() const
+{
+    return WTF::assertIsCurrent(*thread());
+}
+#endif
+
 void WorkerOrWorkletThread::startRunningDebuggerTasks()
 {
     ASSERT(!m_pausedForDebugger);

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -29,6 +29,7 @@
 #include "WorkerThreadMode.h"
 #include <wtf/Forward.h>
 #include <wtf/Function.h>
+#include <wtf/FunctionDispatcher.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/threads/BinarySemaphore.h>
@@ -42,9 +43,14 @@ namespace WebCore {
 class WorkerDebuggerProxy;
 class WorkerLoaderProxy;
 
-class WorkerOrWorkletThread : public ThreadSafeRefCounted<WorkerOrWorkletThread> {
+class WorkerOrWorkletThread : public SerialFunctionDispatcher, public ThreadSafeRefCounted<WorkerOrWorkletThread> {
 public:
     virtual ~WorkerOrWorkletThread();
+
+    void dispatch(Function<void()>&&) final;
+#if ASSERT_ENABLED
+    void assertIsCurrent() const final;
+#endif
 
     Thread* thread() const { return m_thread.get(); }
 

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -592,7 +592,7 @@ uint64_t Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint
             T::callReply(*decoder, WTFMove(completionHandler));
         else
             T::cancelReply(WTFMove(completionHandler));
-    }, CompletionHandlerCallThread::MainThread));
+    }));
     encoder.get() << listenerID;
     encoder.get() << message.arguments();
     sendMessage(WTFMove(encoder), sendOptions);


### PR DESCRIPTION
#### 508461b6877e2c9f6c7b7875422d791c17d715f3
<pre>
Don&apos;t force CompletionHandlerCallThread::MainThread for async replies
<a href="https://bugs.webkit.org/show_bug.cgi?id=246308">https://bugs.webkit.org/show_bug.cgi?id=246308</a>

Reviewed by NOBODY (OOPS!).

This only changes an assertion, doesn&apos;t affect behaviour at all.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithAsyncReply):
</pre>
----------------------------------------------------------------------
#### c3b87699d4881942d8684b390236315333005a3a
<pre>
Add SerialFunctionDispatcher interface.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246305">https://bugs.webkit.org/show_bug.cgi?id=246305</a>

Reviewed by NOBODY (OOPS!).

This creates a common interface between RunLoop, and WorkerOrWorkletThread, that lets you dispatch Functions
that are guaranteed to be executed serially.

* Source/WTF/wtf/FunctionDispatcher.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::assertIsCurrent const):
* Source/WTF/wtf/RunLoop.h:
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::dispatch):
(WebCore::WorkerOrWorkletThread::assertIsCurrent const):
* Source/WebCore/workers/WorkerOrWorkletThread.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/508461b6877e2c9f6c7b7875422d791c17d715f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102091 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162609 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1544 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29932 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98255 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/97979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1020 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78833 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27949 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/70996 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83723 "Found 1 new JSC stress test failure: wasm.yaml/wasm/lowExecutableMemory/imports-oom.js.default-wasm (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36350 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16562 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78730 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17729 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27269 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/37986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40356 "Found 1 new test failure: http/wpt/webrtc/transfer-datachannel-service-worker.https.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81351 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39887 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36871 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18393 "Passed tests") | 
<!--EWS-Status-Bubble-End-->