### PR TITLE
WC shouldn't require ENABLE_WEBGL

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -348,7 +348,7 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
     // RemoteGraphicsContextsGL objects are unneeded after connection closes.
     m_remoteGraphicsContextGLMap.clear();
 #endif
-#if USE(GRAPHICS_LAYER_WC)
+#if USE(GRAPHICS_LAYER_WC) && ENABLE(WEBGL)
     remoteGraphicsContextGLStreamWorkQueue().dispatch([webProcessIdentifier = m_webProcessIdentifier] {
         WCContentBufferManager::singleton().removeAllContentBuffersForProcess(webProcessIdentifier);
     });

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -30,6 +30,10 @@
 #include "PlayStationWebView.h"
 #include "WebPageProxy.h"
 
+#if USE(GRAPHICS_LAYER_WC)
+#include "DrawingAreaProxyWC.h"
+#endif
+
 namespace WebKit {
 
 PageClientImpl::PageClientImpl(PlayStationWebView& view)
@@ -40,6 +44,12 @@ PageClientImpl::PageClientImpl(PlayStationWebView& view)
 // PageClient's pure virtual functions
 std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy&)
 {
+#if USE(GRAPHICS_LAYER_WC)
+    if (m_view.page()->preferences().useGPUProcessForDOMRenderingEnabled()
+        || m_view.page()->preferences().useGPUProcessForCanvasRenderingEnabled()
+        || m_view.page()->preferences().useGPUProcessForWebGLEnabled())
+        return makeUnique<DrawingAreaProxyWC>(*m_view.page());
+#endif
     return makeUnique<DrawingAreaProxyCoordinatedGraphics>(*m_view.page());
 }
 
@@ -186,6 +196,13 @@ RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy&  pa
     notImplemented();
     return { };
 }
+
+#if USE(GRAPHICS_LAYER_WC)
+bool PageClientImpl::usesOffscreenRendering() const
+{
+    return false;
+}
+#endif
 
 void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& context)
 {

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -109,6 +109,10 @@ private:
     void exitAcceleratedCompositingMode() override;
     void updateAcceleratedCompositingMode(const LayerTreeContext&) override;
 
+#if USE(GRAPHICS_LAYER_WC)
+    bool usesOffscreenRendering() const override;
+#endif
+
     // Auxiliary Client Creation
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxyClient& fullScreenManagerProxyClient() override;

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -586,8 +586,10 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
     }
     if (update.changes & WCLayerChange::PlatformLayer) {
         update.hasPlatformLayer = m_platformLayer;
+#if ENABLE(WEBGL)
         if (m_platformLayer)
             update.contentBufferIdentifiers = static_cast<WCPlatformLayerGCGL*>(m_platformLayer)->takeContentBufferIdentifiers();
+#endif
     }
     m_observer->commitLayerUpateInfo(WTFMove(update));
 }


### PR DESCRIPTION
#### c4e0c5d7fd48af4a730c69902c84871d275b6d88
<pre>
WC shouldn&apos;t require ENABLE_WEBGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=245188">https://bugs.webkit.org/show_bug.cgi?id=245188</a>

Reviewed by Fujii Hironori.

Make it so `USE(GRAPHICS_LAYER_WC)` can work without `ENABLE(WEBGL)`.
Guard `ENABLE(WEBGL)` usage and add a single `StreamConnectionWorkQueue`
to submit commands to. This is done due to thread safety issues with
ANGLE.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:

Canonical link: <a href="https://commits.webkit.org/259825@main">https://commits.webkit.org/259825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b330e51e67a3b7e2f2061659d005df6b5f424171

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/105912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/14980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/38758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115106 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/16398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6171 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/114859 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/111662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40028 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/81691 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28448 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/8726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5034 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/47988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/6797 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10279 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->