### PR TITLE
Support installsrc for tools

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -63,6 +63,11 @@ clean:
 	@$(build_target_for_each_module)
 
 installsrc:
+ifeq ($(FORCE_TOOL_INSTALL),YES)
+	@$(build_target_for_each_module)
+	ditto TestRunnerShared "$(SRCROOT)/Tools/TestRunnerShared"
+else
 	@true
+endif
 
 endif # USE_WORKSPACE

--- a/Tools/WebKitTestRunner/Configurations/Base.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/Base.xcconfig
@@ -144,3 +144,5 @@ WK_FRAMEWORK_VERSION_PREFIX[sdk=macosx*] = Versions/A/;
 HEADER_SEARCH_PATHS = $(BUILT_PRODUCTS_DIR)/usr/local/include $(BUILT_PRODUCTS_DIR)/WebCoreTestSupport $(WEBCORE_PRIVATE_HEADERS_DIR)/ForwardingHeaders $(NEXT_ROOT)/usr/local/include/WebCoreTestSupport $(HEADER_SEARCH_PATHS_$(WK_COCOA_TOUCH));
 HEADER_SEARCH_PATHS_ = ;
 HEADER_SEARCH_PATHS_cocoatouch = $(SRCROOT)/../../Source/WebKit/Platform/spi/ios $(SRCROOT)/../../Source/WebKit/Platform/spi/watchos;
+
+EXCLUDED_INSTALLSRC_SUBDIRECTORY_PATTERNS = $(inherited) "$(PROJECT_DIR)/gtk";


### PR DESCRIPTION
#### bb8c8f04c51d5c56917625ed16ba2542f301db75
<pre>
Support installsrc for tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=246532">https://bugs.webkit.org/show_bug.cgi?id=246532</a>
&lt;rdar://101182524&gt;

Reviewed by Elliott Williams.

* Tools/Makefile: Recurse into modules when FORCE_TOOL_INSTALL opt-in is set. Also, copy
TestRunnerShared content, which is not a module. It&apos;s not ideal to use ditto, as it doesn&apos;t
skip invisible files like .DS_Store, but we do the same elsewhere, and I&apos;m not sure if there
is an easy enough way to match what xcodebuild installsrc does.

* Tools/WebKitTestRunner/Configurations/Base.xcconfig: Skip gtk files, because there are
some unrecognized binaries there (fonts).

Canonical link: <a href="https://commits.webkit.org/255609@main">https://commits.webkit.org/255609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26478acecae5c01fbd85325719072dd2c92cd2dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102636 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162902 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2127 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30459 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85308 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98766 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1453 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79396 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28369 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71487 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84247 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36859 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/16994 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79312 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18184 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3882 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40786 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/81942 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37364 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18538 "Passed tests") | 
<!--EWS-Status-Bubble-End-->