### PR TITLE
Do not use the CoreAnimation big angle workaround for 2d rotation

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3489,7 +3489,7 @@ static const TransformOperations& transformationAnimationValueAt(const KeyframeV
     return static_cast<const TransformAnimationValue&>(valueList.at(i)).value();
 }
 
-static bool hasBigRotationAngle(const KeyframeValueList& valueList, const SharedPrimitivesPrefix& prefix)
+static bool hasBig3DRotation(const KeyframeValueList& valueList, const SharedPrimitivesPrefix& prefix)
 {
     // Hardware non-matrix animations are used for every function in the shared primitives prefix.
     // These kind of animations have issues with large rotation angles, so for every function that
@@ -3499,7 +3499,7 @@ static bool hasBigRotationAngle(const KeyframeValueList& valueList, const Shared
     const auto& primitives = prefix.primitives();
     for (unsigned animationIndex = 0; animationIndex < primitives.size(); ++animationIndex) {
         auto type = primitives[animationIndex];
-        if (type != TransformOperation::ROTATE && type != TransformOperation::ROTATE_3D)
+        if (type != TransformOperation::ROTATE_3D)
             continue;
         for (size_t i = 1; i < valueList.size(); ++i) {
             // Since the shared primitive at this index is a rotation, both of these transform
@@ -3536,7 +3536,7 @@ bool GraphicsLayerCA::createTransformAnimationsFromKeyframes(const KeyframeValue
     // If this animation has a big rotation between two keyframes, fall back to software animation. CoreAnimation
     // will always take the shortest path between two rotations, which will result in incorrect animation when
     // the keyframes specify angles larger than one half rotation.
-    if (hasBigRotationAngle(valueList, prefix))
+    if (hasBig3DRotation(valueList, prefix))
         return false;
 
     const auto& primitives = prefix.primitives();


### PR DESCRIPTION
#### 2fe23935f668aa88a1b91623645ff85fa9c86d15
<pre>
Do not use the CoreAnimation big angle workaround for 2d rotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=243864">https://bugs.webkit.org/show_bug.cgi?id=243864</a>

Reviewed by Antoine Quint.

This workaround is only necessary for 3d rotation. It seems that large
angles are handled just fine for simpler 2d rotation. In addition to
allowing hardware animation in more cases, this fixes a regression due
to the software fallback path having a bug that prevents proper
rendering of certain animations.

This change does not come with any tests, due to the fact that the
typical technique of setting the animation delay to observe the
rendering in the middle of the animation does not trigger the bug.
In a sense, this change is just a partial revert of the fix from bug
250920.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::hasBig3DRotation):
(WebCore::GraphicsLayerCA::createTransformAnimationsFromKeyframes):
(WebCore::hasBigRotationAngle): Deleted.

Canonical link: <a href="https://commits.webkit.org/255723@main">https://commits.webkit.org/255723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56cad973c39ffcdeaa4f638747e027b511a747a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102976 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163263 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2492 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30799 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99085 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1738 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79749 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28699 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71761 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37186 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17287 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35007 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18534 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3959 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41063 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37753 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->