### PR TITLE
Modified regex to ignore commit id when it is part of a range URL (starts with https://).

### DIFF
--- a/Websites/bugs.webkit.org/extensions/Commits/Extension.pm
+++ b/Websites/bugs.webkit.org/extensions/Commits/Extension.pm
@@ -36,7 +36,8 @@ sub bug_format_comment {
     # Should match "r12345" and "trac.webkit.org/r12345" but not "https://trac.webkit.org/r12345"
     push(@$regexes, { match => qr/(?<!\/|\#)\b((r[[:digit:]]{5,}))\b/, replace => \&_replace_reference });
     push(@$regexes, { match => qr/(?<!\/)(trac.webkit.org\/(r[[:digit:]]{5,}))\b/, replace => \&_replace_reference });
-    push(@$regexes, { match => qr/(?<!\/)\b((\d*\.?\d+@\S+))\b/, replace => \&_replace_reference });
+    push(@$regexes, { match => qr/\b(?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+@\S+)\b/, replace => \&_replace_reference });
+    push(@$regexes, { match => qr/\b(?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+\.?\d+@\S+)\b/, replace => \&_replace_reference });
 }
 
 sub _replace_reference {


### PR DESCRIPTION
#### 78a2e6028d141264e31109940f3dbf51a03dcc9c
<pre>
Fixed regression due to last changes.  Displayed text link uses matched group 1 while generated link uses matched group 2 due to another regex handing trac.webkit.org link.
My last patch left out a parentesis pair causing group 2 to be NULL.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246692">https://bugs.webkit.org/show_bug.cgi?id=246692</a>
rdar://problem/101297471

Reviewed by NOBODY (OOPS!).

* Websites/bugs.webkit.org/extensions/Commits/Extension.pm:
(bug_format_comment):
</pre>