### PR TITLE
Implement lastLineBaseline for tables.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001-expected.txt
@@ -13,9 +13,7 @@ bottom
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-y="95"><span></span></div>
-offsetTop expected 95 but got 144
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-y="20"><span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-002-expected.txt
@@ -13,8 +13,6 @@ bottom
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="65"><span></span></div>
-offsetLeft expected 65 but got 11
+PASS .target > * 3
 PASS .target > * 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-003-expected.txt
@@ -13,8 +13,6 @@ bottom
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="95"><span></span></div>
-offsetLeft expected 95 but got 149
+PASS .target > * 3
 PASS .target > * 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-001-expected.txt
@@ -13,9 +13,7 @@ bottom
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-y="95"><span></span></div>
-offsetTop expected 95 but got 144
+PASS .target > * 3
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-y="20"><span></span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-002-expected.txt
@@ -13,8 +13,6 @@ bottom
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="65"><span></span></div>
-offsetLeft expected 65 but got 11
+PASS .target > * 3
 PASS .target > * 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-table-003-expected.txt
@@ -13,8 +13,6 @@ bottom
 
 PASS .target > * 1
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="95"><span></span></div>
-offsetLeft expected 95 but got 149
+PASS .target > * 3
 PASS .target > * 4
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -901,6 +901,14 @@ RenderTableSection* RenderTable::topNonEmptySection() const
     return section;
 }
 
+RenderTableSection* RenderTable::bottomNonEmptySection() const
+{
+    auto* section = bottomSection();
+    if (section && !section->numRows())
+        section = sectionAbove(section, SkipEmptySections);
+    return section;
+}
+
 void RenderTable::splitColumn(unsigned position, unsigned firstSpan)
 {
     // We split the column at "position", taking "firstSpan" cells from the span.
@@ -1539,6 +1547,22 @@ std::optional<LayoutUnit> RenderTable::firstLineBaseline() const
 
     // FIXME: A table row always has a baseline per CSS 2.1. Will this return the right value?
     return std::optional<LayoutUnit>();
+}
+
+std::optional<LayoutUnit> RenderTable::lastLineBaseline() const
+{
+    if (isWritingModeRoot() || shouldApplyLayoutContainment())
+        return { };
+
+    recalcSectionsIfNeeded();
+
+    auto* tableSection = bottomNonEmptySection();
+    if (!tableSection)
+        return { };
+
+    if (auto baseline = tableSection->lastLineBaseline())
+        return LayoutUnit { baseline.value() + tableSection->logicalTop() };
+    return { };
 }
 
 LayoutRect RenderTable::overflowClipRect(const LayoutPoint& location, RenderFragmentContainer* fragment, OverlayScrollbarSizeRelevancy relevancy, PaintPhase phase) const

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -163,6 +163,7 @@ public:
 
     // This function returns 0 if the table has no non-empty sections.
     RenderTableSection* topNonEmptySection() const;
+    RenderTableSection* bottomNonEmptySection() const;
 
     unsigned lastColumnIndex() const { return numEffCols() - 1; }
 
@@ -299,6 +300,7 @@ private:
 
     LayoutUnit baselinePosition(FontBaseline, bool firstLine, LineDirectionMode, LinePositionMode = PositionOnContainingLine) const final;
     std::optional<LayoutUnit> firstLineBaseline() const override;
+    std::optional<LayoutUnit> lastLineBaseline() const override;
     std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const final;
 
     RenderTableCol* slowColElement(unsigned col, bool* startEdge, bool* endEdge) const;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -878,10 +878,28 @@ std::optional<LayoutUnit> RenderTableSection::firstLineBaseline() const
     if (firstLineBaseline)
         return firstLineBaseline + m_rowPos[0];
 
+    return baselineFromCellContentEdges(ItemPosition::Baseline);
+}
+
+std::optional<LayoutUnit> RenderTableSection::lastLineBaseline() const
+{
+    if (!m_grid.size())
+        return  { };
+    
+    if (auto lastLineBaseline = m_grid[m_grid.size() - 1].baseline)
+        return lastLineBaseline + m_rowPos[m_grid.size() - 1];
+
+    return baselineFromCellContentEdges(ItemPosition::LastBaseline);
+}
+
+std::optional<LayoutUnit> RenderTableSection::baselineFromCellContentEdges(ItemPosition alignment) const
+{
+    ASSERT(alignment == ItemPosition::Baseline || alignment == ItemPosition::LastBaseline);
+    auto row = alignment == ItemPosition::Baseline ? m_grid[0].row : m_grid[m_grid.size() - 1].row;
+    
     std::optional<LayoutUnit> result;
-    const Row& firstRow = m_grid[0].row;
-    for (size_t i = 0; i < firstRow.size(); ++i) {
-        const CellStruct& cs = firstRow.at(i);
+    for (size_t i = 0; i < row.size(); ++i) {
+        const CellStruct& cs = row.at(i);
         const RenderTableCell* cell = cs.primaryCell();
         // Only cells with content have a baseline
         if (cell && cell->contentLogicalHeight()) {
@@ -889,7 +907,6 @@ std::optional<LayoutUnit> RenderTableSection::firstLineBaseline() const
             result = std::max(result.value_or(candidate), candidate);
         }
     }
-
     return result;
 }
 

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -63,6 +63,8 @@ public:
     RenderTableRow* lastRow() const;
 
     std::optional<LayoutUnit> firstLineBaseline() const override;
+    std::optional<LayoutUnit> lastLineBaseline() const override;
+    std::optional<LayoutUnit> baselineFromCellContentEdges(ItemPosition alignment) const;
 
     void addCell(RenderTableCell*, RenderTableRow* row);
 


### PR DESCRIPTION
#### bf33593289e7c50abaf636fdca635f3bac442eb4
<pre>
Implement lastLineBaseline for tables.
<a href="https://bugs.webkit.org/show_bug.cgi?id=244858">https://bugs.webkit.org/show_bug.cgi?id=244858</a>
rdar://99621230

Reviewed by Alan Bujtas.

CSS Box Alignment Module Level 3 provides a definition of the last
baseline for tables and table rows. We currently keep track of the
baselines for each row if there are cells within that are baseline
aligned, so we just need to add the logic for finding the last baseline
if there are no cells being baseline aligned. This is the same logic
that was already in firstLineBaseline, but instead we are looking at
only the last row. This logic has been refactored out into
baselineFromCellContentEdges and now takes into consideration which
type of baseline alignment we are doing.

Spec reference: <a href="https://www.w3.org/TR/css-align-3/#baseline-export">https://www.w3.org/TR/css-align-3/#baseline-export</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-table-003-expected.txt:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::bottomNonEmptySection const):
(WebCore::RenderTable::lastLineBaseline const):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::firstLineBaseline const):
(WebCore::RenderTableSection::lastLineBaseline const):
(WebCore::RenderTableSection::baselineFromCellContentEdges const):
* Source/WebCore/rendering/RenderTableSection.h:

Canonical link: <a href="https://commits.webkit.org/255546@main">https://commits.webkit.org/255546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0a8496adea8204a217701e5487801b1d9a128c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102533 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2018 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30359 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85204 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98687 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1371 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79292 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28286 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82996 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71403 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36762 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34563 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18099 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3841 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40703 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37269 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->