### PR TITLE
Generate more serialization code, separating DaemonCoders from ArgumentCoders

### DIFF
--- a/Source/WebCore/platform/RegistrableDomain.h
+++ b/Source/WebCore/platform/RegistrableDomain.h
@@ -49,8 +49,12 @@ public:
     {
     }
 
+    static RegistrableDomain fromRawString(String&& origin)
+    {
+        return RegistrableDomain(WTFMove(origin));
+    }
+
     bool isEmpty() const { return m_registrableDomain.isEmpty() || m_registrableDomain == "nullOrigin"_s; }
-    String& string() { return m_registrableDomain; }
     const String& string() const { return m_registrableDomain; }
 
     bool operator!=(const RegistrableDomain& other) const { return m_registrableDomain != other.m_registrableDomain; }
@@ -98,11 +102,6 @@ public:
 #endif
     }
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<RegistrableDomain> decode(Decoder&);
-
-protected:
-
 private:
     explicit RegistrableDomain(String&& domain)
         : m_registrableDomain { domain.isEmpty() ? "nullOrigin"_s : WTFMove(domain) }
@@ -136,25 +135,6 @@ private:
 
     String m_registrableDomain;
 };
-
-template<class Encoder>
-void RegistrableDomain::encode(Encoder& encoder) const
-{
-    encoder << m_registrableDomain;
-}
-
-template<class Decoder>
-std::optional<RegistrableDomain> RegistrableDomain::decode(Decoder& decoder)
-{
-    std::optional<String> domain;
-    decoder >> domain;
-    if (!domain)
-        return std::nullopt;
-
-    RegistrableDomain registrableDomain;
-    registrableDomain.m_registrableDomain = WTFMove(*domain);
-    return registrableDomain;
-}
 
 inline bool areRegistrableDomainsEqual(const URL& a, const URL& b)
 {

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -523,6 +523,8 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/ShareableBitmap.serialization.in
     Shared/TextFlags.serialization.in
     Shared/WebCoreArgumentCoders.serialization.in
+    Shared/WebPushDaemonConnectionConfiguration.serialization.in
+    Shared/WebPushMessage.serialization.in
     Shared/WebsiteDataStoreParameters.serialization.in
 
     Shared/API/APIGeometry.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -150,6 +150,8 @@ $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionControllerParameters.serialization.in
+$(PROJECT_DIR)/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+$(PROJECT_DIR)/Shared/WebPushMessage.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBindGroupEntry.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBlendComponent.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBlendState.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -463,6 +463,8 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/FrameTreeNodeData.serialization.in \
 	Shared/LayerTreeContext.serialization.in \
 	Shared/TextFlags.serialization.in \
+	Shared/WebPushDaemonConnectionConfiguration.serialization.in \
+	Shared/WebPushMessage.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/WebExtensionContextParameters.serialization.in \
 	Shared/WebExtensionControllerParameters.serialization.in \

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -957,3 +957,7 @@ struct WebCore::PublicKeyCredentialRequestOptions {
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
 #endif // ENABLE(WEB_AUTHN)
 };
+
+[CreateUsing=fromRawString] class WebCore::RegistrableDomain {
+    String string()
+}

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h
@@ -31,36 +31,8 @@
 namespace WebKit::WebPushD {
 
 struct WebPushDaemonConnectionConfiguration {
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<WebPushDaemonConnectionConfiguration> decode(Decoder&);
-
     bool useMockBundlesForTesting { false };
     std::optional<Vector<uint8_t>> hostAppAuditTokenData;
 };
-
-template<class Encoder>
-void WebPushDaemonConnectionConfiguration::encode(Encoder& encoder) const
-{
-    encoder << useMockBundlesForTesting << hostAppAuditTokenData;
-}
-
-template<class Decoder>
-std::optional<WebPushDaemonConnectionConfiguration> WebPushDaemonConnectionConfiguration::decode(Decoder& decoder)
-{
-    std::optional<bool> useMockBundlesForTesting;
-    decoder >> useMockBundlesForTesting;
-    if (!useMockBundlesForTesting)
-        return std::nullopt;
-
-    std::optional<std::optional<Vector<uint8_t>>> hostAppAuditTokenData;
-    decoder >> hostAppAuditTokenData;
-    if (!hostAppAuditTokenData)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*useMockBundlesForTesting),
-        WTFMove(*hostAppAuditTokenData)
-    } };
-}
 
 } // namespace WebKit::WebPushD

--- a/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+++ b/Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in
@@ -1,0 +1,27 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "WebPushDaemonConnectionConfiguration.h"
+[CustomHeader] struct WebKit::WebPushD::WebPushDaemonConnectionConfiguration {
+    bool useMockBundlesForTesting;
+    std::optional<Vector<uint8_t>> hostAppAuditTokenData;
+};

--- a/Source/WebKit/Shared/WebPushMessage.h
+++ b/Source/WebKit/Shared/WebPushMessage.h
@@ -34,9 +34,6 @@ OBJC_CLASS NSDictionary;
 namespace WebKit {
 
 struct WebPushMessage {
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<WebPushMessage> decode(Decoder&);
-
     std::optional<Vector<uint8_t>> pushData;
     URL registrationURL;
 
@@ -45,30 +42,5 @@ struct WebPushMessage {
     NSDictionary *toDictionary() const;
 #endif
 };
-
-template<class Encoder>
-void WebPushMessage::encode(Encoder& encoder) const
-{
-    encoder << pushData << registrationURL;
-}
-
-template<class Decoder>
-std::optional<WebPushMessage> WebPushMessage::decode(Decoder& decoder)
-{
-    std::optional<std::optional<Vector<uint8_t>>> pushData;
-    decoder >> pushData;
-    if (!pushData)
-        return std::nullopt;
-
-    std::optional<URL> registrationURL;
-    decoder >> registrationURL;
-    if (!registrationURL)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*pushData),
-        WTFMove(*registrationURL)
-    } };
-}
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPushMessage.serialization.in
+++ b/Source/WebKit/Shared/WebPushMessage.serialization.in
@@ -1,0 +1,26 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+struct WebKit::WebPushMessage {
+    std::optional<Vector<uint8_t>> pushData;
+    URL registrationURL;
+};

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3170,7 +3170,7 @@ void WKPageLoadedSubresourceDomains(WKPageRef pageRef, WKPageLoadedSubresourceDo
 #if ENABLE(TRACKING_PREVENTION)
     toImpl(pageRef)->getLoadedSubresourceDomains([callbackContext, callback](Vector<RegistrableDomain>&& domains) {
         Vector<RefPtr<API::Object>> apiDomains = WTF::map(domains, [](auto& domain) {
-            return RefPtr<API::Object>(API::String::create(WTFMove(domain.string())));
+            return RefPtr<API::Object>(API::String::create(String(domain.string())));
         });
         callback(toAPI(API::Array::create(WTFMove(apiDomains)).ptr()), callbackContext);
     });

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -448,7 +448,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
     
     webPageProxy->getLoadedSubresourceDomains([completionHandler = makeBlockPtr(completionHandler)] (Vector<WebCore::RegistrableDomain>&& loadedSubresourceDomains) {
         Vector<RefPtr<API::Object>> apiDomains = WTF::map(loadedSubresourceDomains, [](auto& domain) {
-            return RefPtr<API::Object>(API::String::create(WTFMove(domain.string())));
+            return RefPtr<API::Object>(API::String::create(String(domain.string())));
         });
         completionHandler(wrapper(API::Array::create(WTFMove(apiDomains))));
     });

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5477,6 +5477,7 @@
 		5C9E56801DF7F05500C9EE33 /* WKWebsitePolicies.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKWebsitePolicies.cpp; sourceTree = "<group>"; };
 		5C9E56811DF7F05500C9EE33 /* WKWebsitePolicies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebsitePolicies.h; sourceTree = "<group>"; };
 		5C9EF2E721F058F9003BDC56 /* NetworkStorageSessionProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkStorageSessionProvider.h; sourceTree = "<group>"; };
+		5CA133EE28F61C4100541DAE /* WebPushDaemonConnectionConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebPushDaemonConnectionConfiguration.serialization.in; sourceTree = "<group>"; };
 		5CA26D7F217ABBB600F97A35 /* WKSafeBrowsingWarning.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKSafeBrowsingWarning.mm; sourceTree = "<group>"; };
 		5CA26D80217ABBB600F97A35 /* WKSafeBrowsingWarning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSafeBrowsingWarning.h; sourceTree = "<group>"; };
 		5CA2F7472350E15400BE5194 /* NetworkSchemeRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkSchemeRegistry.h; sourceTree = "<group>"; };
@@ -5488,6 +5489,7 @@
 		5CABDC8322C40FA7001EDE8E /* APIMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIMessageListener.h; sourceTree = "<group>"; };
 		5CABDC8422C40FCC001EDE8E /* WKMessageListener.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKMessageListener.cpp; sourceTree = "<group>"; };
 		5CABDC8522C40FCC001EDE8E /* WKMessageListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKMessageListener.h; sourceTree = "<group>"; };
+		5CABE07A28F60E8A00D83FD9 /* WebPushMessage.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebPushMessage.serialization.in; sourceTree = "<group>"; };
 		5CADDE0D2151AA010067D309 /* AuthenticationChallengeDisposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthenticationChallengeDisposition.h; sourceTree = "<group>"; };
 		5CAECB5E27465AE300AB78D0 /* UnifiedSource115.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource115.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource115.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CAF7AA426F93A750003F19E /* adattributiond */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = adattributiond; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -8292,8 +8294,10 @@
 				BC306822125A6B9400E71278 /* WebProcessCreationParameters.h */,
 				467E43E72243FF6D00B13924 /* WebProcessDataStoreParameters.h */,
 				517B5F2D2757382A002DC22D /* WebPushDaemonConnectionConfiguration.h */,
+				5CA133EE28F61C4100541DAE /* WebPushDaemonConnectionConfiguration.serialization.in */,
 				512CD6992721F04900F7F8EC /* WebPushDaemonConstants.h */,
 				517B5F96275EC5E5002DC22D /* WebPushMessage.h */,
+				5CABE07A28F60E8A00D83FD9 /* WebPushMessage.serialization.in */,
 				5C8DD37F1FE4519200F2A556 /* WebsiteAutoplayPolicy.h */,
 				5C8DD3811FE455CA00F2A556 /* WebsiteAutoplayQuirk.h */,
 				511F7D401EB1BCEE00E47B83 /* WebsiteDataStoreParameters.h */,


### PR DESCRIPTION
#### 12f417282701d97084722aa8cad975f458fd66e4
<pre>
Generate more serialization code, separating DaemonCoders from ArgumentCoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=246367">https://bugs.webkit.org/show_bug.cgi?id=246367</a>
rdar://101053162

Reviewed by Tim Horton.

* Source/WebCore/platform/RegistrableDomain.h:
(WebCore::RegistrableDomain::fromRawString):
(WebCore::RegistrableDomain::isEmpty const):
(WebCore::RegistrableDomain::string): Deleted.
(WebCore::RegistrableDomain::encode const): Deleted.
(WebCore::RegistrableDomain::decode): Deleted.
* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::void&gt;::encode):
(WebKit::Daemon::void&gt;::decode):
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionIdentifier&gt;::encode):
(WebKit::Daemon::Coder&lt;WebCore::PushSubscriptionIdentifier&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.h:
(WebKit::WebPushD::WebPushDaemonConnectionConfiguration::encode const): Deleted.
(WebKit::WebPushD::WebPushDaemonConnectionConfiguration::decode): Deleted.
* Source/WebKit/Shared/WebPushDaemonConnectionConfiguration.serialization.in: Added.
* Source/WebKit/Shared/WebPushMessage.h:
(WebKit::WebPushMessage::encode const): Deleted.
(WebKit::WebPushMessage::decode): Deleted.
* Source/WebKit/Shared/WebPushMessage.serialization.in: Added.
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageLoadedSubresourceDomains):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _loadedSubresourceDomainsFor:completionHandler:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/255412@main">https://commits.webkit.org/255412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/259cb14330c2ea4a4c434da31a374b07c8d852ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102210 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1669 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30050 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98363 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1113 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78957 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28048 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36463 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34235 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3746 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38105 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36982 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->