### PR TITLE
[JSC] Add support for Atomics.waitAsync

### DIFF
--- a/JSTests/stress/SharedArrayBuffer.js
+++ b/JSTests/stress/SharedArrayBuffer.js
@@ -85,6 +85,8 @@ for (bad of [void 0, null, false, true, 1, 0.5, Symbol(), {}, "hello", dv, u8ca,
 for (bad of [void 0, null, false, true, 1, 0.5, Symbol(), {}, "hello", dv, i8a, i16a, u8a, u8ca, u16a, u32a, f32a, f64a]) {
     shouldFail(() => Atomics.notify(bad, 0, 0), TypeError);
     shouldFail(() => Atomics.wait(bad, 0, 0), TypeError);
+    shouldFail(() => Atomics.waitAsync(bad, 0, 0), TypeError);
+    shouldFail(() => waiterListSize(bad, 0), TypeError);
 }
 
 for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
@@ -101,6 +103,8 @@ for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
     }
     shouldFail(() => Atomics.notify(i32a, idx, 0), RangeError);
     shouldFail(() => Atomics.wait(i32a, idx, 0), RangeError);
+    shouldFail(() => Atomics.waitAsync(i32a, idx, 0), RangeError);
+    shouldFail(() => waiterListSize(i32a, idx), RangeError);
 }
 
 for (idx of ["hello"]) {
@@ -117,6 +121,7 @@ for (idx of ["hello"]) {
     }
     shouldSucceed(() => Atomics.notify(i32a, idx, 0));
     shouldSucceed(() => Atomics.wait(i32a, idx, 0, 1));
+    shouldSucceed(() => Atomics.waitAsync(i32a, idx, 0, 1));
 }
 
 function runAtomic(array, index, init, name, args, expectedResult, expectedOutcome)
@@ -146,9 +151,17 @@ i32a[0] = 0;
 var result = Atomics.wait(i32a, 0, 1);
 if (result != "not-equal")
     throw "Error: bad result from Atomics.wait: " + result;
+
+var result = Atomics.waitAsync(i32a, 0, 1);
+if (result.value != "not-equal")
+    throw "Error: bad result from Atomics.waitAsync: " + result;
+
 for (timeout of [0, 1, 10]) {
     var result = Atomics.wait(i32a, 0, 0, timeout);
     if (result != "timed-out")
         throw "Error: bad result from Atomics.wait: " + result;
 }
 
+var result = Atomics.waitAsync(i32a, 0, 0, 0);
+if (result.value != "timed-out")
+    throw "Error: bad result from Atomics.waitAsync: " + result;

--- a/JSTests/stress/bigint-atomics-fail.js
+++ b/JSTests/stress/bigint-atomics-fail.js
@@ -21,5 +21,9 @@ shouldThrow(() => {
 }, `TypeError: Typed array argument must be an Int32Array or BigInt64Array.`);
 
 shouldThrow(() => {
+    Atomics.waitAsync(u64a, 0, 0n);
+}, `TypeError: Typed array argument must be an Int32Array or BigInt64Array.`);
+
+shouldThrow(() => {
     Atomics.load(new Float64Array(8), 0);
 }, `TypeError: Typed array argument must be an Int8Array, Int16Array, Int32Array, Uint8Array, Uint16Array, Uint32Array, BigInt64Array, or BigUint64Array.`);

--- a/JSTests/stress/settimeout-starvation.js
+++ b/JSTests/stress/settimeout-starvation.js
@@ -1,0 +1,13 @@
+let promise = new Promise((resolve, _) => {
+    setTimeout(() => { resolve("timed-out") }, 1);
+});
+let outcome = null;
+
+(function wait() {
+    if (outcome === "timed-out") {
+        return;
+    }
+    setTimeout(wait, 0);
+})();
+
+promise.then(result => { outcome = result; });

--- a/JSTests/stress/shared-array-buffer-bigint.js
+++ b/JSTests/stress/shared-array-buffer-bigint.js
@@ -22,6 +22,8 @@ function shouldSucceed(f)
 for (bad of [bu64a]) {
     shouldFail(() => Atomics.notify(bad, 0, 0n), TypeError);
     shouldFail(() => Atomics.wait(bad, 0, 0n), TypeError);
+    shouldFail(() => Atomics.waitAsync(bad, 0, 0n), TypeError);
+    shouldFail(() => waiterListSize(bad, 0), TypeError);
 }
 
 for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
@@ -38,6 +40,8 @@ for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
     }
     shouldFail(() => Atomics.notify(bi64a, idx, 0n), RangeError);
     shouldFail(() => Atomics.wait(bi64a, idx, 0n), RangeError);
+    shouldFail(() => Atomics.waitAsync(bi64a, idx, 0n), RangeError);
+    shouldFail(() => waiterListSize(bi64a, idx), RangeError);
 }
 
 for (idx of ["hello"]) {
@@ -54,6 +58,7 @@ for (idx of ["hello"]) {
     }
     shouldSucceed(() => Atomics.notify(bi64a, idx, 0));
     shouldSucceed(() => Atomics.wait(bi64a, idx, 0n, 1));
+    shouldSucceed(() => Atomics.waitAsync(bi64a, idx, 0n, 1));
 }
 
 function runAtomic(array, index, init, name, args, expectedResult, expectedOutcome)
@@ -83,8 +88,17 @@ bi64a[0] = 0n;
 var result = Atomics.wait(bi64a, 0, 1n);
 if (result != "not-equal")
     throw "Error: bad result from Atomics.wait: " + result;
+
+var result = Atomics.waitAsync(bi64a, 0, 1n);
+if (result.value != "not-equal")
+    throw "Error: bad result from Atomics.waitAsync: " + result;
+
 for (timeout of [0, 1, 10]) {
     var result = Atomics.wait(bi64a, 0, 0n, timeout);
     if (result != "timed-out")
         throw "Error: bad result from Atomics.wait: " + result;
 }
+
+var result = Atomics.waitAsync(bi64a, 0, 0n, 0);
+if (result.value != "timed-out")
+    throw "Error: bad result from Atomics.waitAsync: " + result;

--- a/JSTests/stress/waitasync-notify-multi-workers.js
+++ b/JSTests/stress/waitasync-notify-multi-workers.js
@@ -1,0 +1,75 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const READY_INDEX_A = 1;
+const READY_INDEX_B = 2;
+const NOTIFY_COUNT = 2;
+
+startWorker(`
+    $.agent.receiveBroadcast(async (sab) => {
+        var i32a = new Int32Array(sab);
+    
+        let p = Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, undefined).value;
+
+        Atomics.store(i32a, ${READY_INDEX_A}, 1);
+        Atomics.notify(i32a, ${READY_INDEX_A});
+
+        let res = await p;
+        if (res !== 'ok')
+            throw new Error("A resolve: " + res);
+
+        $.agent.report("done");
+    });
+`);
+
+startWorker(`
+    $.agent.receiveBroadcast(async (sab) => {
+        var i32a = new Int32Array(sab);
+    
+        let p = Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, undefined).value;
+
+        Atomics.store(i32a, ${READY_INDEX_B}, 1);
+        Atomics.notify(i32a, ${READY_INDEX_B});
+
+        let res = await p;
+        if (res !== 'ok')
+            throw new Error("B resolve: " + res);
+
+        $.agent.report("done");
+    });
+`);
+
+startWorker(`
+    $.agent.receiveBroadcast((sab) => {
+        var i32a = new Int32Array(sab);
+    
+        Atomics.wait(i32a, ${READY_INDEX_A}, 0);
+        Atomics.wait(i32a, ${READY_INDEX_B}, 0);
+
+        let res = Atomics.notify(i32a, ${WAIT_INDEX}, ${NOTIFY_COUNT});
+        if (res !== 2)
+            throw new Error("C notified workers: " + res);
+
+        $.agent.report("done");
+    });
+`);
+
+$.agent.broadcast(sab);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else
+        print("report: " + report);
+}

--- a/JSTests/stress/waitasync-promise-timeout-finite-gc.js
+++ b/JSTests/stress/waitasync-promise-timeout-finite-gc.js
@@ -1,0 +1,57 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const TOTAL_WAITER_COUNT = 1;
+
+startWorker(`
+    $.agent.receiveBroadcast((sab) => {
+
+        (function() {
+            var i32a = new Int32Array(sab);
+    
+            Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, 100).value.then((value) => {
+                $.agent.report("value " + value);
+                $.agent.report("done");
+            },
+            () => {
+                $.agent.report("error");
+            });
+        })();
+
+        gc();
+    });
+`);
+
+$.agent.broadcast(sab);
+
+let waiters = 0;
+do {
+    waiters = waiterListSize(i32a, WAIT_INDEX);
+} while (waiters != TOTAL_WAITER_COUNT);
+
+if (Atomics.notify(i32a, WAIT_INDEX, 1) != TOTAL_WAITER_COUNT)
+    throw new Error(`Atomics.notify should return ${TOTAL_WAITER_COUNT}.`);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else if (report.startsWith('value')) {
+        if (report != 'value ok')
+            throw new Error("The promise should be resolved with ok");
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-promise-timeout-infinity-gc.js
+++ b/JSTests/stress/waitasync-promise-timeout-infinity-gc.js
@@ -1,0 +1,57 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const TOTAL_WAITER_COUNT = 1;
+
+startWorker(`
+    $.agent.receiveBroadcast((sab) => {
+
+        (function() {
+            var i32a = new Int32Array(sab);
+    
+            Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0).value.then((value) => {
+                $.agent.report("value " + value);
+                $.agent.report("done");
+            },
+            () => {
+                $.agent.report("error");
+            });
+        })();
+
+        gc();
+    });
+`);
+
+$.agent.broadcast(sab);
+
+let waiters = 0;
+do {
+    waiters = waiterListSize(i32a, WAIT_INDEX);
+} while (waiters != TOTAL_WAITER_COUNT);
+
+if (Atomics.notify(i32a, WAIT_INDEX, 1) != TOTAL_WAITER_COUNT)
+    throw new Error(`Atomics.notify should return ${TOTAL_WAITER_COUNT}.`);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else if (report.startsWith('value')) {
+        if (report != 'value ok')
+            throw new Error("The promise should be resolved with ok");
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-timeout-finite-gc.js
+++ b/JSTests/stress/waitasync-timeout-finite-gc.js
@@ -1,0 +1,48 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+
+startWorker(`
+    $.agent.receiveBroadcast((unused_sab) => {
+        (function() {
+            var sab = new SharedArrayBuffer(8 * 4);
+            var i32a = new Int32Array(sab);
+    
+            Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, 1).value.then((value) => {
+                $.agent.report("value " + value);
+                $.agent.report("done");
+            },
+            () => {
+                $.agent.report("error");
+            });
+        })();
+
+        gc();
+    });
+`);
+
+$.agent.broadcast(sab);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else if (report.startsWith('value')) {
+        if (report != 'value timed-out')
+            throw new Error("The promise should be resolved with timed-out");
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-timeout-infinity-gc.js
+++ b/JSTests/stress/waitasync-timeout-infinity-gc.js
@@ -1,0 +1,50 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+
+startWorker(`
+    $.agent.receiveBroadcast((unused_sab) => {
+        (function() {
+            var sab = new SharedArrayBuffer(8 * 4);
+            var i32a = new Int32Array(sab);
+    
+            Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0).value.then((value) => {
+                $.agent.report("value " + value);
+            },
+            () => {
+                $.agent.report("error");
+            });
+        })();
+
+        gc();
+
+        setTimeout(() => {
+            $.agent.report("done");
+        }, 100);
+    });
+`);
+
+$.agent.broadcast(sab);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else if (report.startsWith('value')) {
+        throw new Error("The waiter should be removed when sab is gc'ed since its timeout is infinity");
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-wait-infinity-notify-all-multi-workers.js
+++ b/JSTests/stress/waitasync-wait-infinity-notify-all-multi-workers.js
@@ -1,0 +1,70 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const WAITER_COUNT = 10;
+const ASYNC_WAITER_MULTIPLIER = 2;
+const ASYNC_WAITER_COUNT = WAITER_COUNT * ASYNC_WAITER_MULTIPLIER;
+const TOTAL_WAITER_COUNT = WAITER_COUNT + ASYNC_WAITER_COUNT;
+
+for (let i = 0; i < WAITER_COUNT; i++) {
+    startWorker(`
+        $.agent.receiveBroadcast((sab) => {
+            var i32a = new Int32Array(sab);
+
+            let result = Atomics.wait(i32a, ${WAIT_INDEX}, 0, undefined);
+            if (result !== 'ok')
+                throw new Error("Atomics.wait result: " + result);
+
+            $.agent.report("done");
+        });
+    `);
+
+    startWorker(`
+        $.agent.receiveBroadcast(async (sab) => {
+            var i32a = new Int32Array(sab);
+
+            let promises = [];
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                promises.push(Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0).value);
+
+            function check(result) {
+                if (result !== 'ok')
+                    throw new Error("Atomics.waitAsync resolve: " + result);
+            }
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                check(await promises[i]);
+
+            $.agent.report("done");
+        });
+    `);
+}
+
+$.agent.broadcast(sab);
+
+while (waiterListSize(i32a, WAIT_INDEX) != TOTAL_WAITER_COUNT);
+
+if (Atomics.notify(i32a, WAIT_INDEX, TOTAL_WAITER_COUNT + 10) != TOTAL_WAITER_COUNT)
+    throw new Error(`Atomics.notify should return ${TOTAL_WAITER_COUNT}.`);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-wait-infinity-notify-half-multi-workers.js
+++ b/JSTests/stress/waitasync-wait-infinity-notify-half-multi-workers.js
@@ -1,0 +1,76 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const WAITER_COUNT = 10;
+const ASYNC_WAITER_MULTIPLIER = 2;
+const ASYNC_WAITER_COUNT = WAITER_COUNT * ASYNC_WAITER_MULTIPLIER;
+const TOTAL_WAITER_COUNT = WAITER_COUNT + ASYNC_WAITER_COUNT;
+
+for (let i = 0; i < WAITER_COUNT; i++) {
+    startWorker(`
+        $.agent.receiveBroadcast((sab) => {
+            var i32a = new Int32Array(sab);
+
+            let result = Atomics.wait(i32a, ${WAIT_INDEX}, 0, undefined);
+            if (result !== 'ok')
+                throw new Error("Atomics.wait result: " + result);
+
+            $.agent.report("done");
+        });
+    `);
+
+    startWorker(`
+        $.agent.receiveBroadcast(async (sab) => {
+            var i32a = new Int32Array(sab);
+
+            let promises = [];
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                promises.push(Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0).value);
+
+            function check(result) {
+                if (result !== 'ok')
+                    throw new Error("Atomics.waitAsync resolve: " + result);
+            }
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                check(await promises[i]);
+
+            $.agent.report("done");
+        });
+    `);
+}
+
+$.agent.broadcast(sab);
+
+while (waiterListSize(i32a, WAIT_INDEX) != TOTAL_WAITER_COUNT);
+
+let expectedNotified = TOTAL_WAITER_COUNT / 2;
+if (Atomics.notify(i32a, WAIT_INDEX, expectedNotified) != expectedNotified)
+    throw new Error(`Atomics.notify should return ${expectedNotified}.`);
+
+while (waiterListSize(i32a, WAIT_INDEX) != expectedNotified);
+
+if (Atomics.notify(i32a, WAIT_INDEX, expectedNotified) != expectedNotified)
+    throw new Error(`Atomics.notify should return ${expectedNotified}.`);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-wait-timeout-multi-workers.js
+++ b/JSTests/stress/waitasync-wait-timeout-multi-workers.js
@@ -1,0 +1,65 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const WAITER_COUNT = 10;
+const ASYNC_WAITER_MULTIPLIER = 2;
+const ASYNC_WAITER_COUNT = WAITER_COUNT * ASYNC_WAITER_MULTIPLIER;
+const TOTAL_WAITER_COUNT = WAITER_COUNT + ASYNC_WAITER_COUNT;
+
+for (let i = 0; i < WAITER_COUNT; i++) {
+    startWorker(`
+        $.agent.receiveBroadcast((sab) => {
+            var i32a = new Int32Array(sab);
+
+            let result = Atomics.wait(i32a, ${WAIT_INDEX}, 0, 1);
+            if (result !== 'timed-out')
+                throw new Error("Atomics.wait result: " + result);
+
+            $.agent.report("done");
+        });
+    `);
+
+    startWorker(`
+        $.agent.receiveBroadcast(async (sab) => {
+            var i32a = new Int32Array(sab);
+
+            let promises = [];
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                promises.push(Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, 1).value);
+
+            function check(res) {
+                if (res !== 'timed-out')
+                    throw new Error("Atomics.waitAsync resolve: " + res);
+            }
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                check(await promises[i]);
+
+            $.agent.report("done");
+        });
+    `);
+}
+
+$.agent.broadcast(sab);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/stress/waitasync-waiter-list-order.js
+++ b/JSTests/stress/waitasync-waiter-list-order.js
@@ -1,0 +1,60 @@
+const TOTAL_WAITER_COUNT = 10;
+const WAIT_INDEX = TOTAL_WAITER_COUNT * 2 - 1;
+
+var sab = new SharedArrayBuffer(TOTAL_WAITER_COUNT * 2 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+Atomics.store(i32a, 0, 1);
+for (let i = 0; i < TOTAL_WAITER_COUNT; i++) {
+    startWorker(`
+        $.agent.receiveBroadcast(async (sab) => {
+            var i32a = new Int32Array(sab);
+
+            Atomics.wait(i32a, ${i}, 0);
+
+            let p = Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0).value;
+
+            Atomics.store(i32a, ${i + 1}, 1);
+            Atomics.notify(i32a, ${i + 1});
+
+            let res = await p;
+            if (res !== 'ok')
+                throw new Error("AsyncWaiter ${i} resolve: " + res);
+
+            $.agent.report("AsyncWaiter ${i} done");
+        });
+    `);
+}
+
+$.agent.broadcast(sab);
+
+while (waiterListSize(i32a, WAIT_INDEX) != TOTAL_WAITER_COUNT);
+
+let reports = [];
+for (let i = 0; i < TOTAL_WAITER_COUNT; i++) {
+    Atomics.notify(i32a, WAIT_INDEX, 1);
+    reports.push(waitForReport());
+}
+
+let expected = [];
+for (let i = 0; i < TOTAL_WAITER_COUNT; i++) {
+    expected.push(`AsyncWaiter ${i} done`);
+}
+
+function assert(actual, expected) {
+    let size = actual.length;
+    for (let i = 0; i < size; i++)
+        if (actual[i] != expected[i])
+            throw new Error(`Error: actual[${i}]=${actual[i]} but expected[${i}]=${expected[i]}`);
+}
+
+assert(reports, expected);
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -11,7 +11,6 @@ flags:
   resizable-arraybuffer: useResizableArrayBuffer
 skip:
   features:
-    - Atomics.waitAsync
     # https://bugs.webkit.org/show_bug.cgi?id=174931
     - regexp-lookbehind
     - regexp-v-flag

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2162,6 +2162,7 @@
 		FEF5B430262A338B0016E776 /* ExceptionExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF5B42F262A338B0016E776 /* ExceptionExpectation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEF90A8D28AC135F00C14B84 /* APIIntegrityPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF90A8C28AC135C00C14B84 /* APIIntegrityPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEFD6FC61D5E7992008F2F0B /* JSStringInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -5875,6 +5876,8 @@
 		FEF90A8C28AC135C00C14B84 /* APIIntegrityPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIIntegrityPrivate.h; sourceTree = "<group>"; };
 		FEF90A8E28AC187A00C14B84 /* APIIntegrity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIIntegrity.cpp; sourceTree = "<group>"; };
 		FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringInlines.h; sourceTree = "<group>"; };
+		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
+		FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaiterListManager.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -8480,6 +8483,8 @@
 				FE6F56DC1E64E92000D17801 /* VMTraps.cpp */,
 				FE6F56DD1E64E92000D17801 /* VMTraps.h */,
 				FEF5B42B2628CBC80016E776 /* VMTrapsInlines.h */,
+				FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */,
+				FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */,
 				FED94F2B171E3E2300BE77A4 /* Watchdog.cpp */,
 				FED94F2C171E3E2300BE77A4 /* Watchdog.h */,
 				BCE2FAFE26091782000A510F /* WeakGCHashTable.h */,
@@ -11368,6 +11373,7 @@
 				FEC5797323105B5100BCA83F /* VMInspectorInlines.h in Headers */,
 				FE6F56DE1E64EAD600D17801 /* VMTraps.h in Headers */,
 				FEF5B42C2628CBC80016E776 /* VMTrapsInlines.h in Headers */,
+				FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */,
 				52847ADC21FFB8690061A9DB /* WasmAirIRGenerator.h in Headers */,
 				53F40E931D5A4AB30099A1B6 /* WasmB3IRGenerator.h in Headers */,
 				53CA730A1EA533D80076049D /* WasmBBQPlan.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1075,6 +1075,7 @@ runtime/VM.cpp
 runtime/VMEntryScope.cpp
 runtime/VMTraps.cpp
 runtime/VarOffset.cpp
+runtime/WaiterListManager.cpp
 runtime/Watchdog.cpp
 runtime/WeakMapConstructor.cpp
 runtime/WeakMapImpl.cpp

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -55,13 +55,7 @@ public:
         WebAssembly,
     };
 
-    ~SharedArrayBufferContents()
-    {
-        if (m_destructor) {
-            // FIXME: we shouldn't use getUnsafe here https://bugs.webkit.org/show_bug.cgi?id=197698
-            m_destructor->run(m_data.getUnsafe());
-        }
-    }
+    JS_EXPORT_PRIVATE ~SharedArrayBufferContents();
 
     static Ref<SharedArrayBufferContents> create(void* data, size_t size, std::optional<size_t> maxByteLength, RefPtr<BufferMemoryHandle> memoryHandle, ArrayBufferDestructorFunction&& destructor, Mode mode)
     {

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -31,6 +31,7 @@
 #include "JSTypedArrays.h"
 #include "ReleaseHeapAccessScope.h"
 #include "TypedArrayController.h"
+#include "WaiterListManager.h"
 
 namespace JSC {
 
@@ -54,6 +55,8 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(AtomicsObject);
     static JSC_DECLARE_HOST_FUNCTION(atomicsFunc ## upperName);
 FOR_EACH_ATOMICS_FUNC(DECLARE_FUNC_PROTO)
 #undef DECLARE_FUNC_PROTO
+
+static JSC_DECLARE_HOST_FUNCTION(atomicsFuncWaitAsync);
 
 const ClassInfo AtomicsObject::s_info = { "Atomics"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(AtomicsObject) };
 
@@ -83,6 +86,9 @@ void AtomicsObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, #lowerName ""_s), count, atomicsFunc ## upperName, ImplementationVisibility::Public, Atomics ## upperName ## Intrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     FOR_EACH_ATOMICS_FUNC(PUT_DIRECT_NATIVE_FUNC)
 #undef PUT_DIRECT_NATIVE_FUNC
+
+    if (Options::useAtomicsWaitAsync() && vm.vmType == VM::Default)
+        putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "waitAsync"_s), 4, atomicsFuncWaitAsync, ImplementationVisibility::Public, AtomicsWaitAsyncIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
@@ -428,8 +434,9 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncSub, (JSGlobalObject* globalObject, CallFram
     return atomicReadModifyWrite(globalObject, callFrame, SubFunc());
 }
 
+
 template<typename ValueType, typename JSArrayType>
-JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, unsigned accessIndex, ValueType expectedValue, JSValue timeoutValue)
+JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, unsigned accessIndex, ValueType expectedValue, JSValue timeoutValue, AtomicsWaitType type)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -443,28 +450,13 @@ JSValue atomicsWaitImpl(JSGlobalObject* globalObject, JSArrayType* typedArray, u
         timeout = std::max(Seconds::fromMilliseconds(timeoutInMilliseconds), 0_s);
 
     if (!vm.m_typedArrayController->isAtomicsWaitAllowedOnCurrentThread()) {
-        throwTypeError(globalObject, scope, "Atomics.wait cannot be called from the current thread."_s);
+        throwTypeError(globalObject, scope, makeString("Atomics."_s,
+            (type == AtomicsWaitType::Async ? "waitAsync"_s : "wait"_s), " cannot be called from the current thread."_s));
         return { };
     }
 
-    bool didPassValidation = false;
-    ParkingLot::ParkResult result;
-    {
-        ReleaseHeapAccessScope releaseHeapAccessScope(vm.heap);
-        result = ParkingLot::parkConditionally(
-            ptr,
-            [&] () -> bool {
-                didPassValidation = WTF::atomicLoad(ptr) == expectedValue;
-                return didPassValidation;
-            },
-            [] () { },
-            MonotonicTime::now() + timeout);
-    }
-    if (!didPassValidation)
-        return vm.smallStrings.notEqualString();
-    if (!result.wasUnparked)
-        return vm.smallStrings.timedOutString();
-    return vm.smallStrings.okString();
+    AtomicsWaitValidation validation = WTF::atomicLoad(ptr) == expectedValue ? AtomicsWaitValidation::Pass : AtomicsWaitValidation::Fail;
+    return WaiterListManager::singleton().wait(globalObject, vm, ptr, validation, timeout, type);
 }
 
 JSC_DEFINE_HOST_FUNCTION(atomicsFuncWait, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -476,7 +468,7 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncWait, (JSGlobalObject* globalObject, CallFra
     RETURN_IF_EXCEPTION(scope, { });
 
     if (!typedArrayView->isShared())
-        return throwVMTypeError(globalObject, scope, "Typed array for wait/notify must wrap a SharedArrayBuffer."_s);
+        return throwVMTypeError(globalObject, scope, "Typed array for wait/waitAsync/notify must wrap a SharedArrayBuffer."_s);
 
     unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, { });
@@ -485,18 +477,81 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncWait, (JSGlobalObject* globalObject, CallFra
     case Int32ArrayType: {
         int32_t expectedValue = callFrame->argument(2).toInt32(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, jsCast<JSInt32Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3))));
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, jsCast<JSInt32Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Sync)));
     }
     case BigInt64ArrayType: {
         int64_t expectedValue = callFrame->argument(2).toBigInt64(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, jsCast<JSBigInt64Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3))));
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, jsCast<JSBigInt64Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Sync)));
     }
     default:
         RELEASE_ASSERT_NOT_REACHED();
         break;
     }
     return { };
+}
+
+JSC_DEFINE_HOST_FUNCTION(atomicsFuncWaitAsync, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* typedArrayView = validateIntegerTypedArray<TypedArrayOperationMode::Wait>(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!typedArrayView->isShared())
+        return throwVMTypeError(globalObject, scope, "Typed array for wait/waitAsync/notify must wrap a SharedArrayBuffer."_s);
+
+    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    switch (typedArrayView->type()) {
+    case Int32ArrayType: {
+        int32_t expectedValue = callFrame->argument(2).toInt32(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int32_t>(globalObject, jsCast<JSInt32Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Async)));
+    }
+    case BigInt64ArrayType: {
+        int64_t expectedValue = callFrame->argument(2).toBigInt64(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+        RELEASE_AND_RETURN(scope, JSValue::encode(atomicsWaitImpl<int64_t>(globalObject, jsCast<JSBigInt64Array*>(typedArrayView), accessIndex, expectedValue, callFrame->argument(3), AtomicsWaitType::Async)));
+    }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+    return { };
+}
+
+EncodedJSValue getWaiterListSize(JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* typedArrayView = validateIntegerTypedArray<TypedArrayOperationMode::Wait>(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (!typedArrayView->isShared())
+        return throwVMTypeError(globalObject, scope, "Typed array for waiterListSize must wrap a SharedArrayBuffer."_s);
+
+    unsigned accessIndex = validateAtomicAccess(globalObject, vm, typedArrayView, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, { });
+
+    switch (typedArrayView->type()) {
+    case Int32ArrayType: {
+        auto ptr = jsCast<JSInt32Array*>(typedArrayView)->typedVector() + accessIndex;
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(WaiterListManager::singleton().waiterListSize(ptr))));
+    }
+    case BigInt64ArrayType: {
+        auto ptr = jsCast<JSBigInt64Array*>(typedArrayView)->typedVector() + accessIndex;
+        RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(WaiterListManager::singleton().waiterListSize(ptr))));
+    }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(atomicsFuncNotify, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -526,11 +581,11 @@ JSC_DEFINE_HOST_FUNCTION(atomicsFuncNotify, (JSGlobalObject* globalObject, CallF
     switch (typedArrayView->type()) {
     case Int32ArrayType: {
         int32_t* ptr = jsCast<JSInt32Array*>(typedArrayView)->typedVector() + accessIndex;
-        return JSValue::encode(jsNumber(ParkingLot::unparkCount(ptr, count)));
+        return JSValue::encode(jsNumber(WaiterListManager::singleton().notifyWaiter(ptr, count)));
     }
     case BigInt64ArrayType: {
         int64_t* ptr = jsCast<JSBigInt64Array*>(typedArrayView)->typedVector() + accessIndex;
-        return JSValue::encode(jsNumber(ParkingLot::unparkCount(ptr, count)));
+        return JSValue::encode(jsNumber(WaiterListManager::singleton().notifyWaiter(ptr, count)));
     }
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/runtime/AtomicsObject.h
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.h
@@ -62,5 +62,7 @@ JSC_DECLARE_JIT_OPERATION(operationAtomicsStore, EncodedJSValue, (JSGlobalObject
 JSC_DECLARE_JIT_OPERATION(operationAtomicsSub, EncodedJSValue, (JSGlobalObject*, EncodedJSValue base, EncodedJSValue index, EncodedJSValue operand));
 JSC_DECLARE_JIT_OPERATION(operationAtomicsXor, EncodedJSValue, (JSGlobalObject*, EncodedJSValue base, EncodedJSValue index, EncodedJSValue operand));
 
+JS_EXPORT_PRIVATE EncodedJSValue getWaiterListSize(JSGlobalObject*, CallFrame*);
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -158,6 +158,7 @@ namespace JSC {
     macro(AtomicsStoreIntrinsic) \
     macro(AtomicsSubIntrinsic) \
     macro(AtomicsWaitIntrinsic) \
+    macro(AtomicsWaitAsyncIntrinsic) \
     macro(AtomicsXorIntrinsic) \
     macro(ParseIntIntrinsic) \
     macro(FunctionToStringIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -110,7 +110,6 @@ class JSModuleRecord;
 class JSPromise;
 class JSPromiseConstructor;
 class JSPromisePrototype;
-class JSSharedArrayBuffer;
 class JSSharedArrayBufferPrototype;
 class JSTypedArrayViewConstructor;
 class JSTypedArrayViewPrototype;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -545,12 +545,14 @@ bool canUseWebAssemblyFastMemory();
     /* Feature Flags */\
     \
     v(Bool, useArrayGroupMethod, true, Normal, "Expose the group() and groupToMap() methods on Array.") \
+    v(Bool, useAtomicsWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics.") \
     v(Bool, useImportAssertion, true, Normal, "Enable import assertion.") \
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
     v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object.") \
+    v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec.") \
     v(Bool, useWebAssemblyTypedFunctionReferences, false, Normal, "Allow function types from the wasm typed function references spec.") \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
     v(Bool, useWebAssemblySIMD, false, Normal, "Allow the new simd instructions and types from the wasm simd spec.") \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -110,6 +110,7 @@
 #include "VMInlines.h"
 #include "VMInspector.h"
 #include "VariableEnvironment.h"
+#include "WaiterListManager.h"
 #include "WasmWorklist.h"
 #include "Watchdog.h"
 #include "WeakGCMapInlines.h"
@@ -212,6 +213,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , m_codeCache(makeUnique<CodeCache>())
     , m_intlCache(makeUnique<IntlCache>())
     , m_builtinExecutables(makeUnique<BuiltinExecutables>(*this))
+    , m_syncWaiter(adoptRef(*new Waiter(this)))
 {
     if (UNLIKELY(vmCreationShouldCrash))
         CRASH_WITH_INFO(0x4242424220202020, 0xbadbeef0badbeef, 0x1234123412341234, 0x1337133713371337);
@@ -395,7 +397,10 @@ void waitForVMDestruction()
 VM::~VM()
 {
     Locker destructionLocker { s_destructionLock.read() };
-    
+
+    if (Options::useAtomicsWaitAsync() && vmType == Default)
+        WaiterListManager::singleton().unregisterVM(this);
+
     Gigacage::removePrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);
     deferredWorkTimer->stopRunningTasks();
 #if ENABLE(WEBASSEMBLY)
@@ -1378,6 +1383,12 @@ bool VM::isScratchBuffer(void* ptr)
             return true;
     }
     return false;
+}
+
+Ref<Waiter> VM::syncWaiter()
+{
+    m_syncWaiter->setVM(this);
+    return m_syncWaiter;
 }
 
 void VM::ensureShadowChicken()

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -144,6 +144,7 @@ class TypeProfiler;
 class TypeProfilerLog;
 class Watchdog;
 class WatchpointSet;
+class Waiter;
 
 #if ENABLE(DFG_JIT) && ASSERT_ENABLED
 #define ENABLE_DFG_DOES_GC_VALIDATION 1
@@ -916,6 +917,8 @@ public:
     template<typename Func>
     void forEachDebugger(const Func&);
 
+    Ref<Waiter> syncWaiter();
+
 private:
     VM(VMType, HeapType, WTF::RunLoop* = nullptr, bool* success = nullptr);
     static VM*& sharedInstanceInternal();
@@ -1034,6 +1037,8 @@ private:
 
     Lock m_loopHintExecutionCountLock;
     HashMap<const JSInstruction*, std::pair<unsigned, std::unique_ptr<uintptr_t>>> m_loopHintExecutionCounts;
+
+    Ref<Waiter> m_syncWaiter;
 
 #if ENABLE(DFG_DOES_GC_VALIDATION)
     DoesGCCheck m_doesGC;

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "config.h"
+#include "WaiterListManager.h"
+
+#include "JSGlobalObject.h"
+#include "JSLock.h"
+#include "ObjectConstructor.h"
+#include <wtf/DataLog.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/RawPointer.h>
+
+namespace JSC {
+
+namespace WaiterListsManagerInternal {
+static constexpr bool verbose = false;
+}
+
+WaiterListManager& WaiterListManager::singleton()
+{
+    static LazyNeverDestroyed<WaiterListManager> manager;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        manager.construct();
+    });
+    return manager;
+}
+
+JSValue WaiterListManager::wait(JSGlobalObject* globalObject, VM& vm, void* ptr, AtomicsWaitValidation validation, Seconds timeout, AtomicsWaitType type)
+{
+    if (type == AtomicsWaitType::Async) {
+        JSObject* object = constructEmptyObject(globalObject);
+
+        bool isAsync = false;
+        JSValue value;
+        if (validation == AtomicsWaitValidation::Fail)
+            value = vm.smallStrings.notEqualString();
+        else if (!timeout)
+            value = vm.smallStrings.timedOutString();
+        else {
+            isAsync = true;
+            JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
+            addAsyncWaiter(ptr, promise, timeout);
+            value = promise;
+        }
+
+        object->putDirect(vm, vm.propertyNames->async, jsBoolean(isAsync));
+        object->putDirect(vm, vm.propertyNames->value, value);
+        return object;
+    }
+
+    if (validation == AtomicsWaitValidation::Fail)
+        return vm.smallStrings.notEqualString();
+
+    Ref<Waiter> syncWaiter = vm.syncWaiter();
+    Ref<WaiterList> list = findOrCreateList(ptr);
+    MonotonicTime time = MonotonicTime::now() + timeout;
+
+    {
+        Locker listLocker { list->lock };
+        list->addLast(listLocker, syncWaiter);
+        dataLogLnIf(WaiterListsManagerInternal::verbose, "WaiterListManager added a new SyncWaiter ", RawPointer(&syncWaiter), " to a waiterList for ptr ", RawPointer(ptr));
+
+        while (syncWaiter->vm() && time.now() < time)
+            syncWaiter->condition().waitUntil(list->lock, time.approximateWallTime());
+
+        // At this point, syncWaiter should be either notified (dequeued) or timeout (not dequeued).
+        // If it's notified by other thread, it's vm should be nulled out.
+        bool didGetDequeued = !syncWaiter->vm();
+        ASSERT(didGetDequeued || syncWaiter->vm() == &vm);
+        if (didGetDequeued)
+            return vm.smallStrings.okString();
+
+        didGetDequeued = list->findAndRemove(listLocker, syncWaiter);
+        ASSERT(didGetDequeued);
+        return vm.smallStrings.timedOutString();
+    }
+}
+
+void WaiterListManager::addAsyncWaiter(void* ptr, JSPromise* promise, Seconds timeout)
+{
+    Ref<WaiterList> list = findOrCreateList(ptr);
+    Ref<Waiter> waiter = adoptRef(*new Waiter(promise));
+
+    {
+        Locker listLocker { list->lock };
+        list->addLast(listLocker, waiter);
+
+        if (timeout != Seconds::infinity()) {
+            Ref<RunLoop::DispatchTimer> timer = RunLoop::current().dispatchAfter(timeout, [this, ptr, waiter = waiter.copyRef()]() mutable {
+                if (RefPtr<WaiterList> list = findList(ptr)) {
+                    // All cases:
+                    // 1. Find a list for ptr.
+                    Locker listLocker { list->lock };
+                    if (waiter->ticket(listLocker)) {
+                        if (waiter->isOnList()) {
+                            // 1.1. The list contains the waiter which must be in the list and hasn't been notified.
+                            //      It should have a ticket, then notify it with timeout.
+                            bool didGetDequeued = list->findAndRemove(listLocker, waiter);
+                            ASSERT_UNUSED(didGetDequeued, didGetDequeued);
+                        }
+                        // 1.2. The list doesn't contain the waiter.
+                        //      1.2.1 It's a new list, then the waiter must be removed from a list which is destructed.
+                        //            Then, the waiter may (notify it if it does) or may not have a ticket.
+                        notifyWaiterImpl(listLocker,  WTFMove(waiter), ResolveResult::Timeout);
+                        return;
+                    }
+                    // 1.2.2 It's the list the waiter used to belong. Then it must be notified by other thread and ignore it.
+                }
+
+                // 2. Doesn't find a list for ptr, then the waiter must be removed from the list.
+                //      2.1. The waiter has a ticket, then notify it.
+                //      2.2. The waiter doesn't has a ticket, then it's notified and ignore it.
+                ASSERT(!waiter->isOnList());
+                if (waiter->ticket(NoLockingNecessary))
+                    notifyWaiterImpl(NoLockingNecessary, WTFMove(waiter), ResolveResult::Timeout);
+            });
+            waiter->setTimer(listLocker, WTFMove(timer));
+        }
+    }
+
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "WaiterListManager added a new AsyncWaiter ", RawPointer(waiter.ptr()), " to a waiterList for ptr ", RawPointer(ptr));
+}
+
+unsigned WaiterListManager::notifyWaiter(void* ptr, unsigned count)
+{
+    ASSERT(ptr);
+    unsigned notified = 0;
+    RefPtr<WaiterList> list = findList(ptr);
+    if (list) {
+        Locker listLocker { list->lock };
+        while (notified < count && list->size()) {
+            notifyWaiterImpl(listLocker, list->takeFirst(listLocker), ResolveResult::Ok);
+            notified++;
+        }
+    }
+
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "WaiterListManager notified waiters (count ", notified, ") for ptr ", RawPointer(ptr));
+    return notified;
+}
+
+void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<Waiter>&& waiter, const ResolveResult resolveResult)
+{
+    if (waiter->isAsync()) {
+        VM& vm = *waiter->vm();
+        auto ticket = waiter->takeTicket(listLocker);
+        ASSERT(ticket);
+        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [resolveResult](DeferredWorkTimer::Ticket ticket) {
+            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+            JSGlobalObject* globalObject = promise->globalObject();
+            VM& vm = promise->vm();
+            JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
+            promise->resolve(globalObject, result);
+        });
+
+        // If waiter is an AsyncWaiter, we null out its ticket first to indicate that it's notified.
+        // Then, cancel its RunLoop timer if it's not timed-out.
+        if (resolveResult != ResolveResult::Timeout)
+            waiter->cancelTimer(listLocker);
+
+        return;
+    }
+
+    // If waiter is a SyncWaiter, we null out its vm to indicate that this waiter
+    // is removed from the WaiterList.
+    ASSERT(waiter->vm());
+    waiter->clearVM(listLocker);
+    waiter->condition().notifyOne();
+}
+
+size_t WaiterListManager::waiterListSize(void* ptr)
+{
+    RefPtr<WaiterList> list = findList(ptr);
+    size_t size = 0;
+    if (list) {
+        Locker listLocker { list->lock };
+        size = list->size();
+    }
+    return size;
+}
+
+void WaiterListManager::cancelAsyncWaiter(const AbstractLocker& listLocker, Waiter* waiter)
+{
+    ASSERT(waiter->isAsync());
+    waiter->vm()->deferredWorkTimer->scheduleWorkSoon(waiter->takeTicket(listLocker), [](DeferredWorkTimer::Ticket) mutable { });
+    waiter->cancelTimer(listLocker);
+}
+
+void WaiterListManager::unregisterVM(VM* vm)
+{
+    Locker waiterListsLocker { m_waiterListsLock };
+    for (auto& entry : m_waiterLists) {
+        Ref<WaiterList> list = entry.value;
+        Locker listLocker { list->lock };
+        list->removeIf(listLocker, [&](Waiter* waiter) {
+            if (waiter->vm() == vm) {
+                // If the vm is about destructing, then it shouldn't
+                // been blocked. That means we shouldn't find any SyncWaiter.
+                ASSERT(waiter->isAsync());
+                cancelAsyncWaiter(listLocker, waiter);
+
+                dataLogLnIf(WaiterListsManagerInternal::verbose,
+                    "WaiterListManager::unregisterVM ",
+                    (waiter->isAsync() ? " deleted AsyncWaiter " : " removed SyncWaiter "),
+                    RawPointer(waiter),
+                    " in WaiterList for ptr ",
+                    RawPointer(entry.key));
+
+                return true;
+            }
+            return false;
+        });
+    }
+}
+
+void WaiterListManager::unregisterSharedArrayBuffer(uint8_t* arrayPtr, size_t size)
+{
+    Locker listLocker { m_waiterListsLock };
+    m_waiterLists.removeIf([&](auto& entry) {
+        if (entry.key >= arrayPtr && entry.key < arrayPtr + size) {
+            Ref<WaiterList> list = entry.value;
+            Locker listLocker { list->lock };
+            list->removeIf(listLocker, [&](Waiter* waiter) {
+                // If the SharedArrayBuffer is about destructing, then no VM is
+                // referencing the buffer. That means no blocking SyncWaiter
+                // on the buffer for any VM.
+                ASSERT(waiter->isAsync());
+                // If the AsyncWaiter has valid timer, then let it
+                // timeout. Otherwise un-task it.
+                if (!waiter->hasTimer(listLocker))
+                    cancelAsyncWaiter(listLocker, waiter);
+
+                dataLogLnIf(WaiterListsManagerInternal::verbose,
+                    "WaiterListManager::unregisterSharedArrayBuffer ",
+                    (waiter->isAsync() ? " deleted AsyncWaiter " : " removed SyncWaiter "),
+                    RawPointer(waiter),
+                    " in WaiterList for ptr ",
+                    RawPointer(entry.key));
+
+                return true;
+            });
+
+            ASSERT(!list->size());
+            return true;
+        }
+        return false;
+    });
+}
+
+Ref<WaiterList> WaiterListManager::findOrCreateList(void* ptr)
+{
+    Locker waiterListsLocker { m_waiterListsLock };
+    return m_waiterLists.ensure(ptr, [] {
+        return adoptRef(*new WaiterList()); 
+    }).iterator->value.get();
+}
+
+RefPtr<WaiterList> WaiterListManager::findList(void* ptr)
+{
+    Locker waiterListsLocker { m_waiterListsLock };
+    auto it = m_waiterLists.find(ptr);
+    if (it == m_waiterLists.end())
+        return nullptr;
+    return it->value.ptr();
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "DeferredWorkTimer.h"
+#include "JSPromise.h"
+#include <wtf/Condition.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/SentinelLinkedList.h>
+
+namespace JSC {
+
+enum class AtomicsWaitType : uint8_t { Sync, Async };
+enum class AtomicsWaitValidation : uint8_t { Pass, Fail };
+
+class Waiter final : public WTF::BasicRawSentinelNode<Waiter>, public ThreadSafeRefCounted<Waiter> {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    Waiter(VM* vm)
+        : m_vm(vm)
+        , m_isAsync(false)
+    {
+    }
+
+    Waiter(JSPromise* promise)
+        : m_vm(&promise->vm())
+        , m_ticket(m_vm->deferredWorkTimer->addPendingWork(*m_vm, promise, { }))
+        , m_isAsync(true)
+    {
+    }
+
+    bool isAsync() const
+    {
+        return m_isAsync;
+    }
+
+    VM* vm()
+    {
+        return m_vm;
+    }
+
+    void setVM(VM* vm)
+    {
+        m_vm = vm;
+    }
+
+    void clearVM(const AbstractLocker&)
+    {
+        m_vm = nullptr;
+    }
+
+    Condition& condition()
+    {
+        ASSERT(!m_isAsync);
+        return m_condition;
+    }
+
+    DeferredWorkTimer::Ticket ticket(const AbstractLocker&) const
+    {
+        ASSERT(m_isAsync);
+        return m_ticket;
+    }
+
+    DeferredWorkTimer::Ticket takeTicket(const AbstractLocker&)
+    {
+        ASSERT(m_isAsync);
+        return std::exchange(m_ticket, nullptr);
+    }
+
+    void setTimer(const AbstractLocker&, Ref<RunLoop::DispatchTimer>&& timer)
+    {
+        ASSERT(m_isAsync);
+        m_timer = WTFMove(timer);
+    }
+
+    bool hasTimer(const AbstractLocker&)
+    {
+        return !!m_timer;
+    }
+
+    void cancelTimer(const AbstractLocker&)
+    {
+        ASSERT(m_isAsync);
+        // If the timeout for AsyncWaiter is infinity, we won't dispatch any timer.
+        if (!m_timer)
+            return;
+        m_timer->stop();
+        m_timer = nullptr;
+    }
+
+private:
+    VM* m_vm { nullptr };
+    DeferredWorkTimer::Ticket m_ticket { nullptr };
+    RefPtr<RunLoop::DispatchTimer> m_timer { nullptr };
+    Condition m_condition;
+    bool m_isAsync { false };
+};
+
+class WaiterList : public ThreadSafeRefCounted<WaiterList> {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    ~WaiterList()
+    {
+        removeIf([](Waiter*) {
+            return true;
+        });
+    }
+
+    void addLast(const AbstractLocker&, Waiter& waiter)
+    {
+        m_waiters.append(&waiter);
+        waiter.ref();
+        m_size++;
+    }
+
+    Ref<Waiter> takeFirst(const AbstractLocker&)
+    {
+        // `takeFisrt` is used to consume a waiter (either notify, timeout, or remove).
+        // So, the waiter must not be removed and belong to this list.
+        Waiter& waiter = *m_waiters.begin();
+        ASSERT((waiter.vm() || waiter.ticket(NoLockingNecessary)) && waiter.isOnList());
+        Ref<Waiter> protectedWaiter = Ref { waiter };
+        removeWithUpdate(waiter);
+        return protectedWaiter;
+    }
+
+    bool findAndRemove(const AbstractLocker&, Waiter& target)
+    {
+#if ASSERT_ENABLED
+        if (target.isOnList()) {
+            bool found = false;
+            for (auto iter = m_waiters.begin(); iter != m_waiters.end(); ++iter) {
+                if (&*iter == &target)
+                    found = true;
+            }
+            ASSERT(found);
+        }
+#endif
+
+        if (!target.isOnList())
+            return false;
+        removeWithUpdate(target);
+        return true;
+    }
+
+    template<typename Functor>
+    void removeIf(const AbstractLocker&, const Functor& functor)
+    {
+        removeIf(functor);
+    }
+
+    unsigned size()
+    {
+        return m_size;
+    }
+
+    Lock lock;
+
+private:
+    template<typename Functor>
+    void removeIf(const Functor& functor)
+    {
+        m_waiters.forEach([&](Waiter* waiter) {
+            if (functor(waiter))
+                removeWithUpdate(*waiter);
+        });
+    }
+
+    void removeWithUpdate(Waiter& waiter)
+    {
+        m_waiters.remove(&waiter);
+        waiter.deref();
+        m_size--;
+    }
+
+    unsigned m_size { 0 };
+    SentinelLinkedList<Waiter, BasicRawSentinelNode<Waiter>> m_waiters;
+};
+
+class WaiterListManager {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    static WaiterListManager& singleton();
+
+    JS_EXPORT_PRIVATE JSValue wait(JSGlobalObject*, VM&, void* ptr, AtomicsWaitValidation, Seconds timeout, AtomicsWaitType);
+
+    void addAsyncWaiter(void* ptr, JSPromise*, Seconds timeout);
+
+    enum class ResolveResult : uint8_t { Ok, Timeout };
+    unsigned notifyWaiter(void* ptr, unsigned count);
+
+    size_t waiterListSize(void* ptr);
+
+    void unregisterVM(VM*);
+
+    void unregisterSharedArrayBuffer(uint8_t* arrayPtr, size_t);
+
+private:
+    void notifyWaiterImpl(const AbstractLocker&, Ref<Waiter>&&, const ResolveResult);
+
+    void timeoutAsyncWaiter(void* ptr, Waiter* target);
+
+    void cancelAsyncWaiter(const AbstractLocker&, Waiter*);
+
+    Ref<WaiterList> findOrCreateList(void* ptr);
+
+    RefPtr<WaiterList> findList(void* ptr);
+
+    Lock m_waiterListsLock;
+    HashMap<void*, Ref<WaiterList>> m_waiterLists;
+};
+
+} // namespace JSC

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -973,6 +973,7 @@ void ApplicationCacheGroup::associateDocumentLoaderWithCache(DocumentLoader* loa
 }
 
 class ChromeClientCallbackTimer final : public TimerBase {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     ChromeClientCallbackTimer(ApplicationCacheGroup& group)
         : m_group(group)

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -51,6 +51,7 @@ class WheelEventTestMonitor;
 struct ScrollExtents;
 
 class ScrollingEffectsControllerTimer : public RunLoop::TimerBase {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     ScrollingEffectsControllerTimer(RunLoop& runLoop, Function<void()>&& callback)
         : RunLoop::TimerBase(runLoop)


### PR DESCRIPTION
#### 7e3fb31d598706ca0d25f05030fa41fbfb458566
<pre>
[JSC] Add support for Atomics.waitAsync
<a href="https://bugs.webkit.org/show_bug.cgi?id=241414">https://bugs.webkit.org/show_bug.cgi?id=241414</a>
rdar://94655073

Reviewed by Yusuke Suzuki.

Atomics.waitAsync() waits asynchronously on a shared array buffer and
returns an object { async: bool, value: Promise }. Compare to Atomics.wait(),
waitAsync is non-blocking and usable on the main thread.

TC39 Spec: <a href="https://tc39.es/proposal-atomics-wait-async/">https://tc39.es/proposal-atomics-wait-async/</a>
TC39 Proposal: <a href="https://github.com/tc39/proposal-atomics-wait-async">https://github.com/tc39/proposal-atomics-wait-async</a>
MDN Web Doc: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync</a>

* JSTests/stress/settimeout-starvation.js: Added.
(let.promise.new.Promise):
(wait):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::atomicsWaitImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Intrinsic.cpp:
(JSC::intrinsicName):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::JSArrayBufferView::hasArrayBuffer const):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp:
(JSC::SimpleTypedArrayController::isAtomicsWaitAsyncAllowedOnCurrentThread):
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.h:
* Source/JavaScriptCore/runtime/TypedArrayController.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::~VM):
* Source/JavaScriptCore/runtime/WaiterListsManager.h: Added.
(JSC::Waiter::Waiter):
(JSC::Waiter::isAsync const):
(JSC::Waiter::getVM const):
(JSC::Waiter::getPromise const):
(JSC::Waiter::getTicket const):
(JSC::Waiter::dump const):
(JSC::WaiterList::enqueue):
(JSC::WaiterList::dequeue):
(JSC::WaiterList::takeFirst):
(JSC::WaiterList::isEmpty):
(JSC::WaiterList::dump const):
(JSC::WaiterListsManager::singleton):
(JSC::WaiterListsManager::addWaiter):
(JSC::WaiterListsManager::notifyWaiter):
(JSC::WaiterListsManager::timeoutAsyncWaiter):
(JSC::WaiterListsManager::unregister):
(JSC::WaiterListsManager::dump const):
(JSC::WaiterListsManager::RegisteredVMs::add):
(JSC::WaiterListsManager::RegisteredVMs::remove):
(JSC::WaiterListsManager::RegisteredVMs::contains):
(JSC::WaiterListsManager::RegisteredVMs::dump const):
(JSC::WaiterListsManager::notifyWaiterImpl):
(JSC::WaiterListsManager::add):
(JSC::WaiterListsManager::find):
* Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp:
(WebCore::WebCoreTypedArrayController::isAtomicsWaitAsyncAllowedOnCurrentThread):
* Source/WebCore/bindings/js/WebCoreTypedArrayController.h:

Canonical link: <a href="https://commits.webkit.org/257061@main">https://commits.webkit.org/257061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6429e921f3a554c19b5a6448f3135c87158a3899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107226 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167494 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7391 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35746 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103877 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5547 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84366 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32515 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89176 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75435 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88633 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/969 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84310 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22106 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28529 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4849 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44566 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87141 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2214 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41501 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19551 "Passed tests") | 
<!--EWS-Status-Bubble-End-->