### PR TITLE
Have DisplayLink use IPC::Connection::UniqueID, rather than IPC::Connection

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -770,7 +770,7 @@ private:
     HashMap<WebCore::RegistrableDomain, std::unique_ptr<WebCore::PrewarmInformation>> m_prewarmInformationPerRegistrableDomain;
 
 #if HAVE(CVDISPLAYLINK)
-    Vector<std::unique_ptr<DisplayLink>> m_displayLinks;
+    DisplayLinkCollection m_displayLinks;
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)


### PR DESCRIPTION
#### 21ff04706f4f15f6d82110254309d225306dcd5b
<pre>
Have DisplayLink use IPC::Connection::UniqueID, rather than IPC::Connection
<a href="https://bugs.webkit.org/show_bug.cgi?id=246320">https://bugs.webkit.org/show_bug.cgi?id=246320</a>
rdar://101014516

Reviewed by Chris Dumez.

DisplayLink doesn&apos;t need to know anything about the details of IPC::Connection;
it just needs a unique identifier to use as a hash key, so change it to use
IPC::Connection::UniqueID.

Also make a collection class to hold the set of DisplayLinks, so it&apos;s easier
to move them out of WebProcessPool at some point.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::nominalFramesPerSecondForDisplay):
(WebKit::WebProcessPool::startDisplayLink):
(WebKit::WebProcessPool::stopDisplayLink):
(WebKit::WebProcessPool::stopDisplayLinks):
(WebKit::WebProcessPool::setDisplayLinkPreferredFramesPerSecond):
(WebKit::WebProcessPool::setDisplayLinkForDisplayWantsFullSpeedUpdates):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/DisplayLink.cpp:
(WebKit::DisplayLink::addObserver):
(WebKit::DisplayLink::removeObserver):
(WebKit::DisplayLink::removeObservers):
(WebKit::DisplayLink::removeInfoForConnectionIfPossible):
(WebKit::DisplayLink::incrementFullSpeedRequestClientCount):
(WebKit::DisplayLink::decrementFullSpeedRequestClientCount):
(WebKit::DisplayLink::setPreferredFramesPerSecond):
(WebKit::DisplayLinkCollection::displayLinkForDisplay const):
(WebKit::DisplayLinkCollection::add):
* Source/WebKit/UIProcess/mac/DisplayLink.h:
(WebKit::DisplayLinkCollection::displayLinks const):

Canonical link: <a href="https://commits.webkit.org/255404@main">https://commits.webkit.org/255404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5528f4d64e898b67239deb2b6383c6e7e124dbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92416 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102183 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1641 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30024 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98341 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98077 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78929 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36439 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34207 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36965 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->