### PR TITLE
Use OS_UNFAIR_LOCK_DATA_SYNCHRONIZATION and OS_UNFAIR_LOCK_ADAPTIVE_SPIN

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -176,6 +176,10 @@
 #define PAS_PLATFORM_APPLETV 1
 #endif
 
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#define PAS_PLATFORM_VISION 1
+#endif
+
 #if defined(__SCE__)
 #define PAS_PLATFORM_PLAYSTATION 1
 #endif


### PR DESCRIPTION
#### 37914219bec20c62483b16dbac4d4e0b6d323bb9
<pre>
Use OS_UNFAIR_LOCK_DATA_SYNCHRONIZATION and OS_UNFAIR_LOCK_ADAPTIVE_SPIN
<a href="https://bugs.webkit.org/show_bug.cgi?id=246373">https://bugs.webkit.org/show_bug.cgi?id=246373</a>
<a href="https://rdar.apple.com/101055626">rdar://101055626</a>

Reviewed by Saam Barati.

From the description of OS_UNFAIR_LOCK_DATA_SYNCHRONIZATION and OS_UNFAIR_LOCK_ADAPTIVE_SPIN[1], it looks good to use it in libpas.
So, this patch is just enabling them. Though we are not seeing any improvement / regression in benchmarks. Probably this is because
these locks are not contended anyway in libpas because libpas is designed to be extremely scalable (by deploying per-page locking when
it is contended).

[1]: <a href="https://opensource.apple.com/source/libplatform/libplatform-220.100.1/private/os/lock_private.h">https://opensource.apple.com/source/libplatform/libplatform-220.100.1/private/os/lock_private.h</a>

* Source/bmalloc/libpas/src/libpas/pas_lock.h:
(pas_lock_lock):

Canonical link: <a href="https://commits.webkit.org/281849@main">https://commits.webkit.org/281849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7102e9dcdefcdd49ebd8f02ce62eafe3ee36335b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61112 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11661 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49406 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8112 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10573 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54216 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66787 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60360 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56972 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4190 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82115 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9208 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36277 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14322 "Found 1465 new JSC stress test failures: microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-medium.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-small.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm.js.no-cjit-validate-phases, microbenchmarks/wasm-cc-int-to-int.js.default-wasm, stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->