### PR TITLE
"display" property value of computed style for audio element without controls is "inline" (not "none")

### DIFF
--- a/LayoutTests/media/audio-controls-hidden-display-none-expected.txt
+++ b/LayoutTests/media/audio-controls-hidden-display-none-expected.txt
@@ -1,0 +1,10 @@
+This tests if an audio file that has no controls is always display: none, including after script removal of attribute.
+
+EXPECTED (getComputedStyle(audio)['display'] == 'none') OK
+
+EXPECTED (getComputedStyle(audio)['display'] == 'inline') OK
+
+EXPECTED (getComputedStyle(audio)['display'] == 'none') OK
+
+END OF TEST
+

--- a/LayoutTests/media/audio-controls-hidden-display-none.html
+++ b/LayoutTests/media/audio-controls-hidden-display-none.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Audio Controls - selective control element display</title>
+<script src="video-test.js"></script>
+<script src="media-file.js"></script>
+<script>
+var audio;
+
+function testDisplay(event)
+{
+    audio = event.target;
+
+    testExpected("getComputedStyle(audio)['display']", 'none', "==");
+    consoleWrite("");
+
+    audio.setAttribute("controls", "");
+
+    testExpected("getComputedStyle(audio)['display']", 'inline', "==");
+    consoleWrite("");
+
+    audio.removeAttribute("controls");
+
+    testExpected("getComputedStyle(audio)['display']", 'none', "==");
+    consoleWrite("");
+
+    endTest();
+    }
+
+function init()
+{
+    audio = document.getElementsByTagName("audio")[0];
+    audio.addEventListener('canplaythrough', testDisplay, false);
+    audio.src = findMediaFile('audio', 'content/short');
+}
+</script>
+</head>
+<body onload="init()">
+    <audio></audio>
+    <p>
+        This tests if an audio file that has no controls is always display: none,
+        including after script removal of attribute.
+    </p>
+</body>
+</html>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -131,6 +131,10 @@ audio {
     height: 25px;
 }
 
+audio:not([controls]) {
+    display: none !important;
+}
+
 /* heading elements */
 
 h1 {


### PR DESCRIPTION
#### 13c796fb7f1d6bc0cb660bedae2f9f6e8e510675
<pre>
&quot;display&quot; property value of computed style for audio element without controls is &quot;inline&quot; (not &quot;none&quot;)

&quot;display&quot; property value of computed style for audio element without controls is &quot;inline&quot; (not &quot;none&quot;)

<a href="https://bugs.webkit.org/show_bug.cgi?id=88105">https://bugs.webkit.org/show_bug.cgi?id=88105</a>

Reviewed by Devin Rousso.

This is to align Webkit behavior with Blink / Chrome and Gecko / Firefox and Web-Specifications:

<a href="https://html.spec.whatwg.org/#embedded-content-rendering-rules">https://html.spec.whatwg.org/#embedded-content-rendering-rules</a>

&quot;When an audio element is not exposing a user interface, the user agent is expected
to force its &apos;display&apos; property to compute to &apos;none&apos;, irrespective of CSS rules.&quot;

When an audio element has no controls attribute, it should not be visible on the page.
Before this patch, when we removed the &quot;controls&quot; attribute, an empty div of the size of the controls remained.

Tests from Patch Authored by Silvia Pfeiffer.

* Source/WebCore/css/html.css: Update UA stylesheet where the audio controls are not visible
* LayoutTests/media/audio-controls-hidden-display-none.html: Added Test Cases
* LayoutTests/media/audio-controls-hidden-display-none-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/255528@main">https://commits.webkit.org/255528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b506ffe156add0a515912c02e2ae37fd9a7a144

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102486 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1969 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30315 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98628 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1333 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79244 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28264 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71349 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36719 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16876 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18064 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40667 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37232 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->