### PR TITLE
Encode Markable values without a separate isEmpty boolean

### DIFF
--- a/Source/WTF/wtf/ApproximateTime.h
+++ b/Source/WTF/wtf/ApproximateTime.h
@@ -27,6 +27,7 @@
 
 #include <wtf/ClockType.h>
 #include <wtf/GenericTimeMixin.h>
+#include <wtf/Markable.h>
 
 namespace WTF {
 
@@ -66,7 +67,7 @@ private:
 };
 static_assert(sizeof(ApproximateTime) == sizeof(double));
 
-struct ApproximateTime::MarkableTraits {
+struct ApproximateTime::MarkableTraits : DirectCodedMarkableTraits<ApproximateTime, ApproximateTime::MarkableTraits> {
     static bool isEmptyValue(ApproximateTime time)
     {
         return std::isnan(time.m_value);

--- a/Source/WTF/wtf/MonotonicTime.h
+++ b/Source/WTF/wtf/MonotonicTime.h
@@ -67,7 +67,7 @@ private:
 };
 static_assert(sizeof(MonotonicTime) == sizeof(double));
 
-struct MonotonicTime::MarkableTraits {
+struct MonotonicTime::MarkableTraits : DirectCodedMarkableTraits<MonotonicTime, MonotonicTime::MarkableTraits> {
     static bool isEmptyValue(MonotonicTime time)
     {
         return std::isnan(time.m_value);

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -103,7 +103,7 @@ public:
         return String::number(m_identifier);
     }
 
-    struct MarkableTraits {
+    struct MarkableTraits : DirectCodedMarkableTraits<ObjectIdentifier, MarkableTraits> {
         static bool isEmptyValue(ObjectIdentifier identifier)
         {
             return !identifier.m_identifier;

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -27,6 +27,7 @@
 
 #include <optional>
 #include <wtf/FastMalloc.h>
+#include <wtf/Markable.h>
 #include <wtf/MathExtras.h>
 
 namespace WTF {
@@ -260,7 +261,7 @@ private:
 
 WTF_EXPORT_PRIVATE void sleep(Seconds);
 
-struct Seconds::MarkableTraits {
+struct Seconds::MarkableTraits : DirectCodedMarkableTraits<Seconds, Seconds::MarkableTraits> {
     static bool isEmptyValue(Seconds seconds)
     {
         return std::isnan(seconds.value());

--- a/Source/WTF/wtf/WallTime.h
+++ b/Source/WTF/wtf/WallTime.h
@@ -28,6 +28,7 @@
 #include <wtf/ClockType.h>
 #include <wtf/GenericTimeMixin.h>
 #include <wtf/Int128.h>
+#include <wtf/Markable.h>
 
 namespace WTF {
 
@@ -64,7 +65,7 @@ private:
 };
 static_assert(sizeof(WallTime) == sizeof(double));
 
-struct WallTime::MarkableTraits {
+struct WallTime::MarkableTraits : DirectCodedMarkableTraits<WallTime, WallTime::MarkableTraits> {
     static bool isEmptyValue(WallTime time)
     {
         return std::isnan(time.m_value);

--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h
@@ -50,7 +50,7 @@ public:
     template <class Decoder> static std::optional<ContentSecurityPolicyResponseHeaders> decode(Decoder&);
 
     enum EmptyTag { Empty };
-    struct MarkableTraits {
+    struct MarkableTraits : DirectCodedMarkableTraits<ContentSecurityPolicyResponseHeaders, MarkableTraits> {
         static bool isEmptyValue(const ContentSecurityPolicyResponseHeaders& identifier)
         {
             return identifier.m_emptyForMarkable;

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -99,7 +99,7 @@ public:
     template<typename Encoder> void encode(Encoder& encoder) const { encoder << m_object << m_processIdentifier; }
     template<typename Decoder> static std::optional<ProcessQualified> decode(Decoder&);
 
-    struct MarkableTraits {
+    struct MarkableTraits : DirectCodedMarkableTraits<ProcessQualified, MarkableTraits> {
         static bool isEmptyValue(const ProcessQualified& identifier) { return !identifier; }
         static constexpr ProcessQualified emptyValue() { return { }; }
     };


### PR DESCRIPTION
#### aa967169dc51f09a4da763b56cfd727a82e42538
<pre>
Encode Markable values without a separate isEmpty boolean
<a href="https://bugs.webkit.org/show_bug.cgi?id=246319">https://bugs.webkit.org/show_bug.cgi?id=246319</a>
&lt;rdar://problem/101014331&gt;

Reviewed by NOBODY (OOPS!).

The purpose of WTF::Markable is to allow a special &quot;empty&quot; value to be
represented without any additional storage space. We currently encode
Markable values by writing a bool indicating whether the value is the
empty value.

This patch:

* moves encode and decode functionality to a Markable&apos;s traits
  type, so that the exact coding can be specialized
* adds encode and decode functions to EnumMarkableTraits that writes and
  reads the underlying value, while continuing to check for valid enum
  values during decode
* adds a DirectCodedMarkableTraits base class for other Markable traits
  classes to inherit from, where the storage type can be written and
  read without any additional checking
* uses DirectCodedMarkableTraits on the existing Markable traits classes
  that are used in IPC

* Source/WTF/wtf/ApproximateTime.h:
* Source/WTF/wtf/Markable.h:
(WTF::std::underlying_type&lt;EnumType&gt;::type&gt;::max):
(WTF::DirectCodedMarkableTraits::encode):
(WTF::DirectCodedMarkableTraits::decode):
(WTF::Traits&gt;::encode const):
(WTF::Traits&gt;::decode):
* Source/WTF/wtf/MonotonicTime.h:
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WTF/wtf/Seconds.h:
* Source/WTF/wtf/WallTime.h:
* Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.h:
* Source/WebCore/platform/ProcessQualified.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa967169dc51f09a4da763b56cfd727a82e42538

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102119 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1575 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29962 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98281 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98011 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1042 "Found 30 new test failures: accessibility/accessibility-node-reparent.html, accessibility/ancestor-computation.html, accessibility/aria-current-state-changed-notification.html, accessibility/aria-describedby-on-input.html, accessibility/ios-simulator/accessibility-crash-in-axcontainer.html, accessibility/ios-simulator/accessibility-hint.html, accessibility/ios-simulator/accessibility-make-first-responder.html, accessibility/ios-simulator/aria-errormessage.html, accessibility/text-marker/character-offset-visible-position-conversion-hang.html, accessibility/text-marker/media-emits-object-replacement.html ... (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78864 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27983 "Found unexpected failure with change (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82961 "Found 1123 new API test failures: TestWebKitAPI.WKWebView.LocalStorageDirectoryExcludedFromBackup, TestWebKitAPI.ProcessSwap.NavigatingSameOriginFromCOOPSameOrigin, TestWebKitAPI.WKContentRuleListStoreTest.Compile, TestWebKitAPI.WKWebViewThemeColor.MetaElementInvalidColor, TestWebKitAPI.ProcessSwap.NavigatingSameOriginFromCOOPAndCOEPSameOriginAllowPopup, TestWebKitAPI.URLSchemeHandler.LoadsFromNetwork, TestWebKitAPI.WebKit.InteractionDeadlockAfterCrash, TestWebKitAPI.DragAndDropTests.DragElementWithImageOverlay, TestWebKitAPI.AppPrivacyReport.LoadFileRequestIsNonAppInitiated, TestWebKitAPI.WKWebView.ClearAppCache ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82640 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; 335 api tests failed or timed out; re-run-api-tests (exception)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36380 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78762 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34143 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17757 "Found 30 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-setattribute.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/mac/abbr-acronym-tags.html, accessibility/mac/accessibility-make-first-responder.html, accessibility/mac/attributed-string/attributed-string-does-not-includes-misspelled-for-non-editable.html, accessibility/mac/attributed-string/attributed-string-for-range-with-options.html, accessibility/mac/search-text/search-text.html, accessibility/mac/select-text/select-text-1.html ... (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27276 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38017 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40381 "Found 30 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-node-reparent.html, accessibility/accessibility-object-detached.html, accessibility/activation-of-input-field-inside-other-element.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/custom-elements/controls.html, accessibility/custom-elements/current.html, accessibility/custom-elements/describedby-shadow.html ... (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81383 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36901 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18399 "Passed tests") | 
<!--EWS-Status-Bubble-End-->