### PR TITLE
[git-webkit] Use correct cherry-pick message after conflict resolution

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -8,6 +8,9 @@ import sys
 LOCATION = r'{{ location }}'
 SPACING = 8
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
+CHERRY_PICKING_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
+IDENTIFIER_RE = re.compile(r'(\d+\.)?\d+@\S+')
+PREFER_RADAR = {{ prefer_radar }}
 
 sys.path.append(SCRIPTS)
 from webkitpy.common.checkout.diff_parser import DiffParser
@@ -91,21 +94,53 @@ def cherry_pick(content):
     cherry_picked = os.environ.get('GIT_WEBKIT_CHERRY_PICKED')
     bug = os.environ.get('GIT_WEBKIT_BUG')
 
+    if PREFER_RADAR and not bug:
+        RADAR_RES = [
+            re.compile(r'<?rdar://problem/(?P<id>\d+)>?'),
+            re.compile(r'<?radar://problem/(?P<id>\d+)>?'),
+            re.compile(r'<?rdar:\/\/(?P<id>\d+)>?'),
+            re.compile(r'<?radar:\/\/(?P<id>\d+)>?'),
+        ]
+        seen_empty = False
+        for line in content.splitlines():
+            if not line and seen_empty:
+                break
+            elif not line:
+                seen_empty = True
+                continue
+            words = line.split()
+            for word in [words[0], words[-1]] if words[0] != words[-1] else [words[0]]:
+                for regex in RADAR_RES:
+                    if regex.match(word):
+                        bug = word
+                        break
+                if bug:
+                    break
+
     if not cherry_picked or not bug:
         LINK_RE = re.compile(r'^\S+:\/\/\S+\d+\S*$')
-        HASH_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
 
+        last_line = ''
         for line in content.splitlines():
             if not line:
                 continue
+            if not line.startswith('#'):
+                last_line = line
             if not bug and LINK_RE.match(line):
                 bug = line
-            match = None if cherry_picked else HASH_RE.match(line)
+            match = None if cherry_picked else CHERRY_PICKING_RE.match(line)
             if match:
                 cherry_picked = match.group('hash')
 
             if bug and cherry_picked:
                 break
+
+        if last_line and (not cherry_picked or not IDENTIFIER_RE.search(cherry_picked)):
+            from_last_line = IDENTIFIER_RE.search(last_line)
+            if from_last_line and not cherry_picked:
+                cherry_picked = from_last_line.group(0)
+            elif from_last_line:
+                cherry_picked = '{} ({})'.format(from_last_line.group(0), cherry_picked)
 
     result = 'Cherry-pick {}. {}\n\n'.format(cherry_picked or '???', bug or '<bug>')
     for line in content.splitlines():
@@ -124,6 +159,11 @@ def main(file_name=None, source=None, sha=None):
 
     if source not in (None, 'commit', 'template', 'merge'):
         return 0
+
+    for line in content.splitlines():
+        if CHERRY_PICKING_RE.match(line):
+            os.environ['GIT_REFLOG_ACTION'] = 'cherry-pick'
+            break
 
     if source == 'merge' and os.environ.get('GIT_REFLOG_ACTION') == 'cherry-pick':
         with open(file_name, 'w') as commit_message_file:

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.15',
+    version='5.6.16',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 15)
+version = Version(5, 6, 16)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -28,6 +28,7 @@ import time
 
 from .command import Command
 from requests.auth import HTTPBasicAuth
+from webkitbugspy import radar
 from webkitcorepy import arguments, run, Editor, OutputCapture, Terminal
 from webkitscmpy import log, local, remote
 
@@ -339,6 +340,7 @@ class Setup(Command):
                     contents = Template(f.read()).render(
                         location=source_path,
                         python=os.path.basename(sys.executable),
+                        prefer_radar=bool(radar.Tracker.radarclient()),
                     )
 
                 target = os.path.join(repository.common_directory, 'hooks', hook)


### PR DESCRIPTION
#### 8de97725972201e18e8ea2c48f9cabe5aef3c193
<pre>
[git-webkit] Use correct cherry-pick message after conflict resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=246341">https://bugs.webkit.org/show_bug.cgi?id=246341</a>
rdar://problem/101035018

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/hooks/prepare-commit-msg: Check git message template for cherry-pick.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Pass radar install flag in template.

Canonical link: <a href="https://commits.webkit.org/255401@main">https://commits.webkit.org/255401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6dc5ec844946973718ff1878abdc97dd32e13f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1656 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/102194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96429 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/1652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/30035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/98090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/1652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/78940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/84856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/96003 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/1652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/84856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/36449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/91474 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/34218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/78940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1698 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/39992 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/23022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->