### PR TITLE
~NetworkStorageManager is run in the wrong thread in certain conditions

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -29,6 +29,7 @@
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
+#import "TestNavigationDelegate.h"
 #import "TestNotificationProvider.h"
 #import "TestURLSchemeHandler.h"
 #import "TestWKWebView.h"


### PR DESCRIPTION
#### fa84ebb53d5b0cee06eaaa20727b6495fcbabfb7
<pre>
~NetworkStorageManager is run in the wrong thread in certain conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=245869">https://bugs.webkit.org/show_bug.cgi?id=245869</a>
rdar://problem/100602521

Reviewed by NOBODY (OOPS!).

Short running tests would sometimes fail
ASSERT(!RunLoop::isMain()) during ~NetworkStorageManager().

This would happen when the NetworkStorageManager::close() would
be first called, invalidating the storage manager. Then
NetworkProcess::didClose() would call NetworkStorageManager::syncLocalStorage().

NetworkStorageManager was a ref counted class and close() was intended to
post the last shared ref back to the main thread, ensuring main thread destruction
when the real owning ref in NetworkSession::m_storageManager was lost.

However, posting the invalid syncLocalStorage() task after close() would put an
unexpected new ref to the work queue. This would mean that losing m_storageManager
ref was not losing the last ref.

Fix this by making sure closed NetworkStorageManagers do not run
needless sync or low memory tasks.

This is not really fixing the underlying problems of NetworkStorageManager ownership,
but should reduce the flakiness of:
run-api-tests  TestWebKitAPI.WebKit.MigrateLocalStorageDataToGeneralStorageDirectory --repeat 100

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::handleLowMemoryWarning):
(WebKit::NetworkStorageManager::syncLocalStorage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa84ebb53d5b0cee06eaaa20727b6495fcbabfb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/22964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102140 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162633 "Failed to checkout and rebase branch from PR 5233") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1597 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/29982 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98300 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1057 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78886 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/27995 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/82975 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36400 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34165 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38037 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36920 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->