### PR TITLE
Cap cookie lifetimes to 7 days for responses from third party IP addresses

### DIFF
--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -57,6 +57,8 @@ public:
     {
     }
 
+    WEBCORE_EXPORT IPAddress isolatedCopy() const;
+    WEBCORE_EXPORT unsigned matchingNetMaskLength(const IPAddress& other) const;
     WEBCORE_EXPORT static std::optional<IPAddress> fromString(const String&);
 
     bool isIPv4() const { return std::holds_alternative<struct in_addr>(m_address); }
@@ -83,7 +85,7 @@ inline std::optional<IPAddress> IPAddress::fromSockAddrIn6(const struct sockaddr
     if (address.sin6_family == AF_INET6)
         return IPAddress { address.sin6_addr };
     if (address.sin6_family == AF_INET)
-        return IPAddress {reinterpret_cast<const struct sockaddr_in&>(address).sin_addr };
+        return IPAddress { reinterpret_cast<const struct sockaddr_in&>(address).sin_addr };
     return { };
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -360,7 +360,11 @@ std::optional<WebCore::IPAddress> NetworkSession::firstPartyHostIPAddress(const 
     if (firstPartyHost.isEmpty())
         return std::nullopt;
 
-    return m_firstPartyHostIPAddresses.get(firstPartyHost);
+    auto iterator = m_firstPartyHostIPAddresses.find(firstPartyHost);
+    if (iterator == m_firstPartyHostIPAddresses.end())
+        return std::nullopt;
+
+    return { iterator->value };
 }
 #endif // ENABLE(TRACKING_PREVENTION)
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -101,8 +101,8 @@ private:
 #if ENABLE(TRACKING_PREVENTION)
     static NSHTTPCookieStorage *statelessCookieStorage();
     void updateFirstPartyInfoForSession(const URL&);
-    bool shouldApplyCookiePolicyForThirdPartyCNAMECloaking() const;
-    void applyCookiePolicyForThirdPartyCNAMECloaking(const WebCore::ResourceRequest&);
+    bool shouldApplyCookiePolicyForThirdPartyCloaking() const;
+    void applyCookiePolicyForThirdPartyCloaking(const WebCore::ResourceRequest&);
     void blockCookies();
     void unblockCookies();
     bool needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const;

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1181,6 +1181,7 @@
 		F4B0168425AE08F800E445C4 /* DisableSpellcheckPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B0167F25AE02D600E445C4 /* DisableSpellcheckPlugIn.mm */; };
 		F4B825D81EF4DBFB006E417F /* compressed-files.zip in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4B825D61EF4DBD4006E417F /* compressed-files.zip */; };
 		F4B86D4F20BCD5B20099A7E6 /* paint-significant-area-milestone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4B86D4E20BCD5970099A7E6 /* paint-significant-area-milestone.html */; };
+		F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */; };
 		F4BC0B142146C849002A0478 /* FocusPreservationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BC0B132146C849002A0478 /* FocusPreservationTests.mm */; };
 		F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */; };
 		F4BFA68E1E4AD08000154298 /* LegacyDragAndDropTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4BFA68C1E4AD08000154298 /* LegacyDragAndDropTests.mm */; };
@@ -3419,6 +3420,7 @@
 		F4B0168225AE060F00E445C4 /* DisableSpellcheck.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisableSpellcheck.mm; sourceTree = "<group>"; };
 		F4B825D61EF4DBD4006E417F /* compressed-files.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = "compressed-files.zip"; sourceTree = "<group>"; };
 		F4B86D4E20BCD5970099A7E6 /* paint-significant-area-milestone.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "paint-significant-area-milestone.html"; sourceTree = "<group>"; };
+		F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IPAddressTests.cpp; sourceTree = "<group>"; };
 		F4BC0B132146C849002A0478 /* FocusPreservationTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FocusPreservationTests.mm; sourceTree = "<group>"; };
 		F4BDA42E27F8BF2F00F9647D /* FullscreenVideoTextRecognition.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenVideoTextRecognition.mm; sourceTree = "<group>"; };
 		F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-fullscreen.html"; sourceTree = "<group>"; };
@@ -4168,6 +4170,7 @@
 				7A909A731D877475007E10F8 /* IntPointTests.cpp */,
 				7A909A741D877475007E10F8 /* IntRectTests.cpp */,
 				7A909A751D877475007E10F8 /* IntSizeTests.cpp */,
+				F4B8A5C028F8B54F00E3F54F /* IPAddressTests.cpp */,
 				CD5FF4962162E27E004BD86F /* ISOBox.cpp */,
 				278E3E1823CD82FA005A6B80 /* KeyedCoding.cpp */,
 				14464012167A8305000BD218 /* LayoutUnitTests.cpp */,
@@ -6254,6 +6257,7 @@
 				7A909A811D877480007E10F8 /* IntPointTests.cpp in Sources */,
 				7A909A821D877480007E10F8 /* IntRectTests.cpp in Sources */,
 				7A909A831D877480007E10F8 /* IntSizeTests.cpp in Sources */,
+				F4B8A5C128F8B54F00E3F54F /* IPAddressTests.cpp in Sources */,
 				5C0BF8931DD599BD00B00328 /* IsNavigationActionTrusted.mm in Sources */,
 				CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */,
 				7CCE7EA51A411A0800447C4C /* JavaScriptTestMac.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/DNS.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+
+#if OS(UNIX)
+
+TEST(IPAddressTests, MatchingNetMaskLength)
+{
+    auto address1 = WebCore::IPAddress::fromString("17.100.120.255"_s);
+    auto address2 = WebCore::IPAddress::fromString("17.100.100.255"_s);
+    auto address3 = WebCore::IPAddress::fromString("2001:db8::1234:5678"_s);
+    auto address4 = WebCore::IPAddress::fromString("2001:db8::1111:0000"_s);
+    auto address5 = WebCore::IPAddress::fromString("::1234:5678"_s);
+    auto address6 = WebCore::IPAddress::fromString("::"_s);
+
+    EXPECT_EQ(address1->matchingNetMaskLength(*address2), 19U);
+    EXPECT_EQ(address2->matchingNetMaskLength(*address1), 19U);
+    EXPECT_EQ(address1->matchingNetMaskLength(*address3), 0U);
+    EXPECT_EQ(address3->matchingNetMaskLength(*address1), 0U);
+    EXPECT_EQ(address3->matchingNetMaskLength(*address4), 102U);
+    EXPECT_EQ(address4->matchingNetMaskLength(*address3), 102U);
+    EXPECT_EQ(address3->matchingNetMaskLength(*address5), 2U);
+    EXPECT_EQ(address5->matchingNetMaskLength(*address3), 2U);
+    EXPECT_EQ(address5->matchingNetMaskLength(*address6), 99U);
+    EXPECT_EQ(address6->matchingNetMaskLength(*address5), 99U);
+}
+
+TEST(IPAddressTests, InvalidAddresses)
+{
+    EXPECT_EQ(WebCore::IPAddress::fromString(""_s), std::nullopt);
+    EXPECT_EQ(WebCore::IPAddress::fromString("foo"_s), std::nullopt);
+    EXPECT_EQ(WebCore::IPAddress::fromString("2001:88888::"_s), std::nullopt);
+    EXPECT_EQ(WebCore::IPAddress::fromString("192.168.255.256"_s), std::nullopt);
+}
+
+#endif // OS(UNIX)
+
+} // namespace TestWebKitAPI
+


### PR DESCRIPTION
#### b0305b173106ba984cbc0475b3681daea137390c
<pre>
Cap cookie lifetimes to 7 days for responses from third party IP addresses
<a href="https://bugs.webkit.org/show_bug.cgi?id=246477">https://bugs.webkit.org/show_bug.cgi?id=246477</a>
rdar://100831206

Reviewed by John Wilander.

Safari currently caps the lifetime of cookies to 7 days, if third-party CNAME cloaking is detected.
This helps to mitigate many instances where CNAME cloaking is used to store cookies on device (in
the first party context) for far longer than a third party cookie would normally be allowed to;
however, in the case where the resolved CNAME is empty, we end up skipping this mitigation
altogether.

This means that websites can use direct A/AAAA records (instead of CNAME mapping) to cloak third
party requests as first party and subsequently store cookies in the first party context, bypassing
the aforementioned defense.

To strengthen our existing protections, we implement a heuristic to fall back on comparing resolved
IP addresses only in the case where the resolved CNAME of the incoming response is empty. If the IP
address of the response is _mostly_ different than the IP address of the main resource response
(i.e. by comparing the matching subnet mask length of the two addresses), then we apply the same
level of mitigation as we otherwise would for third party CNAMEs.

For now, the minimum matching subnet mask length to consider as &quot;third party&quot; or not is arbitrarily
chosen to be half the IP address length (i.e. 16 for IPv4, and 64 for IPv6). This could be enhanced
in the future, given facilities to query for the IP network block that contains the main resource&apos;s
IP address and checking whether the incoming response address falls within that range.

* Source/WebCore/platform/network/DNS.cpp:
(WebCore::IPAddress::isolatedCopy const):

Add an `isolatedCopy` method, so that we&apos;re able to perform a cross-thread copy of `IPAddress`.

(WebCore::IPAddress::matchingNetMaskLength const):

Add a helper method to compute the length of the matching subnet mask between the current IP address
and the given address. If the two IP addresses are of different families (i.e. v4 and v6), this
method returns 0.

* Source/WebCore/platform/network/DNS.h:
(WebCore::IPAddress::fromSockAddrIn6):

Minor style fix - add a missing space after the initializer.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking const):

Adjust this to check for third party IP addresses, in the case where the incoming response&apos;s CNAME
is empty.

(WebKit::NetworkDataTaskCocoa::updateFirstPartyInfoForSession):
(WebKit::shouldCapCookieExpiryForThirdPartyIPAddress):
(WebKit::NetworkDataTaskCocoa::applyCookiePolicyForThirdPartyCloaking):
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCocoa::shouldApplyCookiePolicyForThirdPartyCNAMECloaking const): Deleted.
(WebKit::NetworkDataTaskCocoa::applyCookiePolicyForThirdPartyCNAMECloaking): Deleted.

Rename these to reference &quot;ThirdPartyCloaking&quot; instead of &quot;ThirdPartyCNAMECloaking&quot;, since this now
applies to both.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/IPAddressTests.cpp: Added.
(TestWebKitAPI::TEST):

Add a couple of API tests to exercise the new functionality in `WebCore::IPAddress`.

Canonical link: <a href="https://commits.webkit.org/255849@main">https://commits.webkit.org/255849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/005e133a23727555a4e1f183885e46901e7ac172

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93759 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103403 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163724 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2970 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31207 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86096 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2117 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80198 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84043 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37602 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18856 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41414 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38087 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->