### PR TITLE
worker and other values are valid keyword for the 'as' property in link preload

### DIFF
--- a/LayoutTests/http/tests/preload/download_resources-expected.txt
+++ b/LayoutTests/http/tests/preload/download_resources-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 This test makes sure that link preload preloads resources
 
 PASS Makes sure that preloaded resources are downloaded

--- a/LayoutTests/http/tests/preload/download_resources_from_header_iframe-expected.txt
+++ b/LayoutTests/http/tests/preload/download_resources_from_header_iframe-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 
 
 --------

--- a/LayoutTests/http/tests/preload/onerror_event-expected.txt
+++ b/LayoutTests/http/tests/preload/onerror_event-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 This test makes sure that link preload triggers error events for non-existing resources.
 
 PASS Makes sure that preloaded resources trigger onerror

--- a/LayoutTests/http/wpt/preload/as-attribute-expected.txt
+++ b/LayoutTests/http/wpt/preload/as-attribute-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
+CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+
+
+PASS Test preload as attribute values.
+

--- a/LayoutTests/http/wpt/preload/as-attribute.html
+++ b/LayoutTests/http/wpt/preload/as-attribute.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var loaded = 0;
+    var expectedToLoad = 2;
+</script>
+<link rel=preload href="/WebKit/preload/resources/square.png?asemptystring" as="" onload="++loaded;">
+<link rel=preload href="/WebKit/preload/resources/square.png?asbadvalue" as="unknown" onload="++loaded;">
+<link rel=preload href="/WebKit/preload/resources/classic.js" as="worker" onload="++loaded;">
+<link rel=preload href="/WebKit/preload/resources/square.png?img_good_type" as="image" onload="++loaded;">
+<script src="/WebKit/preload/resources/dummy.js?pipe=trickle(d0.5)"></script>
+<script>
+    var t = async_test('Test preload as attribute values.');
+    window.setInterval(t.step_func(function() {
+        function verifyDownloadNumber(url, number) {
+            var absolute_url = new URL(url, window.location.href);
+            assert_equals(performance.getEntriesByName(absolute_url).length, number, url);
+        }
+        if (loaded == 2) {
+            verifyDownloadNumber("/WebKit/preload/resources/square.png?asemptystring", 0);
+            verifyDownloadNumber("/WebKit/preload/resources/square.png?asbadvalue", 0);
+            verifyDownloadNumber("/WebKit/preload/resources/classic.js", 1);
+            verifyDownloadNumber("/WebKit/preload/resources/square.png?img_good_type", 1);
+
+            document.write('<img src="/WebKit/preload/resources/square.png?img_good_type">');
+            new Worker("/WebKit/preload/resources/classic.js");
+
+            t.done();
+        }
+    }), 200);
+</script>
+<span>foo</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/onload-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/onload-event-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 
 PASS Makes sure that preloaded resources trigger the onload event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/preload-csp.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/preload-csp.sub-expected.txt
@@ -13,7 +13,7 @@ CONSOLE MESSAGE: Refused to load http://localhost:8800/preload/resources/white.m
 CONSOLE MESSAGE: Refused to load http://localhost:8800/preload/resources/sound_5.oga because it does not appear in the media-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to load http://localhost:8800/preload/resources/foo.vtt because it does not appear in the media-src directive of the Content Security Policy.
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 
 PASS Makes sure that preload requests respect CSP
 

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/preload-default-csp.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/preload-default-csp.sub-expected.txt
@@ -13,7 +13,7 @@ CONSOLE MESSAGE: Refused to load http://localhost:8800/preload/resources/white.m
 CONSOLE MESSAGE: Refused to load http://localhost:8800/preload/resources/sound_5.oga because it appears in neither the media-src directive nor the default-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to load http://localhost:8800/preload/resources/foo.vtt because it appears in neither the media-src directive nor the default-src directive of the Content Security Policy.
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 
 PASS Makes sure that preload requests respect CSP
 

--- a/LayoutTests/imported/w3c/web-platform-tests/preload/single-download-preload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/preload/single-download-preload-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
-CONSOLE MESSAGE: <link rel=preload> must have a valid `as` value
+CONSOLE MESSAGE: <link rel=preload> cannot have the empty string as `as` value
 CONSOLE MESSAGE: The resource http://localhost:8800/preload/resources/square.png?background&single-download-preload was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it wasn't preloaded for nothing.
 CONSOLE MESSAGE: The resource http://localhost:8800/preload/resources/white.mp4?single-download-preload was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it wasn't preloaded for nothing.
 CONSOLE MESSAGE: The resource http://localhost:8800/preload/resources/sound_5.oga?single-download-preload was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it wasn't preloaded for nothing.

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -128,6 +128,8 @@ fast/scrolling/rtl-scrollbars-positioning.html [ Pass ]
 fast/scrolling/rtl-scrollbars-simple.html [ Pass ]
 fast/scrolling/rtl-scrollbars.html [ Pass ]
 
+http/tests/preload/onload_event.html [ Pass Failure ]
+
 http/tests/storageAccess/ [ Pass ]
 http/tests/storageAccess/deny-with-prompt-does-not-preserve-gesture.html [ Skip ]
 webkit.org/b/208400 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies-ephemeral.html [ Failure ]
@@ -140,6 +142,11 @@ imported/mozilla/svg/blend-hard-light.svg [ Pass ]
 imported/mozilla/svg/dynamic-textPath-02.svg [ Pass ]
 
 inspector/page/setScreenSizeOverride.html [ Pass ]
+
+# Might need rebasing.
+imported/w3c/web-platform-tests/preload/preload-csp.sub.html [ Pass Failure ]
+imported/w3c/web-platform-tests/preload/preload-default-csp.sub.html [ Pass Failure ]
+imported/w3c/web-platform-tests/preload/single-download-preload.html [ Pass Failure ]
 
 # Content Extensions
 http/tests/contentextensions [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2112,7 +2112,7 @@ webkit.org/b/226299 [ BigSur ] http/tests/performance/performance-resource-timin
 [ Monterey ] imported/w3c/web-platform-tests/css/css-text-decor/text-underline-position-from-font-variable.html [ Pass ImageOnlyFailure ]
 
 # rdar://80340581 ([ Monterey ] http/tests/preload/onload_event.html is a flaky failure)
-[ Monterey ] http/tests/preload/onload_event.html [ Pass Failure ]
+http/tests/preload/onload_event.html [ Pass Failure ]
 
 # rdar://80347712 ([ Monterey ] media/video-src-blob-replay.html is a flaky timeout)
 [ Monterey ] media/video-src-blob-replay.html [ Timeout ]

--- a/Source/WebCore/bindings/js/JSDOMConvertEnumeration.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertEnumeration.h
@@ -28,10 +28,12 @@
 #include "IDLTypes.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMGlobalObject.h"
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 // Specialized by generated code for IDL enumeration conversion.
+template<typename T> std::optional<T> parseEnumerationFromString(const String&);
 template<typename T> std::optional<T> parseEnumeration(JSC::JSGlobalObject&, JSC::JSValue);
 template<typename T> const char* expectedEnumerationValues();
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2399,9 +2399,8 @@ sub GenerateEnumerationImplementationContent
     # FIXME: Change to take VM& instead of JSGlobalObject&.
     # FIXME: Consider using toStringOrNull to make exception checking faster.
     # FIXME: Consider finding a more efficient way to match against all the strings quickly.
-    $result .= "template<> std::optional<$className> parseEnumeration<$className>(JSGlobalObject& lexicalGlobalObject, JSValue value)\n";
+    $result .= "template<> std::optional<$className> parseEnumerationFromString<${className}>(const String& stringValue)\n";
     $result .= "{\n";
-    $result .= "    auto stringValue = value.toWTFString(&lexicalGlobalObject);\n";
     my @sortedEnumerationValues = sort @{$enumeration->values};
     if ($sortedEnumerationValues[0] eq "") {
         $result .= "    if (stringValue.isEmpty())\n";
@@ -2418,6 +2417,11 @@ sub GenerateEnumerationImplementationContent
     $result .= "    if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))\n";
     $result .= "        return *enumerationValue;\n";
     $result .= "    return std::nullopt;\n";
+    $result .= "}\n\n";
+
+    $result .= "template<> std::optional<$className> parseEnumeration<$className>(JSGlobalObject& lexicalGlobalObject, JSValue value)\n";
+    $result .= "{\n";
+    $result .= "    return parseEnumerationFromString<${className}>(value.toWTFString(&lexicalGlobalObject));\n";
     $result .= "}\n\n";
 
     $result .= "template<> const char* expectedEnumerationValues<$className>()\n";
@@ -2458,6 +2462,7 @@ sub GenerateEnumerationHeaderContent
 
     $result .= "${exportMacro}String convertEnumerationToString($className);\n";
     $result .= "template<> ${exportMacro}JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, $className);\n\n";
+    $result .= "template<> ${exportMacro}std::optional<$className> parseEnumerationFromString<${className}>(const String&);\n";
     $result .= "template<> ${exportMacro}std::optional<$className> parseEnumeration<$className>(JSC::JSGlobalObject&, JSC::JSValue);\n";
     $result .= "template<> ${exportMacro}const char* expectedEnumerationValues<$className>();\n\n";
     $result .= "#endif\n\n" if $conditionalString;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -67,9 +67,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestCallbackInterface::Enum> parseEnumeration<TestCallbackInterface::Enum>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestCallbackInterface::Enum> parseEnumerationFromString<TestCallbackInterface::Enum>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum> mappings[] = {
         { "value1", TestCallbackInterface::Enum::Value1 },
         { "value2", TestCallbackInterface::Enum::Value2 },
@@ -78,6 +77,11 @@ template<> std::optional<TestCallbackInterface::Enum> parseEnumeration<TestCallb
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestCallbackInterface::Enum> parseEnumeration<TestCallbackInterface::Enum>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestCallbackInterface::Enum>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestCallbackInterface::Enum>()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -68,6 +68,7 @@ inline JSC::JSValue toJS(TestCallbackInterface* impl) { return impl ? toJS(*impl
 String convertEnumerationToString(TestCallbackInterface::Enum);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestCallbackInterface::Enum);
 
+template<> std::optional<TestCallbackInterface::Enum> parseEnumerationFromString<TestCallbackInterface::Enum>(const String&);
 template<> std::optional<TestCallbackInterface::Enum> parseEnumeration<TestCallbackInterface::Enum>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestCallbackInterface::Enum>();
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
@@ -47,9 +47,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestDefaultToJSONEnum> parseEnumeration<TestDefaultToJSONEnum>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestDefaultToJSONEnum> parseEnumerationFromString<TestDefaultToJSONEnum>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum> mappings[] = {
         { "EnumValue1", TestDefaultToJSONEnum::EnumValue1 },
         { "EnumValue2", TestDefaultToJSONEnum::EnumValue2 },
@@ -58,6 +57,11 @@ template<> std::optional<TestDefaultToJSONEnum> parseEnumeration<TestDefaultToJS
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestDefaultToJSONEnum> parseEnumeration<TestDefaultToJSONEnum>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestDefaultToJSONEnum>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestDefaultToJSONEnum>()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.h
@@ -28,6 +28,7 @@ namespace WebCore {
 String convertEnumerationToString(TestDefaultToJSONEnum);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestDefaultToJSONEnum);
 
+template<> std::optional<TestDefaultToJSONEnum> parseEnumerationFromString<TestDefaultToJSONEnum>(const String&);
 template<> std::optional<TestDefaultToJSONEnum> parseEnumeration<TestDefaultToJSONEnum>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestDefaultToJSONEnum>();
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -149,9 +149,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::EnumType> parseEnumeration<TestObj::EnumType>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::EnumType> parseEnumerationFromString<TestObj::EnumType>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     if (stringValue.isEmpty())
         return TestObj::EnumType::EmptyString;
     static constexpr std::pair<ComparableASCIILiteral, TestObj::EnumType> mappings[] = {
@@ -163,6 +162,11 @@ template<> std::optional<TestObj::EnumType> parseEnumeration<TestObj::EnumType>(
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumType> parseEnumeration<TestObj::EnumType>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumType>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::EnumType>()
@@ -187,9 +191,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::EnumTrailingComma> parseEnumeration<TestObj::EnumTrailingComma>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::EnumTrailingComma> parseEnumerationFromString<TestObj::EnumTrailingComma>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma> mappings[] = {
         { "enumValue1", TestObj::EnumTrailingComma::EnumValue1 },
         { "enumValue2", TestObj::EnumTrailingComma::EnumValue2 },
@@ -198,6 +201,11 @@ template<> std::optional<TestObj::EnumTrailingComma> parseEnumeration<TestObj::E
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumTrailingComma> parseEnumeration<TestObj::EnumTrailingComma>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumTrailingComma>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::EnumTrailingComma>()
@@ -226,9 +234,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::Optional> parseEnumeration<TestObj::Optional>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::Optional> parseEnumerationFromString<TestObj::Optional>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     if (stringValue.isEmpty())
         return TestObj::Optional::EmptyString;
     static constexpr std::pair<ComparableASCIILiteral, TestObj::Optional> mappings[] = {
@@ -240,6 +247,11 @@ template<> std::optional<TestObj::Optional> parseEnumeration<TestObj::Optional>(
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::Optional> parseEnumeration<TestObj::Optional>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::Optional>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::Optional>()
@@ -264,9 +276,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<AlternateEnumName> parseEnumeration<AlternateEnumName>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<AlternateEnumName> parseEnumerationFromString<AlternateEnumName>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, AlternateEnumName> mappings[] = {
         { "EnumValue2", AlternateEnumName::EnumValue2 },
         { "enumValue1", AlternateEnumName::EnumValue1 },
@@ -275,6 +286,11 @@ template<> std::optional<AlternateEnumName> parseEnumeration<AlternateEnumName>(
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<AlternateEnumName> parseEnumeration<AlternateEnumName>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<AlternateEnumName>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<AlternateEnumName>()
@@ -299,9 +315,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::EnumA> parseEnumeration<TestObj::EnumA>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::EnumA> parseEnumerationFromString<TestObj::EnumA>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::EnumA> mappings[] = {
         { "A", TestObj::EnumA::A },
     };
@@ -309,6 +324,11 @@ template<> std::optional<TestObj::EnumA> parseEnumeration<TestObj::EnumA>(JSGlob
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumA> parseEnumeration<TestObj::EnumA>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumA>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::EnumA>()
@@ -335,9 +355,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::EnumB> parseEnumeration<TestObj::EnumB>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::EnumB> parseEnumerationFromString<TestObj::EnumB>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::EnumB> mappings[] = {
         { "B", TestObj::EnumB::B },
     };
@@ -345,6 +364,11 @@ template<> std::optional<TestObj::EnumB> parseEnumeration<TestObj::EnumB>(JSGlob
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumB> parseEnumeration<TestObj::EnumB>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumB>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::EnumB>()
@@ -371,9 +395,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::EnumC> parseEnumeration<TestObj::EnumC>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::EnumC> parseEnumerationFromString<TestObj::EnumC>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::EnumC> mappings[] = {
         { "C", TestObj::EnumC::C },
     };
@@ -381,6 +404,11 @@ template<> std::optional<TestObj::EnumC> parseEnumeration<TestObj::EnumC>(JSGlob
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::EnumC> parseEnumeration<TestObj::EnumC>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::EnumC>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::EnumC>()
@@ -407,9 +435,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::Kind> parseEnumeration<TestObj::Kind>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::Kind> parseEnumerationFromString<TestObj::Kind>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::Kind> mappings[] = {
         { "dead", TestObj::Kind::Dead },
         { "quick", TestObj::Kind::Quick },
@@ -418,6 +445,11 @@ template<> std::optional<TestObj::Kind> parseEnumeration<TestObj::Kind>(JSGlobal
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::Kind> parseEnumeration<TestObj::Kind>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::Kind>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::Kind>()
@@ -442,9 +474,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::Size> parseEnumeration<TestObj::Size>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::Size> parseEnumerationFromString<TestObj::Size>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::Size> mappings[] = {
         { "much-much-larger", TestObj::Size::MuchMuchLarger },
         { "small", TestObj::Size::Small },
@@ -453,6 +484,11 @@ template<> std::optional<TestObj::Size> parseEnumeration<TestObj::Size>(JSGlobal
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::Size> parseEnumeration<TestObj::Size>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::Size>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::Size>()
@@ -477,9 +513,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestObj::Confidence> parseEnumeration<TestObj::Confidence>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj::Confidence>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestObj::Confidence> mappings[] = {
         { "high", TestObj::Confidence::High },
         { "kinda-low", TestObj::Confidence::KindaLow },
@@ -488,6 +523,11 @@ template<> std::optional<TestObj::Confidence> parseEnumeration<TestObj::Confiden
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestObj::Confidence> parseEnumeration<TestObj::Confidence>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestObj::Confidence>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestObj::Confidence>()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -118,24 +118,28 @@ template<> struct JSDOMWrapperConverterTraits<TestObj> {
 String convertEnumerationToString(TestObj::EnumType);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumType);
 
+template<> std::optional<TestObj::EnumType> parseEnumerationFromString<TestObj::EnumType>(const String&);
 template<> std::optional<TestObj::EnumType> parseEnumeration<TestObj::EnumType>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumType>();
 
 String convertEnumerationToString(TestObj::EnumTrailingComma);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumTrailingComma);
 
+template<> std::optional<TestObj::EnumTrailingComma> parseEnumerationFromString<TestObj::EnumTrailingComma>(const String&);
 template<> std::optional<TestObj::EnumTrailingComma> parseEnumeration<TestObj::EnumTrailingComma>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumTrailingComma>();
 
 String convertEnumerationToString(TestObj::Optional);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Optional);
 
+template<> std::optional<TestObj::Optional> parseEnumerationFromString<TestObj::Optional>(const String&);
 template<> std::optional<TestObj::Optional> parseEnumeration<TestObj::Optional>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Optional>();
 
 String convertEnumerationToString(AlternateEnumName);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, AlternateEnumName);
 
+template<> std::optional<AlternateEnumName> parseEnumerationFromString<AlternateEnumName>(const String&);
 template<> std::optional<AlternateEnumName> parseEnumeration<AlternateEnumName>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<AlternateEnumName>();
 
@@ -144,6 +148,7 @@ template<> const char* expectedEnumerationValues<AlternateEnumName>();
 String convertEnumerationToString(TestObj::EnumA);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumA);
 
+template<> std::optional<TestObj::EnumA> parseEnumerationFromString<TestObj::EnumA>(const String&);
 template<> std::optional<TestObj::EnumA> parseEnumeration<TestObj::EnumA>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumA>();
 
@@ -154,6 +159,7 @@ template<> const char* expectedEnumerationValues<TestObj::EnumA>();
 String convertEnumerationToString(TestObj::EnumB);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumB);
 
+template<> std::optional<TestObj::EnumB> parseEnumerationFromString<TestObj::EnumB>(const String&);
 template<> std::optional<TestObj::EnumB> parseEnumeration<TestObj::EnumB>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumB>();
 
@@ -164,6 +170,7 @@ template<> const char* expectedEnumerationValues<TestObj::EnumB>();
 String convertEnumerationToString(TestObj::EnumC);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::EnumC);
 
+template<> std::optional<TestObj::EnumC> parseEnumerationFromString<TestObj::EnumC>(const String&);
 template<> std::optional<TestObj::EnumC> parseEnumeration<TestObj::EnumC>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::EnumC>();
 
@@ -172,18 +179,21 @@ template<> const char* expectedEnumerationValues<TestObj::EnumC>();
 String convertEnumerationToString(TestObj::Kind);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Kind);
 
+template<> std::optional<TestObj::Kind> parseEnumerationFromString<TestObj::Kind>(const String&);
 template<> std::optional<TestObj::Kind> parseEnumeration<TestObj::Kind>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Kind>();
 
 String convertEnumerationToString(TestObj::Size);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Size);
 
+template<> std::optional<TestObj::Size> parseEnumerationFromString<TestObj::Size>(const String&);
 template<> std::optional<TestObj::Size> parseEnumeration<TestObj::Size>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Size>();
 
 String convertEnumerationToString(TestObj::Confidence);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestObj::Confidence);
 
+template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj::Confidence>(const String&);
 template<> std::optional<TestObj::Confidence> parseEnumeration<TestObj::Confidence>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestObj::Confidence>();
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -348,9 +348,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile> mappings[] = {
         { "enumValue1", TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 },
         { "enumValue2", TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue2 },
@@ -359,6 +358,11 @@ template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFil
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.h
@@ -35,6 +35,7 @@ WEBCORE_EXPORT JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject&, JSDOMG
 String convertEnumerationToString(TestStandaloneDictionary::EnumInStandaloneDictionaryFile);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestStandaloneDictionary::EnumInStandaloneDictionaryFile);
 
+template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(const String&);
 template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>();
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -50,9 +50,8 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
     return jsStringWithCache(lexicalGlobalObject.vm(), convertEnumerationToString(enumerationValue));
 }
 
-template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandaloneEnumeration>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String& stringValue)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
     static constexpr std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> mappings[] = {
         { "enumValue1", TestStandaloneEnumeration::EnumValue1 },
         { "enumValue2", TestStandaloneEnumeration::EnumValue2 },
@@ -61,6 +60,11 @@ template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandal
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); LIKELY(enumerationValue))
         return *enumerationValue;
     return std::nullopt;
+}
+
+template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandaloneEnumeration>(JSGlobalObject& lexicalGlobalObject, JSValue value)
+{
+    return parseEnumerationFromString<TestStandaloneEnumeration>(value.toWTFString(&lexicalGlobalObject));
 }
 
 template<> const char* expectedEnumerationValues<TestStandaloneEnumeration>()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.h
@@ -30,6 +30,7 @@ namespace WebCore {
 String convertEnumerationToString(TestStandaloneEnumeration);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, TestStandaloneEnumeration);
 
+template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String&);
 template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandaloneEnumeration>(JSC::JSGlobalObject&, JSC::JSValue);
 template<> const char* expectedEnumerationValues<TestStandaloneEnumeration>();
 

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -62,7 +62,8 @@ public:
     virtual ~LinkLoader();
 
     void loadLink(const LinkLoadParameters&, Document&);
-    static std::optional<CachedResource::Type> resourceTypeFromAsAttribute(const String&, Document&);
+    enum class ShouldLog { No, Yes };
+    static std::optional<CachedResource::Type> resourceTypeFromAsAttribute(const String&, Document&, ShouldLog = ShouldLog::No);
 
     enum class MediaAttributeCheck { MediaAttributeEmpty, MediaAttributeNotEmpty, SkipMediaAttributeCheck };
     static void loadLinksFromHeader(const String& headerValue, const URL& baseURL, Document&, MediaAttributeCheck);


### PR DESCRIPTION
#### e53707dae94cde937c24d964f9adf89392b7e3f6
<pre>
worker and other values are valid keyword for the &apos;as&apos; property in link preload
<a href="https://bugs.webkit.org/show_bug.cgi?id=245415">https://bugs.webkit.org/show_bug.cgi?id=245415</a>
rdar://problem/100161255

Reviewed by Alex Christensen.

Update binding generator code to allow exposing a parse enumeration routine from a string.
Make use of it in LinkLoader to parse fetch destination and use fetch destination to set the resource type.
Add support for more destination values, including worker, which is tested in the new test.

* LayoutTests/http/wpt/preload/as-attribute-expected.txt: Added.
* LayoutTests/http/wpt/preload/as-attribute.html: Added.
* LayoutTests/http/tests/preload/download_resources-expected.txt:
* LayoutTests/http/tests/preload/download_resources_from_header_iframe-expected.txt:
* LayoutTests/http/tests/preload/onerror_event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/onload-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/preload-csp.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/preload-default-csp.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/preload/single-download-preload-expected.txt:
* Source/WebCore/bindings/js/JSDOMConvertEnumeration.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateEnumerationImplementationContent):
(GenerateEnumerationHeaderContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::parseEnumerationFromString&lt;TestCallbackInterface::Enum&gt;):
(WebCore::parseEnumeration&lt;TestCallbackInterface::Enum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp:
(WebCore::parseEnumerationFromString&lt;TestDefaultToJSONEnum&gt;):
(WebCore::parseEnumeration&lt;TestDefaultToJSONEnum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::parseEnumerationFromString&lt;TestObj::EnumType&gt;):
(WebCore::parseEnumeration&lt;TestObj::EnumType&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumTrailingComma&gt;):
(WebCore::parseEnumeration&lt;TestObj::EnumTrailingComma&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Optional&gt;):
(WebCore::parseEnumeration&lt;TestObj::Optional&gt;):
(WebCore::parseEnumerationFromString&lt;AlternateEnumName&gt;):
(WebCore::parseEnumeration&lt;AlternateEnumName&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumA&gt;):
(WebCore::parseEnumeration&lt;TestObj::EnumA&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumB&gt;):
(WebCore::parseEnumeration&lt;TestObj::EnumB&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumC&gt;):
(WebCore::parseEnumeration&lt;TestObj::EnumC&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Kind&gt;):
(WebCore::parseEnumeration&lt;TestObj::Kind&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Size&gt;):
(WebCore::parseEnumeration&lt;TestObj::Size&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Confidence&gt;):
(WebCore::parseEnumeration&lt;TestObj::Confidence&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
(WebCore::parseEnumerationFromString&lt;TestStandaloneDictionary::EnumInStandaloneDictionaryFile&gt;):
(WebCore::parseEnumeration&lt;TestStandaloneDictionary::EnumInStandaloneDictionaryFile&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp:
(WebCore::parseEnumerationFromString&lt;TestStandaloneEnumeration&gt;):
(WebCore::parseEnumeration&lt;TestStandaloneEnumeration&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::resourceTypeFromAsAttribute):
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/LinkLoader.h:

Canonical link: <a href="https://commits.webkit.org/255669@main">https://commits.webkit.org/255669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/571dc24eabf7fac3aa33f696e1a4d06576874839

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102952 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2467 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30774 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99066 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98932 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79725 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28631 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37163 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34984 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3927 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37727 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->