### PR TITLE
Shadows paint at the wrong scale in replayed CGDisplayLists

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -135,8 +135,13 @@ public:
     GraphicsContextPlatformPrivate* deprecatedPrivateContext() const final;
 #endif
 
+protected:
+    virtual void setCGShadow(RenderingMode, const FloatSize& offset, float blur, const Color&, bool shadowsIgnoreTransforms);
+
 private:
     void convertToDestinationColorSpaceIfNeeded(RetainPtr<CGImageRef>&);
+
+    void clearCGShadow();
 
     GraphicsContextPlatformPrivate* m_data { nullptr };
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -54,6 +54,7 @@ public:
         m_immutableBaseTransform.translate(0, -ceilf(parameters.logicalSize.height() * parameters.resolutionScale));
         m_immutableBaseTransform.scale(parameters.resolutionScale);
         m_inverseImmutableBaseTransform = *m_immutableBaseTransform.inverse();
+        m_resolutionScale = parameters.resolutionScale;
     }
 
     void setCTM(const WebCore::AffineTransform& transform) final
@@ -68,9 +69,19 @@ public:
 
     bool canUseShadowBlur() const final { return false; }
 
+protected:
+    void setCGShadow(WebCore::RenderingMode renderingMode, const WebCore::FloatSize& offset, float blur, const WebCore::Color& color, bool shadowsIgnoreTransforms) override
+    {
+        // This doesn't use `m_immutableBaseTransform.mapSize` because it doesn't output negative lengths.
+        WebCore::FloatSize scaledOffset = offset;
+        scaledOffset.scale(m_resolutionScale, -m_resolutionScale);
+        GraphicsContextCG::setCGShadow(renderingMode, scaledOffset, blur * m_resolutionScale, color, shadowsIgnoreTransforms);
+    }
+
 private:
     WebCore::AffineTransform m_immutableBaseTransform;
     WebCore::AffineTransform m_inverseImmutableBaseTransform;
+    float m_resolutionScale;
 };
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CGDisplayListImageBufferBackend);


### PR DESCRIPTION
#### ff0ba2bfd3e434a922fcac79a8fa8207cd57c7f0
<pre>
Shadows paint at the wrong scale in replayed CGDisplayLists
<a href="https://bugs.webkit.org/show_bug.cgi?id=246369">https://bugs.webkit.org/show_bug.cgi?id=246369</a>
rdar://96967173

Reviewed by Simon Fraser.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::fillRect):
(WebCore::GraphicsContextCG::fillRoundedRectImpl):
(WebCore::GraphicsContextCG::fillRectWithRoundedHole):
(WebCore::GraphicsContextCG::setCGShadow):
(WebCore::GraphicsContextCG::clearCGShadow):
(WebCore::GraphicsContextCG::didUpdateState):
(WebCore::setCGShadow): Deleted.
Make setCGShadow virtual so that GraphicsContextCGDisplayList can adjust its behavior.
Drive-by factor out clearCGShadow so all the CGContext-touching code is all in one place.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::GraphicsContextCGDisplayList::GraphicsContextCGDisplayList):
Work around a confusion re: the base CTM with CGDisplayList image buffers
by mapping the shadow parameters out through the hidden immutable base transform.
We don&apos;t actually use the transform here, instead just faking it with the scale
and flip, because we have no mechanism for mapping a size with negative values
through an AffineTransform.

Canonical link: <a href="https://commits.webkit.org/255442@main">https://commits.webkit.org/255442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69d409cada7dd7dccbb2a2c62bdc52fc88e5f728

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102215 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1675 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30055 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98368 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1119 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/78962 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28051 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82726 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36468 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17838 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40458 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/36988 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->