### PR TITLE
Close WebCodecsVideo remote decoders in case of failure

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -234,11 +234,13 @@ imported/w3c/web-platform-tests/video-rvfc [ Skip ]
 fast/mediastream/getUserMedia-rvfc.html [ Skip ]
 webrtc/peerConnection-rvfc.html [ Skip ]
 
-imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?h264_avc [ Pass Failure ]
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_annexb [ Pass Failure ]
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_avc [ Pass Failure ]
 imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?h264_annexb [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.html?h264_avc [ Pass Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?h264 [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb [ Pass Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.html [ Pass Failure ]
 
 # This test only makes sense on Mac

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt
@@ -9,12 +9,12 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Decode corrupt frame assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp
 PASS Test reset during flush
 PASS Test low-latency decoding
-PASS VideoDecoder decodeQueueSize test
+FAIL VideoDecoder decodeQueueSize test promise_test: Unhandled rejection with value: object "AbortError: aborting flush as decoder is reset"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt
@@ -9,8 +9,8 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Decode corrupt frame assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt
@@ -9,8 +9,8 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error 1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
-FAIL Decode corrupt frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error -1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt
@@ -9,8 +9,8 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error 1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
-FAIL Decode corrupt frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error -1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt
@@ -9,12 +9,12 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Decode corrupt frame assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp
 PASS Test reset during flush
 PASS Test low-latency decoding
-PASS VideoDecoder decodeQueueSize test
+FAIL VideoDecoder decodeQueueSize test promise_test: Unhandled rejection with value: object "AbortError: aborting flush as decoder is reset"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt
@@ -9,8 +9,8 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Decode corrupt frame assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt
@@ -9,8 +9,8 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error 1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
-FAIL Decode corrupt frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error -1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt
@@ -9,8 +9,8 @@ PASS Decode a non key frame first fails
 PASS Verify reset() suppresses outputs
 PASS Test unconfigured VideoDecoder operations
 PASS Test closed VideoDecoder operations
-FAIL Decode empty frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error 1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
-FAIL Decode corrupt frame promise_rejects_dom: function "function () { throw e }" threw object "EncodingError: VPx decoding failed with error -1" that is not a DOMException AbortError: property "code" is equal to 0, expected 20
+PASS Decode empty frame
+PASS Decode corrupt frame
 PASS Close while decoding corrupt frame
 PASS Test decoding after flush
 PASS Test decoding a with negative timestamp

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitDecoder.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitDecoder.mm
@@ -58,6 +58,10 @@
     if (self = [super init]) {
         m_h264Decoder = [[RTCVideoDecoderH264 alloc] init];
         [m_h264Decoder setCallback:^(RTCVideoFrame *frame) {
+            if (!frame) {
+              callback(nil, 0, 0);
+              return;
+            }
             auto *buffer = (RTCCVPixelBuffer *)frame.buffer;
             callback(buffer.pixelBuffer, frame.timeStamp, frame.timeStampNs);
         }];
@@ -69,6 +73,10 @@
     if (self = [super init]) {
         m_h265Decoder = [[RTCVideoDecoderH265 alloc] init];
         [m_h265Decoder setCallback:^(RTCVideoFrame *frame) {
+            if (!frame) {
+              callback(nil, 0, 0);
+              return;
+            }
             auto *buffer = (RTCCVPixelBuffer *)frame.buffer;
             callback(buffer.pixelBuffer, frame.timeStamp, frame.timeStampNs);
         }];
@@ -80,6 +88,10 @@
     if (self = [super init]) {
         m_vp9Decoder = [[RTCVideoDecoderVTBVP9 alloc] init];
         [m_vp9Decoder setCallback:^(RTCVideoFrame *frame) {
+            if (!frame) {
+              callback(nil, 0, 0);
+              return;
+            }
             auto *buffer = (RTCCVPixelBuffer *)frame.buffer;
             callback(buffer.pixelBuffer, frame.timeStamp, frame.timeStampNs);
         }];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/base/RTCVideoDecoder.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/base/RTCVideoDecoder.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Callback block for decoder. */
-typedef void (^RTCVideoDecoderCallback)(RTCVideoFrame *frame);
+typedef void (^RTCVideoDecoderCallback)(RTCVideoFrame * __nullable frame);
 
 /** Protocol for decoder implementations. */
 RTC_OBJC_EXPORT

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm
@@ -58,16 +58,17 @@ void decompressionOutputCallback(void *decoderRef,
                                  CVImageBufferRef imageBuffer,
                                  CMTime timestamp,
                                  CMTime duration) {
+  std::unique_ptr<RTCFrameDecodeParams> decodeParams(reinterpret_cast<RTCFrameDecodeParams *>(params));
   if (status != noErr || !imageBuffer) {
     RTCVideoDecoderH264 *decoder = (__bridge RTCVideoDecoderH264 *)decoderRef;
     [decoder setError:status != noErr ? status : 1];
     RTC_LOG(LS_ERROR) << "Failed to decode frame. Status: " << status;
+    decodeParams->callback(nil);
     return;
   }
 
   overrideColorSpaceAttachments(imageBuffer);
 
-  std::unique_ptr<RTCFrameDecodeParams> decodeParams(reinterpret_cast<RTCFrameDecodeParams *>(params));
   // TODO(tkchin): Handle CVO properly.
   RTCCVPixelBuffer *frameBuffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:imageBuffer];
   RTCVideoFrame *decodedFrame =

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -55,16 +55,17 @@ void h265DecompressionOutputCallback(void* decoderRef,
                                      CVImageBufferRef imageBuffer,
                                      CMTime timestamp,
                                      CMTime duration) {
+  std::unique_ptr<RTCH265FrameDecodeParams> decodeParams(reinterpret_cast<RTCH265FrameDecodeParams*>(params));
   if (status != noErr || !imageBuffer) {
     RTCVideoDecoderH265 *decoder = (__bridge RTCVideoDecoderH265 *)decoderRef;
     [decoder setError:status != noErr ? status : 1];
     RTC_LOG(LS_ERROR) << "Failed to decode frame. Status: " << status;
+    decodeParams->callback(nil);
     return;
   }
 
   overrideColorSpaceAttachments(imageBuffer);
 
-  std::unique_ptr<RTCH265FrameDecodeParams> decodeParams(reinterpret_cast<RTCH265FrameDecodeParams*>(params));
   // TODO(tkchin): Handle CVO properly.
   RTCCVPixelBuffer* frameBuffer =
       [[RTCCVPixelBuffer alloc] initWithPixelBuffer:imageBuffer];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderVTBVP9.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderVTBVP9.mm
@@ -149,14 +149,15 @@ void vp9DecompressionOutputCallback(void *decoderRef,
                                  CVImageBufferRef imageBuffer,
                                  CMTime timestamp,
                                  CMTime duration) {
+  std::unique_ptr<RTCFrameDecodeParams> decodeParams(reinterpret_cast<RTCFrameDecodeParams *>(params));
   if (status != noErr || !imageBuffer) {
     RTCVideoDecoderVTBVP9 *decoder = (__bridge RTCVideoDecoderVTBVP9 *)decoderRef;
     [decoder setError:status != noErr ? status : 1];
     RTC_LOG(LS_ERROR) << "Failed to decode frame. Status: " << status;
+    decodeParams->callback(nil);
     return;
   }
 
-  std::unique_ptr<RTCFrameDecodeParams> decodeParams(reinterpret_cast<RTCFrameDecodeParams *>(params));
   RTCCVPixelBuffer *frameBuffer = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:imageBuffer];
   RTCVideoFrame *decodedFrame =
       [[RTCVideoFrame alloc] initWithBuffer:frameBuffer

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -1563,7 +1563,6 @@
 		416731D5212E0430001280EB /* mcomp.h in Headers */ = {isa = PBXBuildFile; fileRef = 41CBAFA5212E03AC00DE1E1D /* mcomp.h */; };
 		416731D6212E0430001280EB /* pickinter.c in Sources */ = {isa = PBXBuildFile; fileRef = 41CBAFAA212E03AD00DE1E1D /* pickinter.c */; };
 		416731D7212E0430001280EB /* vp8_quantize.c in Sources */ = {isa = PBXBuildFile; fileRef = 41CBAFA8212E03AD00DE1E1D /* vp8_quantize.c */; };
-		416B440E235DC23C0040E255 /* RTCWrappedNativeVideoDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41795403216985200028266B /* RTCWrappedNativeVideoDecoder.mm */; };
 		416D3BDE212731C200775F09 /* adaptive_mode_level_estimator.cc in Sources */ = {isa = PBXBuildFile; fileRef = 41D6B45F212731A1008F9353 /* adaptive_mode_level_estimator.cc */; };
 		416D3BDF212731C200775F09 /* agc2_common.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D6B46D212731A4008F9353 /* agc2_common.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		416D3BE0212731C200775F09 /* biquad_filter.cc in Sources */ = {isa = PBXBuildFile; fileRef = 41D6B45E212731A0008F9353 /* biquad_filter.cc */; };
@@ -2466,6 +2465,7 @@
 		41CBAF9A212E039300DE1E1D /* onyxd_if.c in Sources */ = {isa = PBXBuildFile; fileRef = 4105EBB1212E035C008C0C20 /* onyxd_if.c */; };
 		41CBAF9B212E039300DE1E1D /* threading.c in Sources */ = {isa = PBXBuildFile; fileRef = 4105EBB3212E035C008C0C20 /* threading.c */; };
 		41CBAF9C212E039300DE1E1D /* treereader.h in Headers */ = {isa = PBXBuildFile; fileRef = 4105EBB6212E035D008C0C20 /* treereader.h */; };
+		41CDC66D28F6FC2C00603E59 /* RTCWrappedNativeVideoDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 41795403216985200028266B /* RTCWrappedNativeVideoDecoder.mm */; };
 		41D12414215C51D80036B057 /* dwarf2-info.c in Sources */ = {isa = PBXBuildFile; fileRef = 41D1240E215C51CE0036B057 /* dwarf2-info.c */; };
 		41D12415215C51D80036B057 /* dwarf2-aranges.c in Sources */ = {isa = PBXBuildFile; fileRef = 419EA20F215C51B60082BFD2 /* dwarf2-aranges.c */; };
 		41D12416215C51D80036B057 /* dwarf2-dbgfmt.c in Sources */ = {isa = PBXBuildFile; fileRef = 419EA20E215C51B60082BFD2 /* dwarf2-dbgfmt.c */; };
@@ -22576,7 +22576,7 @@
 				413E67652169854600EF37ED /* RTCVideoEncoderVP8.mm in Sources */,
 				414035ED24AA0EBC00BCE9B2 /* RTCVideoEncoderVP9.mm in Sources */,
 				413E6790216987DB00EF37ED /* RTCVideoFrame.mm in Sources */,
-				416B440E235DC23C0040E255 /* RTCWrappedNativeVideoDecoder.mm in Sources */,
+				41CDC66D28F6FC2C00603E59 /* RTCWrappedNativeVideoDecoder.mm in Sources */,
 				413E676D2169854B00EF37ED /* RTCWrappedNativeVideoEncoder.mm in Sources */,
 				41D6B45921273159008F9353 /* rtp_bitrate_configurator.cc in Sources */,
 				419C82B41FE20DCD0040C30F /* rtp_config.cc in Sources */,

--- a/Source/WebCore/platform/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/LibWebRTCVPXVideoDecoder.cpp
@@ -133,10 +133,10 @@ void LibWebRTCVPXInternalVideoDecoder::decode(Span<const uint8_t> data, int64_t 
         if (protectedThis->m_isClosed)
             return;
 
-        String result;
         if (error)
-            result = makeString("VPx decoding failed with error ", error);
-        callback(WTFMove(result));
+            protectedThis->m_outputCallback(makeUnexpected(makeString("VPx decoding failed with error ", error)));
+
+        callback({ });
     });
 }
 
@@ -169,7 +169,7 @@ int32_t LibWebRTCVPXInternalVideoDecoder::Decoded(webrtc::VideoFrame& frame)
             return nullptr;
         });
 
-        protectedThis->m_outputCallback({ WTFMove(videoFrame), timestamp, duration });
+        protectedThis->m_outputCallback(VideoDecoder::DecodedFrame { WTFMove(videoFrame), timestamp, duration });
     });
     return 0;
 }

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -59,7 +59,7 @@ public:
     };
 
     using PostTaskCallback = Function<void(Function<void()>&&)>;
-    using OutputCallback = Function<void(DecodedFrame&&)>;
+    using OutputCallback = Function<void(Expected<DecodedFrame, String>&&)>;
     using CreateResult = Expected<UniqueRef<VideoDecoder>, String>;
     using CreateCallback = CompletionHandler<void(CreateResult&&)>;
 

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -100,6 +100,10 @@ auto LibWebRTCCodecsProxy::createDecoderCallback(VideoDecoderIdentifier identifi
     if (useRemoteFrames)
         videoFrameObjectHeap = m_videoFrameObjectHeap.ptr();
     return [identifier, connection = m_connection, resourceOwner = m_resourceOwner, videoFrameObjectHeap = WTFMove(videoFrameObjectHeap)] (CVPixelBufferRef pixelBuffer, int64_t timeStamp, int64_t timeStampNs) mutable {
+        if (!pixelBuffer) {
+            connection->send(Messages::LibWebRTCCodecs::FailedDecoding { identifier }, 0);
+            return;
+        }
         auto videoFrame = WebCore::VideoFrameCV::create(MediaTime(timeStampNs, 1), false, WebCore::VideoFrame::Rotation::None, pixelBuffer);
         if (resourceOwner)
             videoFrame->setOwnershipIdentity(resourceOwner);

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -366,8 +366,12 @@ void LibWebRTCCodecs::failedDecoding(VideoDecoderIdentifier decoderIdentifier)
 {
     assertIsCurrent(workQueue());
 
-    if (auto* decoder = m_decoders.get(decoderIdentifier))
+    if (auto* decoder = m_decoders.get(decoderIdentifier)) {
         decoder->hasError = true;
+        Locker locker { decoder->decodedImageCallbackLock };
+        if (decoder->decoderCallback)
+            decoder->decoderCallback(nullptr, 0);
+    }
 }
 
 void LibWebRTCCodecs::flushDecoderCompleted(VideoDecoderIdentifier decoderIdentifier)

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -71,7 +71,7 @@ public:
 
     std::optional<VideoCodecType> videoCodecTypeFromWebCodec(const String&);
 
-    using DecoderCallback = Function<void(Ref<WebCore::VideoFrame>&&, int64_t timestamp)>;
+    using DecoderCallback = Function<void(RefPtr<WebCore::VideoFrame>&&, int64_t timestamp)>;
     struct Decoder {
         WTF_MAKE_FAST_ALLOCATED;
     public:


### PR DESCRIPTION
#### bc3de35f87affc761d98072443c5e3cbd35aae91
<pre>
Close WebCodecsVideo remote decoders in case of failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=246449">https://bugs.webkit.org/show_bug.cgi?id=246449</a>
rdar://problem/101118814

Reviewed by Eric Carlson.

Update RTC decoders to return an asynchronous error by calling the callback with an empty frame.
Make use in GPUProcess of this new code to send back the error to WebProcess as soon as retrieved.
This ensures to get an error for the last submitted frame.

Update WebCore code to handle this case. If there is no frame, error the WebCodecs decoder.
Update WebKit code to make sure the remote decoder notifies the error to the WebCodecs decoder.

Covered by rebased tests.
Newly failing test is due to the fact that previously the error was silenced.
We need to figure out why the test is triggering an error.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitDecoder.mm:
(-[WK_RTCLocalVideoH264H265VP9Decoder initH264DecoderWithCallback:]):
(-[WK_RTCLocalVideoH264H265VP9Decoder initH265DecoderWithCallback:]):
(-[WK_RTCLocalVideoH264H265VP9Decoder initVP9DecoderWithCallback:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/base/RTCVideoDecoder.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH264.mm:
(decompressionOutputCallback):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm:
(h265DecompressionOutputCallback):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderVTBVP9.mm:
(vp9DecompressionOutputCallback):
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::resetDecoder):
* Source/WebCore/platform/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::decode):
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createDecoderCallback):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoder::RemoteVideoDecoder):
(WebKit::RemoteVideoDecoderCallbacks::notifyDecodingResult):
(WebKit::RemoteVideoDecoderCallbacks::notifyVideoFrame): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::failedDecoding):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:

Canonical link: <a href="https://commits.webkit.org/255630@main">https://commits.webkit.org/255630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81346d45c5d3e169bbaabac464e6f398ac200120

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102828 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2326 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30649 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98946 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98787 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79595 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37040 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3900 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40947 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40653 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37620 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->