### PR TITLE
re-land r255421@main

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8526,7 +8526,7 @@ std::optional<PageIdentifier> Document::pageID() const
 
 std::optional<FrameIdentifier> Document::frameID() const
 {
-    return m_frame ? m_frame->loader().frameID() : std::nullopt;
+    return m_frame ? std::optional<FrameIdentifier>(m_frame->loader().frameID()) : std::nullopt;
 }
 
 void Document::registerArticleElement(Element& article)

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -766,11 +766,11 @@ void InspectorFrontendHost::didShowExtensionTab(const String& extensionID, const
     if (!m_client)
         return;
 
-    Frame* frame = extensionFrameElement.contentFrame();
+    auto* frame = extensionFrameElement.contentFrame();
     if (!frame)
         return;
 
-    m_client->didShowExtensionTab(extensionID, extensionTabID, valueOrDefault(frame->frameID()));
+    m_client->didShowExtensionTab(extensionID, extensionTabID, frame->frameID());
 }
 
 void InspectorFrontendHost::didHideExtensionTab(const String& extensionID, const String& extensionTabID)

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -128,7 +128,7 @@
 #endif
 
 #define PAGE_ID ((m_frame ? valueOrDefault(m_frame->pageID()) : PageIdentifier()).toUInt64())
-#define FRAME_ID ((m_frame ? valueOrDefault(m_frame->frameID()).object() : FrameIdentifier().object()).toUInt64())
+#define FRAME_ID ((m_frame ? m_frame->frameID() : FrameIdentifier()).object().toUInt64())
 #define IS_MAIN_FRAME (m_frame ? m_frame->isMainFrame() : false)
 #define DOCUMENTLOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] DocumentLoader::" fmt, this, PAGE_ID, FRAME_ID, IS_MAIN_FRAME, ##__VA_ARGS__)
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -637,11 +637,6 @@ RefPtr<Widget> EmptyFrameLoaderClient::createPlugin(const IntSize&, HTMLPlugInEl
     return nullptr;
 }
 
-std::optional<FrameIdentifier> EmptyFrameLoaderClient::frameID() const
-{
-    return std::nullopt;
-}
-
 std::optional<PageIdentifier> EmptyFrameLoaderClient::pageID() const
 {
     return std::nullopt;

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -33,7 +33,6 @@ class WEBCORE_EXPORT EmptyFrameLoaderClient : public FrameLoaderClient {
 private:
     Ref<DocumentLoader> createDocumentLoader(const ResourceRequest&, const SubstituteData&) override;
 
-    std::optional<FrameIdentifier> frameID() const override;
     std::optional<PageIdentifier> pageID() const override;
 
     bool hasWebView() const final;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -155,7 +155,7 @@
 #endif
 
 #define PAGE_ID (valueOrDefault(pageID()).toUInt64())
-#define FRAME_ID (valueOrDefault(frameID()).object().toUInt64())
+#define FRAME_ID (frameID().object().toUInt64())
 #define FRAMELOADER_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] FrameLoader::" fmt, this, PAGE_ID, FRAME_ID, m_frame.isMainFrame(), ##__VA_ARGS__)
 #define FRAMELOADER_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] FrameLoader::" fmt, this, PAGE_ID, FRAME_ID, m_frame.isMainFrame(), ##__VA_ARGS__)
 
@@ -390,9 +390,9 @@ std::optional<PageIdentifier> FrameLoader::pageID() const
     return client().pageID();
 }
 
-std::optional<FrameIdentifier> FrameLoader::frameID() const
+FrameIdentifier FrameLoader::frameID() const
 {
-    return client().frameID();
+    return m_frame.frameID();
 }
 
 Frame* FrameLoader::opener()

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -216,7 +216,7 @@ public:
     FrameLoaderClient& client() { return m_client.get(); }
 
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
-    WEBCORE_EXPORT std::optional<FrameIdentifier> frameID() const;
+    WEBCORE_EXPORT FrameIdentifier frameID() const;
 
     void setDefersLoading(bool);
 

--- a/Source/WebCore/loader/FrameLoaderClient.h
+++ b/Source/WebCore/loader/FrameLoaderClient.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include "FrameIdentifier.h"
 #include "FrameLoaderTypes.h"
 #include "LayoutMilestone.h"
 #include "LinkIcon.h"
@@ -125,7 +124,6 @@ public:
     virtual void makeRepresentation(DocumentLoader*) = 0;
 
     virtual std::optional<PageIdentifier> pageID() const = 0;
-    virtual std::optional<FrameIdentifier> frameID() const = 0;
 
 #if PLATFORM(IOS_FAMILY)
     // Returns true if the client forced the layout.

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -36,15 +36,15 @@ namespace WebCore {
 
 static std::optional<GlobalFrameIdentifier> createGlobalFrameIdentifier(const Document& document)
 {
-    if (!document.frame())
+    auto* frame = document.frame();
+    if (!frame)
         return std::nullopt;
 
-    auto pageID = document.frame()->loader().pageID();
-    auto frameID = document.frame()->loader().frameID();
-    if (!pageID || !frameID)
+    auto pageID = frame->loader().pageID();
+    if (!pageID)
         return std::nullopt;
 
-    return GlobalFrameIdentifier { *pageID, *frameID };
+    return GlobalFrameIdentifier { *pageID, frame->frameID() };
 }
 
 NavigationRequester NavigationRequester::from(Document& document)

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -56,7 +56,7 @@
 #endif
 
 #define PAGE_ID (valueOrDefault(m_frame.loader().pageID()).toUInt64())
-#define FRAME_ID (valueOrDefault(m_frame.loader().frameID()).object().toUInt64())
+#define FRAME_ID (m_frame.loader().frameID().object().toUInt64())
 #define POLICYCHECKER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Loading, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 "] PolicyChecker::" fmt, this, PAGE_ID, FRAME_ID, ##__VA_ARGS__)
 
 namespace WebCore {

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -71,7 +71,7 @@
 
 #undef RESOURCELOADER_RELEASE_LOG
 #define PAGE_ID ((frame() ? valueOrDefault(frame()->pageID()) : PageIdentifier()).toUInt64())
-#define FRAME_ID ((frame() ? valueOrDefault(frame()->frameID()).object() : FrameIdentifier().object()).toUInt64())
+#define FRAME_ID ((frame() ? frame()->frameID() : FrameIdentifier()).object().toUInt64())
 #define RESOURCELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", frameLoader=%p, resourceID=%" PRIu64 "] ResourceLoader::" fmt, this, PAGE_ID, FRAME_ID, frameLoader(), identifier().toUInt64(), ##__VA_ARGS__)
 
 namespace WebCore {

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -70,7 +70,7 @@
 #undef SUBRESOURCELOADER_RELEASE_LOG
 #undef SUBRESOURCELOADER_RELEASE_LOG_ERROR
 #define PAGE_ID ((frame() ? valueOrDefault(frame()->pageID()) : PageIdentifier()).toUInt64())
-#define FRAME_ID ((frame() ? valueOrDefault(frame()->frameID()).object() : FrameIdentifier().object()).toUInt64())
+#define FRAME_ID ((frame() ? frame()->frameID() : FrameIdentifier()).object().toUInt64())
 #if RELEASE_LOG_DISABLED
 #define SUBRESOURCELOADER_RELEASE_LOG(fmt, ...) UNUSED_VARIABLE(this)
 #define SUBRESOURCELOADER_RELEASE_LOG_ERROR(fmt, ...) UNUSED_VARIABLE(this)

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -65,7 +65,7 @@
 
 #undef CACHEDRESOURCE_RELEASE_LOG
 #define PAGE_ID(frame) (valueOrDefault(frame.pageID()).toUInt64())
-#define FRAME_ID(frame) (valueOrDefault(frame.frameID()).object().toUInt64())
+#define FRAME_ID(frame) (frame.frameID().object().toUInt64())
 #define CACHEDRESOURCE_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - CachedResource::" fmt, this, ##__VA_ARGS__)
 #define CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME(fmt, frame, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 "] CachedResource::" fmt, this, PAGE_ID(frame), FRAME_ID(frame), ##__VA_ARGS__)
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -96,7 +96,7 @@
 
 #undef CACHEDRESOURCELOADER_RELEASE_LOG
 #define PAGE_ID(frame) (valueOrDefault(frame.pageID()).toUInt64())
-#define FRAME_ID(frame) (valueOrDefault(frame.frameID()).object().toUInt64())
+#define FRAME_ID(frame) (frame.frameID().object().toUInt64())
 #define CACHEDRESOURCELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - CachedResourceLoader::" fmt, this, ##__VA_ARGS__)
 #define CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME(fmt, frame, ...) RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 "] CachedResourceLoader::" fmt, this, PAGE_ID(frame), FRAME_ID(frame), ##__VA_ARGS__)
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -164,6 +164,7 @@ Frame::Frame(Page& page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoa
     , m_treeNode(*this, parentFromOwnerElement(ownerElement))
     , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(frameLoaderClient)))
     , m_navigationScheduler(makeUniqueRef<NavigationScheduler>(*this))
+    , m_frameID(FrameIdentifier::generate())
     , m_ownerElement(ownerElement)
     , m_script(makeUniqueRef<ScriptController>(*this))
     , m_pageZoomFactor(parentPageZoomFactor(this))
@@ -719,11 +720,6 @@ void Frame::injectUserScriptsAwaitingNotification()
 std::optional<PageIdentifier> Frame::pageID() const
 {
     return loader().pageID();
-}
-
-std::optional<FrameIdentifier> Frame::frameID() const
-{
-    return loader().frameID();
 }
 
 RenderView* Frame::contentRenderer() const

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -167,7 +167,7 @@ public:
     void resetScript();
 
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
-    WEBCORE_EXPORT std::optional<FrameIdentifier> frameID() const;
+    FrameIdentifier frameID() const { return m_frameID; }
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
     WEBCORE_EXPORT RenderWidget* ownerRenderer() const; // Renderer for the element that contains this frame.
@@ -326,6 +326,7 @@ private:
     mutable FrameTree m_treeNode;
     UniqueRef<FrameLoader> m_loader;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
+    const FrameIdentifier m_frameID;
 
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
     RefPtr<FrameView> m_view;

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -145,7 +145,7 @@
 #include "LayoutContext.h"
 
 #define PAGE_ID valueOrDefault(frame().pageID()).toUInt64()
-#define FRAME_ID valueOrDefault(frame().frameID()).object().toUInt64()
+#define FRAME_ID frame().frameID().object().toUInt64()
 #define FRAMEVIEW_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] FrameView::" fmt, this, PAGE_ID, FRAME_ID, frame().isMainFrame(), ##__VA_ARGS__)
 
 namespace WebCore {

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2868,7 +2868,7 @@ bool Internals::isElementAlive(uint64_t elementIdentifier) const
 uint64_t Internals::frameIdentifier(const Document& document) const
 {
     if (auto* page = document.page())
-        return valueOrDefault(page->mainFrame().loader().frameID()).object().toUInt64();
+        return page->mainFrame().loader().frameID().object().toUInt64();
     return 0;
 }
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -118,7 +118,7 @@ void WebLoaderStrategy::loadResource(Frame& frame, CachedResource& resource, Res
         if (loader)
             scheduleLoad(*loader, resource.get(), referrerPolicy == ReferrerPolicy::NoReferrerWhenDowngrade);
         else
-            RELEASE_LOG(Network, "%p - [webPageID=%" PRIu64 ", frameID=%" PRIu64 "] WebLoaderStrategy::loadResource: Unable to create SubresourceLoader", this, valueOrDefault(frame->pageID()).toUInt64(), valueOrDefault(frame->frameID()).object().toUInt64());
+            RELEASE_LOG(Network, "%p - [webPageID=%" PRIu64 ", frameID=%" PRIu64 "] WebLoaderStrategy::loadResource: Unable to create SubresourceLoader", this, valueOrDefault(frame->pageID()).toUInt64(), frame->frameID().object().toUInt64());
         completionHandler(WTFMove(loader));
     });
 }
@@ -176,7 +176,9 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
     auto identifier = resourceLoader.identifier();
     ASSERT(identifier);
 
-    auto& frameLoaderClient = resourceLoader.frameLoader()->client();
+    auto* frameLoader = resourceLoader.frameLoader();
+    ASSERT(frameLoader);
+    auto& frameLoaderClient = frameLoader->client();
 
     WebResourceLoader::TrackingParameters trackingParameters;
     if (auto* webFrameLoaderClient = toWebFrameLoaderClient(frameLoaderClient))
@@ -184,7 +186,7 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
     else if (is<RemoteWorkerFrameLoaderClient>(frameLoaderClient))
         trackingParameters.webPageProxyID = downcast<RemoteWorkerFrameLoaderClient>(frameLoaderClient).webPageProxyID();
     trackingParameters.pageID = valueOrDefault(frameLoaderClient.pageID());
-    trackingParameters.frameID = valueOrDefault(frameLoaderClient.frameID());
+    trackingParameters.frameID = frameLoader->frameID();
     trackingParameters.resourceID = identifier;
 
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp
@@ -31,13 +31,12 @@
 
 namespace WebKit {
 
-RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, const String& userAgent)
+RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, const String& userAgent)
     : m_webPageProxyID(webPageProxyID)
     , m_pageID(pageID)
-    , m_frameID(frameID)
     , m_userAgent(userAgent)
 {
-    RELEASE_LOG(Worker, "RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient webPageProxyID %" PRIu64 ", pageID %" PRIu64 ", frameID  %" PRIu64, webPageProxyID.toUInt64(), pageID.toUInt64(), frameID.object().toUInt64());
+    RELEASE_LOG(Worker, "RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient webPageProxyID %" PRIu64 ", pageID %" PRIu64, webPageProxyID.toUInt64(), pageID.toUInt64());
 }
 
 Ref<WebCore::DocumentLoader> RemoteWorkerFrameLoaderClient::createDocumentLoader(const WebCore::ResourceRequest& request, const WebCore::SubstituteData& substituteData)

--- a/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h
@@ -33,7 +33,7 @@ namespace WebKit {
 
 class RemoteWorkerFrameLoaderClient final : public WebCore::EmptyFrameLoaderClient {
 public:
-    RemoteWorkerFrameLoaderClient(WebPageProxyIdentifier, WebCore::PageIdentifier, WebCore::FrameIdentifier, const String& userAgent);
+    RemoteWorkerFrameLoaderClient(WebPageProxyIdentifier, WebCore::PageIdentifier, const String& userAgent);
 
     WebPageProxyIdentifier webPageProxyID() const { return m_webPageProxyID; }
 
@@ -46,7 +46,6 @@ private:
     Ref<WebCore::DocumentLoader> createDocumentLoader(const WebCore::ResourceRequest&, const WebCore::SubstituteData&) final;
 
     std::optional<WebCore::PageIdentifier> pageID() const final { return m_pageID; }
-    std::optional<WebCore::FrameIdentifier> frameID() const final { return m_frameID; }
 
     bool shouldUseCredentialStorage(WebCore::DocumentLoader*, WebCore::ResourceLoaderIdentifier) final { return true; }
     bool isRemoteWorkerFrameLoaderClient() const final { return true; }
@@ -55,7 +54,6 @@ private:
 
     WebPageProxyIdentifier m_webPageProxyID;
     WebCore::PageIdentifier m_pageID;
-    WebCore::FrameIdentifier m_frameID;
     String m_userAgent;
     std::optional<WebCore::ScriptExecutionContextIdentifier> m_serviceWorkerPageIdentifier;
 };

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -160,7 +160,7 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
         if (effectiveUserAgent.isNull())
             effectiveUserAgent = m_userAgent;
 
-        auto loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, FrameIdentifier::generate(), effectiveUserAgent);
+        auto loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, effectiveUserAgent);
         if (contextData.serviceWorkerPageIdentifier)
             loaderClientForMainFrame->setServiceWorkerPageIdentifier(*contextData.serviceWorkerPageIdentifier);
         pageConfiguration.loaderClientForMainFrame = WTFMove(loaderClientForMainFrame);

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -104,7 +104,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     pageConfiguration.webRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif
 
-    pageConfiguration.loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, WebCore::FrameIdentifier::generate(), m_userAgent);
+    pageConfiguration.loaderClientForMainFrame = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, m_userAgent);
 
     auto page = makeUniqueRef<WebCore::Page>(WTFMove(pageConfiguration));
     if (m_preferencesStore) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -137,11 +137,6 @@ std::optional<PageIdentifier> WebFrameLoaderClient::pageID() const
     return std::nullopt;
 }
 
-std::optional<FrameIdentifier> WebFrameLoaderClient::frameID() const
-{
-    return m_frame->frameID();
-}
-
 #if ENABLE(TRACKING_PREVENTION)
 void WebFrameLoaderClient::setHasFrameSpecificStorageAccess(FrameSpecificStorageAccessIdentifier&& frameSpecificStorageAccessIdentifier )
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -27,6 +27,7 @@
 
 #include "SameDocumentNavigationType.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/FrameLoaderClient.h>
 #include <pal/SessionID.h>
 
@@ -51,7 +52,6 @@ public:
 
     std::optional<WebPageProxyIdentifier> webPageProxyID() const;
     std::optional<WebCore::PageIdentifier> pageID() const final;
-    std::optional<WebCore::FrameIdentifier> frameID() const final;
 
 #if ENABLE(TRACKING_PREVENTION)
     bool hasFrameSpecificStorageAccess() final { return !!m_frameSpecificStorageAccessIdentifier; }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -108,6 +108,10 @@ static uint64_t generateListenerID()
 
 void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame)
 {
+    ASSERT(!m_frameID);
+    m_frameID = coreFrame.frameID();
+    WebProcess::singleton().addWebFrame(frameID(), this);
+
     page.send(Messages::WebPageProxy::DidCreateMainFrame(frameID()));
 
     m_coreFrame = coreFrame;
@@ -118,10 +122,13 @@ void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame)
 Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const AtomString& frameName, HTMLFrameOwnerElement* ownerElement)
 {
     auto frame = create(page);
-    page.send(Messages::WebPageProxy::DidCreateSubframe(frame->frameID(), parent.frameID()));
-
     auto coreFrame = Frame::create(page.corePage(), ownerElement, makeUniqueRef<WebFrameLoaderClient>(frame.get()));
     frame->m_coreFrame = coreFrame;
+
+    ASSERT(!frame->m_frameID);
+    frame->m_frameID = coreFrame->frameID();
+    WebProcess::singleton().addWebFrame(coreFrame->frameID(), frame.ptr());
+    page.send(Messages::WebPageProxy::DidCreateSubframe(coreFrame->frameID(), parent.frameID()));
 
     coreFrame->tree().setName(frameName);
     if (ownerElement) {
@@ -135,10 +142,7 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
 
 WebFrame::WebFrame(WebPage& page)
     : m_page(page)
-    , m_frameID(FrameIdentifier::generate())
 {
-    WebProcess::singleton().addWebFrame(m_frameID, this);
-
 #ifndef NDEBUG
     webFrameCounter.increment();
 #endif
@@ -197,16 +201,22 @@ FrameInfoData WebFrame::info() const
         ResourceRequest(url()),
         SecurityOriginData::fromFrame(m_coreFrame.get()),
         m_coreFrame ? m_coreFrame->tree().name().string() : String(),
-        m_frameID,
+        frameID(),
         parent ? std::optional<WebCore::FrameIdentifier> { parent->frameID() } : std::nullopt,
     };
 
     return info;
 }
 
+WebCore::FrameIdentifier WebFrame::frameID() const
+{
+    ASSERT(m_frameID);
+    return m_frameID;
+}
+
 void WebFrame::invalidate()
 {
-    WebProcess::singleton().removeWebFrame(m_frameID, m_page ? std::optional<WebPageProxyIdentifier>(m_page->webPageProxyIdentifier()) : std::nullopt);
+    WebProcess::singleton().removeWebFrame(frameID(), m_page ? std::optional<WebPageProxyIdentifier>(m_page->webPageProxyIdentifier()) : std::nullopt);
     m_coreFrame = 0;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -85,7 +85,7 @@ public:
     WebCore::Frame* coreFrame() const;
 
     FrameInfoData info() const;
-    WebCore::FrameIdentifier frameID() const { return m_frameID; }
+    WebCore::FrameIdentifier frameID() const;
 
     enum class ForNavigationAction { No, Yes };
     uint64_t setUpPolicyListener(WebCore::PolicyCheckIdentifier, WebCore::FramePolicyFunction&&, ForNavigationAction);
@@ -216,7 +216,7 @@ private:
     std::optional<DownloadID> m_policyDownloadID;
 
     WeakPtr<LoadListener> m_loadListener;
-    
+
     WebCore::FrameIdentifier m_frameID;
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -68,7 +68,6 @@ private:
     bool hasWebView() const final; // mainly for assertions
 
     std::optional<WebCore::PageIdentifier> pageID() const final;
-    std::optional<WebCore::FrameIdentifier> frameID() const final;
 
     void makeRepresentation(WebCore::DocumentLoader*) final;
     bool hasHTMLView() const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -203,11 +203,6 @@ std::optional<WebCore::PageIdentifier> WebFrameLoaderClient::pageID() const
     return std::nullopt;
 }
 
-std::optional<WebCore::FrameIdentifier> WebFrameLoaderClient::frameID() const
-{
-    return std::nullopt;
-}
-
 WebFrameLoaderClient::~WebFrameLoaderClient()
 {
     [m_webFrame.get() _clearCoreFrame];

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -117,11 +117,6 @@ std::optional<WebCore::PageIdentifier> WebFrameLoaderClient::pageID() const
     return std::nullopt;
 }
 
-std::optional<WebCore::FrameIdentifier> WebFrameLoaderClient::frameID() const
-{
-    return std::nullopt;
-}
-
 bool WebFrameLoaderClient::hasWebView() const
 {
     return m_webFrame->webView();

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.h
@@ -45,7 +45,6 @@ public:
     WebFrame* webFrame() const { return m_webFrame; }
 
     std::optional<WebCore::PageIdentifier> pageID() const final;
-    std::optional<WebCore::FrameIdentifier> frameID() const final;
 
     bool hasWebView() const override;
 


### PR DESCRIPTION
#### 0436378205460edb8877d57eb930613045fe19c9
<pre>
re-land r255421@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=246411">https://bugs.webkit.org/show_bug.cgi?id=246411</a>
rdar://101085321

Reviewed by Tim Horton.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::frameID const):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::didShowExtensionTab):
* Source/WebCore/loader/DocumentLoader.cpp:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::frameID const): Deleted.
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::frameID const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/FrameLoaderClient.h:
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::createGlobalFrameIdentifier):
* Source/WebCore/loader/PolicyChecker.cpp:
* Source/WebCore/loader/ResourceLoader.cpp:
* Source/WebCore/loader/SubresourceLoader.cpp:
* Source/WebCore/loader/cache/CachedResource.cpp:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
(WebCore::Frame::frameID const): Deleted.
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameView.cpp:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::frameIdentifier const):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResource):
(WebKit::WebLoaderStrategy::scheduleLoad):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.cpp:
(WebKit::RemoteWorkerFrameLoaderClient::RemoteWorkerFrameLoaderClient):
* Source/WebKit/WebProcess/Storage/RemoteWorkerFrameLoaderClient.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::frameID const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::initWithCoreMainFrame):
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::WebFrame):
(WebKit::WebFrame::info const):
(WebKit::WebFrame::frameID const):
(WebKit::WebFrame::invalidate):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
(WebKit::WebFrame::frameID const): Deleted.
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::frameID const): Deleted.
* Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebFrameLoaderClient::frameID const): Deleted.
* Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.h:

Canonical link: <a href="https://commits.webkit.org/255448@main">https://commits.webkit.org/255448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75b55975ece1de22bde53c3aa0d1cfba73aa2050

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23155 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/102313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1783 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30150 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84975 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79065 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36561 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34343 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38213 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1718 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37083 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->