### PR TITLE
[JSC] Fix ArithMin/ArithMax handling for double, and Int32 speculation

### DIFF
--- a/JSTests/stress/arith-min-max-multiple.js
+++ b/JSTests/stress/arith-min-max-multiple.js
@@ -39,6 +39,18 @@ function test6(num)
 }
 noInline(test6);
 
+function test7(num)
+{
+    return Math.max(44.3, 0.2, 0.3, -1.3, 2.5, num);
+}
+noInline(test7);
+
+function test8(num)
+{
+    return Math.min(-44.3, 0.2, 0.3, -1.3, 2.5, num);
+}
+noInline(test8);
+
 for (let i = 0; i < 1e5; ++i) {
     shouldBe(test1(0), -4);
     shouldBe(test1(-100), -100);
@@ -50,4 +62,6 @@ for (let i = 0; i < 1e5; ++i) {
     shouldBe(test4(1e1000), 1e1000);
     shouldBe(Number.isNaN(test5(0)), true);
     shouldBe(Number.isNaN(test6(2000.1)), true);
+    shouldBe(test7(10), 44.3);
+    shouldBe(test8(10), -44.3);
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3010,7 +3010,7 @@ private:
             ScratchBuffer* scratchBuffer = vm().scratchBufferForSize(scratchSize);
             LValue buffer = m_out.constIntPtr(static_cast<const double*>(scratchBuffer->dataBuffer()));
 
-            for (unsigned index = 1; index < m_node->numChildren(); ++index) {
+            for (unsigned index = 0; index < m_node->numChildren(); ++index) {
                 LValue value = lowDouble(m_graph.child(m_node, index));
                 m_out.storeDouble(value, m_out.baseIndex(m_heaps.indexedDoubleProperties, buffer, m_out.constInt32(index), jsNumber(index)));
             }


### PR DESCRIPTION
#### 6e034bbd26837f492aa03d5bd1e5ce197b6bc61b
<pre>
[JSC] Fix ArithMin/ArithMax handling for double, and Int32 speculation
<a href="https://bugs.webkit.org/show_bug.cgi?id=246422">https://bugs.webkit.org/show_bug.cgi?id=246422</a>
rdar://101048572

Reviewed by Justin Michaud.

This patch fixes two issues: one is just a bug fix and one is a bit theoretical.

1. FTL ArithMin/ArithMax double case is skipping the first parameter accidentally. This patch fixes it.
2. DFG ArithMin/ArithMax Int32 case can OSR exit after clobbering first parameter&apos;s register, which can theoretically
   puts different output if type speculation failed in the second or later parameters.

* JSTests/stress/arith-min-max-multiple.js:
(test7):
(test8):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithMinOrMax):

Canonical link: <a href="https://commits.webkit.org/255465@main">https://commits.webkit.org/255465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d0000e91f8e2b8f8aca6e8b4176e505148f1eba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102334 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1819 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30180 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98497 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1224 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79098 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28155 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/83971 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36589 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79013 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34376 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/17978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/27398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3791 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40559 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81633 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37138 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18464 "Passed tests") | 
<!--EWS-Status-Bubble-End-->