### PR TITLE
Webkit pr should have an option not to create a commit

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.18',
+    version='5.6.19',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 18)
+version = Version(5, 6, 19)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -309,6 +309,7 @@ class Git(Scm):
         'webkitscmpy.history': ['when-user-owned', 'disabled', 'always', 'never'],
         'webkitscmpy.update-fork': ['true', 'false'],
         'webkitscmpy.auto-check': ['true', 'false'],
+        'webkitscmpy.auto-create-commit': ['true', 'false'],
     }
     CONFIG_LOCATIONS = ['global', 'repository', 'project']
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -78,6 +78,12 @@ class PullRequest(Command):
             help='When creating a pull request, append a new commit on the existing branch by default',
         )
         parser.add_argument(
+            '--commit', '--no-commit',
+            dest='commit', default=None,
+            help='When creating a pull request, create (or do not create) a commit from the set of staged changes',
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
             '--with-history', '--no-history',
             dest='history', default=None,
             help='Create numbered branches to track the history of a change',
@@ -545,9 +551,12 @@ class PullRequest(Command):
         if not branch_point:
             return 1
 
-        result = cls.create_commit(args, repository, **kwargs)
-        if result:
-            return result
+        if args.commit is None:
+            args.commit = repository.config().get('webkitscmpy.auto-create-commit') == 'true'
+        if args.commit:
+            result = cls.create_commit(args, repository, **kwargs)
+            if result:
+                return result
         if args.squash:
             result = Squash.squash_commit(args, repository, branch_point, **kwargs)
             if result:


### PR DESCRIPTION
#### 72ad3b19fdd6da90481ada9144e3e4e5fd5cad56
<pre>
Webkit pr should have an option not to create a commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=246380">https://bugs.webkit.org/show_bug.cgi?id=246380</a>
&lt;rdar://problem/101060897&gt;

Reviewed by Jonathan Bedard.

Canonical link: <a href="https://commits.webkit.org/255495@main">https://commits.webkit.org/255495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e790898fd6d081e2ac644003cbf93026e1bddf46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102383 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1881 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30232 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98541 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1271 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79157 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28194 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/96242 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83188 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36640 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/91709 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34431 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18001 "Found 1 new test failure: http/tests/privateClickMeasurement/store-private-click-measurement-with-source-nonce.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40607 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1737 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37162 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->