### PR TITLE
Add option for presenting the web view share sheet modally

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -29,6 +29,7 @@
 
 #import <CoreSVG/CGSVGDocument.h>
 #import <UIKit/NSTextAlternatives.h>
+#import <UIKit/UIActivityViewController_Private.h>
 #import <UIKit/UIAlertController_Private.h>
 #import <UIKit/UIApplication_Private.h>
 #import <UIKit/UIBarButtonItem_Private.h>
@@ -735,6 +736,10 @@ typedef enum {
 - (void)setOperation:(UINavigationControllerOperation)operation;
 @optional
 - (UIWindow *)window;
+@end
+
+@interface UIActivityViewController ()
+@property (nonatomic) BOOL allowsCustomPresentationStyle;
 @end
 
 typedef NS_ENUM (NSInteger, _UIBackdropMaskViewFlags) {

--- a/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm
@@ -46,6 +46,10 @@
 #import <pal/spi/mac/NSSharingServicePickerSPI.h>
 #endif
 
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
+#include <WebKitAdditions/WKShareSheetAdditions.h>
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 
 @interface WKShareSheetFileItemProvider : UIActivityItemProvider
@@ -251,12 +255,20 @@ static void appendFilesAsShareableURLs(RetainPtr<NSMutableArray>&& shareDataArra
             [self dismiss];
     }];
 
-    UIPopoverPresentationController *popoverController = [_shareSheetViewController popoverPresentationController];
-    if (rect) {
-        popoverController.sourceView = webView;
-        popoverController.sourceRect = *rect;
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
+    if (shareSheetUsesModalPresentationForWebView(webView)) {
+        [_shareSheetViewController setAllowsCustomPresentationStyle:YES];
+        [_shareSheetViewController setModalPresentationStyle:UIModalPresentationFormSheet];
     } else
-        popoverController._centersPopoverIfSourceViewNotSet = YES;
+#endif // HAVE(UIKIT_WEBKIT_INTERNALS)
+    {
+        UIPopoverPresentationController *popoverController = [_shareSheetViewController popoverPresentationController];
+        if (rect) {
+            popoverController.sourceView = webView;
+            popoverController.sourceRect = *rect;
+        } else
+            popoverController._centersPopoverIfSourceViewNotSet = YES;
+    }
 
     if ([_delegate respondsToSelector:@selector(shareSheet:willShowActivityItems:)])
         [_delegate shareSheet:self willShowActivityItems:sharingItems];


### PR DESCRIPTION
#### c7c7e5c69bfd68ec6076e583c35bb8b6f13dc689
<pre>
Add option for presenting the web view share sheet modally
<a href="https://bugs.webkit.org/show_bug.cgi?id=246376">https://bugs.webkit.org/show_bug.cgi?id=246376</a>
rdar://101050446

Reviewed by Aditya Keerthi.

Add an option to present the web view&apos;s share sheet modally instead of as a
popover.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/Cocoa/WKShareSheet.mm:
(-[WKShareSheet presentWithShareDataArray:inRect:]):

Canonical link: <a href="https://commits.webkit.org/255794@main">https://commits.webkit.org/255794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b186622645b0b21113e1f79aeaa9538950372a31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103183 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2733 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31013 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99266 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1927 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79973 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28976 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71930 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37393 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18711 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4005 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41233 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37938 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->