### PR TITLE
Margin collapsing should not occur at the foreignObject boundary

### DIFF
--- a/LayoutTests/svg/foreignObject/fO-margin-collapse-expected.html
+++ b/LayoutTests/svg/foreignObject/fO-margin-collapse-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        #outer-1 {
+          display: table;
+          border: 1px solid black;
+          width: 400px;
+          height: 400px;
+        }   
+        #outer-2 {
+            margin: 20px;
+            width: 300px;
+            height: 200px;
+        }
+    </style>
+</head>
+<body>
+	<div id="outer-1">
+      <div id="outer-2">
+        <div id="inner" xmlns="http://www.w3.org/1999/xhtml" style="position: relative; width: 100px; border: 1px solid black;">Here is some text</div>
+      </div>
+	</div>
+</body>
+</html>

--- a/LayoutTests/svg/foreignObject/fO-margin-collapse.html
+++ b/LayoutTests/svg/foreignObject/fO-margin-collapse.html
@@ -1,0 +1,30 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <style>
+        foreignObject {
+            width: 300px;
+            height: 200px;
+        }
+        svg {
+            border: 1px solid black;
+        }
+        
+        foreignObject div {
+            margin: 20px;
+        }
+        
+    </style>
+</head>
+<body>
+
+	<svg width="400" height="400">
+      <foreignObject width="200" height="200">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="position: relative; width: 100px; border: 1px solid black;">Here is some text</div>
+      </foreignObject>
+	</svg>
+    
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2130,7 +2130,8 @@ bool RenderElement::createsNewFormattingContext() const
         return true;
     return isInlineBlockOrInlineTable() || isFlexItemIncludingDeprecated()
         || isTableCell() || isTableCaption() || isFieldset() || isDocumentElementRenderer() || isRenderFragmentedFlow()
-        || style().specifiesColumns() || style().columnSpan() == ColumnSpan::All || style().display() == DisplayType::FlowRoot || establishesIndependentFormattingContext();
+        || style().specifiesColumns() || style().columnSpan() == ColumnSpan::All || style().display() == DisplayType::FlowRoot || establishesIndependentFormattingContext()
+        || isSVGForeignObject();
 }
 
 bool RenderElement::establishesIndependentFormattingContext() const


### PR DESCRIPTION
<pre>
Margin collapsing should not occur at the foreignObject boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=23963">https://bugs.webkit.org/show_bug.cgi?id=23963</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/eb26f063d73fce4d8a2cf64541667e0863cb6421">https://chromium.googlesource.com/chromium/src.git/+/eb26f063d73fce4d8a2cf64541667e0863cb6421</a>

This patch makes foreignObject a block formatting context which prevents margin collapsing across the foreignObject boundary.
EdgeHTML, Blink and Gecko do not collapse margins across foreignObject whereas WebKit do.

This is not explicitly stated in the spec but may be implicit from "initial containing block" in:

<a href="https://www.w3.org/TR/svg-integration">https://www.w3.org/TR/svg-integration</a>

* Source/WebCore/rendering/RenderElement.cpp:
(RenderElement::createsNewFormattingContext): Add "isSVGForeignObject"
* LayoutTests/svg/foreignObject/fO-margin-collapse.html: Added Test Case
* LayoutTests/svg/foreignObject/fO-margin-collapse-expected.html: Added Test Case Expectations

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a8644a65a275268b3dfbe1f9f7b3e0fe4cb8ed5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102484 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162814 "Found 1 new test failure: svg/foreignObject/fO-margin-collapse.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1967 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30313 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98624 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98416 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1331 "Found 1 new test failure: svg/foreignObject/fO-margin-collapse.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79242 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28250 "Found 1 new test failure: svg/foreignObject/fO-margin-collapse.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71336 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36717 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16873 "Found 1 new test failure: svg/foreignObject/fO-margin-collapse.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34514 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18061 "Found 1 new test failure: svg/foreignObject/fO-margin-collapse.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38385 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40666 "Found 1 new test failure: svg/foreignObject/fO-margin-collapse.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37229 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->