### PR TITLE
Switch to alternate <source> element for AirPlay when necessary

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4872,6 +4872,7 @@ imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-snap-002.html 
 webkit.org/b/218325 imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-001.html [ Pass ImageOnlyFailure ]
 
 # Cocoa-only
+media/media-source/remoteplayback-from-source-element.html [ Skip ]
 http/tests/media/hls/hls-hdr-switch.html [ Skip ]
 http/tests/media/video-canplaythrough-webm.html [ Skip ]
 media/media-session/mock-coordinator.html [ Skip ]

--- a/LayoutTests/media/media-source/remoteplayback-from-source-element-expected.txt
+++ b/LayoutTests/media/media-source/remoteplayback-from-source-element-expected.txt
@@ -1,0 +1,28 @@
+
+
+** Setup MSE and URL <source> elements
+EXPECTED (source.readyState == 'closed') OK
+EVENT(sourceopen)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EVENT(update)
+EXPECTED (video.currentSrc.indexOf("blob:") === '0') OK
+EXPECTED (video.readyState >= '1') OK
+
+** Simulate a device becoming available
+
+** Simulate selecting a device
+EVENT(connect)
+EXPECTED (video.currentSrc.indexOf("blob:") < '0') OK
+EXPECTED (video.readyState >= '1') OK
+
+END OF TEST
+

--- a/LayoutTests/media/media-source/remoteplayback-from-source-element.html
+++ b/LayoutTests/media/media-source/remoteplayback-from-source-element.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Remote playback from source element</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script src="../media-file.js"></script>
+    <script>
+
+    let source;
+
+    if (window.internals) {
+        internals.setMockMediaPlaybackTargetPickerEnabled(true);
+        internals.settings.setAllowsAirPlayForMediaPlayback(true);
+    }
+
+    async function setupSources()
+    {
+        consoleWrite('<br>** Setup MSE and URL &lt;source&gt; elements')
+
+        let canPlayListener = new Promise(resolve => {
+            video.addEventListener('canplay', event => {
+                resolve(event);
+            }, { once: true });
+        });
+
+        let loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+
+        source = new MediaSource();
+        testExpected('source.readyState', 'closed');
+
+        let sourceElement = document.createElement('source');
+        sourceElement.id = 'MSE';
+        sourceElement.type = loader.type();
+        sourceElement.src = URL.createObjectURL(source);
+        video.appendChild(sourceElement);
+        await waitFor(source, 'sourceopen');
+
+        let sourceBuffer = source.addSourceBuffer(loader.type());
+        sourceBuffer.appendBuffer(loader.initSegment());
+        await waitFor(sourceBuffer, 'update');
+
+        for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+            sourceBuffer.appendBuffer(loader.mediaSegment(i));
+            await waitForEventWithTimeout(sourceBuffer, 'update', 5000, '"update" for sample never fired')
+        }
+
+        sourceElement = document.createElement('source');
+        let sourceFile = findMediaFile('video', '../content/test');
+        sourceElement.id = 'MP4';
+        sourceElement.src = sourceFile
+        sourceElement.type = mimeTypeForFile(sourceFile);
+        video.appendChild(sourceElement);
+
+        await canPlayListener;
+        testExpected('video.currentSrc.indexOf("blob:")', 0, '===');
+        testExpected('video.readyState', HTMLMediaElement.HAVE_METADATA, '>=');
+    }
+
+    async function setupRemote()
+    {
+        consoleWrite('<br>** Simulate a device becoming available')
+
+        let pendingTimeout = setTimeout(_ => {
+            failTest(`<br>Remote device not available after 8 seconds!`);
+        }, 8000);
+
+        let resolveCallback;
+        try {
+            video.remote.watchAvailability((available) => {
+                if (!available)
+                    return;
+
+                video.remote.cancelWatchAvailability();
+                clearTimeout(pendingTimeout);
+                resolveCallback();
+            });
+        } catch (error) {
+            failTest(`<br>'watchAvailability' threw error ${error}`);
+        }
+
+        if (window.internals)
+            internals.setMockMediaPlaybackTargetPickerState('Sleepy', 'DeviceAvailable');
+
+        return new Promise(resolve => { resolveCallback = resolve; });
+    }
+
+    async function connectToRemote()
+    {
+        consoleWrite('<br>** Simulate selecting a device');
+
+        await video.play();
+        video.pause();
+
+        runWithKeyDown(async () => {
+            video.remote.prompt().catch(error => {
+                consoleWrite(`remote.prompt() failed with error '${ error }'`);
+            })
+        });
+
+        await waitForEventWithTimeout(video.remote, 'connect', 8000, "'connect' not fired after 8 seconds");
+
+        await testExpectedEventually('video.currentSrc.indexOf("blob:")', 0, '<', 8000);
+        testExpected('video.readyState', HTMLMediaElement.HAVE_METADATA, '>=');
+        consoleWrite('');
+    }
+
+    async function runTest()
+    {
+        findMediaElement();
+
+        waitForEventAndFail('error');
+
+        await setupSources();
+
+        await setupRemote();
+
+        await connectToRemote();
+
+        endTest();
+    }
+
+    </script>
+</head>
+<body onload="runTest()">
+    <video muted controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -94,6 +94,7 @@ http/tests/media/fairplay [ Pass ]
 media/track/track-description-cue.html [ Pass ]
 media/track/track-extended-descriptions.html [ Pass ]
 svg/filters/feDisplacementMap-filterUnits.svg [ Pass ]
+media/media-source/remoteplayback-from-source-element.html [ Pass ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -31,6 +31,7 @@
 #include "EventTarget.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/HashMap.h>
+#include <wtf/LoggerHelper.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
@@ -42,7 +43,11 @@ class MediaPlaybackTarget;
 class Node;
 class RemotePlaybackAvailabilityCallback;
 
-class RemotePlayback final : public RefCounted<RemotePlayback>, public ActiveDOMObject, public EventTarget {
+class RemotePlayback final
+    : public RefCounted<RemotePlayback>
+    , public ActiveDOMObject
+    , public EventTarget
+{
     WTF_MAKE_ISO_ALLOCATED(RemotePlayback);
 public:
     static Ref<RemotePlayback> create(HTMLMediaElement&);
@@ -89,6 +94,16 @@ private:
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return RemotePlaybackEventTargetInterfaceType; }
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const { return m_logger.get(); }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    WTFLogChannel& logChannel() const;
+    const char* logClassName() const { return "RemotePlayback"; }
+
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier { nullptr };
+#endif
 
     WeakPtr<HTMLMediaElement, WeakPtrImplWithEventTargetData> m_mediaElement;
     uint32_t m_nextId { 0 };

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -682,22 +682,22 @@ bool MediaElementSession::wantsToObserveViewportVisibilityForAutoplay() const
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 void MediaElementSession::showPlaybackTargetPicker()
 {
-    INFO_LOG(LOGIDENTIFIER);
+    ALWAYS_LOG(LOGIDENTIFIER);
 
     auto& document = m_element.document();
     if (m_restrictions & RequireUserGestureToShowPlaybackTargetPicker && !document.processingUserGestureForMedia()) {
-        INFO_LOG(LOGIDENTIFIER, "returning early because of permissions");
+        ALWAYS_LOG(LOGIDENTIFIER, "returning early because of permissions");
         return;
     }
 
     if (!document.page()) {
-        INFO_LOG(LOGIDENTIFIER, "returning early because page is NULL");
+        ALWAYS_LOG(LOGIDENTIFIER, "returning early because page is NULL");
         return;
     }
 
 #if !PLATFORM(IOS_FAMILY)
     if (m_element.readyState() < HTMLMediaElementEnums::HAVE_METADATA) {
-        INFO_LOG(LOGIDENTIFIER, "returning early because element is not playable");
+        ALWAYS_LOG(LOGIDENTIFIER, "returning early because element is not playable");
         return;
     }
 #endif

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -480,7 +480,7 @@ void MediaPlayer::invalidate()
     m_client = &nullMediaPlayerClient();
 }
 
-bool MediaPlayer::load(const URL& url, const ContentType& contentType, const String& keySystem)
+bool MediaPlayer::load(const URL& url, const ContentType& contentType, const String& keySystem, bool requiresRemotePlayback)
 {
     ASSERT(!m_reloadTimer.isActive());
 
@@ -490,6 +490,7 @@ bool MediaPlayer::load(const URL& url, const ContentType& contentType, const Str
     m_contentType = contentType;
     m_url = url;
     m_keySystem = keySystem.convertToASCIILowercase();
+    m_requiresRemotePlayback = requiresRemotePlayback;
     m_contentMIMETypeWasInferredFromExtension = false;
 
 #if ENABLE(MEDIA_SOURCE)
@@ -531,6 +532,7 @@ bool MediaPlayer::load(const URL& url, const ContentType& contentType, MediaSour
     m_contentType = contentType;
     m_url = url;
     m_keySystem = emptyString();
+    m_requiresRemotePlayback = false;
     m_contentMIMETypeWasInferredFromExtension = false;
     loadWithNextMediaEngine(nullptr);
     return m_currentMediaEngine;
@@ -544,6 +546,7 @@ bool MediaPlayer::load(MediaStreamPrivate& mediaStream)
 
     m_mediaStream = &mediaStream;
     m_keySystem = emptyString();
+    m_requiresRemotePlayback = false;
     m_contentType = { };
     m_contentMIMETypeWasInferredFromExtension = false;
     loadWithNextMediaEngine(nullptr);

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -98,6 +98,7 @@ struct MediaEngineSupportParameters {
     URL url;
     bool isMediaSource { false };
     bool isMediaStream { false };
+    bool requiresRemotePlayback { false };
     Vector<ContentType> contentTypesRequiringHardwareSupport;
     std::optional<Vector<String>> allowedMediaContainerTypes;
     std::optional<Vector<String>> allowedMediaCodecTypes;
@@ -112,6 +113,7 @@ struct MediaEngineSupportParameters {
         encoder << url;
         encoder << isMediaSource;
         encoder << isMediaStream;
+        encoder << requiresRemotePlayback;
         encoder << contentTypesRequiringHardwareSupport;
         encoder << allowedMediaContainerTypes;
         encoder << allowedMediaCodecTypes;
@@ -127,6 +129,7 @@ struct MediaEngineSupportParameters {
             && decoder.decode(parameters.url)
             && decoder.decode(parameters.isMediaSource)
             && decoder.decode(parameters.isMediaStream)
+            && decoder.decode(parameters.requiresRemotePlayback)
             && decoder.decode(parameters.contentTypesRequiringHardwareSupport)
             && decoder.decode(parameters.allowedMediaContainerTypes)
             && decoder.decode(parameters.allowedMediaCodecTypes)
@@ -358,7 +361,7 @@ public:
     IntSize size() const { return m_size; }
     void setSize(const IntSize& size);
 
-    bool load(const URL&, const ContentType&, const String& keySystem);
+    bool load(const URL&, const ContentType&, const String&, bool);
 #if ENABLE(MEDIA_SOURCE)
     bool load(const URL&, const ContentType&, MediaSourcePrivateClient&);
 #endif
@@ -717,6 +720,8 @@ public:
     void setShouldDisableHDR(bool);
     bool shouldDisableHDR() const { return client().mediaPlayerShouldDisableHDR(); }
 
+    bool requiresRemotePlayback() const { return m_requiresRemotePlayback; }
+
 private:
     MediaPlayer(MediaPlayerClient&);
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
@@ -763,6 +768,7 @@ private:
     bool m_shouldContinueAfterKeyNeeded { false };
 #endif
     bool m_isGatheringVideoFrameMetadata { false };
+    bool m_requiresRemotePlayback { false };
     String m_lastErrorMessage;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -228,7 +228,7 @@ void MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes(HashSet<String, ASC
 
 MediaPlayer::SupportsType MediaPlayerPrivateMediaStreamAVFObjC::supportsType(const MediaEngineSupportParameters& parameters)
 {
-    return parameters.isMediaStream ? MediaPlayer::SupportsType::IsSupported : MediaPlayer::SupportsType::IsNotSupported;
+    return (parameters.isMediaStream && !parameters.requiresRemotePlayback) ? MediaPlayer::SupportsType::IsSupported : MediaPlayer::SupportsType::IsNotSupported;
 }
 
 #pragma mark -

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -140,7 +140,7 @@ void MediaPlayerPrivateWebM::getSupportedTypes(HashSet<String, ASCIICaseInsensit
 
 MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngineSupportParameters& parameters)
 {
-    if (parameters.isMediaSource || parameters.isMediaStream)
+    if (parameters.isMediaSource || parameters.isMediaStream || parameters.requiresRemotePlayback)
         return MediaPlayer::SupportsType::IsNotSupported;
     
     return SourceBufferParserWebM::isContentTypeSupported(parameters.type);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4776,16 +4776,18 @@ ExceptionOr<RefPtr<VTTCue>> Internals::mediaElementCurrentlySpokenCue(HTMLMediaE
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 void Internals::setMockMediaPlaybackTargetPickerEnabled(bool enabled)
 {
-    Page* page = contextDocument()->frame()->page();
-    ASSERT(page);
+    auto frame = this->frame();
+    if (!frame || !frame->page())
+        return;
 
-    page->setMockMediaPlaybackTargetPickerEnabled(enabled);
+    frame->page()->setMockMediaPlaybackTargetPickerEnabled(enabled);
 }
 
 ExceptionOr<void> Internals::setMockMediaPlaybackTargetPickerState(const String& deviceName, const String& deviceState)
 {
-    Page* page = contextDocument()->frame()->page();
-    ASSERT(page);
+    auto frame = this->frame();
+    if (!frame || !frame->page())
+        return Exception { InvalidAccessError };
 
     MediaPlaybackTargetContext::MockState state = MediaPlaybackTargetContext::MockState::Unknown;
 
@@ -4798,18 +4800,18 @@ ExceptionOr<void> Internals::setMockMediaPlaybackTargetPickerState(const String&
     else
         return Exception { InvalidAccessError };
 
-    page->setMockMediaPlaybackTargetPickerState(deviceName, state);
+    frame->page()->setMockMediaPlaybackTargetPickerState(deviceName, state);
     return { };
 }
 
 void Internals::mockMediaPlaybackTargetPickerDismissPopup()
 {
-    auto* page = contextDocument()->frame()->page();
-    ASSERT(page);
+    auto frame = this->frame();
+    if (!frame || !frame->page())
+        return;
 
-    page->mockMediaPlaybackTargetPickerDismissPopup();
+    frame->page()->mockMediaPlaybackTargetPickerDismissPopup();
 }
-
 #endif
 
 ExceptionOr<Ref<MockPageOverlay>> Internals::installMockPageOverlay(PageOverlayType type)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -143,7 +143,7 @@ void RemoteMediaPlayerProxy::getConfiguration(RemoteMediaPlayerConfiguration& co
     });
 }
 
-void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Handle>&& sandboxExtensionHandle, const ContentType& contentType, const String& keySystem, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&& completionHandler)
+void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Handle>&& sandboxExtensionHandle, const ContentType& contentType, const String& keySystem, bool requiresRemotePlayback, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&& completionHandler)
 {
     RemoteMediaPlayerConfiguration configuration;
     if (sandboxExtensionHandle) {
@@ -154,7 +154,7 @@ void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Han
             WTFLogAlways("Unable to create sandbox extension for media url.\n");
     }
     
-    m_player->load(url, contentType, keySystem);
+    m_player->load(url, contentType, keySystem, requiresRemotePlayback);
     getConfiguration(configuration);
     completionHandler(WTFMove(configuration));
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -134,7 +134,7 @@ public:
     void prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload, bool preservesPitch, bool prepareForRendering, float videoContentScale, WebCore::DynamicRangeMode, CompletionHandler<void(std::optional<LayerHostingContextID>&& inlineLayerHostingContextId)>&&);
     void prepareForRendering();
 
-    void load(URL&&, std::optional<SandboxExtension::Handle>&&, const WebCore::ContentType&, const String&, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
+    void load(URL&&, std::optional<SandboxExtension::Handle>&&, const WebCore::ContentType&, const String&, bool, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
 #if ENABLE(MEDIA_SOURCE)
     void loadMediaSource(URL&&, const WebCore::ContentType&, bool webMParserEnabled, RemoteMediaSourceIdentifier, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -26,7 +26,7 @@
 messages -> RemoteMediaPlayerProxy NotRefCounted {
     PrepareForPlayback(bool privateMode, enum:uint8_t WebCore::MediaPlayerEnums::Preload preload, bool preservesPitch, bool prepareForRendering, float videoContentScale, enum:uint8_t WebCore::DynamicRangeMode mode) -> (std::optional<WebKit::LayerHostingContextID> inlineLayerHostingContextId)
 
-    Load(URL url, std::optional<WebKit::SandboxExtension::Handle> sandboxExtension, WebCore::ContentType contentType, String keySystem) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
+    Load(URL url, std::optional<WebKit::SandboxExtension::Handle> sandboxExtension, WebCore::ContentType contentType, String keySystem, bool requiresRemotePlayback) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
 #if ENABLE(MEDIA_SOURCE)
     LoadMediaSource(URL url, WebCore::ContentType contentType, bool webMParserEnabled, WebKit::RemoteMediaSourceIdentifier mediaSourceIdentifier) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -204,7 +204,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
         sandboxExtensionHandle = WTFMove(handle);
     }
 
-    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, sandboxExtensionHandle, contentType, keySystem), [weakThis = WeakPtr { *this }, this](auto&& configuration) {
+    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, sandboxExtensionHandle, contentType, keySystem, m_player->requiresRemotePlayback()), [weakThis = WeakPtr { *this }, this](auto&& configuration) {
         if (!weakThis)
             return;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -72,7 +72,7 @@ MediaPlayerEnums::SupportsType RemoteMediaPlayerMIMETypeCache::supportsTypeAndCo
     if (parameters.type.raw().isEmpty())
         return MediaPlayerEnums::SupportsType::MayBeSupported;
 
-    SupportedTypesAndCodecsKey searchKey { parameters.type.raw(), parameters.isMediaSource, parameters.isMediaStream };
+    SupportedTypesAndCodecsKey searchKey { parameters.type.raw(), parameters.isMediaSource, parameters.isMediaStream, parameters.requiresRemotePlayback };
 
     if (m_supportsTypeAndCodecsCache) {
         auto it = m_supportsTypeAndCodecsCache->find(searchKey);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -55,7 +55,7 @@ private:
     RemoteMediaPlayerManager& m_manager;
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_engineIdentifier;
 
-    using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool>;
+    using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool, bool>;
     std::optional<HashMap<SupportedTypesAndCodecsKey, WebCore::MediaPlayerEnums::SupportsType>> m_supportsTypeAndCodecsCache;
     HashSet<String, ASCIICaseInsensitiveHash> m_supportedTypesCache;
     bool m_hasPopulatedSupportedTypesCacheFromGPUProcess { false };


### PR DESCRIPTION
#### 4ec10f6ab8204352d7e35c0f16f8219b6688348d
<pre>
Switch to alternate &lt;source&gt; element for AirPlay when necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=246466">https://bugs.webkit.org/show_bug.cgi?id=246466</a>
&lt;rdar://101136233&gt;

Reviewed by Jer Noble.

* LayoutTests/media/media-source/remoteplayback-from-source-element-expected.txt: Added.
* LayoutTests/media/media-source/remoteplayback-from-source-element.html: Added.
* LayoutTests/TestExpectations: New test skipped everywhere.
* LayoutTests/platform/mac/TestExpectations: New test enabled.

* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(WebCore::RemotePlayback::watchAvailability): Add runtime logging.
(WebCore::RemotePlayback::cancelWatchAvailability): Ditto.
(WebCore::RemotePlayback::prompt): Ditto.
(WebCore::RemotePlayback::shouldPlayToRemoteTargetChanged): Ditto.
(WebCore::RemotePlayback::setState): Ditto.
(WebCore::RemotePlayback::disconnect): Ditto.
(WebCore::RemotePlayback::availabilityChanged): Ditto.
(WebCore::RemotePlayback::setLogger):  Ditto.
(WebCore::RemotePlayback::logChannel const): Ditto.
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::HTMLMediaElement): Set remote logger.
(WebCore::HTMLMediaElement::checkPlaybackTargetCompatibility): If loaded from a &lt;source&gt;
element and is another &lt;source&gt; uses a media engine that supports remote playback, try
loading that.
(WebCore::HTMLMediaElement::loadResource): Don&apos;t bother trying MSE, MediaStream, or blob
if the load requires remote playback.
(WebCore::HTMLMediaElement::applyConfiguration): Apply the stored configuration.
(WebCore::HTMLMediaElement::setReadyState): Apply the remote configuration once
HAVE_FUTURE_DATA is reached.
(WebCore::HTMLMediaElement::selectNextSourceChild): Set parameter `requiresRemotePlayback`
field.
(WebCore::HTMLMediaElement::clearMediaPlayer): Force a target availability event.
(WebCore::HTMLMediaElement::wirelessRoutesAvailableDidChange): Only post availability event
when availability actually changes.
(WebCore::HTMLMediaElement::setIsPlayingToWirelessTarget):
(WebCore::HTMLMediaElement::enqueuePlaybackTargetAvailabilityChangedEvent): Add parameter
so we don&apos;t necessarily post events when availability doesn&apos;t change.
(WebCore::HTMLMediaElement::addEventListener): Force a target availability event.
* Source/WebCore/html/HTMLMediaElement.h:

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::showPlaybackTargetPicker): Always log.

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::load): Add `requiresRemotePlayback` parameter.
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaEngineSupportParameters::encode const):
(WebCore::MediaEngineSupportParameters::decode):

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::supportsType): Consider new support field.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::supportsType): Ditto.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setMockMediaPlaybackTargetPickerEnabled): NULL-check frame and page.
(WebCore::Internals::setMockMediaPlaybackTargetPickerState): Ditto.
(WebCore::Internals::mockMediaPlaybackTargetPickerDismissPopup): Ditto.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::load): Add &quot;requires remote playback&quot; parameter.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in: Ditto.

* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load): Ditto.

* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs): Ditto.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:

Canonical link: <a href="https://commits.webkit.org/255624@main">https://commits.webkit.org/255624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4870c571f3585509f79e00acf1655f10dd01c2ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92935 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102653 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162916 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2147 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30475 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98780 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1473 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79413 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28383 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71502 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36875 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17014 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34680 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18204 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40800 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37385 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->