### PR TITLE
[iOS] Add screen orientation locking / unlocking support outside layout tests

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -36,6 +36,7 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include <WebCore/IntRect.h>
+#include <WebCore/ScreenOrientationType.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -209,6 +210,16 @@ void WebFullScreenManagerProxy::beganEnterFullScreen(const IntRect& initialFrame
 void WebFullScreenManagerProxy::beganExitFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)
 {
     m_client.beganExitFullScreen(initialFrame, finalFrame);
+}
+
+bool WebFullScreenManagerProxy::lockFullscreenOrientation(WebCore::ScreenOrientationType orientation)
+{
+    return m_client.lockFullscreenOrientation(orientation);
+}
+
+void WebFullScreenManagerProxy::unlockFullscreenOrientation()
+{
+    m_client.unlockFullscreenOrientation();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -38,6 +38,8 @@ namespace WebCore {
 class FloatSize;
 class IntRect;
 
+enum class ScreenOrientationType : uint8_t;
+
 template <typename> class RectEdges;
 using FloatBoxExtent = RectEdges<float>;
 }
@@ -60,6 +62,9 @@ public:
     virtual void exitFullScreen() = 0;
     virtual void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) = 0;
     virtual void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) = 0;
+
+    virtual bool lockFullscreenOrientation(WebCore::ScreenOrientationType) { return false; }
+    virtual void unlockFullscreenOrientation() { }
 };
 
 class WebFullScreenManagerProxy : public IPC::MessageReceiver {
@@ -96,6 +101,8 @@ public:
     void setFullscreenAutoHideDuration(Seconds);
     void setFullscreenControlsHidden(bool);
     void closeWithCallback(CompletionHandler<void()>&&);
+    bool lockFullscreenOrientation(WebCore::ScreenOrientationType);
+    void unlockFullscreenOrientation();
 
 private:
     void supportsFullScreen(bool withKeyboard, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -27,6 +27,7 @@
 #include "WebScreenOrientationManagerProxy.h"
 
 #include "APIUIClient.h"
+#include "WebFullScreenManagerProxy.h"
 #include "WebPageProxy.h"
 #include "WebScreenOrientationManagerMessages.h"
 #include "WebScreenOrientationManagerProxyMessages.h"
@@ -92,9 +93,22 @@ void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType l
     auto currentOrientation = m_provider->currentOrientation();
     auto resolvedLockedOrientation = resolveScreenOrientationLockType(currentOrientation, lockType);
     bool shouldOrientationChange = currentOrientation != resolvedLockedOrientation;
-    if (resolvedLockedOrientation != m_currentlyLockedOrientation && !m_page.uiClient().lockScreenOrientation(m_page, resolvedLockedOrientation)) {
-        m_currentLockRequest(WebCore::Exception { WebCore::NotSupportedError, "Screen orientation locking is not supported"_s });
-        return;
+
+    if (resolvedLockedOrientation != m_currentlyLockedOrientation) {
+        bool didLockOrientation = false;
+#if ENABLE(FULLSCREEN_API)
+        if (m_page.fullScreenManager() && m_page.fullScreenManager()->isFullScreen()) {
+            if (!m_page.fullScreenManager()->lockFullscreenOrientation(resolvedLockedOrientation)) {
+                m_currentLockRequest(WebCore::Exception { WebCore::NotSupportedError, "Screen orientation locking is not supported"_s });
+                return;
+            }
+            didLockOrientation = true;
+        }
+#endif
+        if (!didLockOrientation && !m_page.uiClient().lockScreenOrientation(m_page, resolvedLockedOrientation)) {
+            m_currentLockRequest(WebCore::Exception { WebCore::NotSupportedError, "Screen orientation locking is not supported"_s });
+            return;
+        }
     }
     m_currentlyLockedOrientation = resolvedLockedOrientation;
     if (!shouldOrientationChange)
@@ -109,7 +123,16 @@ void WebScreenOrientationManagerProxy::unlock()
     if (m_currentLockRequest)
         m_currentLockRequest(WebCore::Exception { WebCore::AbortError, "Unlock request was received"_s });
 
-    m_page.uiClient().unlockScreenOrientation(m_page);
+    bool didUnlockOrientation = false;
+#if ENABLE(FULLSCREEN_API)
+    if (m_page.fullScreenManager() && m_page.fullScreenManager()->isFullScreen()) {
+        m_page.fullScreenManager()->unlockFullscreenOrientation();
+        didUnlockOrientation = true;
+    }
+#endif
+    if (!didUnlockOrientation)
+        m_page.uiClient().unlockScreenOrientation(m_page);
+
     m_currentlyLockedOrientation = std::nullopt;
 }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -230,6 +230,8 @@ private:
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    bool lockFullscreenOrientation(WebCore::ScreenOrientationType) override;
+    void unlockFullscreenOrientation() override;
 #endif
 
     void didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, const IPC::DataReference&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -67,6 +67,7 @@
 #import <WebCore/NotImplemented.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/PromisedAttachmentInfo.h>
+#import <WebCore/ScreenOrientationType.h>
 #import <WebCore/ShareData.h>
 #import <WebCore/SharedBuffer.h>
 #import <WebCore/TextIndicator.h>
@@ -739,6 +740,33 @@ void PageClientImpl::enterFullScreen(FloatSize videoDimensions)
 void PageClientImpl::exitFullScreen()
 {
     [[m_webView fullScreenWindowController] exitFullScreen];
+}
+
+static UIInterfaceOrientationMask toUIInterfaceOrientationMask(WebCore::ScreenOrientationType orientation)
+{
+    switch (orientation) {
+    case WebCore::ScreenOrientationType::PortraitPrimary:
+        return UIInterfaceOrientationMaskPortrait;
+    case WebCore::ScreenOrientationType::PortraitSecondary:
+        return UIInterfaceOrientationMaskPortraitUpsideDown;
+    case WebCore::ScreenOrientationType::LandscapePrimary:
+        return UIInterfaceOrientationMaskLandscapeLeft;
+    case WebCore::ScreenOrientationType::LandscapeSecondary:
+        return UIInterfaceOrientationMaskLandscapeRight;
+    }
+    ASSERT_NOT_REACHED();
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+bool PageClientImpl::lockFullscreenOrientation(WebCore::ScreenOrientationType orientation)
+{
+    [[m_webView fullScreenWindowController] setSupportedOrientations:toUIInterfaceOrientationMask(orientation)];
+    return true;
+}
+
+void PageClientImpl::unlockFullscreenOrientation()
+{
+    [[m_webView fullScreenWindowController] resetSupportedOrientations];
 }
 
 void PageClientImpl::beganEnterFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -47,6 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideUI;
 - (void)videoControlsManagerDidChange;
 - (void)setAnimatingViewAlpha:(CGFloat)alpha;
+- (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations;
+- (void)resetSupportedOrientations;
 #if HAVE(UIKIT_WEBKIT_INTERNALS)
 - (void)hideMediaControls:(BOOL)hidden;
 #endif

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -124,6 +124,7 @@ private:
     WebKit::FullscreenTouchSecheuristic _secheuristic;
     WKFullScreenViewControllerPlaybackSessionModelClient _playbackClient;
     CGFloat _nonZeroStatusBarHeight;
+    std::optional<UIInterfaceOrientationMask> _supportedOrientations;
 #if HAVE(UIKIT_WEBKIT_INTERNALS)
     BOOL m_shouldHideMediaControls;
 #endif
@@ -145,7 +146,6 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_statusBarFrameDidChange:) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
 ALLOW_DEPRECATED_DECLARATIONS_END
     _secheuristic.setParameters(WebKit::FullscreenTouchSecheuristicParameters::iosParameters());
-
     self._webView = webView;
 
     _playbackClient.setParent(self);
@@ -178,6 +178,25 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_location release];
 
     [super dealloc];
+}
+
+- (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations
+{
+    _supportedOrientations = supportedOrientations;
+    [self setNeedsUpdateOfSupportedInterfaceOrientations];
+}
+
+- (void)resetSupportedOrientations
+{
+    _supportedOrientations = std::nullopt;
+    [self setNeedsUpdateOfSupportedInterfaceOrientations];
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
+{
+    if (!_supportedOrientations)
+        return [super supportedInterfaceOrientations];
+    return *_supportedOrientations;
 }
 
 - (void)showUI

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -40,6 +40,8 @@
 - (void)requestExitFullScreen;
 - (void)exitFullScreen;
 - (void)beganExitFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;
+- (void)setSupportedOrientations:(UIInterfaceOrientationMask)orientations;
+- (void)resetSupportedOrientations;
 - (void)close;
 - (void)webViewDidRemoveFromSuperviewWhileInFullscreen;
 - (void)videoControlsManagerDidChange;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -526,6 +526,16 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
 #pragma mark -
 #pragma mark External Interface
 
+- (void)setSupportedOrientations:(UIInterfaceOrientationMask)orientations
+{
+    [_fullscreenViewController setSupportedOrientations:orientations];
+}
+
+- (void)resetSupportedOrientations
+{
+    [_fullscreenViewController resetSupportedOrientations];
+}
+
 - (void)enterFullScreen:(CGSize)videoDimensions
 {
     if ([self isFullScreen])


### PR DESCRIPTION
#### d6f850a7728e6788cfd4947b40ca5ec45976bc7a
<pre>
[iOS] Add screen orientation locking / unlocking support outside layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=246435">https://bugs.webkit.org/show_bug.cgi?id=246435</a>

Reviewed by Wenson Hsieh.

Add screen orientation locking / unlocking support outside layout tests, on iOS
devices. Outside tests, the fullscreen API uses the WKFullScreenWindowController
to display a new fullscreen view on top of the current one. This new view has its
own UIViewController that WebKit controls. As a result, when locking the screen
orientation (which is gated on being in fullscreen), we need to do so via the
WKFullScreenWindowController, instead of relying on the client application.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::lockFullscreenOrientation):
(WebKit::WebFullScreenManagerProxy::unlockFullscreenOrientation):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxyClient::lockFullscreenOrientation):
(WebKit::WebFullScreenManagerProxyClient::unlockFullscreenOrientation):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::unlock):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::toUIInterfaceOrientationMask):
(WebKit::PageClientImpl::lockFullscreenOrientation):
(WebKit::PageClientImpl::unlockFullscreenOrientation):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController setSupportedOrientation:]):
(-[WKFullScreenViewController supportedInterfaceOrientations]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController setSupportedOrientations:]):

Canonical link: <a href="https://commits.webkit.org/255555@main">https://commits.webkit.org/255555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e05e3802d107a5be6236864cf6323d110dbc6e01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102599 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2088 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30427 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85274 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98538 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79361 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28344 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36828 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34627 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38498 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1773 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37338 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->