### PR TITLE
[JSC] Integrate constant folding for StringSlice

### DIFF
--- a/JSTests/microbenchmarks/string-slice-constants-binary.js
+++ b/JSTests/microbenchmarks/string-slice-constants-binary.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".slice(1) === 'assets/omfg';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-slice-constants-identity.js
+++ b/JSTests/microbenchmarks/string-slice-constants-identity.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".slice(0) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (!test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-slice-constants.js
+++ b/JSTests/microbenchmarks/string-slice-constants.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".slice(0,8) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-slice-empty-constant-folding.js
+++ b/JSTests/microbenchmarks/string-slice-empty-constant-folding.js
@@ -1,0 +1,13 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function slice(string) {
+    return string.slice(3, 3);
+}
+noInline(slice);
+
+for (var i = 0; i < 1e6; ++i)
+    shouldBe(slice("Cocoa"), "");

--- a/JSTests/microbenchmarks/string-slice-length-constant.js
+++ b/JSTests/microbenchmarks/string-slice-length-constant.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1() {
+    return "/assets/omfg".slice(0,'/assets/'.length) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1())
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-slice2.js
+++ b/JSTests/microbenchmarks/string-slice2.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(start, end) {
+    return "/assets/omfg".slice(start, end) === '/assets/';
+}
+noInline(test1);
+
+var count = 0;
+for (var i = 0; i < 1e6; ++i) {
+    if (test1(0, 8))
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/JSTests/microbenchmarks/string-starts-with-mod-prototype-slice.js
+++ b/JSTests/microbenchmarks/string-starts-with-mod-prototype-slice.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+String.prototype._startsWith = function (find) {
+    return this.slice(0,find.length) === find
+}
+
+function test1() {
+    return "/assets/omfg"._startsWith('/assets/');
+}
+noInline(test1);
+
+function test2(string) {
+    return "/assets/omfg"._startsWith(string);
+}
+noInline(test2);
+
+var count = 0;
+for (var i = 0; i < 5e5; ++i) {
+    if (test1())
+        ++count;
+    if (test2('/assets/'))
+        ++count;
+}
+shouldBe(count, 1e6);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2744,15 +2744,24 @@ JSC_DEFINE_JIT_OPERATION(operationStringSubstr, JSCell*, (JSGlobalObject* global
     return jsSubstring(vm, globalObject, jsCast<JSString*>(cell), from, span);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationStringSlice, JSCell*, (JSGlobalObject* globalObject, JSCell* cell, int32_t start, int32_t end))
+JSC_DEFINE_JIT_OPERATION(operationStringSlice, JSString*, (JSGlobalObject* globalObject, JSString* string, int32_t start))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
 
-    JSString* string = asString(cell);
     static_assert(static_cast<uint64_t>(JSString::MaxLength) <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
-    return stringSlice(globalObject, vm, string, string->length(), start, end);
+    return stringSlice<int32_t>(globalObject, vm, string, string->length(), start, std::nullopt);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringSliceWithEnd, JSString*, (JSGlobalObject* globalObject, JSString* string, int32_t start, int32_t end))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    static_assert(static_cast<uint64_t>(JSString::MaxLength) <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
+    return stringSlice<int32_t>(globalObject, vm, string, string->length(), start, end);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationStringSubstring, JSString*, (JSGlobalObject* globalObject, JSString* string, int32_t start))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -247,7 +247,8 @@ JSC_DECLARE_JIT_OPERATION(operationResolveRopeString, JSString*, (JSGlobalObject
 JSC_DECLARE_JIT_OPERATION(operationSingleCharacterString, JSString*, (VM*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationStringSubstr, JSCell*, (JSGlobalObject*, JSCell*, int32_t, int32_t));
-JSC_DECLARE_JIT_OPERATION(operationStringSlice, JSCell*, (JSGlobalObject*, JSCell*, int32_t, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringSlice, JSString*, (JSGlobalObject*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringSliceWithEnd, JSString*, (JSGlobalObject*, JSString*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringValueOf, JSString*, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringString, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithoutSubstitution, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1954,9 +1954,9 @@ void SpeculativeJIT::compileStringSlice(Node* node)
     addSlowPathGenerator(slowPathCall(slowCases, this, operationStringSubstr, tempGPR, JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, startIndexGPR, tempGPR));
 
     if (endGPR)
-        addSlowPathGenerator(slowPathCall(isRope, this, operationStringSlice, tempGPR, JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, startGPR, *endGPR));
+        addSlowPathGenerator(slowPathCall(isRope, this, operationStringSliceWithEnd, tempGPR, JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, startGPR, *endGPR));
     else
-        addSlowPathGenerator(slowPathCall(isRope, this, operationStringSlice, tempGPR, JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, startGPR, TrustedImm32(std::numeric_limits<int32_t>::max())));
+        addSlowPathGenerator(slowPathCall(isRope, this, operationStringSlice, tempGPR, JITCompiler::LinkableConstant(m_jit, m_graph.globalObjectFor(node->origin.semantic)), stringGPR, startGPR));
 
     doneCases.link(&m_jit);
     cellResult(tempGPR, node);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -15631,8 +15631,6 @@ IGNORE_CLANG_WARNINGS_END
         LValue end = nullptr;
         if (m_node->child3())
             end = lowInt32(m_node->child3());
-        else
-            end = m_out.constInt32(std::numeric_limits<int32_t>::max());
         m_out.branch(isRopeString(string, m_node->child1()), rarely(ropeSlowCase), usually(lengthCheckCase));
 
         LBasicBlock lastNext = m_out.appendTo(lengthCheckCase, emptyCase);
@@ -15690,7 +15688,10 @@ IGNORE_CLANG_WARNINGS_END
         m_out.jump(continuation);
 
         m_out.appendTo(ropeSlowCase, continuation);
-        results.append(m_out.anchor(vmCall(pointerType(), operationStringSlice, weakPointer(globalObject), string, start, end)));
+        if (end)
+            results.append(m_out.anchor(vmCall(pointerType(), operationStringSliceWithEnd, weakPointer(globalObject), string, start, end)));
+        else
+            results.append(m_out.anchor(vmCall(pointerType(), operationStringSlice, weakPointer(globalObject), string, start)));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1004,7 +1004,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSlice, (JSGlobalObject* globalObject, Ca
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     double end = a1.isUndefined() ? length : a1.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    RELEASE_AND_RETURN(scope, JSValue::encode(stringSlice(globalObject, vm, string, length, start, end)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(stringSlice<double>(globalObject, vm, string, length, start, end)));
 }
 
 // Return true in case of early return (resultLength got to limitLength).


### PR DESCRIPTION
#### 92626c6d115a104a3ad50e0eb1d9f2278a638fa2
<pre>
[JSC] Integrate constant folding for StringSlice
<a href="https://bugs.webkit.org/show_bug.cgi?id=246433">https://bugs.webkit.org/show_bug.cgi?id=246433</a>
rdar://problem/101107093

Reviewed by Alexey Shvayka.

This patch applies StringSubstring optimization to StringSlice. We add strength reduction for
StringSlice so that we can compute constant strings. We also enhance existing optimization to
capture more cases: generating empty string if from and to are the same.

                                                ToT                     Patched

string-slice-constants-binary             16.9754+-0.2657     ^     10.8552+-0.2213        ^ definitely 1.5638x faster
string-slice-empty                         4.3653+-0.1431            4.2705+-0.0257          might be 1.0222x faster
string-slice-constants                    17.1748+-0.2821     ^      6.8719+-0.0946        ^ definitely 2.4993x faster
string-slice-one-char                      4.7544+-0.0539            4.7483+-0.0480
string-slice2                             18.0453+-0.0894           17.9867+-0.0282
string-slice-constants-identity            6.4399+-0.0305     ^      2.9076+-0.0162        ^ definitely 2.2149x faster
string-slice-empty-constant-folding        3.7372+-0.0237     ^      3.6572+-0.0245        ^ definitely 1.0219x faster
string-slice-length-constant              17.0568+-0.0695     ^      6.8520+-0.0438        ^ definitely 2.4893x faster
string-slice                              13.6193+-0.0590     ?     13.6565+-0.1618        ?

* JSTests/microbenchmarks/string-slice-constants-binary.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-slice-constants-identity.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-slice-constants.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-slice-length-constant.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-slice2.js: Added.
(shouldBe):
(test1):
* JSTests/microbenchmarks/string-starts-with-mod-prototype-slice.js: Added.
(shouldBe):
(String.prototype._startsWith):
(test1):
(test2):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringSlice):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::extractSliceOffsets):
(JSC::stringSlice):
(JSC::stringSubstring):

Canonical link: <a href="https://commits.webkit.org/255552@main">https://commits.webkit.org/255552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d231ccdf3168a2c0c37dafd6f76203dfa9fd1f17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92646 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102364 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1861 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30212 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98525 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98310 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1257 "Found 1 new test failure: imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79136 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71265 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84006 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36620 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16801 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79055 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/17984 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27415 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3846 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40591 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81675 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37144 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18474 "Passed tests") | 
<!--EWS-Status-Bubble-End-->