### PR TITLE
Resync web-platform-tests/screen-orientation from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml
@@ -2,3 +2,4 @@ spec: https://w3c.github.io/screen-orientation/
 suggested_reviewers:
   - marcoscaceres
   - cdumez
+  - michaelwasserman

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL When performing a fragment navigation, the orientation must not change or unlock promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+Harness Error (FAIL), message = Test named 'When performing a fragment navigation, the change must not abort' specified 1 'cleanup' function, and 1 failed.
+
+FAIL When performing a fragment navigation, the change must not abort promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
@@ -4,22 +4,17 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <p id="#fragment"></p>
-<script>
-  promise_test(async t => {
-    await test_driver.bless("request full screen", () => {
-      return document.documentElement.requestFullscreen();
-    });
-    const fragment = document.createElement("p");
-    fragment.id = "fragment";
-    document.body.appendChild(fragment);
-    const { type: preType } = screen.orientation;
-    const isPortrait = preType.startsWith("portrait");
-    const newType = `${isPortrait ? "landscape" : "portrait"}`;
-    const p = screen.orientation.lock(newType);
-    screen.orientation.onchange = t.unreached_func(
-      "change event must not fire"
-    );
+<script type="module">
+  import { makeCleanup } from "./resources/orientation-utils.js";
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const orientation = screen.orientation.type.startsWith("portrait")
+      ? "landscape"
+      : "portrait";
+    const p = screen.orientation.lock(orientation);
     window.location.href = "#fragment";
     await p;
-  }, "When performing a fragment navigation, the orientation must not change or unlock");
+  }, "When performing a fragment navigation, the change must not abort");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/empty.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/empty.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
@@ -15,3 +15,15 @@ export function getOppositeOrientation() {
   const isPortrait = currentOrientation.includes("portrait");
   return isPortrait ? "landscape" : "portrait";
 }
+
+export function makeCleanup(initialOrientation = screen.orientation?.type.split(/-/)[0]) {
+  return async () => {
+    if (initialOrientation) {
+      await screen.orientation.lock(initialOrientation);
+    }
+    screen.orientation.unlock();
+    requestAnimationFrame(async () => {
+      await document.exitFullscreen();
+    });
+  }
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/empty.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/iframe-listen-orientation-change.html
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
 /LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL When performing a fragment navigation, the orientation must not change or unlock assert_unreached: change event must not fire Reached unreachable code
+PASS When performing a fragment navigation, the change must not abort
 


### PR DESCRIPTION
#### c09169ca551d8a828503326bd453e3e09c7b05c4
<pre>
Resync web-platform-tests/screen-orientation from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=246436">https://bugs.webkit.org/show_bug.cgi?id=246436</a>

Reviewed by Tim Nguyen.

Resync web-platform-tests/screen-orientation from upstream a63431f501db4cb3877.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/empty.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
(export.makeCleanup.return.async if):
(export.makeCleanup):
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt:

Canonical link: <a href="https://commits.webkit.org/255481@main">https://commits.webkit.org/255481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b903a4c848a0e81ef0741ec20db41a5850c367e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102368 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1866 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30217 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98529 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1256 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79141 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28178 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83173 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36625 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17988 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38287 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40596 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1727 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37149 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->