### PR TITLE
Warnings when building ANGLE

### DIFF
--- a/Source/ThirdParty/ANGLE/CMakeLists.txt
+++ b/Source/ThirdParty/ANGLE/CMakeLists.txt
@@ -242,16 +242,8 @@ endif ()
 if (COMPILER_IS_GCC_OR_CLANG)
     foreach (angle_target ANGLE EGL GLESv2)
         if (TARGET ${angle_target})
-            WEBKIT_ADD_TARGET_CXX_FLAGS(${angle_target}
-                -Wno-cast-align
-                -Wno-class-memaccess
-                -Wno-dangling-pointer
-                -Wno-extra
-                -Wno-suggest-attribute=format
-                -Wno-undef
-                -Wno-unused-parameter
-                -Wno-return-type
-                -Wno-comment)
+            WEBKIT_ADD_TARGET_C_FLAGS(${angle_target} -w)
+            WEBKIT_ADD_TARGET_CXX_FLAGS(${angle_target} -w)
         endif ()
     endforeach ()
 endif ()

--- a/Source/ThirdParty/ANGLE/adjust-angle-include-paths.py
+++ b/Source/ThirdParty/ANGLE/adjust-angle-include-paths.py
@@ -56,4 +56,3 @@ for filename in os.listdir('.'):
     newLines = [replace(line) for line in lines]
     if lines != newLines:
         open(filename, 'w').writelines(newLines)
-        print("Postprocessed ANGLE header {}".format(filename))


### PR DESCRIPTION
#### 92dbcacf4c3e3a8fc6eea68e7022ca59401749e0
<pre>
Warnings when building ANGLE
<a href="https://bugs.webkit.org/show_bug.cgi?id=246289">https://bugs.webkit.org/show_bug.cgi?id=246289</a>

Reviewed by Kenneth Russell.

Let&apos;s suppress compiler warnings when building ANGLE. This is
third-party code that is not maintained here. Warnings should be dealt
with upstream.

Historically, I have suppressed individual warnings when they arise.
Upstream is either not building with -Wall like we do, or not using GCC
at all, or else just not fixing warnings. This isn&apos;t scaling very well
and the effort required is not worth it.

Also, remove a print statement from adjust-angle-include-paths.py. Our
build should be quiet except in case of bugs.

* Source/ThirdParty/ANGLE/CMakeLists.txt:
* Source/ThirdParty/ANGLE/adjust-angle-include-paths.py:

Canonical link: <a href="https://commits.webkit.org/255738@main">https://commits.webkit.org/255738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f10366c471197491bbff9d49a246c0e4023d0fc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2071 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102584 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162871 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2073 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30411 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98736 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1417 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79347 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28334 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71453 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36815 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16958 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34615 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18148 "Found 1 new test failure: compositing/backing/backing-store-attachment-animating-outside-viewport.html (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3969 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40749 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37326 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->