### PR TITLE
Validate width, height, x and y for I420 and NV12 video frames

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -16,7 +16,7 @@ PASS Test visibleRect metadata override where source display width = 2 * visible
 PASS Test visibleRect metadata override where source display size = 2 * visible size for both width and height
 FAIL Test visibleRect + display size metadata override Can't find variable: OffscreenCanvas
 FAIL Test display size metadata override Can't find variable: OffscreenCanvas
-FAIL Test invalid buffer constructed VideoFrames assert_throws_js: odd coded height function "() => constructFrame({timestamp: 1234, codedWidth: 4, codedHeight: 1})" did not throw
+PASS Test invalid buffer constructed VideoFrames
 PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
 PASS Test ArrayBuffer constructed I420 VideoFrame
 PASS Test planar constructed I420 VideoFrame with colorSpace

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
@@ -16,7 +16,7 @@ PASS Test visibleRect metadata override where source display width = 2 * visible
 PASS Test visibleRect metadata override where source display size = 2 * visible size for both width and height
 FAIL Test visibleRect + display size metadata override Can't find variable: OffscreenCanvas
 FAIL Test display size metadata override Can't find variable: OffscreenCanvas
-FAIL Test invalid buffer constructed VideoFrames assert_throws_js: odd coded height function "() => constructFrame({timestamp: 1234, codedWidth: 4, codedHeight: 1})" did not throw
+PASS Test invalid buffer constructed VideoFrames
 PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
 PASS Test ArrayBuffer constructed I420 VideoFrame
 PASS Test planar constructed I420 VideoFrame with colorSpace

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -180,17 +180,25 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(BufferSource&&
         return Exception { TypeError, makeString("Data is too small ", data.length(), " / ", layout.allocationSize) };
     
     RefPtr<VideoFrame> videoFrame;
-    if (init.format == VideoPixelFormat::NV12)
+    if (init.format == VideoPixelFormat::NV12) {
+        if (init.codedWidth % 2 || init.codedHeight % 2)
+            return Exception { TypeError, "coded width or height is odd"_s };
+        if (init.visibleRect && (static_cast<size_t>(init.visibleRect->x) % 2 || static_cast<size_t>(init.visibleRect->x) % 2))
+            return Exception { TypeError, "visible x or y is odd"_s };
         videoFrame = VideoFrame::createNV12({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1]);
-    else if (init.format == VideoPixelFormat::RGBA || init.format == VideoPixelFormat::RGBX)
+    } else if (init.format == VideoPixelFormat::RGBA || init.format == VideoPixelFormat::RGBX)
         videoFrame = VideoFrame::createRGBA({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0]);
     else if (init.format == VideoPixelFormat::BGRA || init.format == VideoPixelFormat::BGRX)
         videoFrame = VideoFrame::createBGRA({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0]);
-    else if (init.format == VideoPixelFormat::I420)
+    else if (init.format == VideoPixelFormat::I420) {
+        if (init.codedWidth % 2 || init.codedHeight % 2)
+            return Exception { TypeError, "coded width or height is odd"_s };
+        if (init.visibleRect && (static_cast<size_t>(init.visibleRect->x) % 2 || static_cast<size_t>(init.visibleRect->x) % 2))
+            return Exception { TypeError, "visible x or y is odd"_s };
         videoFrame = VideoFrame::createI420({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2]);
-    else
+    } else
         return Exception { NotSupportedError, "VideoPixelFormat is not supported"_s };
-    
+
     if (!videoFrame)
         return Exception { TypeError, "Unable to create internal resource from data"_s };
     


### PR DESCRIPTION
#### cc18bcb28839ac9d58a7705b6e30b28561e2fcf8
<pre>
Validate width, height, x and y for I420 and NV12 video frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=246394">https://bugs.webkit.org/show_bug.cgi?id=246394</a>
rdar://problem/101068854

Reviewed by Eric Carlson.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):

Canonical link: <a href="https://commits.webkit.org/255489@main">https://commits.webkit.org/255489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abef3519325ba47e99b3e65e461d082e3b5c2574

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102265 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1733 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30103 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98440 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1162 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79014 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28095 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36514 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34294 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17885 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40497 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37039 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->