### PR TITLE
Don't use defaulted comparison operator yet

### DIFF
--- a/Source/WebCore/css/StyleColor.h
+++ b/Source/WebCore/css/StyleColor.h
@@ -50,7 +50,7 @@ enum class StyleColorOptions : uint8_t {
 };
 
 struct CurrentColor {
-    bool operator==(const CurrentColor&) const = default;
+    bool operator==(const CurrentColor&) const { return true; };
 };
 
 class StyleColor {
@@ -75,7 +75,7 @@ public:
     StyleColor(const StyleColor&) = default;
     StyleColor(StyleColor&&) = default;
     StyleColor& operator=(const StyleColor&) = default;
-    bool operator==(const StyleColor&) const = default;
+    bool operator==(const StyleColor& other) const { return m_color == other.m_color; };
 
     static StyleColor currentColor() { return StyleColor { CurrentColor { } }; }
 

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -163,11 +163,20 @@ enum class FontVariantNumericOrdinal : bool { Normal, Yes };
 enum class FontVariantNumericSlashedZero : bool { Normal, Yes };
 
 struct FontVariantAlternatesNormal {
-    bool operator==(const FontVariantAlternatesNormal&) const = default;
+    bool operator==(const FontVariantAlternatesNormal&) const { return true; }
 };
 
 struct FontVariantAlternatesValues {
-    bool operator==(const FontVariantAlternatesValues&) const = default;
+    bool operator==(const FontVariantAlternatesValues& other) const
+    {
+        return stylistic == other.styleset
+            && styleset == other.styleset
+            && characterVariant == other.characterVariant
+            && swash == other.swash
+            && ornaments == other.ornaments
+            && annotation == other.annotation
+            && historicalForms == other.historicalForms;
+    }
 
     std::optional<String> stylistic;
     std::optional<String> styleset;
@@ -184,7 +193,7 @@ class FontVariantAlternates {
     using Values = FontVariantAlternatesValues;
 
 public:
-    bool operator==(const FontVariantAlternates&) const = default;
+    bool operator==(const FontVariantAlternates& other) const { return m_val == other.m_val; }
 
     bool isNormal() const
     {


### PR DESCRIPTION
#### 1837ee7c61b5c88aeac83b1add0afcfc02abe4a8
<pre>
Don&apos;t use defaulted comparison operator yet
<a href="https://bugs.webkit.org/show_bug.cgi?id=246447">https://bugs.webkit.org/show_bug.cgi?id=246447</a>

Reviewed by NOBODY (OOPS!).

GCC 9.3 doesn&apos;t support it.

* Source/WebCore/css/StyleColor.h:
(WebCore::CurrentColor::operator== const):
(WebCore::StyleColor::operator== const):
* Source/WebCore/platform/text/TextFlags.h:
(WebCore::FontVariantAlternatesNormal::operator== const):
(WebCore::FontVariantAlternatesValues::operator== const):
(WebCore::FontVariantAlternates::operator== const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1837ee7c61b5c88aeac83b1add0afcfc02abe4a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/1886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102388 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/1886 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30237 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98544 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98334 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79162 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28198 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/82898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36645 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34436 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18006 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37169 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->