### PR TITLE
Add setting to disable the fullscreen requirement to lock screen orientation

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -353,6 +353,18 @@ FullScreenEnabled:
     WebCore:
       default: false
 
+FullscreenRequirementForScreenOrientationLockingEnabled:
+  type: bool
+  humanReadableName: "Require being in Fullscreen to lock screen orientation"
+  humanReadableDescription: "Require being in Fullscreen to lock screen orientation"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 GetUserMediaRequiresFocus:
   type: bool
   humanReadableName: "Require focus to start getUserMedia"

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -109,13 +109,15 @@ void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
         promise->reject(Exception { SecurityError, "Only first party documents can lock the screen orientation"_s });
         return;
     }
+    if (document->settings().fullscreenRequirementForScreenOrientationLockingEnabled()) {
 #if ENABLE(FULLSCREEN_API)
-    if (!document->fullscreenManager().isFullscreen()) {
+        if (!document->fullscreenManager().isFullscreen()) {
 #else
-    if (true) {
+        if (true) {
 #endif
-        promise->reject(Exception { SecurityError, "Locking the screen orientation is only allowed when in fullscreen"_s });
-        return;
+            promise->reject(Exception { SecurityError, "Locking the screen orientation is only allowed when in fullscreen"_s });
+            return;
+        }
     }
     if (!isSupportedLockType(lockType)) {
         promise->reject(Exception { NotSupportedError, "Lock type should be one of { \"any\", \"natural\", \"portrait\", \"landscape\" }"_s });

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1568,6 +1568,16 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->modelDocumentEnabled();
 }
 
+- (void)_setRequiresFullscreenToLockScreenOrientation:(BOOL)enabled
+{
+    _preferences->setFullscreenRequirementForScreenOrientationLockingEnabled(enabled);
+}
+
+- (BOOL)_requiresFullscreenToLockScreenOrientation
+{
+    return _preferences->fullscreenRequirementForScreenOrientationLockingEnabled();
+}
+
 - (void)_setInteractionRegionMinimumCornerRadius:(double)radius
 {
     _preferences->setInteractionRegionMinimumCornerRadius(radius);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -181,6 +181,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setModelDocumentEnabled:) BOOL _modelDocumentEnabled WK_API_AVAILABLE(macos(13.0), ios(16.0));
 @property (nonatomic, setter=_setInteractionRegionMinimumCornerRadius:) double _interactionRegionMinimumCornerRadius WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, setter=_setInteractionRegionInlinePadding:) double _interactionRegionInlinePadding WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, setter=_setRequiresFullscreenToLockScreenOrientation:) BOOL _requiresFullscreenToLockScreenOrientation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setWebGLEnabled:) BOOL _webGLEnabled WK_API_AVAILABLE(macos(10.13.4));


### PR DESCRIPTION
#### 2ca6817c090a1012544584e4e0f0b54782533e6a
<pre>
Add setting to disable the fullscreen requirement to lock screen orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=246528">https://bugs.webkit.org/show_bug.cgi?id=246528</a>

Reviewed by Wenson Hsieh.

Add setting to disable the fullscreen requirement to lock screen orientation.
This will be useful for Home Screen Web Apps, which are technically fullscreen
but don&apos;t rely on the fullscreen API.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setRequiresFullscreenToLockScreenOrientation:]):
(-[WKPreferences _requiresFullscreenToLockScreenOrientation]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/255560@main">https://commits.webkit.org/255560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86365e4241c666522fadc015d7773b4645afaf0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102613 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2102 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30439 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85286 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98553 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79375 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28352 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84229 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36839 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/16980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79289 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18170 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27466 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38511 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81917 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1776 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37350 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18527 "Passed tests") | 
<!--EWS-Status-Bubble-End-->