### PR TITLE
Parsing for at-rule @font-feature-values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt
@@ -14,19 +14,19 @@ PASS CSSFontFaceRule must be primary interface of cssFontFaceRule
 PASS Stringification of cssFontFaceRule
 PASS CSSFontFaceRule interface: cssFontFaceRule must inherit property "style" with the proper type
 FAIL CSSRule interface: cssFontFaceRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type assert_inherits: property "FONT_FEATURE_VALUES_RULE" not found in prototype chain
-FAIL CSSFontFeatureValuesRule interface: existence and properties of interface object assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface object length assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface object name assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: existence and properties of interface prototype object assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute fontFamily assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute annotation assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute ornaments assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute stylistic assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute swash assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute characterVariant assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
-FAIL CSSFontFeatureValuesRule interface: attribute styleset assert_own_property: self does not have own property "CSSFontFeatureValuesRule" expected property "CSSFontFeatureValuesRule" missing
+PASS CSSFontFeatureValuesRule interface: existence and properties of interface object
+PASS CSSFontFeatureValuesRule interface object length
+PASS CSSFontFeatureValuesRule interface object name
+PASS CSSFontFeatureValuesRule interface: existence and properties of interface prototype object
+PASS CSSFontFeatureValuesRule interface: existence and properties of interface prototype object's "constructor" property
+PASS CSSFontFeatureValuesRule interface: existence and properties of interface prototype object's @@unscopables property
+FAIL CSSFontFeatureValuesRule interface: attribute fontFamily assert_equals: setter must be function for PutForwards, Replaceable, or non-readonly attributes expected "function" but got "undefined"
+FAIL CSSFontFeatureValuesRule interface: attribute annotation assert_true: The prototype object must have a property "annotation" expected true got false
+FAIL CSSFontFeatureValuesRule interface: attribute ornaments assert_true: The prototype object must have a property "ornaments" expected true got false
+FAIL CSSFontFeatureValuesRule interface: attribute stylistic assert_true: The prototype object must have a property "stylistic" expected true got false
+FAIL CSSFontFeatureValuesRule interface: attribute swash assert_true: The prototype object must have a property "swash" expected true got false
+FAIL CSSFontFeatureValuesRule interface: attribute characterVariant assert_true: The prototype object must have a property "characterVariant" expected true got false
+FAIL CSSFontFeatureValuesRule interface: attribute styleset assert_true: The prototype object must have a property "styleset" expected true got false
 FAIL CSSFontFeatureValuesMap interface: existence and properties of interface object assert_own_property: self does not have own property "CSSFontFeatureValuesMap" expected property "CSSFontFeatureValuesMap" missing
 FAIL CSSFontFeatureValuesMap interface object length assert_own_property: self does not have own property "CSSFontFeatureValuesMap" expected property "CSSFontFeatureValuesMap" missing
 FAIL CSSFontFeatureValuesMap interface object name assert_own_property: self does not have own property "CSSFontFeatureValuesMap" expected property "CSSFontFeatureValuesMap" missing

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/test_font_feature_values_parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/test_font_feature_values_parsing-expected.txt
@@ -3,47 +3,98 @@ PASS basic parse tests - @font-feature-values;
 PASS basic parse tests - @font-feature-values bongo;
 PASS basic parse tests - @font-feature-value {;}
 PASS basic parse tests - @font-features-values {;}
-FAIL basic parse tests - @font-feature-values bongo {  } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { ; } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { ,; } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { ;, } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { ,;, } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset; } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset,; } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset abc; } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { ;;abc } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc;; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc,: } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc:, } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc:,; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { a,b } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { a;b } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { a:;b: } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { a:,;b: } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { a:1,;b: } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc 1 2 3 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc:, 1 2 3 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc:; 1 2 3 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3a } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3, def: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @blah @styleset { abc: 1 2 3; } } assert_true: unexpected syntax error expected true got false
+PASS basic parse tests - @font-feature-values bongo {  }
+PASS no value definitions in serialization - @font-feature-values bongo {  }
+PASS basic parse tests - @font-feature-values bongo { ; }
+PASS no value definitions in serialization - @font-feature-values bongo { ; }
+PASS basic parse tests - @font-feature-values bongo { ,; }
+PASS no value definitions in serialization - @font-feature-values bongo { ,; }
+PASS basic parse tests - @font-feature-values bongo { ;, }
+PASS no value definitions in serialization - @font-feature-values bongo { ;, }
+PASS basic parse tests - @font-feature-values bongo { ,;, }
+PASS no value definitions in serialization - @font-feature-values bongo { ,;, }
+PASS basic parse tests - @font-feature-values bongo { @styleset; }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset; }
+PASS basic parse tests - @font-feature-values bongo { @styleset,; }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset,; }
+PASS basic parse tests - @font-feature-values bongo { @styleset abc; }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset abc; }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { ;;abc } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { ;;abc } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc;; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc;; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc: } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc,: } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc,: } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc:, } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc:, } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc:,; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc:,; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { a,b } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { a,b } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { a;b } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { a;b } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { a:;b: } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { a:;b: } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { a:,;b: } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { a:,;b: } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { a:1,;b: } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { a:1,;b: } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc 1 2 3 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc 1 2 3 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc:, 1 2 3 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc:, 1 2 3 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc:; 1 2 3 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc:; 1 2 3 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3a } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc: 1 2 3a } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3, def: 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { abc: 1 2 3, def: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @blah @styleset { abc: 1 2 3; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @blah @styleset { abc: 1 2 3; } }
 FAIL basic parse tests - @font-feature-values bongo { @blah } @styleset { abc: 1 2 3; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @blah , @styleset { abc: 1 2 3; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3; } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3 } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3; assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3 assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { ok-1: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @annotation { ok-1: 3; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @stylistic { blah: 3; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo {
+PASS basic parse tests - @font-feature-values bongo { @blah , @styleset { abc: 1 2 3; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @blah , @styleset { abc: 1 2 3; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3; }
+PASS serialization check - @font-feature-values bongo { @styleset { abc: 1 2 3; }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { abc: 1 2 3; }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3 }
+PASS serialization check - @font-feature-values bongo { @styleset { abc: 1 2 3 }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { abc: 1 2 3 }
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3;
+PASS serialization check - @font-feature-values bongo { @styleset { abc: 1 2 3;
+PASS serialization round-trip - @font-feature-values bongo { @styleset { abc: 1 2 3;
+PASS basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3
+PASS serialization check - @font-feature-values bongo { @styleset { abc: 1 2 3
+PASS serialization round-trip - @font-feature-values bongo { @styleset { abc: 1 2 3
+PASS basic parse tests - @font-feature-values bongo { @styleset { ok-1: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { ok-1: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { ok-1: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @annotation { ok-1: 3; } }
+PASS serialization check - @font-feature-values bongo { @annotation { ok-1: 3; } }
+PASS serialization round-trip - @font-feature-values bongo { @annotation { ok-1: 3; } }
+PASS basic parse tests - @font-feature-values bongo { @stylistic { blah: 3; } }
+PASS serialization check - @font-feature-values bongo { @stylistic { blah: 3; } }
+PASS serialization round-trip - @font-feature-values bongo { @stylistic { blah: 3; } }
+PASS basic parse tests - @font-feature-values bongo {
 @styleset
   { blah: 3; super-blah: 4 5;
   more-blah: 5 6 7;
- } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo {
+ } }
+FAIL serialization check - @font-feature-values bongo {
+@styleset
+  { blah: 3; super-blah: 4 5;
+  more-blah: 5 6 7;
+ } } assert_equals: canonical cssText serialization doesn't match expected "@styleset { blah: 3; super-blah: 4 5; more-blah: 5 6 7; }" but got "@styleset { blah: 3; more-blah: 5 6 7; super-blah: 4 5; }"
+PASS serialization round-trip - @font-feature-values bongo {
+@styleset
+  { blah: 3; super-blah: 4 5;
+  more-blah: 5 6 7;
+ } }
+PASS basic parse tests - @font-feature-values bongo {
 @styleset
   {
  blah:
@@ -56,80 +107,249 @@ FAIL basic parse tests - @font-feature-values bongo {
   more-blah:
  5 6
  7;
- } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @stylistic { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1 2 3 4; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @character-variant { blah: 1 2; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @swash { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @ornaments { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @annotation { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 0; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 120 124; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @character-variant { blah: 0; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @character-variant { blah: 111; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @character-variant { blah: 111 13; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { styleset { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { stylistic { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { character-variant { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { swash { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { ornaments { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { annotation { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @bongo { blah: 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @bongo { blah: 1 2 3 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @bongo { blah: 1 2 3; burp: 1;;; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: -1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1 -1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1.5 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 15px } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: red } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: (1) } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah:(1) } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah:, 1 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: <1> } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1! } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1,, } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1 1 1 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @stylistic { blah: 1 2 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @character-variant { blah: 1 2 3 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @swash { blah: 1 2 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @ornaments { blah: 1 2 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @annotation { blah: 1 2 } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values "bongo" { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values 'bongo' { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values \62 ongo { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo, super bongo, bongo the supreme { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
+ } }
+FAIL serialization check - @font-feature-values bongo {
+@styleset
+  {
+ blah:
+ 3
+;
+ super-blah:
+ 4
+ 5
+;
+  more-blah:
+ 5 6
+ 7;
+ } } assert_equals: canonical cssText serialization doesn't match expected "@styleset { blah: 3; super-blah: 4 5; more-blah: 5 6 7; }" but got "@styleset { blah: 3; more-blah: 5 6 7; super-blah: 4 5; }"
+PASS serialization round-trip - @font-feature-values bongo {
+@styleset
+  {
+ blah:
+ 3
+;
+ super-blah:
+ 4
+ 5
+;
+  more-blah:
+ 5 6
+ 7;
+ } }
+PASS basic parse tests - @font-feature-values bongo { @stylistic { blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @stylistic { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @stylistic { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1 2 3 4; } }
+PASS serialization check - @font-feature-values bongo { @styleset { blah: 1 2 3 4; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 1 2 3 4; } }
+PASS basic parse tests - @font-feature-values bongo { @character-variant { blah: 1 2; } }
+PASS serialization check - @font-feature-values bongo { @character-variant { blah: 1 2; } }
+PASS serialization round-trip - @font-feature-values bongo { @character-variant { blah: 1 2; } }
+PASS basic parse tests - @font-feature-values bongo { @swash { blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @swash { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @swash { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @ornaments { blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @ornaments { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @ornaments { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @annotation { blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @annotation { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @annotation { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 0; } }
+PASS serialization check - @font-feature-values bongo { @styleset { blah: 0; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 0; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 120 124; } }
+PASS serialization check - @font-feature-values bongo { @styleset { blah: 120 124; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 120 124; } }
+PASS basic parse tests - @font-feature-values bongo { @character-variant { blah: 0; } }
+PASS serialization check - @font-feature-values bongo { @character-variant { blah: 0; } }
+PASS serialization round-trip - @font-feature-values bongo { @character-variant { blah: 0; } }
+PASS basic parse tests - @font-feature-values bongo { @character-variant { blah: 111; } }
+PASS serialization check - @font-feature-values bongo { @character-variant { blah: 111; } }
+PASS serialization round-trip - @font-feature-values bongo { @character-variant { blah: 111; } }
+PASS basic parse tests - @font-feature-values bongo { @character-variant { blah: 111 13; } }
+PASS serialization check - @font-feature-values bongo { @character-variant { blah: 111 13; } }
+PASS serialization round-trip - @font-feature-values bongo { @character-variant { blah: 111 13; } }
+PASS basic parse tests - @font-feature-values bongo { styleset { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { styleset { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { styleset { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { stylistic { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { stylistic { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { stylistic { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { character-variant { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { character-variant { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { character-variant { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { swash { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { swash { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { swash { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { ornaments { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { ornaments { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { ornaments { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { annotation { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { annotation { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { annotation { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { @bongo { blah: 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @bongo { blah: 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @bongo { blah: 1 } }
+PASS basic parse tests - @font-feature-values bongo { @bongo { blah: 1 2 3 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @bongo { blah: 1 2 3 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @bongo { blah: 1 2 3 } }
+PASS basic parse tests - @font-feature-values bongo { @bongo { blah: 1 2 3; burp: 1;;; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @bongo { blah: 1 2 3; burp: 1;;; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @bongo { blah: 1 2 3; burp: 1;;; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: -1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: -1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: -1 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1 -1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: 1 -1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: 1 -1 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1.5 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: 1.5 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: 1.5 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 15px } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: 15px } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: 15px } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: red } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: red } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: red } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: (1) } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: (1) } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: (1) } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah:(1) } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah:(1) } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah:(1) } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah:, 1 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah:, 1 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah:, 1 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: <1> } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: <1> } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: <1> } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1! } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: 1! } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: 1! } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1,, } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { blah: 1,, } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { blah: 1,, } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1 1 1 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { blah: 1 1 1 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 1 1 1 1; } }
+PASS basic parse tests - @font-feature-values bongo { @stylistic { blah: 1 2 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @stylistic { blah: 1 2 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @stylistic { blah: 1 2 } }
+PASS basic parse tests - @font-feature-values bongo { @character-variant { blah: 1 2 3 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @character-variant { blah: 1 2 3 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @character-variant { blah: 1 2 3 } }
+PASS basic parse tests - @font-feature-values bongo { @swash { blah: 1 2 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @swash { blah: 1 2 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @swash { blah: 1 2 } }
+PASS basic parse tests - @font-feature-values bongo { @ornaments { blah: 1 2 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @ornaments { blah: 1 2 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @ornaments { blah: 1 2 } }
+PASS basic parse tests - @font-feature-values bongo { @annotation { blah: 1 2 } }
+PASS no value definitions in serialization - @font-feature-values bongo { @annotation { blah: 1 2 } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @annotation { blah: 1 2 } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; } }
+PASS serialization check - @font-feature-values bongo { @styleset { blah: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values "bongo" { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values "bongo" { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values "bongo" { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values 'bongo' { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values 'bongo' { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values 'bongo' { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values \62 ongo { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values \62 ongo { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values \62 ongo { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo, super bongo, bongo the supreme { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values bongo, super bongo, bongo the supreme { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo, super bongo, bongo the supreme { @styleset { blah: 1; } }
 PASS basic parse tests - @font-feature-values bongo,, super bongo { @styleset { blah: 1; } }
 PASS basic parse tests - @font-feature-values bongo,* { @styleset { blah: 1; } }
 PASS basic parse tests - @font-feature-values bongo, sans-serif { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo, sans-serif { @styleset { blah: 1; } }
 PASS basic parse tests - @font-feature-values serif, sans-serif { @styleset { blah: 1; } }
-FAIL basic parse tests - @font-feature-values 'serif', 'sans-serif' { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo, "super bongo", 'bongo the supreme' { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values 毎日カレーを食べたい！ { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values 毎日カレーを食べたい！, 納豆嫌い { @styleset { blah: 1; } } assert_true: unexpected syntax error expected true got false
+PASS serialization round-trip - @font-feature-values serif, sans-serif { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values 'serif', 'sans-serif' { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values 'serif', 'sans-serif' { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values 'serif', 'sans-serif' { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo, "super bongo", 'bongo the supreme' { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values bongo, "super bongo", 'bongo the supreme' { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo, "super bongo", 'bongo the supreme' { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values 毎日カレーを食べたい！ { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values 毎日カレーを食べたい！ { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values 毎日カレーを食べたい！ { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values 毎日カレーを食べたい！, 納豆嫌い { @styleset { blah: 1; } }
+PASS serialization check - @font-feature-values 毎日カレーを食べたい！, 納豆嫌い { @styleset { blah: 1; } }
+PASS serialization round-trip - @font-feature-values 毎日カレーを食べたい！, 納豆嫌い { @styleset { blah: 1; } }
 PASS basic parse tests - @font-feature-values bongo, "super" bongo, bongo the supreme { @styleset { blah: 1; } }
 PASS basic parse tests - @font-feature-values --bongo { @styleset { blah: 1; } }
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1; blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { blah: 1; de-blah: 1; blah: 2; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { \tra-la: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { b\lah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { \62 lah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { \:blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { \;blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { complex\20 blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { complex\ blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { Håkon: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { Åквариум: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { \1f449\1f4a9\1f448: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { 魅力: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { 毎日カレーを食べたい！: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { TECHNICIÄNS\ ÖF\ SPÅCE\ SHIP\ EÅRTH\ THIS\ IS\ YÖÜR\ CÄPTÅIN\ SPEÄKING\ YÖÜR\ ØÅPTÅIN\ IS\ DEA̋D: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { 123blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { :123blah 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { :123blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { ?123blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { "blah": 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { complex blah: 1; } } assert_true: unexpected syntax error expected true got false
-FAIL basic parse tests - @font-feature-values bongo { @styleset { complex\  blah: 1; } } assert_true: unexpected syntax error expected true got false
+PASS serialization round-trip - @font-feature-values --bongo { @styleset { blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1; blah: 1; } }
+FAIL serialization check - @font-feature-values bongo { @styleset { blah: 1; blah: 1; } } assert_equals: canonical cssText serialization doesn't match expected "@styleset { blah: 1; blah: 1; }" but got "@styleset { blah: 1; }"
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 1; blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { blah: 1; de-blah: 1; blah: 2; } }
+FAIL serialization check - @font-feature-values bongo { @styleset { blah: 1; de-blah: 1; blah: 2; } } assert_equals: canonical cssText serialization doesn't match expected "@styleset { blah: 1; de-blah: 1; blah: 2; }" but got "@styleset { blah: 2; de-blah: 1; }"
+PASS serialization round-trip - @font-feature-values bongo { @styleset { blah: 1; de-blah: 1; blah: 2; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { \tra-la: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { \tra-la: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { \tra-la: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { b\lah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { b\lah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { b\lah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { \62 lah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { \62 lah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { \62 lah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { \:blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { \:blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { \:blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { \;blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { \;blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { \;blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { complex\20 blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { complex\20 blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { complex\20 blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { complex\ blah: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { complex\ blah: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { complex\ blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { Håkon: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { Håkon: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { Håkon: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { Åквариум: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { Åквариум: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { Åквариум: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { \1f449\1f4a9\1f448: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { \1f449\1f4a9\1f448: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { \1f449\1f4a9\1f448: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { 魅力: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { 魅力: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { 魅力: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { 毎日カレーを食べたい！: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { 毎日カレーを食べたい！: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { 毎日カレーを食べたい！: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { TECHNICIÄNS\ ÖF\ SPÅCE\ SHIP\ EÅRTH\ THIS\ IS\ YÖÜR\ CÄPTÅIN\ SPEÄKING\ YÖÜR\ ØÅPTÅIN\ IS\ DEA̋D: 1; } }
+PASS serialization check - @font-feature-values bongo { @styleset { TECHNICIÄNS\ ÖF\ SPÅCE\ SHIP\ EÅRTH\ THIS\ IS\ YÖÜR\ CÄPTÅIN\ SPEÄKING\ YÖÜR\ ØÅPTÅIN\ IS\ DEA̋D: 1; } }
+PASS serialization round-trip - @font-feature-values bongo { @styleset { TECHNICIÄNS\ ÖF\ SPÅCE\ SHIP\ EÅRTH\ THIS\ IS\ YÖÜR\ CÄPTÅIN\ SPEÄKING\ YÖÜR\ ØÅPTÅIN\ IS\ DEA̋D: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { 123blah: 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { 123blah: 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { 123blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { :123blah 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { :123blah 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { :123blah 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { :123blah: 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { :123blah: 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { :123blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { ?123blah: 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { ?123blah: 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { ?123blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { "blah": 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { "blah": 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { "blah": 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { complex blah: 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { complex blah: 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { complex blah: 1; } }
+PASS basic parse tests - @font-feature-values bongo { @styleset { complex\  blah: 1; } }
+PASS no value definitions in serialization - @font-feature-values bongo { @styleset { complex\  blah: 1; } }
+PASS invalid declarations don't affect valid ones - @font-feature-values bongo { @styleset { complex\  blah: 1; } }
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -817,6 +817,7 @@ set(WebCore_NON_SVG_IDL_FILES
     css/CSSContainerRule.idl
     css/CSSCounterStyleRule.idl
     css/CSSFontFaceRule.idl
+    css/CSSFontFeatureValuesRule.idl
     css/CSSFontPaletteValuesRule.idl
     css/CSSGroupingRule.idl
     css/CSSImportRule+Layer.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -937,6 +937,7 @@ $(PROJECT_DIR)/css/CSSConditionRule.idl
 $(PROJECT_DIR)/css/CSSContainerRule.idl
 $(PROJECT_DIR)/css/CSSCounterStyleRule.idl
 $(PROJECT_DIR)/css/CSSFontFaceRule.idl
+$(PROJECT_DIR)/css/CSSFontFeatureValuesRule.idl
 $(PROJECT_DIR)/css/CSSFontPaletteValuesRule.idl
 $(PROJECT_DIR)/css/CSSGroupingRule.idl
 $(PROJECT_DIR)/css/CSSImportRule+Layer.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -330,6 +330,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSCounterStyleRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSCounterStyleRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontFaceRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontFaceRule.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontFeatureValuesRule.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontFeatureValuesRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontPaletteValuesRule.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSFontPaletteValuesRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSGroupingRule.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -818,6 +818,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/CSSContainerRule.idl \
     $(WebCore)/css/CSSCounterStyleRule.idl \
     $(WebCore)/css/CSSFontFaceRule.idl \
+    $(WebCore)/css/CSSFontFeatureValuesRule.idl \
     $(WebCore)/css/CSSFontPaletteValuesRule.idl \
     $(WebCore)/css/CSSGroupingRule.idl \
     $(WebCore)/css/CSSImportRule.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -756,6 +756,7 @@ css/CSSFontFaceSet.cpp
 css/CSSFontFaceSource.cpp
 css/CSSFontFaceSrcValue.cpp
 css/CSSFontFeatureValue.cpp
+css/CSSFontFeatureValuesRule.cpp
 css/CSSFontPaletteValuesOverrideColorsValue.cpp
 css/CSSFontPaletteValuesRule.cpp
 css/CSSFontSelector.cpp
@@ -3053,6 +3054,7 @@ JSCSSConditionRule.cpp
 JSCSSContainerRule.cpp
 JSCSSCounterStyleRule.cpp
 JSCSSFontFaceRule.cpp
+JSCSSFontFeatureValuesRule.cpp
 JSCSSFontPaletteValuesRule.cpp
 JSCSSGroupingRule.cpp
 JSCSSImportRule.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -29,6 +29,7 @@
 #include "CSSContainerRule.h"
 #include "CSSCounterStyleRule.h"
 #include "CSSFontFaceRule.h"
+#include "CSSFontFeatureValuesRule.h"
 #include "CSSFontPaletteValuesRule.h"
 #include "CSSImportRule.h"
 #include "CSSKeyframeRule.h"
@@ -43,6 +44,7 @@
 #include "JSCSSContainerRule.h"
 #include "JSCSSCounterStyleRule.h"
 #include "JSCSSFontFaceRule.h"
+#include "JSCSSFontFeatureValuesRule.h"
 #include "JSCSSFontPaletteValuesRule.h"
 #include "JSCSSImportRule.h"
 #include "JSCSSKeyframeRule.h"
@@ -81,6 +83,8 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSFontFaceRule>(globalObject, WTFMove(rule));
     case StyleRuleType::FontPaletteValues:
         return createWrapper<CSSFontPaletteValuesRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::FontFeatureValues:
+        return createWrapper<CSSFontFeatureValuesRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Page:
         return createWrapper<CSSPageRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Import:
@@ -104,6 +108,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:
+    case StyleRuleType::FontFeatureValuesBlock:
         return createWrapper<CSSRule>(globalObject, WTFMove(rule));
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSFontFeatureValuesRule.h"
+
+#include "CSSMarkup.h"
+
+namespace WebCore {
+
+CSSFontFeatureValuesRule::CSSFontFeatureValuesRule(StyleRuleFontFeatureValues& fontFeatureValuesRule, CSSStyleSheet* parent)
+    : CSSRule(parent)
+    , m_fontFeatureValuesRule(fontFeatureValuesRule)
+{
+}
+
+String CSSFontFeatureValuesRule::cssText() const
+{
+    StringBuilder builder;
+    builder.append("@font-feature-values ");
+    auto joinFontFamiliesWithSeparator = [&builder] (const auto& elements, String separator) {
+        bool first = true;
+        for (auto element : elements) {
+            if (!first)
+                builder.append(separator);
+            builder.append(serializeFontFamily(element));
+            first = false;
+        }
+    };
+    joinFontFamiliesWithSeparator(m_fontFeatureValuesRule->fontFamilies(), ", "_s);
+    builder.append(" { ");
+    auto& value = m_fontFeatureValuesRule->value();
+    
+    auto addVariant = [&builder] (String variantName, Tags tags) {
+        if (!tags.isEmpty()) {
+            builder.append("@", variantName, " { ");
+            for (auto tag : tags) {
+                serializeIdentifier(tag.key, builder);
+                builder.append(':');
+                for (auto integer : tag.value)
+                    builder.append(' ', integer);
+                builder.append("; ");
+            }
+            builder.append("} ");
+        }
+    };
+    
+    // WPT expects the order used in Servo.
+    // https://searchfox.org/mozilla-central/source/servo/components/style/stylesheets/font_feature_values_rule.rs#430
+    addVariant("swash"_s, value.swash);
+    addVariant("stylistic"_s, value.stylistic);
+    addVariant("ornaments"_s, value.ornaments);
+    addVariant("annotation"_s, value.annotation);
+    addVariant("character-variant"_s, value.characterVariant);
+    addVariant("styleset"_s, value.styleset);
+    
+    builder.append('}');
+    return builder.toString();
+}
+
+void CSSFontFeatureValuesRule::reattach(StyleRuleBase& rule)
+{
+    m_fontFeatureValuesRule = static_cast<StyleRuleFontFeatureValues&>(rule);
+}
+
+CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock& block , CSSStyleSheet* parent)
+    : CSSRule(parent)
+    , m_fontFeatureValuesBlockRule(block)
+{
+}
+
+String CSSFontFeatureValuesBlockRule::cssText() const
+{
+    // This rule is always contained inside a FontFeatureValuesRule,
+    // which is the only one we are expected to serialize to CSS.
+    // We should never serialize a Block by itself.
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+void CSSFontFeatureValuesBlockRule::reattach(StyleRuleBase& rule)
+{
+    m_fontFeatureValuesBlockRule = static_cast<StyleRuleFontFeatureValuesBlock&>(rule);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSRule.h"
+
+#include "StyleRule.h"
+
+namespace WebCore {
+
+class CSSFontFeatureValuesRule final : public CSSRule {
+public:
+    static Ref<CSSFontFeatureValuesRule> create(StyleRuleFontFeatureValues& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFeatureValuesRule(rule, sheet)); }
+    virtual ~CSSFontFeatureValuesRule() = default;
+
+    const Vector<AtomString>& fontFamilies() const
+    {
+        return m_fontFeatureValuesRule->fontFamilies();
+    }
+
+    // Used by the CSSOM.
+    AtomString fontFamily() const
+    {
+        StringBuilder builder;
+        bool first = true;
+        for (auto& family : m_fontFeatureValuesRule->fontFamilies()) {
+            if (first)
+                first = false;
+            else
+                builder.append(", ");
+            
+            builder.append(family);
+        }
+        return builder.toAtomString();
+    }
+
+private:
+    CSSFontFeatureValuesRule(StyleRuleFontFeatureValues&, CSSStyleSheet* parent);
+
+    StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValues; }
+    String cssText() const final;
+    void reattach(StyleRuleBase&) final;
+
+    Ref<StyleRuleFontFeatureValues> m_fontFeatureValuesRule;
+};
+
+class CSSFontFeatureValuesBlockRule final : public CSSRule {
+public:
+    static Ref<CSSFontFeatureValuesBlockRule> create(StyleRuleFontFeatureValuesBlock& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSFontFeatureValuesBlockRule(rule, sheet)); }
+    virtual ~CSSFontFeatureValuesBlockRule() = default;
+
+private:
+    CSSFontFeatureValuesBlockRule(StyleRuleFontFeatureValuesBlock&, CSSStyleSheet* parent);
+
+    StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValuesBlock; }
+    String cssText() const final;
+    void reattach(StyleRuleBase&) final;
+
+    Ref<StyleRuleFontFeatureValuesBlock> m_fontFeatureValuesBlockRule;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSFontFeatureValuesRule, StyleRuleType::FontFeatureValues)
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSFontFeatureValuesBlockRule, StyleRuleType::FontFeatureValuesBlock)

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.idl
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+// https://www.w3.org/TR/css-fonts-4/#cssfontfeaturevaluesrule
+
+typedef USVString CSSOMString;
+
+[
+    Exposed=Window
+] interface CSSFontFeatureValuesRule : CSSRule {
+    readonly attribute CSSOMString fontFamily;
+    
+    // Like Gecko, we don't expose the children at-rules @styleset,...etc
+    // https://searchfox.org/mozilla-central/source/dom/webidl/CSSFontFeatureValuesRule.webidl
+};
+

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -25,6 +25,7 @@
 #include "CSSContainerRule.h"
 #include "CSSCounterStyleRule.h"
 #include "CSSFontFaceRule.h"
+#include "CSSFontFeatureValuesRule.h"
 #include "CSSFontPaletteValuesRule.h"
 #include "CSSGroupingRule.h"
 #include "CSSImportRule.h"
@@ -76,6 +77,10 @@ template<typename Visitor> constexpr decltype(auto) StyleRuleBase::visitDerived(
         return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRulePage>(*this));
     case StyleRuleType::FontFace:
         return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontFace>(*this));
+    case StyleRuleType::FontFeatureValues:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontFeatureValues>(*this));
+    case StyleRuleType::FontFeatureValuesBlock:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontFeatureValuesBlock>(*this));
     case StyleRuleType::FontPaletteValues:
         return std::invoke(std::forward<Visitor>(visitor), downcast<StyleRuleFontPaletteValues>(*this));
     case StyleRuleType::Media:
@@ -144,6 +149,12 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSGr
         },
         [&](StyleRuleFontFace& rule) -> Ref<CSSRule> {
             return CSSFontFaceRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleFontFeatureValues& rule) -> Ref<CSSRule> {
+            return CSSFontFeatureValuesRule::create(rule, parentSheet);
+        },
+        [&](StyleRuleFontFeatureValuesBlock& rule) -> Ref<CSSRule> {
+            return CSSFontFeatureValuesBlockRule::create(rule, parentSheet);
         },
         [&](StyleRuleFontPaletteValues& rule) -> Ref<CSSRule> {
             return CSSFontPaletteValuesRule::create(rule, parentSheet);
@@ -314,6 +325,25 @@ MutableStyleProperties& StyleRuleFontFace::mutableProperties()
     if (!is<MutableStyleProperties>(m_properties))
         m_properties = m_properties->mutableCopy();
     return downcast<MutableStyleProperties>(m_properties.get());
+}
+
+StyleRuleFontFeatureValues::StyleRuleFontFeatureValues(const Vector<AtomString>& fontFamilies, const FontFeatureValuesValue& value)
+    : StyleRuleBase(StyleRuleType::FontFeatureValues)
+    , m_fontFamilies(fontFamilies)
+    , m_value(value)
+{
+}
+
+StyleRuleFontFeatureValuesBlock::StyleRuleFontFeatureValuesBlock(FontFeatureValuesType type, const Vector<Tag>& tags)
+    : StyleRuleBase(StyleRuleType::FontFeatureValuesBlock)
+    , m_type(type)
+    , m_tags(tags)
+{
+}
+
+Ref<StyleRuleFontFeatureValues> StyleRuleFontFeatureValues::create(const Vector<AtomString>& fontFamilies, const FontFeatureValuesValue& values)
+{
+    return adoptRef(*new StyleRuleFontFeatureValues(fontFamilies, values));
 }
 
 Ref<StyleRuleFontPaletteValues> StyleRuleFontPaletteValues::create(const AtomString& name, const AtomString& fontFamily, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors)

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,8 @@
 
 namespace WebCore {
 
+// https://w3c.github.io/csswg-drafts/cssom-1/#the-cssrule-interface
+
 enum class StyleRuleType : uint8_t {
     Unknown = 0,
     Style = 1,
@@ -41,10 +43,13 @@ enum class StyleRuleType : uint8_t {
     Namespace = 10,
     CounterStyle = 11,
     Supports = 12,
+    FontFeatureValues = 14,
     LayerBlock = 16,
     LayerStatement = 17,
     Container = 18,
     FontPaletteValues = 19,
+    // Those at-rules (@swash, @annotation,...) don't have a specified number in the spec.
+    FontFeatureValuesBlock = 20,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -1,6 +1,6 @@
 /*
  * (C) 1999-2003 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -517,6 +517,8 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
         case StyleRuleType::LayerBlock:
         case StyleRuleType::LayerStatement:
         case StyleRuleType::Container:
+        case StyleRuleType::FontFeatureValues:
+        case StyleRuleType::FontFeatureValuesBlock:
         case StyleRuleType::FontPaletteValues:
         case StyleRuleType::Margin:
             return false;

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -1,5 +1,5 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
-// Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+// Copyright (C) 2016-2022 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -38,18 +38,25 @@ CSSAtRuleID cssAtRuleID(StringView name)
 {
     static constexpr std::pair<ComparableLettersLiteral, CSSAtRuleID> mappings[] = {
         { "-webkit-keyframes", CSSAtRuleWebkitKeyframes },
+        { "annotation", CSSAtRuleAnnotation },
+        { "character-variant", CSSAtRuleCharacterVariant },
         { "charset", CSSAtRuleCharset },
         { "container", CSSAtRuleContainer },
         { "counter-style", CSSAtRuleCounterStyle },
         { "font-face", CSSAtRuleFontFace },
+        { "font-feature-values", CSSAtRuleFontFeatureValues },
         { "font-palette-values", CSSAtRuleFontPaletteValues },
         { "import", CSSAtRuleImport },
         { "keyframes", CSSAtRuleKeyframes },
         { "layer", CSSAtRuleLayer },
         { "media", CSSAtRuleMedia },
         { "namespace", CSSAtRuleNamespace },
+        { "ornaments", CSSAtRuleOrnaments },
         { "page", CSSAtRulePage },
+        { "styleset", CSSAtRuleStyleset },
+        { "stylistic", CSSAtRuleStylistic },
         { "supports", CSSAtRuleSupports },
+        { "swash", CSSAtRuleSwash },
         { "viewport", CSSAtRuleViewport },
     };
     static constexpr SortedArrayMap cssAtRules { mappings };

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -50,6 +50,14 @@ enum CSSAtRuleID {
     CSSAtRuleLayer,
     CSSAtRuleContainer,
 
+    CSSAtRuleFontFeatureValues,
+    CSSAtRuleStylistic,
+    CSSAtRuleStyleset,
+    CSSAtRuleCharacterVariant,
+    CSSAtRuleSwash,
+    CSSAtRuleOrnaments,
+    CSSAtRuleAnnotation,
+
     CSSAtRuleFontPaletteValues,
 };
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -29,6 +29,7 @@
 
 #pragma once
 
+#include "CSSAtRuleID.h"
 #include "CSSParser.h"
 #include "CSSParserTokenRange.h"
 #include "CSSProperty.h"
@@ -50,6 +51,8 @@ class StyleRuleBase;
 class StyleRuleCharset;
 class StyleRuleContainer;
 class StyleRuleFontFace;
+class StyleRuleFontFeatureValues;
+class StyleRuleFontFeatureValuesBlock;
 class StyleRuleFontPaletteValues;
 class StyleRuleImport;
 class StyleRuleKeyframes;
@@ -82,6 +85,7 @@ public:
         RegularRules,
         KeyframeRules,
         CounterStyleRules,
+        FontFeatureValuesRules,
         NoRules, // For parsing at-rules inside declaration lists
     };
 
@@ -109,7 +113,8 @@ private:
     enum RuleListType {
         TopLevelRuleList,
         RegularRuleList,
-        KeyframesRuleList
+        KeyframesRuleList,
+        FontFeatureValuesRuleList,
     };
 
     // Returns whether the first encountered rule was valid
@@ -127,6 +132,8 @@ private:
     RefPtr<StyleRuleSupports> consumeSupportsRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleViewport> consumeViewportRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleFontFace> consumeFontFaceRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleFontFeatureValuesBlock> consumeFontFeatureValuesRuleBlock(CSSAtRuleID, CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleFontFeatureValues> consumeFontFeatureValuesRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleFontPaletteValues> consumeFontPaletteValuesRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleKeyframes> consumeKeyframesRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRulePage> consumePageRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4534,6 +4534,19 @@ AtomString consumeFamilyNameRaw(CSSParserTokenRange& range)
     return concatenateFamilyName(range);
 }
 
+Vector<AtomString> consumeFamilyNameList(CSSParserTokenRange& range)
+{
+    Vector<AtomString> result;
+    do {
+        auto name = consumeFamilyNameRaw(range);
+        if (name.isNull())
+            return { };
+        
+        result.append(name);
+    } while (consumeCommaIncludingWhitespace(range));
+    return result;
+}
+
 std::optional<CSSValueID> consumeGenericFamilyRaw(CSSParserTokenRange& range)
 {
     return consumeIdentRangeRaw(range, CSSValueSerif, CSSValueWebkitBody);

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -204,6 +204,8 @@ std::optional<CSSValueID> consumeFontStyleKeywordValueRaw(CSSParserTokenRange&);
 std::optional<FontStyleRaw> consumeFontStyleRaw(CSSParserTokenRange&, CSSParserMode);
 AtomString concatenateFamilyName(CSSParserTokenRange&);
 AtomString consumeFamilyNameRaw(CSSParserTokenRange&);
+// https://drafts.csswg.org/css-fonts-4/#family-name-value
+Vector<AtomString> consumeFamilyNameList(CSSParserTokenRange&);
 std::optional<CSSValueID> consumeGenericFamilyRaw(CSSParserTokenRange&);
 std::optional<Vector<FontFamilyRaw>> consumeFontFamilyRaw(CSSParserTokenRange&);
 std::optional<FontSizeRaw> consumeFontSizeRaw(CSSParserTokenRange&, CSSParserMode, UnitlessQuirk = UnitlessQuirk::Forbid);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -131,6 +131,8 @@ static void flattenSourceData(RuleSourceDataList& dataList, RuleSourceDataList& 
         case WebCore::StyleRuleType::Namespace:
         case WebCore::StyleRuleType::CounterStyle:
         case WebCore::StyleRuleType::LayerStatement:
+        case WebCore::StyleRuleType::FontFeatureValues:
+        case WebCore::StyleRuleType::FontFeatureValuesBlock:
         case WebCore::StyleRuleType::FontPaletteValues:
             // These rule types do not contain child rules, and therefore have nothing to display in the Styles panel in
             // the details sidebar of the Elements Tab in Web Inspector.


### PR DESCRIPTION
#### 4303ed343b77ef5e1fa84de8de8dbd0000cd79f1
<pre>
Parsing for at-rule @font-feature-values
<a href="https://bugs.webkit.org/show_bug.cgi?id=246120">https://bugs.webkit.org/show_bug.cgi?id=246120</a>
rdar://100830599

Reviewed by Myles C. Maxfield and Patrick Angle.

This implementation defines the @font-feature-values at-rule
and the six children font variation at-rules (@styleset, @stylistic, @character-variant,
@swash, @ornaments, @annotation), but those children at-rules are not exposed in CSSOM.

<a href="https://www.w3.org/TR/css-fonts-4/#font-feature-values-syntax">https://www.w3.org/TR/css-fonts-4/#font-feature-values-syntax</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/test_font_feature_values_parsing-expected.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp: Added.
(WebCore::CSSFontFeatureValuesRule::CSSFontFeatureValuesRule):
(WebCore::CSSFontFeatureValuesRule::cssText const):
(WebCore::CSSFontFeatureValuesRule::reattach):
(WebCore::CSSFontFeatureValuesBlockRule::CSSFontFeatureValuesBlockRule):
(WebCore::CSSFontFeatureValuesBlockRule::cssText const):
(WebCore::CSSFontFeatureValuesBlockRule::reattach):
* Source/WebCore/css/CSSFontFeatureValuesRule.h: Added.
* Source/WebCore/css/CSSFontFeatureValuesRule.idl: Added.
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleFontFeatureValues::StyleRuleFontFeatureValues):
(WebCore::StyleRuleFontFeatureValuesBlock::StyleRuleFontFeatureValuesBlock):
(WebCore::StyleRuleFontFeatureValues::create):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isFontFeatureValuesRule const):
(WebCore::StyleRuleBase::isFontFeatureValuesBlockRule const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::computeNewAllowedRules):
(WebCore::CSSParserImpl::consumeRuleList):
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::fontFeatureValuesTypeMappings):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRuleBlock):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFamilyNameList):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(flattenSourceData):

Canonical link: <a href="https://commits.webkit.org/255677@main">https://commits.webkit.org/255677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35479ad557477ae371f5550faac822bc18d8ab85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102982 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2498 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30805 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85671 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99091 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98964 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79755 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28709 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71771 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84608 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37192 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79674 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35013 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18537 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27535 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3935 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38887 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41068 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82308 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37757 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18597 "Passed tests") | 
<!--EWS-Status-Bubble-End-->