### PR TITLE
Handle <attachment> painting in GPUP

### DIFF
--- a/LayoutTests/fast/attachment/mac/attachment-element-gpu-process-expected.html
+++ b/LayoutTests/fast/attachment/mac/attachment-element-gpu-process-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true UseGPUProcessForDOMRenderingEnabled=false ] -->
+<html>
+<body>
+<attachment title="title" subtitle="subtitle" action="action" progress="0.5"></attachment>
+</body>
+</html>
+

--- a/LayoutTests/fast/attachment/mac/attachment-element-gpu-process.html
+++ b/LayoutTests/fast/attachment/mac/attachment-element-gpu-process.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true UseGPUProcessForDOMRenderingEnabled=true ] -->
+<html>
+<body>
+<attachment title="title" subtitle="subtitle" action="action" progress="0.5"></attachment>
+</body>
+</html>

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -630,6 +630,7 @@ platform/text/cocoa/LocalizedDateCache.mm
 platform/text/mac/TextBoundaries.mm
 platform/text/mac/TextCheckingMac.mm
 platform/xr/cocoa/PlatformXRCocoa.mm
+rendering/AttachmentLayout.mm
 rendering/RenderThemeCocoa.mm
 rendering/RenderThemeIOS.mm
 rendering/RenderThemeMac.mm

--- a/Source/WebCore/rendering/AttachmentLayout.h
+++ b/Source/WebCore/rendering/AttachmentLayout.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ATTACHMENT_ELEMENT) && PLATFORM(COCOA)
+
+#include "FloatRect.h"
+#include "RenderAttachment.h"
+#include <wtf/RetainPtr.h>
+
+OBJC_CLASS NSDictionary;
+
+namespace WebCore {
+
+class Image;
+
+enum class AttachmentLayoutStyle : uint8_t { NonSelected, Selected };
+struct AttachmentLayout {
+    explicit AttachmentLayout(const RenderAttachment&, AttachmentLayoutStyle style = AttachmentLayoutStyle::NonSelected);
+    
+    float widthPadding { 0 };
+    CGFloat wrappingWidth { 0 };
+    FloatRect iconRect;
+    FloatRect iconBackgroundRect;
+    FloatRect attachmentRect;
+    FloatRect progressRect;
+    AttachmentLayoutStyle style;
+    float progress { 0 };
+    bool excludeTypographicLeading { false };
+    RefPtr<Image> icon;
+    RefPtr<Image> thumbnailIcon;
+    Vector<CGPoint> origins;
+    int baseline { 0 };
+    bool hasProgress { false };
+    
+    struct LabelLine {
+        FloatRect rect;
+        FloatRect backgroundRect;
+        RetainPtr<CTLineRef> line;
+        RetainPtr<CTFontRef> font;
+    };
+    
+    FloatRect subtitleTextRect;
+    
+    Vector<LabelLine> lines;
+    
+    CGFloat contentYOrigin { 0 };
+    void layOutSubtitle(const RenderAttachment& attachment);
+    void layOutTitle(const RenderAttachment& attachment);
+    void buildWrappedLines(String& text, CTFontRef font, NSDictionary* textAttributes, unsigned maximumLineCount);
+    void buildSingleLine(const String& text, CTFontRef font, NSDictionary* textAttributes);
+    void addLine(CTFontRef font, CTLineRef line, bool isSubtitle);
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(ATTACHMENT_ELEMENT) && PLATFORM(COCOA)

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AttachmentLayout.h"
+
+#if ENABLE(ATTACHMENT_ELEMENT) && PLATFORM(COCOA)
+
+#include "ColorCocoa.h"
+#include "FontCacheCoreText.h"
+#include "FrameSelection.h"
+#include "GeometryUtilities.h"
+#include "RenderTheme.h"
+#include <pal/spi/cf/CoreTextSPI.h>
+
+namespace WebCore {
+
+#if PLATFORM(MAC)
+
+const CGFloat attachmentIconSize = 48;
+const CGFloat attachmentIconBackgroundPadding = 6;
+const CGFloat attachmentIconBackgroundSize = attachmentIconSize + attachmentIconBackgroundPadding;
+const CGFloat attachmentIconSelectionBorderThickness = 1;
+const CGFloat attachmentIconBackgroundRadius = 3;
+const CGFloat attachmentIconToTitleMargin = 2;
+
+constexpr auto attachmentIconBackgroundColor = Color::black.colorWithAlphaByte(30);
+constexpr auto attachmentIconBorderColor = Color::white.colorWithAlphaByte(125);
+
+const CGFloat attachmentTitleFontSize = 12;
+const CGFloat attachmentTitleBackgroundRadius = 3;
+const CGFloat attachmentTitleBackgroundPadding = 3;
+const CGFloat attachmentTitleMaximumWidth = 100 - (attachmentTitleBackgroundPadding * 2);
+const CFIndex attachmentTitleMaximumLineCount = 2;
+
+constexpr auto attachmentTitleInactiveBackgroundColor = SRGBA<uint8_t> { 204, 204, 204 };
+constexpr auto attachmentTitleInactiveTextColor = SRGBA<uint8_t> { 100, 100, 100 };
+
+const CGFloat attachmentSubtitleFontSize = 10;
+const int attachmentSubtitleWidthIncrement = 10;
+constexpr auto attachmentSubtitleTextColor = SRGBA<uint8_t> { 82, 145, 214 };
+
+const CGFloat attachmentProgressBarWidth = 30;
+const CGFloat attachmentProgressBarHeight = 5;
+const CGFloat attachmentProgressBarOffset = -9;
+const CGFloat attachmentProgressBarBorderWidth = 1;
+constexpr auto attachmentProgressBarBackgroundColor = Color::black.colorWithAlphaByte(89);
+constexpr auto attachmentProgressBarFillColor = Color::white;
+constexpr auto attachmentProgressBarBorderColor = Color::black.colorWithAlphaByte(128);
+
+const CGFloat attachmentPlaceholderBorderRadius = 5;
+constexpr auto attachmentPlaceholderBorderColor = Color::black.colorWithAlphaByte(56);
+const CGFloat attachmentPlaceholderBorderWidth = 2;
+const CGFloat attachmentPlaceholderBorderDashLength = 6;
+const CGFloat attachmentMargin = 3;
+
+static Color titleTextColorForAttachment(const RenderAttachment& attachment, AttachmentLayoutStyle style)
+{
+    Color result = Color::black;
+    
+    if (style == AttachmentLayoutStyle::Selected) {
+        if (attachment.frame().selection().isFocusedAndActive())
+            result = colorFromCocoaColor([NSColor alternateSelectedControlTextColor]);
+        else
+            result = attachmentTitleInactiveTextColor;
+    }
+
+    return attachment.style().colorByApplyingColorFilter(result);
+}
+
+void AttachmentLayout::layOutTitle(const RenderAttachment& attachment)
+{
+    CFStringRef language = nullptr; // By not specifying a language we use the system language.
+    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, attachmentTitleFontSize, language));
+    baseline = CGRound(attachmentIconBackgroundSize + attachmentIconToTitleMargin + CTFontGetAscent(font.get()));
+    wrappingWidth = attachmentTitleMaximumWidth;
+    widthPadding = attachmentIconBackgroundSize;
+    String title = attachment.attachmentElement().attachmentTitleForDisplay();
+    if (title.isEmpty())
+        return;
+    NSDictionary *textAttributes = @{
+        (__bridge id)kCTFontAttributeName: (__bridge id)font.get(),
+        (__bridge id)kCTForegroundColorAttributeName: (__bridge id)cachedCGColor(titleTextColorForAttachment(attachment, style)).get()
+    };
+    buildWrappedLines(title, font.get(), textAttributes, attachmentTitleMaximumLineCount);
+    CGFloat yOffset = attachmentIconBackgroundSize + attachmentIconToTitleMargin;
+    unsigned i = 0;
+    if (!lines.isEmpty()) {
+        for (auto& line : lines) {
+            if (i)
+                yOffset += origins[i - 1].y - origins[i].y;
+            line.rect.setY(yOffset);
+
+            line.backgroundRect = LayoutRect(line.rect);
+            line.rect.setY(yOffset - origins.last().y);
+
+            line.backgroundRect.inflateX(attachmentTitleBackgroundPadding);
+            line.backgroundRect = encloseRectToDevicePixels(line.backgroundRect, attachment.document().deviceScaleFactor());
+        
+            // If the text rects are close in size, the curved enclosing background won't
+            // look right, so make them the same exact size.
+            if (i) {
+                float previousBackgroundRectWidth = lines[i-1].backgroundRect.width();
+                if (fabs(line.backgroundRect.width() - previousBackgroundRectWidth) < attachmentTitleBackgroundRadius * 4) {
+                    float newBackgroundRectWidth = std::max(previousBackgroundRectWidth, line.backgroundRect.width());
+                    line.backgroundRect.inflateX((newBackgroundRectWidth - line.backgroundRect.width()) / 2);
+                    lines[i-1].backgroundRect.inflateX((newBackgroundRectWidth - previousBackgroundRectWidth) / 2);
+                }
+            }
+            i++;
+        }
+    }
+}
+
+void AttachmentLayout::layOutSubtitle(const RenderAttachment& attachment)
+{
+    auto& subtitleText = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::subtitleAttr);
+    if (subtitleText.isEmpty())
+        return;
+    auto subtitleColor = attachment.style().colorByApplyingColorFilter(attachmentSubtitleTextColor);
+    CFStringRef language = nullptr; // By not specifying a language we use the system language.
+    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, attachmentSubtitleFontSize, language));
+    NSDictionary *textAttributes = @{
+        (__bridge id)kCTFontAttributeName: (__bridge id)font.get(),
+        (__bridge id)kCTForegroundColorAttributeName: (__bridge id)cachedCGColor(subtitleColor).get()
+    };
+    CGFloat yOffset = 0;
+    if (!lines.isEmpty())
+        yOffset = lines.last().backgroundRect.maxY();
+    else
+        yOffset = attachmentIconBackgroundSize + attachmentIconToTitleMargin;
+        
+    buildSingleLine(subtitleText, font.get(), textAttributes);
+    lines.last().rect.setY(yOffset);
+    
+    subtitleTextRect = LayoutRect(lines.last().rect);
+    lines.last().rect.setLocation(subtitleTextRect.minXMaxYCorner());
+    lines.last().rect.setSize(FloatSize(0, 0));
+}
+
+AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle layoutStyle)
+    : style(layoutStyle)
+{
+    excludeTypographicLeading = false;
+    layOutTitle(attachment);
+    layOutSubtitle(attachment);
+
+    iconBackgroundRect = FloatRect(0, 0, attachmentIconBackgroundSize, attachmentIconBackgroundSize);
+
+    iconRect = iconBackgroundRect;
+    iconRect.setSize(FloatSize(attachmentIconSize, attachmentIconSize));
+    iconRect.move(attachmentIconBackgroundPadding / 2, attachmentIconBackgroundPadding / 2);
+
+    attachmentRect = iconBackgroundRect;
+    for (const auto& line : lines)
+        attachmentRect.unite(line.backgroundRect);
+    if (!subtitleTextRect.isEmpty()) {
+        FloatRect roundedSubtitleTextRect = subtitleTextRect;
+        roundedSubtitleTextRect.inflateX(attachmentSubtitleWidthIncrement - clampToInteger(ceilf(subtitleTextRect.width())) % attachmentSubtitleWidthIncrement);
+        attachmentRect.unite(roundedSubtitleTextRect);
+    }
+    attachmentRect.inflate(attachmentMargin);
+    attachmentRect = encloseRectToDevicePixels(attachmentRect, attachment.document().deviceScaleFactor());
+}
+
+#endif // PLATFORM(MAC)
+
+#if PLATFORM(IOS_FAMILY)
+
+const CGSize attachmentSize = { 160, 119 };
+
+const CGFloat attachmentBorderRadius = 16;
+constexpr auto attachmentBorderColor = SRGBA<uint8_t> { 204, 204, 204 };
+static CGFloat attachmentBorderThickness = 1;
+
+constexpr auto attachmentProgressColor = SRGBA<uint8_t> { 222, 222, 222 };
+const CGFloat attachmentProgressBorderThickness = 3;
+
+const CGFloat attachmentProgressSize = 36;
+const CGFloat attachmentIconSize = 48;
+
+const CGFloat attachmentItemMargin = 8;
+
+const CGFloat attachmentWrappingTextMaximumWidth = 140;
+const CFIndex attachmentWrappingTextMaximumLineCount = 2;
+
+static BOOL getAttachmentProgress(const RenderAttachment& attachment, float& progress)
+{
+    auto& progressString = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::progressAttr);
+    if (progressString.isEmpty())
+        return NO;
+    bool validProgress;
+    progress = std::max<float>(std::min<float>(progressString.toFloat(&validProgress), 1), 0);
+    return validProgress;
+}
+
+static RetainPtr<CTFontRef> attachmentActionFont()
+{
+    auto style = kCTUIFontTextStyleFootnote;
+    auto size = contentSizeCategory();
+    auto attributes = static_cast<CFDictionaryRef>(@{ (id)kCTFontTraitsAttribute: @{ (id)kCTFontSymbolicTrait: @(kCTFontTraitTightLeading | kCTFontTraitEmphasized) } });
+#if HAVE(CTFONTDESCRIPTOR_CREATE_WITH_TEXT_STYLE_AND_ATTRIBUTES)
+    auto emphasizedFontDescriptor = adoptCF(CTFontDescriptorCreateWithTextStyleAndAttributes(style, size, attributes));
+#else
+    auto fontDescriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(style, size, 0));
+    auto emphasizedFontDescriptor = adoptCF(CTFontDescriptorCreateCopyWithAttributes(fontDescriptor.get(), attributes));
+#endif
+
+    return adoptCF(CTFontCreateWithFontDescriptor(emphasizedFontDescriptor.get(), 0, nullptr));
+}
+
+static RetainPtr<UIColor> attachmentActionColor(const RenderAttachment& attachment)
+{
+    return cocoaColor(attachment.style().visitedDependentColor(CSSPropertyColor));
+}
+
+static RetainPtr<CTFontRef> attachmentTitleFont()
+{
+    auto fontDescriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleShortCaption1, contentSizeCategory(), 0));
+    return adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), 0, nullptr));
+}
+
+static UIColor *attachmentTitleColor(const RenderAttachment& renderer)
+{
+    return cocoaColor(RenderTheme::singleton().systemColor(CSSValueAppleSystemGray, renderer.styleColorOptions())).autorelease();
+}
+
+static RetainPtr<CTFontRef> attachmentSubtitleFont() { return attachmentTitleFont(); }
+
+static UIColor *attachmentSubtitleColor(const RenderAttachment& renderer) { return attachmentTitleColor(renderer); }
+
+static CGFloat shortCaptionPointSizeWithContentSizeCategory(CFStringRef contentSizeCategory)
+{
+    auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(kCTUIFontTextStyleShortCaption1, contentSizeCategory, 0));
+    auto pointSize = adoptCF(CTFontDescriptorCopyAttribute(descriptor.get(), kCTFontSizeAttribute));
+    return [dynamic_objc_cast<NSNumber>((__bridge id)pointSize.get()) floatValue];
+}
+
+static CGFloat attachmentDynamicTypeScaleFactor()
+{
+    CGFloat fixedPointSize = shortCaptionPointSizeWithContentSizeCategory(kCTFontContentSizeCategoryL);
+    CGFloat dynamicPointSize = shortCaptionPointSizeWithContentSizeCategory(contentSizeCategory());
+    if (!dynamicPointSize || !fixedPointSize)
+        return 1;
+    return std::max<CGFloat>(1, dynamicPointSize / fixedPointSize);
+}
+
+AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle)
+{
+    excludeTypographicLeading = true;
+    attachmentRect = FloatRect(0, 0, attachment.width().toFloat(), attachment.height().toFloat());
+    wrappingWidth = attachmentWrappingTextMaximumWidth * attachmentDynamicTypeScaleFactor();
+    widthPadding = attachmentRect.width();
+
+    hasProgress = getAttachmentProgress(attachment, progress);
+    String title = attachment.attachmentElement().attachmentTitleForDisplay();
+    String action = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::actionAttr);
+    String subtitle = attachment.attachmentElement().attributeWithoutSynchronization(HTMLNames::subtitleAttr);
+
+    CGFloat yOffset = 0;
+
+    if (hasProgress) {
+        progressRect = FloatRect((attachmentRect.width() / 2) - (attachmentProgressSize / 2), 0, attachmentProgressSize, attachmentProgressSize);
+        yOffset += attachmentProgressSize + attachmentItemMargin;
+    }
+
+    if (action.isEmpty() && !hasProgress) {
+        FloatSize iconSize = attachment.attachmentElement().iconSize();
+        icon = attachment.attachmentElement().icon();
+        if (!icon)
+            attachment.attachmentElement().requestIconWithSize(FloatSize());
+        thumbnailIcon = attachment.attachmentElement().thumbnail();
+        if (thumbnailIcon)
+            iconSize = largestRectWithAspectRatioInsideRect(thumbnailIcon->size().aspectRatio(), FloatRect(0, 0, attachmentIconSize, attachmentIconSize)).size();
+        
+        if (thumbnailIcon || icon) {
+            iconRect = FloatRect(FloatPoint((attachmentRect.width() / 2) - (iconSize.width() / 2), 0), iconSize);
+            yOffset += iconRect.height() + attachmentItemMargin;
+        }
+    } else {
+        NSDictionary *textAttributesTitle = @{
+            (id)kCTFontAttributeName: (id)attachmentActionFont().get(),
+            (id)kCTForegroundColorAttributeName: attachmentActionColor(attachment).get()
+        };
+
+        buildWrappedLines(action, attachmentActionFont().get(), textAttributesTitle, attachmentWrappingTextMaximumLineCount);
+    }
+
+    bool forceSingleLineTitle = !action.isEmpty() || !subtitle.isEmpty() || hasProgress;
+    NSDictionary *textAttributesTitle = @{
+        (id)kCTFontAttributeName: (id)attachmentTitleFont().get(),
+        (id)kCTForegroundColorAttributeName: attachmentTitleColor(attachment)
+    };
+
+    buildWrappedLines(title, attachmentTitleFont().get(), textAttributesTitle, forceSingleLineTitle ? 1 : attachmentWrappingTextMaximumLineCount);
+    NSDictionary *textAttributesSubTitle = @{
+        (id)kCTFontAttributeName: (id)attachmentSubtitleFont().get(),
+        (id)kCTForegroundColorAttributeName: attachmentSubtitleColor(attachment)
+    };
+    buildSingleLine(subtitle, attachmentSubtitleFont().get(), textAttributesSubTitle);
+
+    if (!lines.isEmpty()) {
+        for (auto& line : lines) {
+            line.rect.setY(yOffset);
+            yOffset += line.rect.height() + attachmentItemMargin;
+        }
+    }
+
+    yOffset -= attachmentItemMargin;
+
+    contentYOrigin = (attachmentRect.height() / 2) - (yOffset / 2);
+}
+
+#endif // PLATFORM(IOS_FAMILY)
+
+void AttachmentLayout::addLine(CTFontRef font, CTLineRef line, bool isSubtitle = false)
+{
+    CGRect lineBounds = CTLineGetBoundsWithOptions(line, excludeTypographicLeading ? kCTLineBoundsExcludeTypographicLeading : 0);
+    CGFloat trailingWhitespaceWidth = CTLineGetTrailingWhitespaceWidth(line);
+    CGFloat lineWidthIgnoringTrailingWhitespace = lineBounds.size.width - trailingWhitespaceWidth;
+    CGFloat lineHeight = lineBounds.size.height + (excludeTypographicLeading ? lineBounds.origin.y : 0);
+    lineHeight = isSubtitle ? lineHeight : CGCeiling(lineHeight);
+    
+    CGFloat xOffset = (widthPadding / 2) - (lineWidthIgnoringTrailingWhitespace / 2);
+    LabelLine labelLine;
+    labelLine.font = font;
+    labelLine.line = line;
+    labelLine.rect = FloatRect(xOffset, 0, lineWidthIgnoringTrailingWhitespace, lineHeight);
+    
+    lines.append(labelLine);
+}
+
+void AttachmentLayout::buildWrappedLines(String& text, CTFontRef font, NSDictionary *textAttributes, unsigned maximumLineCount)
+{
+    if (text.isEmpty())
+        return;
+    
+    auto attributedText = adoptNS([[NSAttributedString alloc] initWithString:text attributes:textAttributes]);
+    auto framesetter = adoptCF(CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attributedText.get()));
+    
+    CFRange fitRange;
+    auto textSize = CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, 0), nullptr, CGSizeMake(wrappingWidth, CGFLOAT_MAX), &fitRange);
+    
+    auto textPath = adoptCF(CGPathCreateWithRect(CGRectMake(0, 0, textSize.width, textSize.height), nullptr));
+    auto textFrame = adoptCF(CTFramesetterCreateFrame(framesetter.get(), fitRange, textPath.get(), nullptr));
+    
+    auto ctLines = CTFrameGetLines(textFrame.get());
+    auto lineCount = CFArrayGetCount(ctLines);
+    if (!lineCount)
+        return;
+    
+    origins.resize(lineCount);
+    CTFrameGetLineOrigins(textFrame.get(), CFRangeMake(0, 0), origins.data());
+    // Lay out and record the first (maximumLineCount - 1) lines.
+    CFIndex lineIndex = 0;
+    auto nonTruncatedLineCount = std::min<CFIndex>(maximumLineCount - 1, lineCount);
+    for (; lineIndex < nonTruncatedLineCount; ++lineIndex)
+        addLine(font, (CTLineRef)CFArrayGetValueAtIndex(ctLines, lineIndex));
+    
+    if (lineIndex == lineCount)
+        return;
+    
+    // We had text that didn't fit in the first (maximumLineCount - 1) lines.
+    // Combine it into one last line, and center-truncate it.
+    auto firstRemainingLine = (CTLineRef)CFArrayGetValueAtIndex(ctLines, lineIndex);
+    auto remainingRangeStart = CTLineGetStringRange(firstRemainingLine).location;
+    auto remainingRange = CFRangeMake(remainingRangeStart, [attributedText length] - remainingRangeStart);
+    auto remainingPath = adoptCF(CGPathCreateWithRect(CGRectMake(0, 0, CGFLOAT_MAX, CGFLOAT_MAX), nullptr));
+    auto remainingFrame = adoptCF(CTFramesetterCreateFrame(framesetter.get(), remainingRange, remainingPath.get(), nullptr));
+    auto ellipsisString = adoptNS([[NSAttributedString alloc] initWithString:@"\u2026" attributes:textAttributes]);
+    auto ellipsisLine = adoptCF(CTLineCreateWithAttributedString((CFAttributedStringRef)ellipsisString.get()));
+    auto remainingLine = (CTLineRef)CFArrayGetValueAtIndex(CTFrameGetLines(remainingFrame.get()), 0);
+    auto truncatedLine = adoptCF(CTLineCreateTruncatedLine(remainingLine, wrappingWidth, kCTLineTruncationMiddle, ellipsisLine.get()));
+    
+    if (!truncatedLine)
+        truncatedLine = remainingLine;
+    
+    addLine(font, truncatedLine.get());
+}
+
+void AttachmentLayout::buildSingleLine(const String& text, CTFontRef font, NSDictionary *textAttributes)
+{
+    if (text.isEmpty())
+        return;
+    RetainPtr<NSAttributedString> attributedText = adoptNS([[NSAttributedString alloc] initWithString:text attributes:textAttributes]);
+    
+    addLine(font, adoptCF(CTLineCreateWithAttributedString((CFAttributedStringRef)attributedText.get())).get(), true);
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ATTACHMENT_ELEMENT) && PLATFORM(COCOA)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -458,12 +458,20 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
     }
     if (paintInfo.context().paintingDisabled())
         return false;
+    
+    ControlPart part = box.style().effectiveAppearance();
+    IntRect integralSnappedRect = snappedIntRect(rect);
+
+    // Temporarily move this call above the canPaint check to allow
+    // this to work in the GPU process
+#if ENABLE(ATTACHMENT_ELEMENT)
+    if (part == AttachmentPart || part == BorderlessAttachmentPart)
+        return paintAttachment(box, paintInfo, integralSnappedRect);
+#endif
 
     if (UNLIKELY(!canPaint(paintInfo, box.settings())))
         return false;
 
-    ControlPart part = box.style().effectiveAppearance();
-    IntRect integralSnappedRect = snappedIntRect(rect);
     float deviceScaleFactor = box.document().deviceScaleFactor();
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
 
@@ -546,11 +554,6 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
 #if ENABLE(APPLE_PAY)
     case ApplePayButtonPart:
         return paintApplePayButton(box, paintInfo, integralSnappedRect);
-#endif
-#if ENABLE(ATTACHMENT_ELEMENT)
-    case AttachmentPart:
-    case BorderlessAttachmentPart:
-        return paintAttachment(box, paintInfo, integralSnappedRect);
 #endif
 #if ENABLE(DATALIST_ELEMENT)
     case ListButtonPart:

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+struct AttachmentLayout;
 class BorderData;
 class Element;
 class FileList;
@@ -332,6 +333,7 @@ protected:
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual bool paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&);
+    virtual void paintAttachmentText(GraphicsContext&, AttachmentLayout*) { }
 #endif
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -30,6 +30,7 @@
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSDateComponentsFormatter;
+struct AttachmentLayout;
 
 namespace WebCore {
 
@@ -39,6 +40,10 @@ public:
 
 protected:
     virtual Color pictureFrameColor(const RenderObject&);
+#if ENABLE(ATTACHMENT_ELEMENT)
+    int attachmentBaseline(const RenderAttachment& attachment) const final;
+    void paintAttachmentText(GraphicsContext&, AttachmentLayout*) final;
+#endif
 
 private:
     void purgeCaches() override;

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -26,7 +26,9 @@
 #import "config.h"
 #import "RenderThemeCocoa.h"
 
+#import "AttachmentLayout.h"
 #import "ApplePayLogoSystemImage.h"
+#import "DrawGlyphsRecorder.h"
 #import "FloatRoundedRect.h"
 #import "FontCacheCoreText.h"
 #import "GraphicsContextCG.h"
@@ -241,5 +243,23 @@ static inline FontSelectionValue cssWeightOfSystemFont(CTFontRef font)
     }
     return FontSelectionValue(900);
 }
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+
+int RenderThemeCocoa::attachmentBaseline(const RenderAttachment& attachment) const
+{
+    AttachmentLayout layout(attachment, AttachmentLayoutStyle::NonSelected);
+    return layout.baseline;
+}
+
+void RenderThemeCocoa::paintAttachmentText(GraphicsContext& context, AttachmentLayout* layout)
+{
+    DrawGlyphsRecorder recorder(context, 1, DrawGlyphsRecorder::DeriveFontFromContext::Yes);
+
+    for (const auto& line : layout->lines)
+        recorder.drawNativeText(line.font.get(), CTFontGetSize(line.font.get()), line.line.get(), line.rect);
+}
+
+#endif
 
 }

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -171,7 +171,6 @@ private:
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     LayoutSize attachmentIntrinsicSize(const RenderAttachment&) const override;
-    int attachmentBaseline(const RenderAttachment&) const override;
     bool attachmentShouldAllowWidthToShrink(const RenderAttachment&) const override { return true; }
     String attachmentStyleSheet() const final;
     bool paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&) override;

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -150,7 +150,6 @@ private:
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     LayoutSize attachmentIntrinsicSize(const RenderAttachment&) const final;
-    int attachmentBaseline(const RenderAttachment&) const final;
     bool paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&) final;
 #endif
 

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -2309,247 +2309,11 @@ bool RenderThemeMac::isImageControl(const Element& elementPtr) const
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-const CGFloat attachmentIconSize = 48;
-const CGFloat attachmentIconBackgroundPadding = 6;
-const CGFloat attachmentIconBackgroundSize = attachmentIconSize + attachmentIconBackgroundPadding;
-const CGFloat attachmentIconSelectionBorderThickness = 1;
-const CGFloat attachmentIconBackgroundRadius = 3;
-const CGFloat attachmentIconToTitleMargin = 2;
-
-constexpr auto attachmentIconBackgroundColor = Color::black.colorWithAlphaByte(30);
-constexpr auto attachmentIconBorderColor = Color::white.colorWithAlphaByte(125);
-
-const CGFloat attachmentTitleFontSize = 12;
-const CGFloat attachmentTitleBackgroundRadius = 3;
-const CGFloat attachmentTitleBackgroundPadding = 3;
-const CGFloat attachmentTitleMaximumWidth = 100 - (attachmentTitleBackgroundPadding * 2);
-const CFIndex attachmentTitleMaximumLineCount = 2;
-
-constexpr auto attachmentTitleInactiveBackgroundColor = SRGBA<uint8_t> { 204, 204, 204 };
-constexpr auto attachmentTitleInactiveTextColor = SRGBA<uint8_t> { 100, 100, 100 };
-
-const CGFloat attachmentSubtitleFontSize = 10;
-const int attachmentSubtitleWidthIncrement = 10;
-constexpr auto attachmentSubtitleTextColor = SRGBA<uint8_t> { 82, 145, 214 };
-
-const CGFloat attachmentProgressBarWidth = 30;
-const CGFloat attachmentProgressBarHeight = 5;
-const CGFloat attachmentProgressBarOffset = -9;
-const CGFloat attachmentProgressBarBorderWidth = 1;
-constexpr auto attachmentProgressBarBackgroundColor = Color::black.colorWithAlphaByte(89);
-constexpr auto attachmentProgressBarFillColor = Color::white;
-constexpr auto attachmentProgressBarBorderColor = Color::black.colorWithAlphaByte(128);
-
-const CGFloat attachmentPlaceholderBorderRadius = 5;
-constexpr auto attachmentPlaceholderBorderColor = Color::black.colorWithAlphaByte(56);
-const CGFloat attachmentPlaceholderBorderWidth = 2;
-const CGFloat attachmentPlaceholderBorderDashLength = 6;
-
-const CGFloat attachmentMargin = 3;
-
-enum class AttachmentLayoutStyle : uint8_t { NonSelected, Selected };
-
-struct AttachmentLayout {
-    explicit AttachmentLayout(const RenderAttachment&, AttachmentLayoutStyle);
-
-    struct LabelLine {
-        FloatRect backgroundRect;
-        FloatPoint origin;
-        RetainPtr<CTLineRef> line;
-    };
-
-    Vector<LabelLine> lines;
-
-    FloatRect iconRect;
-    FloatRect iconBackgroundRect;
-    FloatRect attachmentRect;
-
-    int baseline;
-    AttachmentLayoutStyle style;
-
-    RetainPtr<CTLineRef> subtitleLine;
-    FloatRect subtitleTextRect;
-
-private:
-    void layOutTitle(const RenderAttachment&);
-    void layOutSubtitle(const RenderAttachment&);
-
-    void addTitleLine(CTLineRef, CGFloat& yOffset, Vector<CGPoint> origins, CFIndex lineIndex, const RenderAttachment&);
-};
-
-static Color titleTextColorForAttachment(const RenderAttachment& attachment, AttachmentLayoutStyle style)
-{
-    Color result = Color::black;
-    
-    if (style == AttachmentLayoutStyle::Selected) {
-        if (attachment.frame().selection().isFocusedAndActive())
-            result = colorFromCocoaColor([NSColor alternateSelectedControlTextColor]);
-        else
-            result = attachmentTitleInactiveTextColor;
-    }
-
-    return attachment.style().colorByApplyingColorFilter(result);
-}
-
-void AttachmentLayout::addTitleLine(CTLineRef line, CGFloat& yOffset, Vector<CGPoint> origins, CFIndex lineIndex, const RenderAttachment& attachment)
-{
-    CGRect lineBounds = CTLineGetBoundsWithOptions(line, 0);
-    CGFloat trailingWhitespaceWidth = CTLineGetTrailingWhitespaceWidth(line);
-    CGFloat lineWidthIgnoringTrailingWhitespace = lineBounds.size.width - trailingWhitespaceWidth;
-    CGFloat lineHeight = CGCeiling(lineBounds.size.height);
-
-    // Center the line relative to the icon.
-    CGFloat xOffset = (attachmentIconBackgroundSize / 2) - (lineWidthIgnoringTrailingWhitespace / 2);
-
-    if (lineIndex)
-        yOffset += origins[lineIndex - 1].y - origins[lineIndex].y;
-
-    LabelLine labelLine;
-    labelLine.origin = FloatPoint(xOffset, yOffset + lineHeight - origins.last().y);
-    labelLine.line = line;
-    labelLine.backgroundRect = FloatRect(xOffset, yOffset, lineWidthIgnoringTrailingWhitespace, lineHeight);
-    labelLine.backgroundRect.inflateX(attachmentTitleBackgroundPadding);
-    labelLine.backgroundRect = encloseRectToDevicePixels(labelLine.backgroundRect, attachment.document().deviceScaleFactor());
-
-    // If the text rects are close in size, the curved enclosing background won't
-    // look right, so make them the same exact size.
-    if (!lines.isEmpty()) {
-        float previousBackgroundRectWidth = lines.last().backgroundRect.width();
-        if (fabs(labelLine.backgroundRect.width() - previousBackgroundRectWidth) < attachmentTitleBackgroundRadius * 4) {
-            float newBackgroundRectWidth = std::max(previousBackgroundRectWidth, labelLine.backgroundRect.width());
-            labelLine.backgroundRect.inflateX((newBackgroundRectWidth - labelLine.backgroundRect.width()) / 2);
-            lines.last().backgroundRect.inflateX((newBackgroundRectWidth - previousBackgroundRectWidth) / 2);
-        }
-    }
-
-    lines.append(labelLine);
-}
-
-void AttachmentLayout::layOutTitle(const RenderAttachment& attachment)
-{
-    CFStringRef language = 0; // By not specifying a language we use the system language.
-    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, attachmentTitleFontSize, language));
-    baseline = CGRound(attachmentIconBackgroundSize + attachmentIconToTitleMargin + CTFontGetAscent(font.get()));
-
-    String title = attachment.attachmentElement().attachmentTitleForDisplay();
-    if (title.isEmpty())
-        return;
-
-    NSDictionary *textAttributes = @{
-        (__bridge id)kCTFontAttributeName: (__bridge id)font.get(),
-        (__bridge id)kCTForegroundColorAttributeName: (__bridge id)cachedCGColor(titleTextColorForAttachment(attachment, style)).get()
-    };
-    RetainPtr<NSAttributedString> attributedTitle = adoptNS([[NSAttributedString alloc] initWithString:title attributes:textAttributes]);
-    RetainPtr<CTFramesetterRef> titleFramesetter = adoptCF(CTFramesetterCreateWithAttributedString((CFAttributedStringRef)attributedTitle.get()));
-
-    CFRange fitRange;
-    CGSize titleTextSize = CTFramesetterSuggestFrameSizeWithConstraints(titleFramesetter.get(), CFRangeMake(0, 0), nullptr, CGSizeMake(attachmentTitleMaximumWidth, CGFLOAT_MAX), &fitRange);
-
-    RetainPtr<CGPathRef> titlePath = adoptCF(CGPathCreateWithRect(CGRectMake(0, 0, titleTextSize.width, titleTextSize.height), nullptr));
-    RetainPtr<CTFrameRef> titleFrame = adoptCF(CTFramesetterCreateFrame(titleFramesetter.get(), fitRange, titlePath.get(), nullptr));
-
-    CFArrayRef ctLines = CTFrameGetLines(titleFrame.get());
-    CFIndex lineCount = CFArrayGetCount(ctLines);
-    if (!lineCount)
-        return;
-
-    Vector<CGPoint> origins(lineCount);
-    CTFrameGetLineOrigins(titleFrame.get(), CFRangeMake(0, 0), origins.data());
-
-    // Lay out and record the first (attachmentTitleMaximumLineCount - 1) lines.
-    CFIndex lineIndex = 0;
-    CGFloat yOffset = attachmentIconBackgroundSize + attachmentIconToTitleMargin;
-    for (; lineIndex < std::min(attachmentTitleMaximumLineCount - 1, lineCount); ++lineIndex) {
-        CTLineRef line = (CTLineRef)CFArrayGetValueAtIndex(ctLines, lineIndex);
-        addTitleLine(line, yOffset, origins, lineIndex, attachment);
-    }
-
-    if (lineIndex == lineCount)
-        return;
-
-    // We had text that didn't fit in the first (attachmentTitleMaximumLineCount - 1) lines.
-    // Combine it into one last line, and center-truncate it.
-    CTLineRef firstRemainingLine = (CTLineRef)CFArrayGetValueAtIndex(ctLines, lineIndex);
-    CFIndex remainingRangeStart = CTLineGetStringRange(firstRemainingLine).location;
-    CFRange remainingRange = CFRangeMake(remainingRangeStart, [attributedTitle length] - remainingRangeStart);
-    RetainPtr<CGPathRef> remainingPath = adoptCF(CGPathCreateWithRect(CGRectMake(0, 0, CGFLOAT_MAX, CGFLOAT_MAX), nullptr));
-    RetainPtr<CTFrameRef> remainingFrame = adoptCF(CTFramesetterCreateFrame(titleFramesetter.get(), remainingRange, remainingPath.get(), nullptr));
-    RetainPtr<NSAttributedString> ellipsisString = adoptNS([[NSAttributedString alloc] initWithString:@"\u2026" attributes:textAttributes]);
-    RetainPtr<CTLineRef> ellipsisLine = adoptCF(CTLineCreateWithAttributedString((CFAttributedStringRef)ellipsisString.get()));
-    CTLineRef remainingLine = (CTLineRef)CFArrayGetValueAtIndex(CTFrameGetLines(remainingFrame.get()), 0);
-    RetainPtr<CTLineRef> truncatedLine = adoptCF(CTLineCreateTruncatedLine(remainingLine, attachmentTitleMaximumWidth, kCTLineTruncationMiddle, ellipsisLine.get()));
-
-    if (!truncatedLine)
-        truncatedLine = remainingLine;
-
-    addTitleLine(truncatedLine.get(), yOffset, origins, lineIndex, attachment);
-}
-
-void AttachmentLayout::layOutSubtitle(const RenderAttachment& attachment)
-{
-    auto& subtitleText = attachment.attachmentElement().attributeWithoutSynchronization(subtitleAttr);
-    if (subtitleText.isEmpty())
-        return;
-
-    Color subtitleColor = attachment.style().colorByApplyingColorFilter(attachmentSubtitleTextColor);
-    CFStringRef language = 0; // By not specifying a language we use the system language.
-    auto font = adoptCF(CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, attachmentSubtitleFontSize, language));
-    NSDictionary *textAttributes = @{
-        (__bridge id)kCTFontAttributeName: (__bridge id)font.get(),
-        (__bridge id)kCTForegroundColorAttributeName: (__bridge id)cachedCGColor(subtitleColor).get()
-    };
-    RetainPtr<NSAttributedString> attributedSubtitleText = adoptNS([[NSAttributedString alloc] initWithString:subtitleText attributes:textAttributes]);
-    subtitleLine = adoptCF(CTLineCreateWithAttributedString((CFAttributedStringRef)attributedSubtitleText.get()));
-
-    CGRect lineBounds = CTLineGetBoundsWithOptions(subtitleLine.get(), 0);
-
-    // Center the line relative to the icon.
-    CGFloat xOffset = (attachmentIconBackgroundSize / 2) - (lineBounds.size.width / 2);
-    CGFloat yOffset = 0;
-
-    if (!lines.isEmpty())
-        yOffset = lines.last().backgroundRect.maxY();
-    else
-        yOffset = attachmentIconBackgroundSize + attachmentIconToTitleMargin;
-
-    LabelLine labelLine;
-    subtitleTextRect = FloatRect(xOffset, yOffset, lineBounds.size.width, lineBounds.size.height);
-}
-
-AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle layoutStyle)
-    : style(layoutStyle)
-{
-    layOutTitle(attachment);
-    layOutSubtitle(attachment);
-
-    iconBackgroundRect = FloatRect(0, 0, attachmentIconBackgroundSize, attachmentIconBackgroundSize);
-
-    iconRect = iconBackgroundRect;
-    iconRect.setSize(FloatSize(attachmentIconSize, attachmentIconSize));
-    iconRect.move(attachmentIconBackgroundPadding / 2, attachmentIconBackgroundPadding / 2);
-
-    attachmentRect = iconBackgroundRect;
-    for (const auto& line : lines)
-        attachmentRect.unite(line.backgroundRect);
-    if (!subtitleTextRect.isEmpty()) {
-        FloatRect roundedSubtitleTextRect = subtitleTextRect;
-        roundedSubtitleTextRect.inflateX(attachmentSubtitleWidthIncrement - clampToInteger(ceilf(subtitleTextRect.width())) % attachmentSubtitleWidthIncrement);
-        attachmentRect.unite(roundedSubtitleTextRect);
-    }
-    attachmentRect.inflate(attachmentMargin);
-    attachmentRect = encloseRectToDevicePixels(attachmentRect, attachment.document().deviceScaleFactor());
-}
 
 LayoutSize RenderThemeMac::attachmentIntrinsicSize(const RenderAttachment& attachment) const
 {
     AttachmentLayout layout(attachment, AttachmentLayoutStyle::NonSelected);
     return LayoutSize(layout.attachmentRect.size());
-}
-
-int RenderThemeMac::attachmentBaseline(const RenderAttachment& attachment) const
-{
-    AttachmentLayout layout(attachment, AttachmentLayoutStyle::NonSelected);
-    return layout.baseline;
 }
 
 static RefPtr<Icon> iconForAttachment(const String& fileName, const String& attachmentType, const String& title)
@@ -2659,17 +2423,10 @@ static void paintAttachmentIcon(const RenderAttachment& attachment, GraphicsCont
         attachment.attachmentElement().requestIconWithSize(layout.iconRect.size());
         return;
     }
-
-    auto image = icon->nsImage();
-    if (!image)
-        return;
     
     if (!shouldDrawIcon(attachment.attachmentElement().attachmentTitleForDisplay()))
         return;
-
-    LocalCurrentGraphicsContext localCurrentGC(context);
-
-    [image drawInRect:layout.iconRect fromRect:NSMakeRect(0, 0, [image size].width, [image size].height) operation:NSCompositingOperationSourceOver fraction:1.0f];
+    context.drawImage(*icon, layout.iconRect);
 }
 
 static std::pair<RefPtr<Image>, float> createAttachmentPlaceholderImage(float deviceScaleFactor, const AttachmentLayout& layout)
@@ -2735,30 +2492,6 @@ static void paintAttachmentTitleBackground(const RenderAttachment& attachment, G
 
     Path backgroundPath = PathUtilities::pathWithShrinkWrappedRects(backgroundRects, attachmentTitleBackgroundRadius);
     context.fillPath(backgroundPath);
-}
-
-static void paintAttachmentTitle(const RenderAttachment&, GraphicsContext& context, AttachmentLayout& layout)
-{
-    for (const auto& line : layout.lines) {
-        GraphicsContextStateSaver saver(context);
-
-        context.translate(toFloatSize(line.origin));
-        context.scale(FloatSize(1, -1));
-
-        CGContextSetTextPosition(context.platformContext(), 0, 0);
-        CTLineDraw(line.line.get(), context.platformContext());
-    }
-}
-
-static void paintAttachmentSubtitle(const RenderAttachment&, GraphicsContext& context, AttachmentLayout& layout)
-{
-    GraphicsContextStateSaver saver(context);
-
-    context.translate(toFloatSize(layout.subtitleTextRect.minXMaxYCorner()));
-    context.scale(FloatSize(1, -1));
-
-    CGContextSetTextPosition(context.platformContext(), 0, 0);
-    CTLineDraw(layout.subtitleLine.get(), context.platformContext());
 }
 
 static void paintAttachmentProgress(const RenderAttachment& attachment, GraphicsContext& context, AttachmentLayout& layout, float progress)
@@ -2842,8 +2575,7 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
         paintAttachmentIcon(attachment, context, layout);
 
     paintAttachmentTitleBackground(attachment, context, layout);
-    paintAttachmentTitle(attachment, context, layout);
-    paintAttachmentSubtitle(attachment, context, layout);
+    paintAttachmentText(context, &layout);
 
     if (validProgress && progress)
         paintAttachmentProgress(attachment, context, layout, progress);


### PR DESCRIPTION
#### b4421d4a471ca4a0d2c02b67713a81380c441725
<pre>
Handle &lt;attachment&gt; painting in GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=246368">https://bugs.webkit.org/show_bug.cgi?id=246368</a>
rdar://83459796

Reviewed by Simon Fraser.

Unify some parts of layout/painting of attachment on mac and ios.
This includes the struct containing layout info of the attachment
element, the functions constructing the lines of the subtitle and
title, painting of the lines. Move the bits constructing the
layout struct out of RenderThemeMac/iOS into AttachmentLayout.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::AttachmentLayout::layOutSubtitle):
(WebCore::paintAttachmentIcon):
(WebCore::drawCTLine):
(WebCore::paintAttachmentTitle):
(WebCore::paintAttachmentSubtitle):

Canonical link: <a href="https://commits.webkit.org/255903@main">https://commits.webkit.org/255903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3935f9d2e92f71e09cda8509daaefabec4bdc5db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93952 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103585 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163922 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3157 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31380 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99640 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2260 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80375 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29276 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84186 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72232 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37769 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17710 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39512 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41543 "Found 1 new test failure: fast/workers/stress-js-execution.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38205 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->