### PR TITLE
IPC::MessageSender::sendWithAsyncReply is not consistent with send failures

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -30,15 +30,18 @@ namespace IPC {
 
 MessageSender::~MessageSender() = default;
 
-bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOption> sendOptions, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&& asyncReplyInfo)
+bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOption> sendOptions)
 {
     auto* connection = messageSenderConnection();
     ASSERT(connection);
-
-    if (asyncReplyInfo)
-        IPC::addAsyncReplyHandler(*connection, asyncReplyInfo->second, WTFMove(asyncReplyInfo->first));
-
     return connection->sendMessage(WTFMove(encoder), sendOptions);
+}
+
+bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncReplyHandler replyHandler, OptionSet<SendOption> sendOptions)
+{
+    auto* connection = messageSenderConnection();
+    ASSERT(connection);
+    return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions);
 }
 
 } // namespace IPC

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -202,20 +202,20 @@ bool AuxiliaryProcessProxy::wasTerminated() const
 #endif
 }
 
-bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&& asyncReplyInfo, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<IPC::Connection::AsyncReplyHandler> asyncReplyHandler, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
 {
     // FIXME: We should turn this into a RELEASE_ASSERT().
     ASSERT(isMainRunLoop());
     if (!isMainRunLoop()) {
-        callOnMainRunLoop([protectedThis = Ref { *this }, encoder = WTFMove(encoder), sendOptions, asyncReplyInfo = WTFMove(asyncReplyInfo), shouldStartProcessThrottlerActivity]() mutable {
-            protectedThis->sendMessage(WTFMove(encoder), sendOptions, WTFMove(asyncReplyInfo), shouldStartProcessThrottlerActivity);
+        callOnMainRunLoop([protectedThis = Ref { *this }, encoder = WTFMove(encoder), sendOptions, asyncReplyHandler = WTFMove(asyncReplyHandler), shouldStartProcessThrottlerActivity]() mutable {
+            protectedThis->sendMessage(WTFMove(encoder), sendOptions, WTFMove(asyncReplyHandler), shouldStartProcessThrottlerActivity);
         });
         return true;
     }
 
-    if (asyncReplyInfo && canSendMessage() && shouldStartProcessThrottlerActivity == ShouldStartProcessThrottlerActivity::Yes) {
-        auto completionHandler = std::exchange(asyncReplyInfo->first, nullptr);
-        asyncReplyInfo->first = [activity = throttler().backgroundActivity({ }), completionHandler = WTFMove(completionHandler)](IPC::Decoder* decoder) mutable {
+    if (asyncReplyHandler && canSendMessage() && shouldStartProcessThrottlerActivity == ShouldStartProcessThrottlerActivity::Yes) {
+        auto completionHandler = WTFMove(asyncReplyHandler->completionHandler);
+        asyncReplyHandler->completionHandler = [activity = throttler().backgroundActivity({ }), completionHandler = WTFMove(completionHandler)](IPC::Decoder* decoder) mutable {
             completionHandler(decoder);
         };
     }
@@ -223,22 +223,25 @@ bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Optio
     switch (state()) {
     case State::Launching:
         // If we're waiting for the child process to launch, we need to stash away the messages so we can send them once we have a connection.
-        m_pendingMessages.append({ WTFMove(encoder), sendOptions, WTFMove(asyncReplyInfo) });
+        m_pendingMessages.append({ WTFMove(encoder), sendOptions, WTFMove(asyncReplyHandler) });
         return true;
 
     case State::Running:
-        if (asyncReplyInfo)
-            IPC::addAsyncReplyHandler(*connection(), asyncReplyInfo->second, std::exchange(asyncReplyInfo->first, nullptr));
-        if (connection()->sendMessage(WTFMove(encoder), sendOptions))
-            return true;
+        if (asyncReplyHandler) {
+            if (connection()->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(*asyncReplyHandler), sendOptions))
+                return true;
+        } else {
+            if (connection()->sendMessage(WTFMove(encoder), sendOptions))
+                return true;
+        }
         break;
 
     case State::Terminated:
         break;
     }
 
-    if (asyncReplyInfo && asyncReplyInfo->first) {
-        RunLoop::current().dispatch([completionHandler = WTFMove(asyncReplyInfo->first)]() mutable {
+    if (asyncReplyHandler && asyncReplyHandler->completionHandler) {
+        RunLoop::current().dispatch([completionHandler = WTFMove(asyncReplyHandler->completionHandler)]() mutable {
             completionHandler(nullptr);
         });
     }
@@ -300,9 +303,10 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher*, IPC::Connection
     for (auto&& pendingMessage : std::exchange(m_pendingMessages, { })) {
         if (!shouldSendPendingMessage(pendingMessage))
             continue;
-        if (pendingMessage.asyncReplyInfo)
-            IPC::addAsyncReplyHandler(*connection(), pendingMessage.asyncReplyInfo->second, WTFMove(pendingMessage.asyncReplyInfo->first));
-        m_connection->sendMessage(WTFMove(pendingMessage.encoder), pendingMessage.sendOptions);
+        if (pendingMessage.asyncReplyHandler)
+            m_connection->sendMessageWithAsyncReply(WTFMove(pendingMessage.encoder), WTFMove(*pendingMessage.asyncReplyHandler), pendingMessage.sendOptions);
+        else
+            m_connection->sendMessage(WTFMove(pendingMessage.encoder), pendingMessage.sendOptions);
     }
 }
 
@@ -310,8 +314,8 @@ void AuxiliaryProcessProxy::replyToPendingMessages()
 {
     ASSERT(isMainRunLoop());
     for (auto& pendingMessage : std::exchange(m_pendingMessages, { })) {
-        if (pendingMessage.asyncReplyInfo)
-            pendingMessage.asyncReplyInfo->first(nullptr);
+        if (pendingMessage.asyncReplyHandler)
+            pendingMessage.asyncReplyHandler->completionHandler(nullptr);
     }
 }
 

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -90,9 +90,14 @@ IPC::Connection* DrawingAreaProxy::messageSenderConnection() const
     return process().connection();
 }
 
-bool DrawingAreaProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&& asyncReplyInfo)
+bool DrawingAreaProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
-    return process().sendMessage(WTFMove(encoder), sendOptions, WTFMove(asyncReplyInfo));
+    return process().sendMessage(WTFMove(encoder), sendOptions);
+}
+
+bool DrawingAreaProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
+{
+    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -154,7 +154,8 @@ private:
 
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final { return m_identifier.toUInt64(); }
-    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&&) final;
+    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
+    bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
 
     // Message handlers.
     // FIXME: These should be pure virtual.

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -622,11 +622,16 @@ uint64_t ProvisionalPageProxy::messageSenderDestinationID() const
     return m_webPageID.toUInt64();
 }
 
-bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&& asyncReplyInfo)
+bool ProvisionalPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
     // Send messages via the WebProcessProxy instead of the IPC::Connection since AuxiliaryProcessProxy implements queueing of messages
     // while the process is still launching.
-    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(asyncReplyInfo));
+    return m_process->sendMessage(WTFMove(encoder), sendOptions);
+}
+
+bool ProvisionalPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
+{
+    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -123,7 +123,8 @@ private:
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
-    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&&) final;
+    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
+    bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
 
     void decidePolicyForNavigationActionAsync(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, NavigationActionData&&, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&&, IPC::FormDataReference&& requestBody, WebCore::ResourceResponse&& redirectResponse, const UserData&, uint64_t listenerID);
     void decidePolicyForResponse(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, bool wasAllowedByInjectedBundle, uint64_t listenerID, const UserData&);

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -276,11 +276,16 @@ uint64_t SuspendedPageProxy::messageSenderDestinationID() const
     return m_webPageID.toUInt64();
 }
 
-bool SuspendedPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&& asyncReplyInfo)
+bool SuspendedPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
     // Send messages via the WebProcessProxy instead of the IPC::Connection since AuxiliaryProcessProxy implements queueing of messages
     // while the process is still launching.
-    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(asyncReplyInfo));
+    return m_process->sendMessage(WTFMove(encoder), sendOptions);
+}
+
+bool SuspendedPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
+{
+    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -100,7 +100,8 @@ private:
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
-    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&&) final;
+    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
+    bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
 
     WebPageProxy& m_page;
     WebCore::PageIdentifier m_webPageID;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7176,9 +7176,14 @@ void WebPageProxy::didFailToFindString(const String& string)
     m_findClient->didFailToFindString(this, string);
 }
 
-bool WebPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&& asyncReplyInfo)
+bool WebPageProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
-    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(asyncReplyInfo));
+    return m_process->sendMessage(WTFMove(encoder), sendOptions);
+}
+
+bool WebPageProxy::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
+{
+    return m_process->sendMessage(WTFMove(encoder), sendOptions, WTFMove(handler));
 }
 
 IPC::Connection* WebPageProxy::messageSenderConnection() const

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2191,7 +2191,9 @@ private:
     void setUserAgent(String&&);
 
     // IPC::MessageSender
-    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, std::optional<std::pair<CompletionHandler<void(IPC::Decoder*)>, uint64_t>>&&) final;
+    bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
+    bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;
+
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -558,6 +558,8 @@
 		7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */; };
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
 		7B6FF89728C22D9400CA76B0 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 2B648DBA28C1C1F700791F2B /* WebKit.framework */; };
+		7B7392E928F849EC007297FC /* MessageSenderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7392E128F849EC007297FC /* MessageSenderTests.cpp */; };
+		7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */; };
 		7B774906267CCE72009873B4 /* TestRunnerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B774904267CCE68009873B4 /* TestRunnerTests.cpp */; };
 		7B7D096A2519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D09692519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm */; };
 		7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CC16C4D80A00BA2BB1 /* mainIOS.mm */; };
@@ -2706,6 +2708,9 @@
 		7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferTests.cpp; sourceTree = "<group>"; };
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
 		7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConnectionTests.cpp; sourceTree = "<group>"; };
+		7B7392E128F849EC007297FC /* MessageSenderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageSenderTests.cpp; sourceTree = "<group>"; };
+		7B7392EA28F849F3007297FC /* IPCTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPCTestUtilities.h; sourceTree = "<group>"; };
+		7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPCTestUtilities.cpp; sourceTree = "<group>"; };
 		7B774904267CCE68009873B4 /* TestRunnerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestRunnerTests.cpp; sourceTree = "<group>"; };
 		7B7D09692519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebGLNoCrashOnOtherThreadAccess.mm; sourceTree = "<group>"; };
 		7B9FC57E28A26137007570E7 /* TestIPC */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestIPC; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4370,6 +4375,9 @@
 			isa = PBXGroup;
 			children = (
 				7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */,
+				7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */,
+				7B7392EA28F849F3007297FC /* IPCTestUtilities.h */,
+				7B7392E128F849EC007297FC /* MessageSenderTests.cpp */,
 				7B9FC58328A26792007570E7 /* StreamConnectionBufferTests.cpp */,
 				7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */,
 			);
@@ -5933,8 +5941,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */,
+				7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */,
 				7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */,
 				7B9FC3A028A26137007570E7 /* mainMac.mm in Sources */,
+				7B7392E928F849EC007297FC /* MessageSenderTests.cpp in Sources */,
 				7B9FC58428A26792007570E7 /* StreamConnectionBufferTests.cpp in Sources */,
 				7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */,
 				7B9FC58C28A2717D007570E7 /* TestsController.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "WTFStringUtilities.h" // NOLINT
+#include "IPCTestUtilities.h" // NOLINT
+#include <wtf/threads/BinarySemaphore.h> // NOLINT
+
+namespace TestWebKitAPI {
+
+void PrintTo(ConnectionTestDirection value, ::std::ostream* o)
+{
+    if (value == ConnectionTestDirection::ServerIsA)
+        *o << "ServerIsA";
+    else if (value == ConnectionTestDirection::ClientIsA)
+        *o << "ClientIsA";
+    else
+        *o << "Unknown";
+}
+
+void ConnectionTestBase::setupBase()
+{
+    WTF::initializeMainThread();
+    auto identifiers = IPC::Connection::createConnectionIdentifierPair();
+    if (!identifiers) {
+        FAIL();
+        return;
+    }
+    m_connections[0].connection = IPC::Connection::createServerConnection(WTFMove(identifiers->server));
+    m_connections[1].connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { identifiers->client.leakSendRight() });
+}
+
+void ConnectionTestBase::teardownBase()
+{
+    for (auto& c : m_connections) {
+        if (c.connection) {
+            c.connection->invalidate();
+            ensureConnectionWorkQueueEmpty(*c.connection);
+        }
+        c.connection = nullptr;
+    }
+    // Tests should handle all messages. Catch unexpected messages.
+    {
+        auto messages = aClient().takeMessages();
+        EXPECT_EQ(messages.size(), 0u);
+        for (uint64_t i = 0u; i < messages.size(); ++i) {
+            SCOPED_TRACE(makeString("A had unexpected message: ", i));
+            EXPECT_EQ(messages[i].messageName, static_cast<IPC::MessageName>(0xaaaa));
+            EXPECT_EQ(messages[i].destinationID, 0xddddddu);
+        }
+    }
+    {
+        auto messages = bClient().takeMessages();
+        EXPECT_EQ(messages.size(), 0u);
+        for (uint64_t i = 0u; i < messages.size(); ++i) {
+            SCOPED_TRACE(makeString("B had unexpected message message: ", i));
+            EXPECT_EQ(messages[i].messageName, static_cast<IPC::MessageName>(0xaaaa));
+            EXPECT_EQ(messages[i].destinationID, 0xddddddu);
+        }
+    }
+}
+
+void ConnectionTestBase::ensureConnectionWorkQueueEmpty(IPC::Connection& connection)
+{
+    // FIXME: currently we have no real way to ensure that a work queue completes.
+    // On Cocoa this is a problem when exit() occurs while work queue is still cancelling
+    // the dispatch queue sources.
+    // To workaround for now, we dispatch one sync message to ensure invalidate is run to
+    // cancel the dispatch sources and one sync message to ensure that the cancel handler
+    // has run.
+    for (int i = 0; i < 2; ++i) {
+        BinarySemaphore semaphore;
+        connection.dispatchOnReceiveQueueForTesting([&semaphore] {
+            semaphore.signal();
+        });
+        semaphore.wait();
+    }
+}
+
+}

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ArgumentCoders.h"
+#include "Connection.h"
+#include "Utilities.h"
+#include <optional>
+
+namespace TestWebKitAPI {
+
+struct MessageInfo {
+    IPC::MessageName messageName;
+    uint64_t destinationID;
+};
+
+struct MockTestMessage1 {
+    static constexpr bool isSync = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
+    std::tuple<> arguments() { return { }; }
+};
+
+struct MockTestMessageWithAsyncReply1 {
+    static constexpr bool isSync = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(124); }
+    // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
+    // If WebPage_GetBytecodeProfileReply is removed, just use another one.
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
+    std::tuple<> arguments() { return { }; }
+    static void callReply(IPC::Decoder& decoder, CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        auto value = decoder.decode<uint64_t>();
+        completionHandler(*value);
+    }
+    static void cancelReply(CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        completionHandler(0);
+    }
+};
+
+class MockConnectionClient final : public IPC::Connection::Client {
+public:
+    ~MockConnectionClient()
+    {
+    }
+
+    Vector<MessageInfo> takeMessages()
+    {
+        Vector<MessageInfo> result;
+        result.appendRange(m_messages.begin(), m_messages.end());
+        m_messages.clear();
+        return result;
+    }
+
+    MessageInfo waitForMessage(Seconds timeout)
+    {
+        if (m_messages.isEmpty()) {
+            m_continueWaitForMessage = false;
+            Util::runFor(&m_continueWaitForMessage, timeout);
+        }
+        ASSERT(m_messages.size() >= 1);
+        return m_messages.takeFirst();
+    }
+
+    bool gotDidClose() const
+    {
+        return m_didClose;
+    }
+
+    bool waitForDidClose(Seconds timeout)
+    {
+        ASSERT(!m_didClose); // Caller checks this.
+        Util::runFor(&m_didClose, timeout);
+        return m_didClose;
+    }
+
+    // Handler returns false if the message should be just recorded.
+    void setAsyncMessageHandler(Function<bool(IPC::Decoder&)>&& handler)
+    {
+        m_asyncMessageHandler = WTFMove(handler);
+    }
+
+    // IPC::Connection::Client overrides.
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder& decoder) override
+    {
+        if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
+            return;
+        m_messages.append({ decoder.messageName(), decoder.destinationID() });
+        m_continueWaitForMessage = true;
+    }
+
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override
+    {
+        return false;
+    }
+
+    void didClose(IPC::Connection&) override
+    {
+        m_didClose = true;
+    }
+
+    void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName message) override
+    {
+        m_didReceiveInvalidMessage = message;
+    }
+
+private:
+    bool m_didClose { false };
+    std::optional<IPC::MessageName> m_didReceiveInvalidMessage;
+    Deque<MessageInfo> m_messages;
+    bool m_continueWaitForMessage { false };
+    Function<bool(IPC::Decoder&)> m_asyncMessageHandler;
+};
+
+enum class ConnectionTestDirection {
+    ServerIsA,
+    ClientIsA
+};
+
+void PrintTo(ConnectionTestDirection, ::std::ostream*);
+
+class ConnectionTestBase {
+public:
+    void setupBase();
+    void teardownBase();
+
+    ::testing::AssertionResult openA()
+    {
+        if (!a())
+            return ::testing::AssertionFailure() << "No A.";
+        if (!a()->open(aClient()))
+            return ::testing::AssertionFailure() << "Failed to open A";
+        return ::testing::AssertionSuccess();
+    }
+
+    ::testing::AssertionResult openB()
+    {
+        if (!b())
+            return ::testing::AssertionFailure() << "No b.";
+        if (!b()->open(bClient()))
+            return ::testing::AssertionFailure() << "Failed to open B";
+
+        return ::testing::AssertionSuccess();
+    }
+
+    ::testing::AssertionResult openBoth()
+    {
+        auto result = openA();
+        if (result)
+            result = openB();
+        return result;
+    }
+
+    IPC::Connection* a()
+    {
+        return m_connections[0].connection.get();
+    }
+
+    MockConnectionClient& aClient()
+    {
+        return m_connections[0].client;
+    }
+
+    IPC::Connection* b()
+    {
+        return m_connections[1].connection.get();
+    }
+
+    MockConnectionClient& bClient()
+    {
+        return m_connections[1].client;
+    }
+
+    void deleteA()
+    {
+        m_connections[0].connection = nullptr;
+    }
+
+    void deleteB()
+    {
+        m_connections[1].connection = nullptr;
+    }
+
+protected:
+    static void ensureConnectionWorkQueueEmpty(IPC::Connection&);
+
+    struct {
+        RefPtr<IPC::Connection> connection;
+        MockConnectionClient client;
+    } m_connections[2];
+};
+
+// Test fixture for tests that are run two times:
+//  - Server as a(), and client as b()
+//  - Server as b() and client as a()
+// The setup and teardown of the Connection is not symmetric, so this fixture is useful to test various scenarios
+// around these.
+class ConnectionTestABBA : public testing::TestWithParam<std::tuple<ConnectionTestDirection>>, protected ConnectionTestBase {
+public:
+    bool serverIsA() const { return std::get<0>(GetParam()) == ConnectionTestDirection::ServerIsA; }
+
+    void SetUp() override
+    {
+        setupBase();
+        if (!serverIsA())
+            std::swap(m_connections[0].connection, m_connections[1].connection);
+    }
+
+    void TearDown() override
+    {
+        teardownBase();
+    }
+};
+
+}

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MessageSender.h"
+
+#include "IPCTestUtilities.h"
+#include "Test.h"
+
+namespace TestWebKitAPI {
+
+class MessageSenderTest : public ConnectionTestABBA {
+};
+
+namespace {
+
+class SimpleMessageSender : public IPC::MessageSender {
+public:
+    SimpleMessageSender(IPC::Connection* connection)
+        : m_connection(connection)
+    {
+    }
+
+private:
+    IPC::Connection* messageSenderConnection() const { return m_connection; };
+    uint64_t messageSenderDestinationID() const { return 0u; };
+    IPC::Connection* m_connection;
+};
+
+}
+
+// Tests that async reply messages sent to a connection after invalidate()
+// will receive the replies as cancelled.
+TEST_P(MessageSenderTest, SendAsyncAfterInvalidateCancelsAllAsyncReplies)
+{
+    ASSERT_TRUE(openBoth());
+    b()->invalidate();
+
+    // This works for IPC::Connection.
+    {
+        HashSet<uint64_t> replies;
+        for (uint64_t i = 100u; i < 160u; ++i) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
+                EXPECT_EQ(value, 0u) << j;
+                if (!value)
+                    replies.add(j);
+            }, i);
+        }
+        while (replies.size() < 60u)
+            RunLoop::current().cycle();
+    }
+
+    // Same should work via IPC::MessageSender.
+    {
+        SimpleMessageSender sender { b() };
+        HashSet<uint64_t> replies;
+        for (uint64_t i = 100u; i < 160u; ++i) {
+            sender.sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
+                EXPECT_EQ(value, 0u) << j;
+                if (!value)
+                    replies.add(j);
+            }, i);
+        }
+        while (replies.size() < 60u)
+            RunLoop::current().cycle();
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(MessageSenderTest,
+    MessageSenderTest,
+    testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
+    TestParametersToStringFormatter());
+
+}


### PR DESCRIPTION
#### b43d9276ab01200f23cc6e40dabda2d7b767396d
<pre>
IPC::MessageSender::sendWithAsyncReply is not consistent with send failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=246457">https://bugs.webkit.org/show_bug.cgi?id=246457</a>
rdar://problem/101124692

Reviewed by Chris Dumez.

The MessageSender would add the async reply handler to the connection
regardless of whether the message send failed or not. This was a
result of exposing Connection-internal addAsyncReplyHandler() function.

Move the addAsyncReplyHandler() out of the Connection interface and
handle the send failures inside Connection. This is possible by
changing the async message format: first encode the arguments in
the message-specific template and then and inside
message agnostic Connection::sendMessageWithAsyncReply
encode the pre-allocated replyID. The replyID must be preallocated
at the moment as AuxiliaryProcessProxy delays the commit of the
reply handler.

This is a requirement for fix other concurrency bugs between
connection thread calling invalidate() and another thread
calling sendWithAsyncReply(). These fixes will be made in
future commits.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::addAsyncReplyHandler):
(IPC::Connection::sendMessageWithAsyncReply):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::makeAsyncReplyHandler):
(IPC::Connection::sendWithAsyncReply):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWantsConnection):
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::sendMessage):
(IPC::MessageSender::sendMessageWithAsyncReply):
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::sendMessage):
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
(WebKit::AuxiliaryProcessProxy::replyToPendingMessages):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::sendMessage):
(WebKit::DrawingAreaProxy::sendMessageWithAsyncReply):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::sendMessage):
(WebKit::ProvisionalPageProxy::sendMessageWithAsyncReply):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::sendMessage):
(WebKit::SuspendedPageProxy::sendMessageWithAsyncReply):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sendMessage):
(WebKit::WebPageProxy::sendMessageWithAsyncReply):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::sendMessageWithJSArguments):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(): Deleted.
(TestWebKitAPI::PrintTo): Deleted.
(TestWebKitAPI::OpenedConnectionTest::serverIsA const): Deleted.
(TestWebKitAPI::OpenedConnectionTest::SetUp): Deleted.
(TestWebKitAPI::OpenedConnectionTest::TearDown): Deleted.
(TestWebKitAPI::OpenedConnectionTest::openA): Deleted.
(TestWebKitAPI::OpenedConnectionTest::openB): Deleted.
(TestWebKitAPI::OpenedConnectionTest::openBoth): Deleted.
(TestWebKitAPI::OpenedConnectionTest::a): Deleted.
(TestWebKitAPI::OpenedConnectionTest::aClient): Deleted.
(TestWebKitAPI::OpenedConnectionTest::b): Deleted.
(TestWebKitAPI::OpenedConnectionTest::bClient): Deleted.
(TestWebKitAPI::OpenedConnectionTest::deleteA): Deleted.
(TestWebKitAPI::OpenedConnectionTest::deleteB): Deleted.

Canonical link: <a href="https://commits.webkit.org/256008@main">https://commits.webkit.org/256008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbf92668b199a148773a0c97f31e0d3169f73419

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103787 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164118 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3377 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31570 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99807 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2427 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80577 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29439 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72387 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37955 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17848 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19120 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4158 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41707 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38351 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->