### PR TITLE
Remove unused SOAuthorization

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h
@@ -63,8 +63,8 @@ public:
 private:
     bool canAuthorize(const URL&) const;
 
-    RetainPtr<SOAuthorization> m_soAuthorization;
     RetainPtr<WKSOAuthorizationDelegate> m_soAuthorizationDelegate;
+    bool m_hasAppSSO { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm
@@ -48,19 +48,19 @@ namespace WebKit {
 
 SOAuthorizationCoordinator::SOAuthorizationCoordinator()
 {
+    m_hasAppSSO = !!PAL::getSOAuthorizationClass();
 #if PLATFORM(MAC)
     // In the case of base system, which doesn't have AppSSO.framework.
-    if (!PAL::getSOAuthorizationClass())
+    if (!m_hasAppSSO)
         return;
 #endif
-    m_soAuthorization = adoptNS([PAL::allocSOAuthorizationInstance() init]);
     m_soAuthorizationDelegate = adoptNS([[WKSOAuthorizationDelegate alloc] init]);
     [NSURLSession _disableAppSSO];
 }
 
 bool SOAuthorizationCoordinator::canAuthorize(const URL& url) const
 {
-    return m_soAuthorization && [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url responseCode:0];
+    return m_hasAppSSO && [PAL::getSOAuthorizationClass() canPerformAuthorizationWithURL:url responseCode:0];
 }
 
 void SOAuthorizationCoordinator::tryAuthorize(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, Function<void(bool)>&& completionHandler)


### PR DESCRIPTION
#### da5e573f872395131582333a99c9b49cf565f32c
<pre>
Remove unused SOAuthorization
<a href="https://bugs.webkit.org/show_bug.cgi?id=246503">https://bugs.webkit.org/show_bug.cgi?id=246503</a>
rdar://100171989

Reviewed by Brent Fulgham.

This SOAuthorization is unused and it&apos;s teardown may cause issues.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationCoordinator.mm:
(WebKit::SOAuthorizationCoordinator::SOAuthorizationCoordinator):
(WebKit::SOAuthorizationCoordinator::canAuthorize const):

Canonical link: <a href="https://commits.webkit.org/255682@main">https://commits.webkit.org/255682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cdc6766ec77bd45211e84c747b0c952bd63a43d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102897 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2395 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30713 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99010 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1667 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79660 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28582 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37104 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17225 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34920 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3936 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41000 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37677 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->