### PR TITLE
Generate serializers for SessionState objects

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -520,6 +520,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/FrameInfoData.serialization.in
     Shared/FrameTreeNodeData.serialization.in
     Shared/LayerTreeContext.serialization.in
+    Shared/SessionState.serialization.in
     Shared/ShareableBitmap.serialization.in
     Shared/TextFlags.serialization.in
     Shared/WTFArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -144,6 +144,7 @@ $(PROJECT_DIR)/Shared/LayerTreeContext.serialization.in
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerMessageHandler.messages.in
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerProxy.messages.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
+$(PROJECT_DIR)/Shared/SessionState.serialization.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
 $(PROJECT_DIR)/Shared/TextFlags.serialization.in
 $(PROJECT_DIR)/Shared/WTFArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -458,11 +458,12 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/API/APIGeometry.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
 	Shared/FocusedElementInformation.serialization.in \
-	Shared/ShareableBitmap.serialization.in \
 	Shared/FrameInfoData.serialization.in \
 	Shared/FrameTreeNodeData.serialization.in \
 	Shared/LayerTreeContext.serialization.in \
 	Shared/TextFlags.serialization.in \
+	Shared/SessionState.serialization.in \
+	Shared/ShareableBitmap.serialization.in \
 	Shared/WTFArgumentCoders.serialization.in \
 	Shared/WebPushDaemonConnectionConfiguration.serialization.in \
 	Shared/WebPushMessage.serialization.in \

--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -26,252 +26,13 @@
 #include "config.h"
 #include "SessionState.h"
 
-#include "WebCoreArgumentCoders.h"
 #include <WebCore/BackForwardItemIdentifier.h>
 
 namespace WebKit {
-using namespace WebCore;
 
-void HTTPBody::Element::encode(IPC::Encoder& encoder) const
+bool FrameState::validateDocumentState(const Vector<AtomString>& documentState)
 {
-    encoder << type;
-    encoder << data;
-    encoder << filePath;
-    encoder << fileStart;
-    encoder << fileLength;
-    encoder << expectedFileModificationTime;
-    encoder << blobURLString;
-}
-
-static bool isValidEnum(HTTPBody::Element::Type type)
-{
-    switch (type) {
-    case HTTPBody::Element::Type::Data:
-    case HTTPBody::Element::Type::File:
-    case HTTPBody::Element::Type::Blob:
-        return true;
-    }
-
-    return false;
-}
-
-auto HTTPBody::Element::decode(IPC::Decoder& decoder) -> std::optional<Element>
-{
-    Element result;
-    if (!decoder.decode(result.type) || !isValidEnum(result.type))
-        return std::nullopt;
-    if (!decoder.decode(result.data))
-        return std::nullopt;
-    if (!decoder.decode(result.filePath))
-        return std::nullopt;
-    if (!decoder.decode(result.fileStart))
-        return std::nullopt;
-    if (!decoder.decode(result.fileLength))
-        return std::nullopt;
-    if (!decoder.decode(result.expectedFileModificationTime))
-        return std::nullopt;
-    if (!decoder.decode(result.blobURLString))
-        return std::nullopt;
-
-    return result;
-}
-
-void HTTPBody::encode(IPC::Encoder& encoder) const
-{
-    encoder << contentType;
-    encoder << elements;
-}
-
-bool HTTPBody::decode(IPC::Decoder& decoder, HTTPBody& result)
-{
-    if (!decoder.decode(result.contentType))
-        return false;
-    if (!decoder.decode(result.elements))
-        return false;
-
-    return true;
-}
-
-void FrameState::encode(IPC::Encoder& encoder) const
-{
-    encoder << urlString;
-    encoder << originalURLString;
-    encoder << referrer;
-    encoder << target;
-
-    encoder << m_documentState;
-    encoder << stateObjectData;
-
-    encoder << documentSequenceNumber;
-    encoder << itemSequenceNumber;
-
-    encoder << scrollPosition;
-    encoder << shouldRestoreScrollPosition;
-    encoder << pageScaleFactor;
-
-    encoder << httpBody;
-
-#if PLATFORM(IOS_FAMILY)
-    encoder << exposedContentRect;
-    encoder << unobscuredContentRect;
-    encoder << minimumLayoutSizeInScrollViewCoordinates;
-    encoder << contentSize;
-    encoder << scaleIsInitial;
-    encoder << obscuredInsets;
-#endif
-
-    encoder << children;
-}
-
-std::optional<FrameState> FrameState::decode(IPC::Decoder& decoder)
-{
-    FrameState result;
-    if (!decoder.decode(result.urlString))
-        return std::nullopt;
-    if (!decoder.decode(result.originalURLString))
-        return std::nullopt;
-    if (!decoder.decode(result.referrer))
-        return std::nullopt;
-    if (!decoder.decode(result.target))
-        return std::nullopt;
-
-    if (!decoder.decode(result.m_documentState))
-        return std::nullopt;
-    result.validateDocumentState();
-
-    if (!decoder.decode(result.stateObjectData))
-        return std::nullopt;
-
-    if (!decoder.decode(result.documentSequenceNumber))
-        return std::nullopt;
-    if (!decoder.decode(result.itemSequenceNumber))
-        return std::nullopt;
-
-    if (!decoder.decode(result.scrollPosition))
-        return std::nullopt;
-    if (!decoder.decode(result.shouldRestoreScrollPosition))
-        return std::nullopt;
-    if (!decoder.decode(result.pageScaleFactor))
-        return std::nullopt;
-
-    if (!decoder.decode(result.httpBody))
-        return std::nullopt;
-
-#if PLATFORM(IOS_FAMILY)
-    if (!decoder.decode(result.exposedContentRect))
-        return std::nullopt;
-    if (!decoder.decode(result.unobscuredContentRect))
-        return std::nullopt;
-    if (!decoder.decode(result.minimumLayoutSizeInScrollViewCoordinates))
-        return std::nullopt;
-    if (!decoder.decode(result.contentSize))
-        return std::nullopt;
-    if (!decoder.decode(result.scaleIsInitial))
-        return std::nullopt;
-    if (!decoder.decode(result.obscuredInsets))
-        return std::nullopt;
-#endif
-
-    if (!decoder.decode(result.children))
-        return std::nullopt;
-
-    return result;
-}
-
-void PageState::encode(IPC::Encoder& encoder) const
-{
-    encoder << title << mainFrameState << !!sessionStateObject;
-
-    if (sessionStateObject)
-        encoder << sessionStateObject->wireBytes();
-
-    encoder << shouldOpenExternalURLsPolicy;
-    encoder << wasCreatedByJSWithoutUserInteraction;
-}
-
-bool PageState::decode(IPC::Decoder& decoder, PageState& result)
-{
-    if (!decoder.decode(result.title))
-        return false;
-    std::optional<FrameState> mainFrameState;
-    decoder >> mainFrameState;
-    if (!mainFrameState)
-        return false;
-    result.mainFrameState = WTFMove(*mainFrameState);
-
-    bool hasSessionState;
-    if (!decoder.decode(hasSessionState))
-        return false;
-
-    if (hasSessionState) {
-        Vector<uint8_t> wireBytes;
-        if (!decoder.decode(wireBytes))
-            return false;
-
-        result.sessionStateObject = SerializedScriptValue::createFromWireBytes(WTFMove(wireBytes));
-    }
-
-    std::optional<ShouldOpenExternalURLsPolicy> shouldOpenExternalURLsPolicy;
-    decoder >> shouldOpenExternalURLsPolicy;
-    if (!shouldOpenExternalURLsPolicy)
-        return false;
-
-    result.shouldOpenExternalURLsPolicy = *shouldOpenExternalURLsPolicy;
-
-    if (!decoder.decode(result.wasCreatedByJSWithoutUserInteraction))
-        return false;
-
-    return true;
-}
-
-void BackForwardListItemState::encode(IPC::Encoder& encoder) const
-{
-    encoder << identifier;
-    encoder << pageState;
-    encoder << hasCachedPage;
-}
-
-std::optional<BackForwardListItemState> BackForwardListItemState::decode(IPC::Decoder& decoder)
-{
-    BackForwardListItemState result;
-
-    auto identifier = BackForwardItemIdentifier::decode(decoder);
-    if (!identifier)
-        return std::nullopt;
-    result.identifier = *identifier;
-
-    if (!decoder.decode(result.pageState))
-        return std::nullopt;
-
-    if (!decoder.decode(result.hasCachedPage))
-        return std::nullopt;
-
-    return result;
-}
-
-void BackForwardListState::encode(IPC::Encoder& encoder) const
-{
-    encoder << items;
-    encoder << currentIndex;
-}
-
-std::optional<BackForwardListState> BackForwardListState::decode(IPC::Decoder& decoder)
-{
-    std::optional<Vector<BackForwardListItemState>> items;
-    decoder >> items;
-    if (!items)
-        return std::nullopt;
-
-    std::optional<uint32_t> currentIndex;
-    if (!decoder.decode(currentIndex))
-        return std::nullopt;
-
-    return {{ WTFMove(*items), WTFMove(currentIndex) }};
-}
-
-void FrameState::validateDocumentState() const
-{
-    for (auto& stateString : m_documentState) {
+    for (auto& stateString : documentState) {
         if (stateString.isNull())
             continue;
 
@@ -285,6 +46,7 @@ void FrameState::validateDocumentState() const
             RELEASE_ASSERT(isLatin1(character));
         }
     }
+    return true;
 }
 
 void FrameState::setDocumentState(const Vector<AtomString>& documentState, ShouldValidate shouldValidate)
@@ -292,7 +54,7 @@ void FrameState::setDocumentState(const Vector<AtomString>& documentState, Shoul
     m_documentState = documentState;
 
     if (shouldValidate == ShouldValidate::Yes)
-        validateDocumentState();
+        validateDocumentState(m_documentState);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -1,0 +1,89 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: "SessionState.h"
+[CustomHeader] struct WebKit::HTTPBody {
+    String contentType;
+    Vector<WebKit::HTTPBody::Element> elements;
+};
+
+[Nested] struct WebKit::HTTPBody::Element {
+    std::variant<Vector<uint8_t>, WebKit::HTTPBody::Element::FileData, String> data;
+};
+
+[Nested] struct WebKit::HTTPBody::Element::FileData {
+    String filePath;
+    int64_t fileStart;
+    std::optional<int64_t> fileLength;
+    std::optional<WallTime> expectedFileModificationTime;
+};
+
+[CustomHeader, LegacyPopulateFrom=EmptyConstructor] class WebKit::FrameState {
+    String urlString;
+    String originalURLString;
+    String referrer;
+    AtomString target;
+
+    std::optional<Vector<uint8_t>> stateObjectData;
+
+    int64_t documentSequenceNumber;
+    int64_t itemSequenceNumber;
+
+    WebCore::IntPoint scrollPosition;
+    bool shouldRestoreScrollPosition;
+    float pageScaleFactor;
+
+    std::optional<WebKit::HTTPBody> httpBody;
+
+#if PLATFORM(IOS_FAMILY)
+    WebCore::FloatRect exposedContentRect;
+    WebCore::IntRect unobscuredContentRect;
+    WebCore::FloatSize minimumLayoutSizeInScrollViewCoordinates;
+    WebCore::IntSize contentSize;
+    bool scaleIsInitial;
+    WebCore::FloatBoxExtent obscuredInsets;
+#endif
+
+    Vector<WebKit::FrameState> children;
+    [Validator='WebKit::FrameState::validateDocumentState(*m_documentState)'] Vector<AtomString> m_documentState;
+};
+
+[CustomHeader] struct WebKit::PageState {
+    String title;
+    WebKit::FrameState mainFrameState;
+    WebCore::ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy;
+    RefPtr<WebCore::SerializedScriptValue> sessionStateObject;
+    bool wasCreatedByJSWithoutUserInteraction;
+};
+
+[CustomHeader] struct WebKit::BackForwardListItemState {
+    WebCore::BackForwardItemIdentifier identifier;
+
+    WebKit::PageState pageState;
+    bool hasCachedPage;
+    # snapshot is not serialized.
+};
+
+[CustomHeader] struct WebKit::BackForwardListState {
+    Vector<WebKit::BackForwardListItemState> items;
+    std::optional<uint32_t> currentIndex;
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -92,6 +92,7 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SerializedAttachmentData.h>
 #include <WebCore/SerializedPlatformDataCueValue.h>
+#include <WebCore/SerializedScriptValue.h>
 #include <WebCore/ServiceWorkerClientData.h>
 #include <WebCore/ServiceWorkerData.h>
 #include <WebCore/ShareData.h>
@@ -2066,6 +2067,31 @@ bool ArgumentCoder<IDBKeyPath>::decode(Decoder& decoder, IDBKeyPath& keyPath)
         keyPath = vector;
     }
     return true;
+}
+
+void ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>>::encode(Encoder& encoder, const RefPtr<WebCore::SerializedScriptValue>& instance)
+{
+    encoder << !!instance;
+    if (instance)
+        encoder << instance->wireBytes();
+}
+
+std::optional<RefPtr<WebCore::SerializedScriptValue>> ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>>::decode(Decoder& decoder)
+{
+    std::optional<bool> nonEmpty;
+    decoder >> nonEmpty;
+    if (!nonEmpty)
+        return std::nullopt;
+
+    if (!*nonEmpty)
+        return nullptr;
+
+    std::optional<Vector<uint8_t>> wireBytes;
+    decoder >> wireBytes;
+    if (!wireBytes)
+        return std::nullopt;
+
+    return SerializedScriptValue::createFromWireBytes(WTFMove(*wireBytes));
 }
 
 #if ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -143,6 +143,7 @@ class ResourceRequest;
 class ResourceResponse;
 class ScriptBuffer;
 class SecurityOrigin;
+class SerializedScriptValue;
 class FragmentedSharedBuffer;
 class StickyPositionViewportConstraints;
 class SystemImage;
@@ -312,6 +313,10 @@ template<> struct ArgumentCoder<WebCore::Cursor> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::Cursor&);
 };
 
+template<> struct ArgumentCoder<RefPtr<WebCore::SerializedScriptValue>> {
+    static void encode(Encoder&, const RefPtr<WebCore::SerializedScriptValue>&);
+    static std::optional<RefPtr<WebCore::SerializedScriptValue>> decode(Decoder&);
+};
 
 template<> struct ArgumentCoder<WebCore::Font> {
     static void encode(Encoder&, const WebCore::Font&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -106,32 +106,18 @@ enum HTMLBodyElementType {
     Blob
 };
 
-static inline unsigned toHTMLBodyElementType(HTTPBody::Element::Type type)
+static inline unsigned toHTMLBodyElementType(size_t index)
 {
     switch (type) {
-    case HTTPBody::Element::Type::Data:
+    case WTF::alternativeIndexV<Vector<uint8_t>, HTTPBody::Element::Data>:
         return HTMLBodyElementType::Data;
-    case HTTPBody::Element::Type::File:
+    case WTF::alternativeIndexV<HTTPBody::Element::FileData, HTTPBody::Element::Data>:
         return HTMLBodyElementType::File;
-    case HTTPBody::Element::Type::Blob:
+    case WTF::alternativeIndexV<String, HTTPBody::Element::Data>:
         return HTMLBodyElementType::Blob;
     }
 
     return HTMLBodyElementType::Data;
-}
-
-static inline HTTPBody::Element::Type toHTTPBodyElementType(unsigned type)
-{
-    switch (type) {
-    case HTMLBodyElementType::Data:
-        return HTTPBody::Element::Type::Data;
-    case HTMLBodyElementType::File:
-        return HTTPBody::Element::Type::File;
-    case HTMLBodyElementType::Blob:
-        return HTTPBody::Element::Type::Blob;
-    }
-
-    return HTTPBody::Element::Type::Data;
 }
 
 static inline void encodeHTTPBody(GVariantBuilder* sessionBuilder, const HTTPBody& httpBody)
@@ -141,22 +127,38 @@ static inline void encodeHTTPBody(GVariantBuilder* sessionBuilder, const HTTPBod
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("a" HTTP_BODY_ELEMENT_TYPE_STRING_V1));
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE(HTTP_BODY_ELEMENT_TYPE_STRING_V1));
     for (const auto& element : httpBody.elements) {
-        g_variant_builder_add(sessionBuilder, "u", toHTMLBodyElementType(element.type));
+        g_variant_builder_add(sessionBuilder, "u", toHTMLBodyElementType(element.data.index()));
+
         g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("ay"));
-        for (auto item : element.data)
-            g_variant_builder_add(sessionBuilder, "y", item);
+        if (auto* vector = std::get_if<Vector<uint8_t>>(&element.data)) {
+            for (auto item : vector)
+                g_variant_builder_add(sessionBuilder, "y", item);
+        }
         g_variant_builder_close(sessionBuilder);
-        g_variant_builder_add(sessionBuilder, "s", element.filePath.utf8().data());
-        g_variant_builder_add(sessionBuilder, "x", element.fileStart);
-        if (element.fileLength)
-            g_variant_builder_add(sessionBuilder, "mx", TRUE, element.fileLength.value());
-        else
+
+        if (auto* fileData = std::get_if<Vector<uint8_t>>(&element.data)) {
+            g_variant_builder_add(sessionBuilder, "s", fileData->filePath.utf8().data());
+            g_variant_builder_add(sessionBuilder, "x", fileData->fileStart);
+            if (fileData->fileLength)
+                g_variant_builder_add(sessionBuilder, "mx", TRUE, fileData->fileLength.value());
+            else
+                g_variant_builder_add(sessionBuilder, "mx", FALSE);
+            if (fileData->expectedFileModificationTime)
+                g_variant_builder_add(sessionBuilder, "md", TRUE, fileData->expectedFileModificationTime.value());
+            else
+                g_variant_builder_add(sessionBuilder, "md", FALSE);
+        } else {
+            g_variant_builder_add(sessionBuilder, "s", "");
+            int64_t fileStart { 0 };
+            g_variant_builder_add(sessionBuilder, "x", fileStart);
             g_variant_builder_add(sessionBuilder, "mx", FALSE);
-        if (element.expectedFileModificationTime)
-            g_variant_builder_add(sessionBuilder, "md", TRUE, element.expectedFileModificationTime.value());
-        else
             g_variant_builder_add(sessionBuilder, "md", FALSE);
-        g_variant_builder_add(sessionBuilder, "s", element.blobURLString.utf8().data());
+        }
+
+        if (auto* blobURLString = std::get_if<String>(&element.data))
+            g_variant_builder_add(sessionBuilder, "s", blobURLString->utf8().data());
+        else
+            g_variant_builder_add(sessionBuilder, "s", "");
     }
     g_variant_builder_close(sessionBuilder);
     g_variant_builder_close(sessionBuilder);
@@ -267,22 +269,29 @@ static inline bool decodeHTTPBody(GVariant* httpBodyVariant, HTTPBody& httpBody)
     const char* blobURLString;
     while (g_variant_iter_loop(elementsIter.get(), HTTP_BODY_ELEMENT_FORMAT_STRING_V1, &type, &dataIter, &filePath, &fileStart, &hasFileLength, &fileLength, &hasFileModificationTime, &fileModificationTime, &blobURLString)) {
         HTTPBody::Element element;
-        element.type = toHTTPBodyElementType(type);
-        if (gsize dataLength = g_variant_iter_n_children(dataIter)) {
-            element.data.reserveInitialCapacity(dataLength);
-            guchar dataValue;
-            while (g_variant_iter_next(dataIter, "y", &dataValue))
-                element.data.uncheckedAppend(dataValue);
+        switch (type) {
+        case WTF::alternativeIndexV<Vector<uint8_t>, HTTPBody::Element::Data>:
+            if (gsize dataLength = g_variant_iter_n_children(dataIter)) {
+                Vector<uint8_t> data;
+                data.reserveInitialCapacity(dataLength);
+                guchar dataValue;
+                while (g_variant_iter_next(dataIter, "y", &dataValue))
+                    data.uncheckedAppend(dataValue);
+                httpBody.elements.uncheckedAppend({ WTFMove(data) });
+            }
+        case WTF::alternativeIndexV<HTTPBody::Element::FileData, HTTPBody::Element::Data>: {
+            FileData fileData;
+            fileData.filePath = String::fromUTF8(filePath);
+            fileData.fileStart = fileStart;
+            if (hasFileLength)
+                fileData.fileLength = fileLength;
+            if (hasFileModificationTime)
+                fileData.expectedFileModificationTime = WallTime::fromRawSeconds(fileModificationTime);
+            httpBody.elements.uncheckedAppend({ WTFMove(fileData) });
         }
-        element.filePath = String::fromUTF8(filePath);
-        element.fileStart = fileStart;
-        if (hasFileLength)
-            element.fileLength = fileLength;
-        if (hasFileModificationTime)
-            element.expectedFileModificationTime = WallTime::fromRawSeconds(fileModificationTime);
-        element.blobURLString = String::fromUTF8(blobURLString);
-
-        httpBody.elements.uncheckedAppend(WTFMove(element));
+        case WTF::alternativeIndexV<String, HTTPBody::Element::Data>:
+            httpBody.elements.uncheckedAppend({ String::fromUTF8(blobURLString) });
+        }
     }
 
     return true;

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -259,29 +259,13 @@ enum class FormDataElementType {
     EncodedBlob = 2,
 };
 
-static bool isValidEnum(FormDataElementType type)
-{
-    switch (type) {
-    case FormDataElementType::Data:
-    case FormDataElementType::EncodedFile:
-    case FormDataElementType::EncodedBlob:
-        return true;
-    }
-
-    return false;
-}
-
 static void encodeFormDataElement(HistoryEntryDataEncoder& encoder, const HTTPBody::Element& element)
 {
-    switch (element.type) {
-    case HTTPBody::Element::Type::Data:
-        encoder << FormDataElementType::Data;
-        encoder << element.data;
-        break;
-
-    case HTTPBody::Element::Type::File:
-        encoder << FormDataElementType::EncodedFile;
-        encoder << element.filePath;
+    encoder << static_cast<uint32_t>(element.data.index());
+    WTF::switchOn(element.data, [&] (const Vector<uint8_t>& data) {
+        encoder << data;
+    }, [&] (const HTTPBody::Element::FileData& fileData) {
+        encoder << fileData.filePath;
 
         // Used to be generatedFilename.
         encoder << String();
@@ -289,16 +273,13 @@ static void encodeFormDataElement(HistoryEntryDataEncoder& encoder, const HTTPBo
         // Used to be shouldGenerateFile.
         encoder << false;
 
-        encoder << element.fileStart;
-        encoder << element.fileLength.value_or(-1);
-        encoder << element.expectedFileModificationTime.value_or(WallTime::nan()).secondsSinceEpoch().value();
-        break;
+        encoder << fileData.fileStart;
+        encoder << fileData.fileLength.value_or(-1);
+        encoder << fileData.expectedFileModificationTime.value_or(WallTime::nan()).secondsSinceEpoch().value();
 
-    case HTTPBody::Element::Type::Blob:
-        encoder << FormDataElementType::EncodedBlob;
-        encoder << element.blobURLString;
-        break;
-    }
+    }, [&] (const String& blobURLString) {
+        encoder << blobURLString;
+    });
 }
 
 static void encodeFormData(HistoryEntryDataEncoder& encoder, const HTTPBody& formData)
@@ -333,7 +314,7 @@ static void encodeFrameStateNode(HistoryEntryDataEncoder& encoder, const FrameSt
 
     encoder << frameState.documentSequenceNumber;
 
-    frameState.validateDocumentState();
+    FrameState::validateDocumentState(frameState.documentState());
     encoder << static_cast<uint64_t>(frameState.documentState().size());
     for (const auto& documentState : frameState.documentState())
         encoder << documentState;
@@ -813,19 +794,22 @@ private:
 
 static void decodeFormDataElement(HistoryEntryDataDecoder& decoder, HTTPBody::Element& formDataElement)
 {
-    std::optional<FormDataElementType> elementType;
+    uint32_t elementType;
     decoder >> elementType;
-    if (!elementType)
+    if (!decoder.isValid())
         return;
 
-    switch (elementType.value()) {
-    case FormDataElementType::Data:
-        formDataElement.type = HTTPBody::Element::Type::Data;
-        decoder >> formDataElement.data;
+    switch (elementType) {
+    case WTF::alternativeIndexV<Vector<uint8_t>, HTTPBody::Element::Data>: {
+        Vector<uint8_t> data;
+        decoder >> data;
+        formDataElement.data = WTFMove(data);
         break;
+    }
 
-    case FormDataElementType::EncodedFile: {
-        decoder >> formDataElement.filePath;
+    case WTF::alternativeIndexV<HTTPBody::Element::FileData, HTTPBody::Element::Data>: {
+        HTTPBody::Element::FileData fileData;
+        decoder >> fileData.filePath;
 
         String generatedFilename;
         decoder >> generatedFilename;
@@ -833,8 +817,8 @@ static void decodeFormDataElement(HistoryEntryDataDecoder& decoder, HTTPBody::El
         bool shouldGenerateFile;
         decoder >> shouldGenerateFile;
 
-        decoder >> formDataElement.fileStart;
-        if (formDataElement.fileStart < 0) {
+        decoder >> fileData.fileStart;
+        if (fileData.fileStart < 0) {
             decoder.markInvalid();
             return;
         }
@@ -842,23 +826,27 @@ static void decodeFormDataElement(HistoryEntryDataDecoder& decoder, HTTPBody::El
         int64_t fileLength;
         decoder >> fileLength;
         if (fileLength != -1) {
-            if (fileLength < formDataElement.fileStart)
+            if (fileLength < fileData.fileStart)
                 return;
 
-            formDataElement.fileLength = fileLength;
+            fileData.fileLength = fileLength;
         }
 
         double expectedFileModificationTime;
         decoder >> expectedFileModificationTime;
         if (!std::isnan(expectedFileModificationTime))
-            formDataElement.expectedFileModificationTime = WallTime::fromRawSeconds(expectedFileModificationTime);
+            fileData.expectedFileModificationTime = WallTime::fromRawSeconds(expectedFileModificationTime);
 
+        formDataElement.data = WTFMove(fileData);
         break;
     }
 
-    case FormDataElementType::EncodedBlob:
-        decoder >> formDataElement.blobURLString;
+    case WTF::alternativeIndexV<String, HTTPBody::Element::Data>: {
+        String blobURLString;
+        decoder >> blobURLString;
+        formDataElement.data = WTFMove(blobURLString);
         break;
+    }
     }
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5335,6 +5335,7 @@
 		5ABF2BEC2862353F000DCE74 /* GPUProcessPreferences.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GPUProcessPreferences.cpp; sourceTree = "<group>"; };
 		5ABF2BED2862353F000DCE74 /* GPUProcessPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessPreferences.h; sourceTree = "<group>"; };
 		5C00993B2417FB7E00D53C25 /* ResourceLoadStatisticsParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsParameters.h; sourceTree = "<group>"; };
+		5C03D5DD28F765F800D096AF /* SessionState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SessionState.serialization.in; sourceTree = "<group>"; };
 		5C05FDF227AB4FA5003A2487 /* PrivateRelayed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateRelayed.h; sourceTree = "<group>"; };
 		5C0A10C1235241A30053E2CA /* NetworkSchemeRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkSchemeRegistry.cpp; sourceTree = "<group>"; };
 		5C0B17741E7C879C00E9123C /* NetworkSocketStreamMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkSocketStreamMessageReceiver.cpp; path = DerivedSources/WebKit/NetworkSocketStreamMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -8197,6 +8198,7 @@
 				5C96003F28C02EAF00F2693B /* SerializedTypeInfo.h */,
 				1AFDE6571954A42B00C48FFA /* SessionState.cpp */,
 				1AFDE6581954A42B00C48FFA /* SessionState.h */,
+				5C03D5DD28F765F800D096AF /* SessionState.serialization.in */,
 				1A6420E212DCE2FF00CAAE2C /* ShareableBitmap.cpp */,
 				1A6420E312DCE2FF00CAAE2C /* ShareableBitmap.h */,
 				861A646128F5A37300E23C8F /* ShareableBitmap.serialization.in */,
@@ -8260,10 +8262,10 @@
 				86DD518C28EF204F00DF2A58 /* WebEvent.serialization.in */,
 				BC032DB010F4380F0058C15A /* WebEventConversion.cpp */,
 				BC032DB110F4380F0058C15A /* WebEventConversion.h */,
+				86DD518F28EF28E800DF2A58 /* WebEventModifier.h */,
 				1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */,
 				1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */,
 				1CBEE26128F334D6006D1A02 /* WebExtensionContextParameters.serialization.in */,
-				86DD518F28EF28E800DF2A58 /* WebEventModifier.h */,
 				1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */,
 				1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */,
 				1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -44,16 +44,17 @@ static HTTPBody toHTTPBody(const FormData& formData)
 
         switchOn(formDataElement.data,
             [&] (const Vector<uint8_t>& bytes) {
-                element.type = HTTPBody::Element::Type::Data;
                 element.data = bytes;
             }, [&] (const FormDataElement::EncodedFileData& fileData) {
-                element.filePath = fileData.filename;
-                element.fileStart = fileData.fileStart;
+                HTTPBody::Element::FileData data;
+                data.filePath = fileData.filename;
+                data.fileStart = fileData.fileStart;
                 if (fileData.fileLength != BlobDataItem::toEndOfFile)
-                    element.fileLength = fileData.fileLength;
-                element.expectedFileModificationTime = fileData.expectedFileModificationTime;
+                    data.fileLength = fileData.fileLength;
+                data.expectedFileModificationTime = fileData.expectedFileModificationTime;
+                element.data = WTFMove(data);
             }, [&] (const FormDataElement::EncodedBlobData& blobData) {
-                element.blobURLString = blobData.url.string();
+                element.data = blobData.url.string();
             }
         );
 
@@ -124,19 +125,13 @@ static Ref<FormData> toFormData(const HTTPBody& httpBody)
     auto formData = FormData::create();
 
     for (const auto& element : httpBody.elements) {
-        switch (element.type) {
-        case HTTPBody::Element::Type::Data:
-            formData->appendData(element.data.data(), element.data.size());
-            break;
-
-        case HTTPBody::Element::Type::File:
-            formData->appendFileRange(element.filePath, element.fileStart, element.fileLength.value_or(BlobDataItem::toEndOfFile), element.expectedFileModificationTime);
-            break;
-
-        case HTTPBody::Element::Type::Blob:
-            formData->appendBlob(URL { element.blobURLString });
-            break;
-        }
+        switchOn(element.data, [&] (const Vector<uint8_t>& data) {
+            formData->appendData(data.data(), data.size());
+        }, [&] (const HTTPBody::Element::FileData& data) {
+            formData->appendFileRange(data.filePath, data.fileStart, data.fileLength.value_or(BlobDataItem::toEndOfFile), data.expectedFileModificationTime);
+        }, [&] (const String& blobURLString) {
+            formData->appendBlob(URL { blobURLString });
+        });
     }
 
     return formData;


### PR DESCRIPTION
#### d4b94f129726c8655c0afac437019ed5cbe69bd3
<pre>
Generate serializers for SessionState objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=246423">https://bugs.webkit.org/show_bug.cgi?id=246423</a>
rdar://101097050

Reviewed by Tim Horton.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::validateDocumentState):
(WebKit::FrameState::setDocumentState):
(WebKit::HTTPBody::Element::encode const): Deleted.
(WebKit::isValidEnum): Deleted.
(WebKit::HTTPBody::Element::decode): Deleted.
(WebKit::HTTPBody::encode const): Deleted.
(WebKit::HTTPBody::decode): Deleted.
(WebKit::FrameState::encode const): Deleted.
(WebKit::FrameState::decode): Deleted.
(WebKit::PageState::encode const): Deleted.
(WebKit::PageState::decode): Deleted.
(WebKit::BackForwardListItemState::encode const): Deleted.
(WebKit::BackForwardListItemState::decode): Deleted.
(WebKit::BackForwardListState::encode const): Deleted.
(WebKit::BackForwardListState::decode): Deleted.
(WebKit::FrameState::validateDocumentState const): Deleted.
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/SessionState.serialization.in: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::SerializedScriptValue&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::SerializedScriptValue&gt;&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeFormDataElement):
(WebKit::encodeFrameStateNode):
(WebKit::decodeFormDataElement):
(WebKit::isValidEnum): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toHTTPBody):
(WebKit::toFormData):

Canonical link: <a href="https://commits.webkit.org/255499@main">https://commits.webkit.org/255499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/631109916f1c36ec6db555b24770805606200cc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23326 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/102454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1957 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/30303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98406 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/79231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/36707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34504 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38375 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/79231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1740 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40287 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/37221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->