### PR TITLE
Increase padding between StreamConnectionBuffer::Header fields

### DIFF
--- a/LayoutTests/ipc/stream-buffer-read-write.html
+++ b/LayoutTests/ipc/stream-buffer-read-write.html
@@ -15,7 +15,7 @@ if (window.IPC) {
     let dataWriteSuccess = false;
 
     const testBytes = Uint8Array.from({length: 16}, (x, i) => i + 0x41);
-    const bufferSize = 48;
+    const bufferSize = 272;
     const streamConnection = IPC.createStreamClientConnection('GPU', bufferSize);
 
     let streamBuffer = streamConnection.streamBuffer();

--- a/LayoutTests/ipc/stream-check-autoreleasepool.html
+++ b/LayoutTests/ipc/stream-check-autoreleasepool.html
@@ -8,7 +8,7 @@ promise_test(async t => {
     if (!window.IPC)
         return;
     const defaultTimeout = 1000;
-    const bufferSize = 100;
+    const bufferSize = 400;
     const streamTesterID = 447;
     for (const processTarget of IPC.processTargets) {
         const streamConnection = IPC.createStreamClientConnection(processTarget, bufferSize);

--- a/LayoutTests/ipc/stream-sync-crash-no-timeout.html
+++ b/LayoutTests/ipc/stream-sync-crash-no-timeout.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 if (window.IPC) { // For compiles with !ENABLE(IPC_TESTING_API)
     const defaultTimeout = 10;
-    const bufferSize = 100;
+    const bufferSize = 400;
     const streamTesterID = 4557;
     for (const processTarget of IPC.processTargets) {
         if (processTarget == "UI")

--- a/LayoutTests/ipc/stream-sync-reply-shared-memory.html
+++ b/LayoutTests/ipc/stream-sync-reply-shared-memory.html
@@ -7,7 +7,7 @@
 setup({ single_test: true });
 if (window.IPC) { // For compiles with !ENABLE(IPC_TESTING_API)
     const defaultTimeout = 1000;
-    const bufferSize = 100;
+    const bufferSize = 400;
     const streamTesterID = 447;
     for (const processTarget of IPC.processTargets) {
         const streamConnection = IPC.createStreamClientConnection(processTarget, bufferSize);

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -125,8 +125,12 @@ private:
         Atomic<ServerOffset> serverOffset;
         // Padding so that the variables mostly accessed by different processes do not share a cache line.
         // This is an attempt to avoid cache-line induced reduction of parallel access.
-        alignas(sizeof(uint64_t[2])) Atomic<ClientOffset> clientOffset;
+        // Use 128 bytes since that's the cache line size on ARM64, and enough to cover other platforms where 64 bytes is common.
+        alignas(128) Atomic<ClientOffset> clientOffset;
     };
+
+#undef HEADER_POINTER_ALIGNMENT
+
     Header& header() const { return *reinterpret_cast<Header*>(m_sharedMemory->data()); }
     static constexpr size_t headerSize() { return roundUpToMultipleOf<alignof(std::max_align_t)>(sizeof(Header)); }
 


### PR DESCRIPTION
#### b9d35939c4a289e7bfcb9016739ade102d262f1c
<pre>
Increase padding between StreamConnectionBuffer::Header fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=246390">https://bugs.webkit.org/show_bug.cgi?id=246390</a>
&lt;rdar://problem/101063947&gt;

Reviewed by Kimmo Kinnunen.

If these fields should be on separate CPU cache lines, the alignment of
the second field needs to be at least 128 bytes on ARM64. It&apos;s 64 bytes
on some other architectures (including x86_64), but we use 128
everywhere for simplicity.

* LayoutTests/ipc/stream-buffer-read-write.html:
* LayoutTests/ipc/stream-check-autoreleasepool.html:
* LayoutTests/ipc/stream-sync-crash-no-timeout.html:
* LayoutTests/ipc/stream-sync-reply-shared-memory.html:
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:

Canonical link: <a href="https://commits.webkit.org/255469@main">https://commits.webkit.org/255469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9251ed0d22ccfdab95ad2e02962b7592f04fd40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102339 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1826 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30186 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98502 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1228 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79104 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28158 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36594 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34382 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3792 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40568 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37115 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->