### PR TITLE
[JSC] Use storage node in ArrayPush for SlowPutArray

### DIFF
--- a/JSTests/stress/slow-put-array-empty-push.js
+++ b/JSTests/stress/slow-put-array-empty-push.js
@@ -1,0 +1,27 @@
+//@ runDefault("--useConcurrentGC=0", "--returnEarlyFromInfiniteLoopsForFuzzing=1", "--earlyReturnFromInfiniteLoopsLimit=1000000", "--verifyGC=true", "--forceGCSlowPaths=true", "--forceEagerCompilation=1", "--jitPolicyScale=0", "--useConcurrentJIT=0")
+function runNearStackLimit() {
+  __v_21 = []
+  try {
+    try {
+        __v_21.push()} catch {}
+  } catch {}
+}
+function __f_6() {
+  try {
+       runNearStackLimit()
+  } catch {}
+}
+try {
+  __f_6()
+  for (__v_19 = 0; __v_19 < 10; ++__v_19)
+    try {
+      Object.defineProperty(Array.prototype, __v_19, {})} catch {}
+} catch {}
+function __f_32() {
+  try {
+    __f_6()
+      } catch {}
+}
+try {
+  __f_32()
+  __f_32()} catch {}

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1437,16 +1437,7 @@ private:
             if (!elementCount)
                 node->setArrayMode(node->arrayMode().refine(m_graph, node, arrayEdge->prediction() & SpecCell, SpecInt32Only));
 
-            switch (node->arrayMode().type()) {
-            case Array::SlowPutArrayStorage: {
-                Edge unusedEdge;
-                blessArrayOperation(arrayEdge, Edge(), unusedEdge, neverNeedsStorage);
-                break;
-            }
-            default:
-                blessArrayOperation(arrayEdge, Edge(), storageEdge);
-                break;
-            }
+            blessArrayOperation(arrayEdge, Edge(), storageEdge);
             fixEdge<KnownCellUse>(arrayEdge);
 
             // Convert `array.push()` to GetArrayLength.


### PR DESCRIPTION
#### 1b4792d4d3661bcde4d66b7be0d02f9b0d506392
<pre>
[JSC] Use storage node in ArrayPush for SlowPutArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=246405">https://bugs.webkit.org/show_bug.cgi?id=246405</a>
rdar://problem/101081844

Reviewed by Justin Michaud.

This patch fixes a bug that GetArrayLength gets nullptr crash when we convert
ArrayPush+SlowPutArray with empty arguments to GetArrayLength because we are discarding
butterfly storage for that case. But since SlowPutArray&apos;s ArrayPush is slow anyway, let&apos;s simplify
our code and always get butterfly storage even for SlowPutArray case.

* JSTests/stress/slow-put-array-empty-push.js: Added.
(runNearStackLimit):
(__f_6):
(__f_32):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayPush):

Canonical link: <a href="https://commits.webkit.org/255454@main">https://commits.webkit.org/255454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1967bbd40e44f11e79afceb4420d263f3d924df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102311 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1781 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30148 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98475 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1199 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79063 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28130 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36559 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/78975 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17923 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38211 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81595 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37080 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18454 "Passed tests") | 
<!--EWS-Status-Bubble-End-->