### PR TITLE
[Live Range Selection] Some tests fail due to DeleteSelectionCommand not canonicalizing ending selection

### DIFF
--- a/LayoutTests/editing/deleting/delete-br-in-last-table-cell-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/delete-br-in-last-table-cell-live-range-expected.txt
@@ -1,0 +1,55 @@
+| <html>
+|   <!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+|   <head>
+|     "\n"
+|     <script>
+|       language="JavaScript"
+|       src="../../resources/dump-as-markup.js"
+|       type="text/JavaScript"
+|     "\n"
+|     <script>
+|       language="JavaScript"
+|       src="../editing.js"
+|       type="text/JavaScript"
+|     "\n"
+|     <script>
+|       "\nfunction runTest()\n{\n    br = document.getElementById("lastBR");\n    sel = window.getSelection();\n    sel.setBaseAndExtent(br, 0, br, 0);\n    deleteCommand();\n}\n"
+|     "\n"
+|   "\n\n"
+|   <body>
+|     "\n"
+|     <p>
+|       <a>
+|         href="https://bugs.webkit.org/show_bug.cgi?id=35369"
+|         "Bug 35369"
+|       " and "
+|       <a>
+|         href="https://bugs.webkit.org/show_bug.cgi?id=35632"
+|         "Bug 35632"
+|     "\n"
+|     <p>
+|       "Executing a delete command when positioned before a BR in a table cell (esp. the last)"
+|     "\n"
+|     <div>
+|       contenteditable=""
+|       "\n"
+|       <table>
+|         id="table"
+|         <tbody>
+|           <tr>
+|             <td>
+|               "1"
+|             <td>
+|               "2"
+|           <tr>
+|             <td>
+|               "3"
+|             <td>
+|               "4<#selection-caret>"
+|               <br>
+|                 id="lastBR"
+|       "\n"
+|     "\n"
+|     <script>
+|       "\nrunTest();\n"
+|     "\n\n\n"

--- a/LayoutTests/editing/deleting/delete-br-in-last-table-cell-live-range.html
+++ b/LayoutTests/editing/deleting/delete-br-in-last-table-cell-live-range.html
@@ -1,0 +1,26 @@
+<html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<head>
+<script src=../../resources/dump-as-markup.js language="JavaScript" type="text/JavaScript" ></script>
+<script src=../editing.js language="JavaScript" type="text/JavaScript" ></script>
+<script>
+function runTest()
+{
+    br = document.getElementById("lastBR");
+    sel = window.getSelection();
+    sel.setBaseAndExtent(br, 0, br, 0);
+    deleteCommand();
+}
+</script>
+</head>
+
+<body>
+<p><a href="https://bugs.webkit.org/show_bug.cgi?id=35369">Bug 35369</a> and <a href="https://bugs.webkit.org/show_bug.cgi?id=35632">Bug 35632</a></p>
+<p>Executing a delete command when positioned before a BR in a table cell (esp. the last)</p>
+<div contenteditable>
+<table id="table"><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4<br><br id="lastBR"></td></tr></table>
+</div>
+<script>
+runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/delete-line-break-before-underlined-content-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/delete-line-break-before-underlined-content-live-range-expected.txt
@@ -1,0 +1,5 @@
+This tests for a bug where underlined content would lose its underliningwhen deleting the line break before the paragraph that contained it.
+| "This shouldn't be underlined.<#selection-caret>"
+| <span>
+|   style="text-decoration: underline;"
+|   "This should be underlined."

--- a/LayoutTests/editing/deleting/delete-line-break-before-underlined-content-live-range.html
+++ b/LayoutTests/editing/deleting/delete-line-break-before-underlined-content-live-range.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<div id="container" contenteditable="true">This shouldn't be underlined.<div id="div" style="text-decoration: underline;">This should be underlined.</div></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+var div = document.getElementById("div");
+var range = document.createRange();
+range.setStart(div, 0);
+range.setEnd(div, 0);
+var sel = window.getSelection();
+sel.addRange(range);
+document.execCommand("Delete", false, null);
+
+Markup.description('This tests for a bug where underlined content would lose its underlining' +
+    'when deleting the line break before the paragraph that contained it.');
+
+Markup.dump('container');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/delete-line-break-between-paragraphs-with-same-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/delete-line-break-between-paragraphs-with-same-style-live-range-expected.txt
@@ -1,0 +1,11 @@
+This tests deleting a line break between paragraphs with the same inline style. Inline style should be preserved after the merge.
+| "\n"
+| <div>
+|   <font>
+|     class="Apple-style-span"
+|     face="monospace"
+|     "hello world<#selection-caret>"
+|   <span>
+|     style="font-family: monospace;"
+|     "WebKit"
+| "\n"

--- a/LayoutTests/editing/deleting/delete-line-break-between-paragraphs-with-same-style-live-range.html
+++ b/LayoutTests/editing/deleting/delete-line-break-between-paragraphs-with-same-style-live-range.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<div id="test" contenteditable>
+<div><font class="Apple-style-span" face="monospace">hello world</font></div><div><font class="Apple-style-span" face="monospace">WebKit</font></div>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+Markup.description('This tests deleting a line break between paragraphs with the same inline style.'
++ ' Inline style should be preserved after the merge.');
+
+document.getElementById('test').focus();
+window.getSelection().modify('move', 'forward', 'line');
+document.execCommand('Delete');
+
+Markup.dump('test');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/delete-table-cell-contents-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/delete-table-cell-contents-live-range-expected.txt
@@ -1,0 +1,14 @@
+This tests for a crash when deleting the contents of a table cell. Below, you should only see one link, 'Cached', pointing to 'fakelink.html', inside of a table. <radr://problem/5156801>
+| <table>
+|   border="0"
+|   cellpadding="0"
+|   cellspacing="0"
+|   id="table"
+|   <tbody>
+|     <tr>
+|       <td>
+|         <br>
+|         <a>
+|           href="fakelink.html"
+|           "Cached<#selection-caret>"
+| "\n"

--- a/LayoutTests/editing/deleting/delete-table-cell-contents-live-range.html
+++ b/LayoutTests/editing/deleting/delete-table-cell-contents-live-range.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<p id="description">This tests for a crash when deleting the contents of a table cell. Below, you should only see one link, 'Cached', pointing to 'fakelink.html', inside of a table. <a href="radr://problem/5156801">&lt;radr://problem/5156801&gt;</a></p>
+<div id="test" contenteditable="true"><table id="table" border=0 cellpadding=0 cellspacing=0><tr><td><br><a  href="fakelink.html">Cached</a><a  href=""fakelink.html">Similar</a></td></tr></table>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+s = window.getSelection();
+table = document.getElementById("table");
+s.setPosition(table, table.childNodes.length);
+s.modify("move", "backward", "character");
+document.execCommand("Delete");
+document.execCommand("Delete");
+document.execCommand("Delete");
+document.execCommand("Delete");
+document.execCommand("Delete");
+document.execCommand("Delete");
+document.execCommand("Delete");
+Markup.description(description.textContent);
+Markup.dump("test");
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/deleting-line-break-preserves-underline-color-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/deleting-line-break-preserves-underline-color-live-range-expected.txt
@@ -1,0 +1,17 @@
+This test for a bug moving a paragraph of underlined text.  The text should look the same before and after the deletion.
+
+Before:
+| <div>
+|   "This should not be underlined."
+| <span>
+|   style="text-decoration: underline; color: blue;"
+|   <span>
+|     style="color:red;"
+|     "This should be underlined."
+
+After:
+| <div>
+|   "This should not be underlined.<#selection-caret>"
+|   <span>
+|     style="color: red; text-decoration: underline;"
+|     "This should be underlined."

--- a/LayoutTests/editing/deleting/deleting-line-break-preserves-underline-color-live-range.html
+++ b/LayoutTests/editing/deleting/deleting-line-break-preserves-underline-color-live-range.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<div id="div" contenteditable="true"><div>This should not be underlined.</div><span style="text-decoration: underline; color: blue;"><span style="color:red;">This should be underlined.</span></span></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description("This test for a bug moving a paragraph of underlined text.  The text should look the same before and after the deletion.");
+
+var div = document.getElementById("div");
+var sel = window.getSelection();
+
+Markup.dump('div', 'Before');
+
+sel.setPosition(div, 0);
+sel.modify("move", "forward", "paragraphBoundary");
+sel.modify("move", "forward", "character");
+document.execCommand("Delete");
+
+Markup.dump('div', 'After');
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-div-from-span-with-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-div-from-span-with-style-live-range-expected.txt
@@ -1,0 +1,8 @@
+The span style should be preserved when merging div element.
+The test passes if "bar" contatins the yellow background and it's underlined.
+| "\n"
+| <div>
+|   "foo<#selection-caret>"
+|   <span>
+|     style="background-color: yellow; text-decoration: underline;"
+|     "bar"

--- a/LayoutTests/editing/deleting/merge-div-from-span-with-style-live-range.html
+++ b/LayoutTests/editing/deleting/merge-div-from-span-with-style-live-range.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<style type="text/css">
+.NonInheritableProperties {
+background-color: yellow;
+text-decoration: underline;
+}
+</style>
+</head>
+<body>
+<div id="test" contenteditable="true">
+<div>foo</div>
+<span id="spanToMerge" class="NonInheritableProperties">bar</span>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description('The span style should be preserved when merging div element.\n'
+    + 'The test passes if "bar" contatins the yellow background and it\'s underlined.');
+
+var spanToMerge = document.getElementById("spanToMerge");
+spanToMerge.focus();
+getSelection().collapse(spanToMerge, 0);
+document.execCommand("Delete");
+Markup.dump(document.getElementById("test"));
+</script>
+ </body>
+</html>

--- a/LayoutTests/editing/deleting/merge-div-with-inline-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-div-with-inline-style-live-range-expected.txt
@@ -1,0 +1,9 @@
+The inline style should be applied when merging div element.
+The test passes if "bar" has the blue color and 20px font-size.
+| "\n"
+| <div>
+|   "foo<#selection-caret>"
+|   <span>
+|     style="color: blue; font-size: 20px;"
+|     "bar"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-div-with-inline-style-live-range.html
+++ b/LayoutTests/editing/deleting/merge-div-with-inline-style-live-range.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<style type="text/css">
+.styleToMerge {
+color: red;
+font-size: 10px;
+}
+</style>
+</head>
+<body>
+<div id="test" contenteditable="true">
+<div>foo</div>
+<div id="divToMerge" class="styleToMerge" style="color:blue;font-size:20px">bar</div>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description('The inline style should be applied when merging div element.\n'
+    + 'The test passes if "bar" has the blue color and 20px font-size.');
+
+var divToMerge = document.getElementById("divToMerge");
+divToMerge.focus();
+getSelection().collapse(divToMerge, 0);
+document.execCommand("Delete");
+Markup.dump(document.getElementById("test"));
+</script>
+ </body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-2-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-2-live-range-expected.txt
@@ -1,0 +1,18 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 5 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 1 of #text > DIV > BODY > HTML > #document to 0 of H6 > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 5 of #text > EM > DIV > BODY > HTML > #document to 5 of #text > EM > DIV > BODY > HTML > #document toDOMRange:range from 5 of #text > EM > DIV > BODY > HTML > #document to 5 of #text > EM > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break before h6.
+WebKit should not cancel styles added by h6 by those of document's default style but still keep "hello" italicized and "world" in red.
+| "\n"
+| <em>
+|   "hello<#selection-caret>"
+| <span>
+|   style="color: red;"
+|   "world"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-2-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-2-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html> 
+<body>
+<p id="description">This tests deleting line break before h6.
+WebKit should not cancel styles added by h6 by those of document's default style but still keep "hello" italicized and "world" in red.</p>
+<div id="test" contenteditable>
+<em>hello</em>
+<h6><font color="blue" style="color:red">world</font></h6>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-live-range-expected.txt
@@ -1,0 +1,18 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 5 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 1 of #text > DIV > BODY > HTML > #document to 0 of H6 > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 5 of #text > EM > DIV > BODY > HTML > #document to 5 of #text > EM > DIV > BODY > HTML > #document toDOMRange:range from 5 of #text > EM > DIV > BODY > HTML > #document to 5 of #text > EM > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break before h6.
+WebKit should not cancel styles added by h6 by those of document's default style but still keep "hello" italicized and "world" in red.
+| "\n"
+| <em>
+|   "hello<#selection-caret>"
+| <span>
+|   style="color: red;"
+|   "world"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html> 
+<body>
+<p id="description">This tests deleting line break before h6.
+WebKit should not cancel styles added by h6 by those of document's default style but still keep "hello" italicized and "world" in red.</p>
+<div id="test" contenteditable>
+<em>hello</em>
+<h6><font color="red">world</font></h6>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-2-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-2-live-range-expected.txt
@@ -1,0 +1,17 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 5 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 0 of P > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 2 of DIV > BODY > HTML > #document to 2 of DIV > BODY > HTML > #document toDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 5 of #text > H1 > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break before p.
+WebKit should not keep the style of p added by a style rule, and "world" should be italic and not be in red.
+| "\n"
+| <h1>
+|   "hello<#selection-caret>"
+|   <i>
+|     "world"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-2-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-2-live-range.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<style>
+div p { color:red; }
+</style>
+<body>
+<p id="description">This tests deleting line break before p.
+WebKit should not keep the style of p added by a style rule, and "world" should be italic and not be in red.</p>
+<div id="test" style="color:red;" contenteditable>
+<h1>hello</h1>
+<p><i>world</i></p>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-3-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-3-live-range-expected.txt
@@ -1,0 +1,20 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 5 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 0 of P > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 2 of DIV > BODY > HTML > #document to 2 of DIV > BODY > HTML > #document toDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 5 of #text > H1 > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break before p.
+WebKit preserves the inline style of the merged paragraph, and "world" should be in green.
+| "\n"
+| <h1>
+|   "hello<#selection-caret>"
+|   <span>
+|     style="color: green;"
+|     "world"
+| <font>
+|   color="red"
+|   "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-3-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-3-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<p id="description">This tests deleting line break before p.
+WebKit preserves the inline style of the merged paragraph, and "world" should be in green.</p>
+<div id="test" style="color:red;" contenteditable>
+<h1>hello</h1>
+<p><font color="red"><span style="color: green;">world</span></i></p>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-live-range-expected.txt
@@ -1,0 +1,16 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 3 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 7 of #text > DIV > BODY > HTML > #document to 0 of P > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 6 of #text > DIV > BODY > HTML > #document to 6 of #text > DIV > BODY > HTML > #document toDOMRange:range from 6 of #text > DIV > BODY > HTML > #document to 6 of #text > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break before p.
+"world" in "helloworld" should be italicized in red.
+| "\nhello<#selection-caret>"
+| <span>
+|   style="color: red; font-style: italic;"
+|   "world"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-live-range.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<style type="text/css">
+p {color: red;}
+</style>
+</head>
+<body>
+<p id="description">This tests deleting line break before p.
+"world" in "helloworld" should be italicized in red.</p>
+<div id="test" contenteditable>
+hello
+<p style="font-style: italic;">world</p>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-span-with-multiple-text-decoration-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-span-with-multiple-text-decoration-live-range-expected.txt
@@ -1,0 +1,8 @@
+The span style should be preserved when merging a pragraph.
+The test passes if the "bar" has underline, overline and line through.
+| "\n"
+| <p>
+|   "foo<#selection-caret>"
+|   <span>
+|     style="text-decoration: underline overline line-through;"
+|     "bar"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-span-with-multiple-text-decoration-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-span-with-multiple-text-decoration-live-range.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<style type="text/css">
+.MultipleTextDecorations {
+text-decoration: underline overline line-through;
+}
+</style>
+</head>
+<body>
+<div id="test" contenteditable="true">
+<p>foo</p>
+<span id="spanToMerge" class="MultipleTextDecorations">bar</span>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description('The span style should be preserved when merging a pragraph.\n'
+    + 'The test passes if the "bar" has underline, overline and line through.');
+
+var spanToMerge = document.getElementById("spanToMerge");
+spanToMerge.focus();
+getSelection().collapse(spanToMerge, 0);
+document.execCommand("Delete");
+Markup.dump(document.getElementById("test"));
+</script>
+ </body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-from-span-with-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-span-with-style-live-range-expected.txt
@@ -1,0 +1,8 @@
+The span style should be preserved when merging a pragraph.
+The test passes if "bar" contatins the yellow background and it's underlined.
+| "\n"
+| <p>
+|   "foo<#selection-caret>"
+|   <span>
+|     style="background-color: yellow; text-decoration: underline;"
+|     "bar"

--- a/LayoutTests/editing/deleting/merge-paragraph-from-span-with-style-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-from-span-with-style-live-range.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<style type="text/css">
+.NonInheritableProperties {
+background-color: yellow;
+text-decoration: underline;
+}
+</style>
+</head>
+<body>
+<div id="test" contenteditable="true">
+<p>foo</p>
+<span id="spanToMerge" class="NonInheritableProperties">bar</span>
+</div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description('The span style should be preserved when merging a pragraph.\n'
+    + 'The test passes if "bar" contatins the yellow background and it\'s underlined.');
+
+var spanToMerge = document.getElementById("spanToMerge");
+spanToMerge.focus();
+getSelection().collapse(spanToMerge, 0);
+document.execCommand("Delete");
+Markup.dump(document.getElementById("test"));
+</script>
+ </body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-dir-2-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-dir-2-live-range-expected.txt
@@ -1,0 +1,18 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 5 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 0 of P > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 2 of DIV > BODY > HTML > #document to 2 of DIV > BODY > HTML > #document toDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 5 of #text > H1 > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break after h1 inside a block with dir attribute.
+WebKit should not add direction or unicode-bidi properties while merging paragraphs.
+| "\n"
+| <h1>
+|   "hello<#selection-caret>"
+|   <b>
+|     "worl"
+|   "d"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-dir-2-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-dir-2-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html> 
+<body>
+<p id="description">This tests deleting line break after h1 inside a block with dir attribute.
+WebKit should not add direction or unicode-bidi properties while merging paragraphs.</p>
+<div id="test" dir="ltr" contenteditable>
+<h1>hello</h1>
+<p><b>worl</b>d</p>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-style-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-style-live-range-expected.txt
@@ -1,0 +1,16 @@
+EDITING DELEGATE: shouldBeginEditingInDOMRange:range from 0 of DIV > BODY > HTML > #document to 5 of DIV > BODY > HTML > #document
+EDITING DELEGATE: webViewDidBeginEditing:WebViewDidBeginEditingNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldDeleteDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 0 of EM > DIV > BODY > HTML > #document
+EDITING DELEGATE: shouldChangeSelectedDOMRange:range from 2 of DIV > BODY > HTML > #document to 2 of DIV > BODY > HTML > #document toDOMRange:range from 5 of #text > H1 > DIV > BODY > HTML > #document to 5 of #text > H1 > DIV > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
+EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: webViewDidChange:WebViewDidChangeNotification
+EDITING DELEGATE: webViewDidEndEditing:WebViewDidEndEditingNotification
+This tests deleting line break after h1.
+WebKit should not cancel styles added by h1 by those of document's default style but keep "world" italicized.
+| "\n"
+| <h1>
+|   "hello<#selection-caret>"
+|   <em>
+|     "world"

--- a/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-style-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-into-h1-with-style-live-range.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html> 
+<body>
+<p id="description">This tests deleting line break after h1.
+WebKit should not cancel styles added by h1 by those of document's default style but keep "world" italicized.</p>
+<div id="test" contenteditable>
+<h1>hello</h1>
+<em>world</em>
+</div>
+</div>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+function editingTest() {
+    moveSelectionForwardByLineCommand();
+    deleteCommand();
+
+    Markup.description(document.getElementById('description').textContent);
+    Markup.dump('test');
+}
+
+runEditingTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/merge-paragraph-with-style-from-rule-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/merge-paragraph-with-style-from-rule-live-range-expected.txt
@@ -1,0 +1,16 @@
+You should see "hello webKit" all in blue:
+| "\n"
+| <p>
+|   <span>
+|     class="someClass"
+|     style="font-size: 12pt;"
+|     "hello"
+|   " "
+|   <span>
+|     class="someClass"
+|     style="font-size: 12pt;"
+|     "w<#selection-caret>"
+|   <span>
+|     style="color: blue; font-size: 12pt;"
+|     "ebKit"
+| "\n"

--- a/LayoutTests/editing/deleting/merge-paragraph-with-style-from-rule-live-range.html
+++ b/LayoutTests/editing/deleting/merge-paragraph-with-style-from-rule-live-range.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<body>
+<style type="text/css">
+.someClass {
+    color: blue;
+}
+</style>
+<p id="description">You should see "hello webKit" all in blue:</p>
+<div id="editor" contenteditable>
+<p><span style="font-size: 12pt;" class="someClass">hello</span> <span style="font-size: 12pt;" class="someClass">world</span></p>
+<p><span style="font-size: 12pt;" class="someClass">WebKit</span></p>
+</div>
+<div id="log"></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+document.getElementById('editor').focus();
+for (var i = 0; i < 7; i++)
+    getSelection().modify('move', 'forward', 'character');
+for (var i = 0; i < 6; i++)
+    getSelection().modify('extend', 'forward', 'character');
+document.execCommand('delete');
+
+Markup.description(document.getElementById('description').textContent);
+Markup.dump('editor');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/deleting/select-and-delete-last-char-in-table-live-range-expected.txt
+++ b/LayoutTests/editing/deleting/select-and-delete-last-char-in-table-live-range-expected.txt
@@ -1,0 +1,17 @@
+In this test the last character of a single-cell table is selected and then deleted using the backspace key. The whole table is deleted.
+
+BeforeDeletion:
+| "First"
+| <table>
+|   border="1"
+|   <tbody>
+|     <tr>
+|       <td>
+|         id="test"
+|         "<#selection-anchor>1<#selection-focus>"
+| "Second"
+
+AfterDeletion:
+| "First<#selection-caret>"
+| <br>
+| "Second"

--- a/LayoutTests/editing/deleting/select-and-delete-last-char-in-table-live-range.html
+++ b/LayoutTests/editing/deleting/select-and-delete-last-char-in-table-live-range.html
@@ -1,0 +1,15 @@
+<!doctype html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<script src=../editing.js ></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<div contenteditable id="root">First<table border="1"><tr><td id="test">1</td></tr></table>Second</div>
+<script>
+Markup.description("In this test the last character of a single-cell table is selected and then deleted using the backspace key. The whole table is deleted.")
+
+const element = document.getElementById("test");
+getSelection().collapse(element, 0);
+extendSelectionForwardByCharacterCommand();
+Markup.dump('root', 'BeforeDeletion');
+
+deleteCommand();
+Markup.dump('root', 'AfterDeletion');
+</script>

--- a/LayoutTests/editing/unsupported-content/table-delete-001-live-range-expected.txt
+++ b/LayoutTests/editing/unsupported-content/table-delete-001-live-range-expected.txt
@@ -1,0 +1,61 @@
+For this test Select and delete a table. Expected Results: Only table should get deleted.Surrounding content that is not selected should (obviously) not be affected.
+
+BeforeDeletion:
+| "\n"
+| <div>
+|   class="editing"
+|   id="test"
+|   "\nFirst\n"
+|   <table>
+|     border="1"
+|     "\n"
+|     <tbody>
+|       <tr>
+|         "\n"
+|         <td>
+|           "<#selection-anchor>1"
+|         "\n"
+|         <td>
+|           "2"
+|         "\n"
+|         <td>
+|           "3"
+|         "\n"
+|       "\n"
+|       <tr>
+|         "\n"
+|         <td>
+|           "4"
+|         "\n"
+|         <td>
+|           "5"
+|         "\n"
+|         <td>
+|           "6"
+|         "\n"
+|       "\n"
+|       <tr>
+|         "\n"
+|         <td>
+|           "7"
+|         "\n"
+|         <td>
+|           "8"
+|         "\n"
+|         <td>
+|           "9"
+|         "\n"
+|       "\n"
+|   <#selection-focus>
+|   "\nSecond\n"
+| "\n"
+
+AfterDeletion:
+| "\n"
+| <div>
+|   class="editing"
+|   id="test"
+|   "\nFirst<#selection-caret>"
+|   <br>
+|   "Second\n"
+| "\n"

--- a/LayoutTests/editing/unsupported-content/table-delete-001-live-range.html
+++ b/LayoutTests/editing/unsupported-content/table-delete-001-live-range.html
@@ -1,0 +1,57 @@
+<html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<head>
+
+<style>
+.editing { 
+    border: 2px solid red; 
+    font-size: 24px; 
+}
+</style>
+
+<script src=../editing.js language="JavaScript" type="text/JavaScript" ></script>
+<script src="../../resources/dump-as-markup.js"></script>
+
+<title>Editing Test</title> 
+</head> 
+<body>
+
+<div contenteditable id="root" style="word-wrap: break-word; -khtml-nbsp-mode: space; -khtml-line-break: after-white-space;">
+<div id="test" class="editing">
+First
+<table border="1">
+<tr>
+<td>1</td>
+<td>2</td>
+<td>3</td>
+</tr>
+<tr>
+<td>4</td>
+<td>5</td>
+<td>6</td>
+</tr>
+<tr>
+<td>7</td>
+<td>8</td>
+<td>9</td>
+</tr>
+</table>
+Second
+</div>
+</div>
+
+<script>
+    Markup.description('For this test Select and delete a table. Expected Results: Only table should get deleted.Surrounding content that is not selected should (obviously) not be affected.')
+
+    var element = document.getElementById("test");
+    getSelection().collapse(element, 0);
+    moveSelectionForwardByLineCommand();
+    for (i = 0; i < 18; i++)
+        extendSelectionForwardByCharacterCommand();
+    Markup.dump('root', 'BeforeDeletion');
+
+    deleteCommand();
+    Markup.dump('root', 'AfterDeletion');
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -1067,7 +1067,7 @@ void DeleteSelectionCommand::doApply()
     if (!originalString.isEmpty())
         document().editor().deletedAutocorrectionAtPosition(m_endingPosition, originalString);
 
-    setEndingSelection(VisibleSelection(m_endingPosition, affinity, endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(VisiblePosition(m_endingPosition, affinity), endingSelection().isDirectional()));
     clearTransientState();
 }
 


### PR DESCRIPTION
#### 64b46e51042f333106fbe9dc43a602a1c55b3c80
<pre>
[Live Range Selection] Some tests fail due to DeleteSelectionCommand not canonicalizing ending selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=246412">https://bugs.webkit.org/show_bug.cgi?id=246412</a>

Reviewed by Wenson Hsieh and Darin Adler.

Explicitly canonicalize the ending selection in DeleteSelectionCommand.
Added copies of various tests that newly pass with this change with live range selection enabled.

* LayoutTests/editing/deleting/delete-br-in-last-table-cell-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/delete-br-in-last-table-cell-live-range.html: Added.
* LayoutTests/editing/deleting/delete-line-break-before-underlined-content-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/delete-line-break-before-underlined-content-live-range.html: Added.
* LayoutTests/editing/deleting/delete-line-break-between-paragraphs-with-same-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/delete-line-break-between-paragraphs-with-same-style-live-range.html: Added.
* LayoutTests/editing/deleting/delete-table-cell-contents-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/delete-table-cell-contents-live-range.html: Added.
* LayoutTests/editing/deleting/deleting-line-break-preserves-underline-color-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/deleting-line-break-preserves-underline-color-live-range.html: Added.
* LayoutTests/editing/deleting/merge-div-from-span-with-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-div-from-span-with-style-live-range.html: Added.
* LayoutTests/editing/deleting/merge-div-with-inline-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-div-with-inline-style-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-2-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-2-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-h6-with-style-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-2-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-2-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-3-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-3-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-p-with-style-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-span-with-multiple-text-decoration-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-span-with-multiple-text-decoration-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-span-with-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-from-span-with-style-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-into-h1-with-dir-2-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-into-h1-with-dir-2-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-into-h1-with-style-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-into-h1-with-style-live-range.html: Added.
* LayoutTests/editing/deleting/merge-paragraph-with-style-from-rule-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/merge-paragraph-with-style-from-rule-live-range.html: Added.
* LayoutTests/editing/deleting/select-and-delete-last-char-in-table-live-range-expected.txt: Added.
* LayoutTests/editing/deleting/select-and-delete-last-char-in-table-live-range.html: Added.
* LayoutTests/editing/unsupported-content/table-delete-001-live-range-expected.txt: Added.
* LayoutTests/editing/unsupported-content/table-delete-001-live-range.html: Added.
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/255472@main">https://commits.webkit.org/255472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fedaf720e99ce723c7f2e1ee03a78b5fa3f2a441

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102319 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1790 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30156 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/84981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98482 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1205 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79072 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28144 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83124 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36567 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16754 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17933 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40543 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1726 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37092 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->