### PR TITLE
[Flatpak SDK][WebDriver] Incompatible python and pytest versions

### DIFF
--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -34,11 +34,11 @@ if sys.platform == 'darwin':
 from webkitcorepy import AutoInstall, Package, Version
 AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
 
-if sys.version_info >= (3, 5):
+if sys.version_info >= (3, 6):
     AutoInstall.register(Package('pylint', Version(2, 6, 0)))
     AutoInstall.register(Package('pytest_asyncio', Version(0, 14), pypi_name='pytest-asyncio'))
     AutoInstall.register(Package('pytest_timeout', Version(1, 4, 2), pypi_name='pytest-timeout'))
-    AutoInstall.register(Package('pytest', Version(6, 1, 2), implicit_deps=['pytest_asyncio', 'pytest_timeout']))
+    AutoInstall.register(Package('pytest', Version(6, 2, 5), implicit_deps=['pytest_asyncio', 'pytest_timeout']))
     AutoInstall.register(Package('websockets', Version(8, 1)))
 elif sys.version_info >= (2, 7) and sys.version_info < (3,):
     AutoInstall.register(Package('pylint', Version(0, 28, 0)))


### PR DESCRIPTION
#### c026bc80903fb3e875bdc13dce87dfdbf52f2241
<pre>
[Flatpak SDK][WebDriver] Incompatible python and pytest versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=246317">https://bugs.webkit.org/show_bug.cgi?id=246317</a>

Reviewed by Philippe Normand, Jonathan Bedard and Adrian Perez de Castro.

Bump pytest to 6.2.5 to include Python 3.10 support.

Bump python to 3.6 given pytest 6.2 requirement.

Pytest 6.2 is incompatible with Python3 &lt; 3.6, so this commit
also bumps the minimum Python3 version to 3.6, which should
not be a problem given Big Sur seems to ship 3.8 and 3.6 was
released in 2016.

* Tools/Scripts/webkitpy/__init__.py:

Canonical link: <a href="https://commits.webkit.org/255410@main">https://commits.webkit.org/255410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6121d39bc6c5665f0c7fc55092cf1a68c2f12566

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102111 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1567 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29954 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98274 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1039 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78856 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27976 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/95914 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82631 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36372 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16581 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17749 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3744 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40374 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36893 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->