### PR TITLE
IPC::Connection cannot be bound to arbitrary run loop

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -242,11 +242,10 @@ public:
     void addMessageReceiver(FunctionDispatcher&, MessageReceiver&, ReceiverName, uint64_t destinationID = 0);
     void removeMessageReceiver(ReceiverName, uint64_t destinationID = 0);
 
-    bool open(Client&);
+    bool open(Client&, RunLoop& = RunLoop::current());
     void invalidate();
     void markCurrentlyDispatchedMessageAsInvalid();
 
-    void postConnectionDidCloseOnConnectionWorkQueue();
     template<typename T, typename C> uint64_t sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID = 0, OptionSet<SendOption> = { }); // Thread-safe.
     template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
     template<typename T> static bool send(UniqueID, T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { }, std::optional<Thread::QOS> qos = std::nullopt); // Thread-safe.
@@ -355,6 +354,7 @@ public:
     void dispatchMessageReceiverMessage(MessageReceiver&, std::unique_ptr<Decoder>&&);
     // Can be called from any thread.
     void dispatchDidReceiveInvalidMessage(MessageName);
+    void dispatchDidCloseAndInvalidate();
 
     size_t pendingMessageCountForTesting() const;
     void dispatchOnReceiveQueueForTesting(Function<void()>&&);
@@ -410,6 +410,9 @@ private:
 #if PLATFORM(COCOA)
     bool sendMessage(std::unique_ptr<MachMessage>);
 #endif
+    template<typename F>
+    void dispatchClient(F&& clientRunLoopTask);
+
     size_t numberOfMessagesToProcess(size_t totalMessages);
     bool isThrottlingIncomingMessages() const { return *m_incomingMessagesThrottlingLevel > 0; }
 
@@ -571,6 +574,8 @@ uint64_t Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint
     static_assert(!T::isSync, "Async message expected");
 
     if (!isValid()) {
+        // FIXME: Current contract is that completionHandler is called on the connection run loop.
+        // This does not make sense. However, this needs a change that is done later.
         RunLoop::main().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
             T::cancelReply(WTFMove(completionHandler));
         });
@@ -584,7 +589,7 @@ uint64_t Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint
             T::callReply(*decoder, WTFMove(completionHandler));
         else
             T::cancelReply(WTFMove(completionHandler));
-    }, CompletionHandlerCallThread::MainThread));
+    }));
     encoder.get() << listenerID;
     encoder.get() << message.arguments();
     sendMessage(WTFMove(encoder), sendOptions);
@@ -613,8 +618,6 @@ void moveTuple(std::tuple<A...>&& a, std::tuple<B...>& b)
 template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, uint64_t destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
 {
     static_assert(T::isSync, "Sync message expected");
-    RELEASE_ASSERT(RunLoop::isMain());
-
     SyncRequestID syncRequestID;
     auto encoder = createSyncMessageEncoder(T::name(), destinationID, syncRequestID);
 
@@ -641,7 +644,6 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
 
 template<typename T> bool Connection::waitForAndDispatchImmediately(uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
-    RELEASE_ASSERT(RunLoop::isMain());
     std::unique_ptr<Decoder> decoder = waitForMessage(T::name(), destinationID, timeout, waitForOptions);
     if (!decoder)
         return false;
@@ -654,7 +656,6 @@ template<typename T> bool Connection::waitForAndDispatchImmediately(uint64_t des
 
 template<typename T> bool Connection::waitForAsyncCallbackAndDispatchImmediately(uint64_t destinationID, Timeout timeout)
 {
-    RELEASE_ASSERT(RunLoop::isMain());
     std::unique_ptr<Decoder> decoder = waitForMessage(T::asyncMessageReplyName(), destinationID, timeout, { });
     if (!decoder)
         return false;

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -50,6 +50,24 @@ struct MockTestMessage1 {
     std::tuple<> arguments() { return { }; }
 };
 
+struct MockTestMessageWithAsyncReply1 {
+    static constexpr bool isSync = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(124); }
+    // Just using WebPage_AttributedSubstringForCharacterRangeAsyncReply as something that is async message name.
+    // If WebPage_AttributedSubstringForCharacterRangeAsyncReply is removed, just use another one.
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_AttributedSubstringForCharacterRangeAsyncReply; }
+    std::tuple<> arguments() { return { }; }
+    static void callReply(IPC::Decoder& decoder, CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        auto value = decoder.decode<uint64_t>();
+        completionHandler(*value);
+    }
+    static void cancelReply(CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        completionHandler(0);
+    }
+};
+
 class MockConnectionClient final : public IPC::Connection::Client {
 public:
     ~MockConnectionClient()
@@ -87,7 +105,7 @@ public:
     }
 
     // Handler returns false if the message should be just recorded.
-    void setAsyncMessageHandler(Function<bool(MessageInfo&)>&& handler)
+    void setAsyncMessageHandler(Function<bool(IPC::Decoder&)>&& handler)
     {
         m_asyncMessageHandler = WTFMove(handler);
     }
@@ -95,10 +113,9 @@ public:
     // IPC::Connection::Client overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder& decoder) override
     {
-        MessageInfo messageInfo { decoder.messageName(), decoder.destinationID() };
-        if (m_asyncMessageHandler && m_asyncMessageHandler(messageInfo))
+        if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
             return;
-        m_messages.append(WTFMove(messageInfo));
+        m_messages.append({ decoder.messageName(), decoder.destinationID() });
         m_continueWaitForMessage = true;
     }
 
@@ -122,7 +139,7 @@ private:
     std::optional<IPC::MessageName> m_didReceiveInvalidMessage;
     Deque<MessageInfo> m_messages;
     bool m_continueWaitForMessage { false };
-    Function<bool(MessageInfo&)> m_asyncMessageHandler;
+    Function<bool(IPC::Decoder&)> m_asyncMessageHandler;
 };
 
 }
@@ -441,7 +458,7 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingWorks)
     std::array<size_t, 18> messageCounts { 600, 300, 200, 150, 120, 100, 85, 75, 66, 60, 60, 66, 75, 85, 100, 120, 37, 1 };
     for (size_t i = 0; i < messageCounts.size(); ++i) {
         SCOPED_TRACE(i);
-        RunLoop::current().dispatch([&otherRunLoopTasksRun] { 
+        RunLoop::current().dispatch([&otherRunLoopTasksRun] {
             otherRunLoopTasksRun++;
         });
         Util::spinRunLoop();
@@ -475,18 +492,19 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
         b()->send(MockTestMessage1 { }, i);
     while (a()->pendingMessageCountForTesting() < testedCount)
         sleep(0.1_s);
-    
+
     // Two messages invoke nested run loop. The handler skips total 4 messages for the
     // proofs of logic that the test was ran.
     bool isProcessing = false;
-    aClient().setAsyncMessageHandler([&] (MessageInfo& message) -> bool {
-        if (message.destinationID == 888 || message.destinationID == 1299) {
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto destinationID = decoder.destinationID();
+        if (destinationID == 888 || destinationID == 1299) {
             isProcessing = true;
             Util::spinRunLoop();
             isProcessing = false;
             return true; // Skiping the message is the proof that the message was processed.
         }
-        if (message.destinationID == 889 || message.destinationID == 1300) {
+        if (destinationID == 889 || destinationID == 1300) {
             EXPECT_TRUE(isProcessing); // Passing the EXPECT is the proof that we ran the message in a nested event loop.
             return true; // Skipping the message is the proof that above EXPECT was ran.
         }
@@ -497,7 +515,7 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
     std::array<size_t, 16> messageCounts { 600, 498, 150, 218, 85, 75, 66, 60, 60, 66, 75, 85, 100, 120, 37, 1 };
     for (size_t i = 0; i < messageCounts.size(); ++i) {
         SCOPED_TRACE(i);
-        RunLoop::current().dispatch([&otherRunLoopTasksRun] { 
+        RunLoop::current().dispatch([&otherRunLoopTasksRun] {
             otherRunLoopTasksRun++;
         });
         Util::spinRunLoop();
@@ -516,8 +534,259 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
     }
 }
 
+
+template<typename C>
+static void dispatchSync(RunLoop& runLoop, C&& function)
+{
+    BinarySemaphore semaphore;
+    runLoop.dispatch([&] () mutable {
+        function();
+        semaphore.signal();
+    });
+    semaphore.wait();
+}
+
+template<typename C>
+static void dispatchAndWait(RunLoop& runLoop, C&& function)
+{
+    std::atomic<bool> done = false;
+    runLoop.dispatch([&] () mutable {
+        function();
+        done = true;
+    });
+    while (!done)
+        RunLoop::current().cycle();
+}
+
+class ConnectionRunLoopTest : public ConnectionTestABBA {
+public:
+    void TearDown() override
+    {
+        ConnectionTestABBA::TearDown();
+        // Remember to call localReferenceBarrier() in test scope.
+        // Otherwise run loops might be executing code that uses variables
+        // that went out of scope.
+        EXPECT_EQ(m_runLoops.size(), 0u);
+    }
+
+    Ref<RunLoop> createRunLoop(const char* name)
+    {
+        auto runLoop = RunLoop::create(name, ThreadType::Unknown);
+        m_runLoops.append(runLoop);
+        return runLoop;
+    }
+
+    void localReferenceBarrier()
+    {
+        // Since we need to send sync to create a barrier to run loops,
+        // we might as well destroy the run loops in this function.
+        Vector<Ref<Thread>> threadsToWait;
+        // FIXME: Cannot wait for RunLoop to really exit.
+        for (auto& runLoop : std::exchange(m_runLoops, { })) {
+            dispatchSync(runLoop, [&] {
+                threadsToWait.append(Thread::current());
+                RunLoop::current().stop();
+            });
+        }
+        while (true) {
+            sleep(0.1_s);
+            Locker lock { Thread::allThreadsLock() };
+            for (auto& thread : threadsToWait) {
+                if (Thread::allThreads().contains(thread.ptr()))
+                    continue;
+            }
+            break;
+        }
+    }
+
+protected:
+    Vector<Ref<RunLoop>> m_runLoops;
+};
+
+#define LOCAL_STRINGIFY(x) #x
+#define RUN_LOOP_NAME "RunLoop at ConnectionTests.cpp:" LOCAL_STRINGIFY(__LINE__)
+
+TEST_P(ConnectionRunLoopTest, RunLoopOpen)
+{
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        bClient().waitForDidClose(kDefaultWaitForTimeout);
+        semaphore.signal();
+    });
+    a()->invalidate();
+    semaphore.wait();
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopInvalidate)
+{
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        b()->invalidate();
+    });
+    aClient().waitForDidClose(kDefaultWaitForTimeout);
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopSend)
+{
+    ASSERT_TRUE(openA());
+    for (uint64_t i = 0u; i < 55u; ++i)
+        a()->send(MockTestMessage1 { }, i);
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        for (uint64_t i = 100u; i < 160u; ++i)
+            b()->send(MockTestMessage1 { }, i);
+        for (uint64_t i = 0u; i < 55u; ++i) {
+            auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+            EXPECT_EQ(message.messageName, MockTestMessage1::name());
+            EXPECT_EQ(message.destinationID, i);
+        }
+        semaphore.wait(); // FIXME: We cannot yet invalidate() and expect all messages get delivered.
+        b()->invalidate();
+    });
+    for (uint64_t i = 100u; i < 160u; ++i) {
+        auto message = aClient().waitForMessage(kDefaultWaitForTimeout);
+        EXPECT_EQ(message.messageName, MockTestMessage1::name());
+        EXPECT_EQ(message.destinationID, i);
+    }
+    semaphore.signal();
+
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
+{
+    ASSERT_TRUE(openA());
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto listenerID = decoder.decode<uint64_t>();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        encoder.get() << decoder.destinationID();
+        a()->sendSyncReply(WTFMove(encoder));
+        return true;
+    });
+    HashSet<uint64_t> replies;
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    dispatchAndWait(runLoop, [&] {
+        ASSERT_TRUE(openB());
+        for (uint64_t i = 100u; i < 160u; ++i) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
+                if (!value)
+                    WTFLogAlways("GOT: %llu", j);
+                EXPECT_GE(value, 100u);
+                replies.add(value);
+            }, i);
+        }
+        while (replies.size() < 60u)
+            RunLoop::current().cycle();
+        b()->invalidate();
+    });
+
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
+// This API contract does not make sense. Not only that, but there is no good way currently
+// to capture this in a thread-safe way (construct completion handler in a thread-safe way
+// so that it would assert that it would execute in the run loop thread). This is disabled
+// until the API contract is changed.
+TEST_P(ConnectionRunLoopTest, DISABLED_RunLoopSendAsyncOnAnotherRunLoopDispatchesOnConnectionRunLoop)
+{
+    ASSERT_TRUE(openA());
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto listenerID = decoder.decode<uint64_t>();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        encoder.get() << decoder.destinationID();
+        a()->sendSyncReply(WTFMove(encoder));
+        return true;
+    });
+    HashSet<uint64_t> replies;
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    dispatchSync(runLoop, [&] {
+        ASSERT_TRUE(openB());
+    });
+
+    BinarySemaphore semaphore;
+    auto otherRunLoop = createRunLoop(RUN_LOOP_NAME);
+    otherRunLoop->dispatch([&] {
+        for (uint64_t i = 100u; i < 160u; ++i) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&] (uint64_t value) {
+                EXPECT_GE(value, 100u);
+                // These should be dispatched on `runLoop` above, which does not make much sense.
+                replies.add(value);
+            }, i);
+        }
+        // Halt the runloop for a proof that the async replies are not processed on
+        // this run loop.
+        semaphore.wait();
+    });
+    dispatchAndWait(runLoop, [&] {
+        while (replies.size() < 60u)
+            RunLoop::current().cycle();
+    });
+
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    semaphore.signal();
+    localReferenceBarrier();
+}
+
+// This makes no sense:
+//  - async reply handlers are dispatched on the connection run loop
+//  - async reply handlers are dispatched as cancelled on connection run loop during invalidate
+//  - async reply handlers that are sent to already invalid connection are dispatched on main run loop
+// We have to make the discrepancy as the Connection is not bound to any run loop if it is invalid, e.g.
+// prior to open() and after invalidate().
+// Previously Connection was bound only to main run loop. In that scenario also the invalid send could cancel the reply handler
+// on main run loop, as that is guaranteed to exist. After Connection could be bound to an arbitrary run loop, we cannot
+// cancel the reply handler on a run loop we do not know about.
+// Will be fixed later. Likely this needs an API contract change, where async reply handlers are dispatched on the
+// calling run loop.
+TEST_P(ConnectionRunLoopTest, InvalidSendWithAsyncReplyDispatchesCancelHandlerOnMainThread)
+{
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    uint64_t reply = 1u;
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        b()->invalidate();
+        b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&] (uint64_t value) {
+            reply = value;
+            }, 77);
+        // Halt the runloop for a proof that the async replies are not processed on
+        // this run loop.
+        semaphore.wait();
+    });
+    EXPECT_EQ(reply, 1u);
+    while (reply == 1u)
+        RunLoop::current().cycle();
+    EXPECT_EQ(reply, 0u);
+    semaphore.signal();
+    localReferenceBarrier();
+}
+
+#undef RUN_LOOP_NAME
+#undef LOCAL_STRINGIFY
+
 INSTANTIATE_TEST_SUITE_P(ConnectionTest,
     ConnectionTestABBA,
+    testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
+    TestParametersToStringFormatter());
+
+INSTANTIATE_TEST_SUITE_P(ConnectionTest,
+    ConnectionRunLoopTest,
     testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
     TestParametersToStringFormatter());
 


### PR DESCRIPTION
#### ba83d24f552d438ebc7e417105e759be771ac81e
<pre>
IPC::Connection cannot be bound to arbitrary run loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=246336">https://bugs.webkit.org/show_bug.cgi?id=246336</a>
rdar://problem/101030022

Reviewed by NOBODY (OOPS!).

Make it possible to bind IPC::Connection::Client to a particular
run loop via Connection::open(Client&amp;, RunLoop&amp;). The messages
will be dispatched to the passed run loop.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::runLoop):
(IPC::Connection::Connection):
(IPC::Connection::~Connection):
(IPC::Connection::connection):
(IPC::Connection::open):
(IPC::Connection::invalidate):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::connectionDidClose):
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::dispatchDidReceiveInvalidMessage):
(IPC::Connection::dispatchDidCloseAndInvalidate):
(IPC::Connection::enqueueIncomingMessage):
(IPC::Connection::dispatchMessage):
(IPC::Connection::dispatchSyncStateMessages):
(IPC::Connection::dispatchIncomingMessages):
(IPC::Connection::wakeUpRunLoop):
(IPC::Connection::dispatchClient):
(IPC::Connection::postConnectionDidCloseOnConnectionWorkQueue): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncCallbackAndDispatchImmediately):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba83d24f552d438ebc7e417105e759be771ac81e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102772 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163108 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2274 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30592 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98888 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98728 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1564 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79537 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28481 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83478 "Found 2 new API test failures: TestIPC.ConnectionTest/ConnectionRunLoopTest.RunLoopSendAsync/ClientIsA, TestIPC.ConnectionTest/ConnectionRunLoopTest.RunLoopSendAsync/ServerIsA (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71593 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84384 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36986 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17122 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79450 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18344 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27507 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38670 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40901 "Found 1 new test failure: http/wpt/webrtc/transfer-datachannel-service-worker.https.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82083 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37543 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18568 "Passed tests") | 
<!--EWS-Status-Bubble-End-->