### PR TITLE
[ iOS16 ] fast/canvas/canvas-large-dimensions-drawing.html is a constant failure

### DIFF
--- a/LayoutTests/fast/canvas/canvas-large-dimensions-drawing-expected.html
+++ b/LayoutTests/fast/canvas/canvas-large-dimensions-drawing-expected.html
@@ -9,12 +9,12 @@
     }
 </style>
 <body>
-    <canvas id="canvas" width="120" height="120"></canvas>
+    <canvas id="canvas" width="100" height="100"></canvas>
     <script>
         const canvas = document.getElementById('canvas');
         const ctx = canvas.getContext('2d');
 
         ctx.fillStyle = 'green';
-        ctx.fillRect(10, 10, 100, 100);
+        ctx.fillRect(0, 0, 100, 100);
     </script>
 </body>

--- a/LayoutTests/fast/canvas/canvas-large-dimensions-drawing.html
+++ b/LayoutTests/fast/canvas/canvas-large-dimensions-drawing.html
@@ -17,6 +17,6 @@
         ctx.resetTransform();
 
         ctx.fillStyle = 'green';
-        ctx.fillRect(10, 10, 100, 100);
+        ctx.fillRect(0, 0, 100, 100);
     </script>
 </body>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2383,8 +2383,6 @@ webkit.org/b/245592 imported/w3c/web-platform-tests/css/css-counter-styles/mongo
 
 webkit.org/b/245595 imported/blink/svg/canvas/canvas-draw-pattern-size.html [ ImageOnlyFailure ]
 
-webkit.org/b/245597 fast/canvas/canvas-large-dimensions-drawing.html [ ImageOnlyFailure ]
-
 webkit.org/b/245600 fast/attachment/attachment-wrapping-action.html [ ImageOnlyFailure ]
 
 webkit.org/b/245608 imported/w3c/web-platform-tests/cookies/value/value-ctl.html [ Failure ]


### PR DESCRIPTION
#### 4d28dc17be952277de6ce87c51a847ef1dd44b6e
<pre>
[ iOS16 ] fast/canvas/canvas-large-dimensions-drawing.html is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=245597">https://bugs.webkit.org/show_bug.cgi?id=245597</a>
rdar://100335937

Reviewed by Simon Fraser.

It looks like CoreAnimation on iOS16 simulator has made anti-aliasing around the
border of the rectangle a little bit wider. The failure of test shows adding the
tag &lt;meta name=&quot;fuzzy&quot; content=&quot;maxDifference=112; totalPixels=400&quot; /&gt; can make
the test pass.

A more appropriate fix is to fit the canvas in the expected page to { 100 x 100 }
pixels. This way the extra anti-aliasing will be truncated.

* LayoutTests/fast/canvas/canvas-large-dimensions-drawing-expected.html:
* LayoutTests/fast/canvas/canvas-large-dimensions-drawing.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/255541@main">https://commits.webkit.org/255541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d10227c438fa12c0dec04a9cf60c74aa9ecc4a1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102356 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1853 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30204 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85024 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98519 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1245 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79128 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/85024 "Updated gtk dependencies (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82872 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/85024 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36612 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34404 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17977 "Found 1 new test failure: compositing/backing/backing-store-attachment-animating-outside-viewport.html (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3812 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40581 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1763 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40186 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37137 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->