### PR TITLE
[WK2] ArgumentCoder<std::tuple<...>> should decode elements directly into std::optional<> values

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -332,8 +332,7 @@ template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
         static_assert(Index == std::tuple_size_v<OptionalTuple>);
 
         if constexpr (Index < sizeof...(Elements)) {
-            std::optional<std::tuple_element_t<Index, std::tuple<Elements...>>> optional;
-            decoder >> optional;
+            auto optional = decoder.template decode<std::tuple_element_t<Index, std::tuple<Elements...>>>();
             if (!optional)
                 return std::nullopt;
             return decode(decoder, std::forward_as_tuple(std::get<Indices>(WTFMove(optionalTuple))..., WTFMove(optional)), std::make_index_sequence<Index + 1> { });

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.h
@@ -38,8 +38,14 @@ public:
     template<typename T>
     Decoder& operator>>(std::optional<T>& t)
     {
-        t = Coder<std::remove_const_t<std::remove_reference_t<T>>>::decode(*this);
+        t = decode<T>();
         return *this;
+    }
+
+    template<typename T>
+    std::optional<T> decode()
+    {
+        return Coder<std::remove_const_t<std::remove_reference_t<T>>>::decode(*this);
     }
 
     template<typename T>


### PR DESCRIPTION
#### aa5bef0fe16f0e5812c7d675570bcb8bd223aa14
<pre>
[WK2] ArgumentCoder&lt;std::tuple&lt;...&gt;&gt; should decode elements directly into std::optional&lt;&gt; values
<a href="https://bugs.webkit.org/show_bug.cgi?id=246510">https://bugs.webkit.org/show_bug.cgi?id=246510</a>

Reviewed by Kimmo Kinnunen.

Requested during review of PR #5083, there shouldn&apos;t be a need to construct a valueless
std::optional&lt;&gt; before having the std::tuple&lt;&gt; decoder decode a given tuple element into it.
The decoder should be returning the std::optional&lt;&gt; instead.

For this to work with every decoder, Daemon::Decoder has to provide this decode&lt;T&gt;() method.
Similar to IPC::Decoder, this method can the be used in the
Daemon::Decoder::operator&gt;&gt;(std::optional&lt;T&gt;&amp;) implementation.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Platform/IPC/DaemonDecoder.h:
(WebKit::Daemon::Decoder::operator&gt;&gt;):
(WebKit::Daemon::Decoder::decode):

Canonical link: <a href="https://commits.webkit.org/255914@main">https://commits.webkit.org/255914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86ac42f18e90f924ef5a11fbc2dce4f7693ce028

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102553 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2039 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30379 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98712 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1390 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79314 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28308 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36783 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16929 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34583 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18120 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40723 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37292 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->