### PR TITLE
Encode WebCore::Paths using a trailing "end of path" marker instead of an element count prefix

### DIFF
--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -71,4 +71,5 @@ constexpr auto enumToUnderlyingType(E e)
 
 }
 
+using WTF::enumToUnderlyingType;
 using WTF::isValidEnum;

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -60,7 +60,7 @@ bool GraphicsContextState::containsOnlyInlineChanges() const
 
 constexpr unsigned toIndex(GraphicsContextState::Change change)
 {
-    return WTF::ctzConstexpr(WTF::enumToUnderlyingType(change));
+    return WTF::ctzConstexpr(enumToUnderlyingType(change));
 }
 
 void GraphicsContextState::mergeChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)


### PR DESCRIPTION
#### 09496e855222f4a787bed209454e539b1a732ba0
<pre>
Encode WebCore::Paths using a trailing &quot;end of path&quot; marker instead of an element count prefix
<a href="https://bugs.webkit.org/show_bug.cgi?id=246322">https://bugs.webkit.org/show_bug.cgi?id=246322</a>
rdar://100873493

Reviewed by Wenson Hsieh.

The WebCore::Path decoder doesn&apos;t need to know the number of path elements ahead
of time. Changing to use an &quot;end of path&quot; marker saves some space in the
encoding, since it&apos;ll take up one byte as opposed to the 16 bytes for the path
element count.

Add EncodedPathElementType to represent &quot;a PathElement::Type or an end of path
marker&quot; and which can encode its value in a single byte. Do this rather than:

* using std::optional&lt;PathElement::Type&gt; or Markable&lt;PathElement::Type&gt;, as both
  will write out a boolean &quot;is empty/present&quot; value, which is wasteful,
  or

* adding an EndOfPath enum value to PathElement::Type, as then various call
  sites unrelated to encoding will need to worry about it.

* Source/WTF/wtf/EnumTraits.h:
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::toIndex):
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::EncodedPathElementType::encode):
(WebCore::Path::EncodedPathElementType::decode):
(WebCore::Path::encode const):
(WebCore::Path::decode):

Canonical link: <a href="https://commits.webkit.org/255452@main">https://commits.webkit.org/255452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e0d1ef76ea73874364063afedd200249186f691

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102255 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1722 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30092 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98435 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1154 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79003 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28094 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83879 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36503 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78910 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34283 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17877 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27351 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40489 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81533 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37031 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18442 "Passed tests") | 
<!--EWS-Status-Bubble-End-->