### PR TITLE
Make WebGL use GPU process on macOS layout tests by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1747,23 +1747,6 @@ UseGPUProcessForDisplayCapture:
     WebKit:
       default: true
 
-UseGPUProcessForWebGLEnabled:
-  type: bool
-  humanReadableName: "GPU Process: WebGL"
-  humanReadableDescription: "Process all WebGL operations in GPU Process"
-  condition: ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
-      "PLATFORM(WIN)": true
-      default: false
-    WebCore:
-      "ENABLE(GPU_PROCESS_BY_DEFAULT) && PLATFORM(IOS_FAMILY) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
-      "PLATFORM(WIN)": true
-      default: false
-
 UserGesturePromisePropagationEnabled:
   type: bool
   humanReadableName: "UserGesture Promise Propagation"

--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -1110,6 +1110,24 @@ UseGPUProcessForMediaEnabled:
       "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
       default: false
 
+UseGPUProcessForWebGLEnabled:
+  type: bool
+  humanReadableName: "GPU Process: WebGL"
+  humanReadableDescription: "Process all WebGL operations in GPU Process"
+  condition: ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "ENABLE(GPU_PROCESS_BY_DEFAULT) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
+      "PLATFORM(WIN)": true
+      default: false
+    WebCore:
+      "ENABLE(GPU_PROCESS_BY_DEFAULT) && !HAVE(UIKIT_WEBKIT_INTERNALS)": true
+      "PLATFORM(WIN)": true
+      default: false
+
+
 UseGeneralDirectoryForStorage:
   type: bool
   humanReadableName: "Use General Directory For Storage"


### PR DESCRIPTION
#### 0882d1833451a0827debe3d4dd4e50129fdb2e35
<pre>
Make WebGL use GPU process on macOS layout tests by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=246445">https://bugs.webkit.org/show_bug.cgi?id=246445</a>
rdar://problem/101113326

Reviewed by Tim Horton.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:

Canonical link: <a href="https://commits.webkit.org/255952@main">https://commits.webkit.org/255952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5da4996b595aa981503c15a5f9081e010067a4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102378 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162772 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1876 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30227 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98539 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1270 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79152 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28190 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/82893 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71279 "Found 4 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84020 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36635 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16815 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79069 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18000 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27419 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4112 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40606 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81690 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37161 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18479 "Passed tests") | 
<!--EWS-Status-Bubble-End-->