### PR TITLE
Scrolling by pressing space bar has regressed in trunk, is choppy (not 120Hz)

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1978,6 +1978,7 @@ platform/ScreenOrientationManager.cpp
 platform/ScreenOrientationProvider.cpp
 platform/ScrollAlignment.cpp
 platform/ScrollAnimation.cpp
+platform/ScrollAnimationKeyboard.cpp
 platform/ScrollAnimationKinetic.cpp
 platform/ScrollAnimationMomentum.cpp
 platform/ScrollAnimationSmooth.cpp

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4353,19 +4353,19 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
 
 void EventHandler::stopKeyboardScrolling()
 {
-    auto animator = m_frame.page()->currentKeyboardScrollingAnimator();
-    if (animator)
-        animator->handleKeyUpEvent();
+    // auto animator = m_frame.page()->currentKeyboardScrollingAnimator();
+    // if (animator)
+    //     animator->handleKeyUpEvent();
 }
 
-bool EventHandler::beginKeyboardScrollGesture(KeyboardScrollingAnimator* animator, ScrollDirection direction, ScrollGranularity granularity)
+bool EventHandler::beginKeyboardScrollGesture(KeyboardScrollingAnimator*, ScrollDirection direction, ScrollGranularity granularity, ScrollableArea& scrollableArea)
 {
-    if (animator && animator->beginKeyboardScrollGesture(direction, granularity)) {
-        m_frame.page()->setCurrentKeyboardScrollingAnimator(animator);
-        return true;
-    }
-
-    return false;
+    // if (animator && animator->beginKeyboardScrollGesture(direction, granularity)) {
+    //     m_frame.page()->setCurrentKeyboardScrollingAnimator(animator);
+    //     return true;
+    // }
+    scrollableArea.beginKeyboardScroll(direction, granularity);
+    return true;
 }
 
 bool EventHandler::startKeyboardScrollAnimationOnDocument(ScrollDirection direction, ScrollGranularity granularity)
@@ -4375,7 +4375,7 @@ bool EventHandler::startKeyboardScrollAnimationOnDocument(ScrollDirection direct
         return false;
 
     auto* animator = view->scrollAnimator().keyboardScrollingAnimator();
-    return beginKeyboardScrollGesture(animator, direction, granularity);
+    return beginKeyboardScrollGesture(animator, direction, granularity, view->scrollAnimator().scrollableArea());
 }
 
 bool EventHandler::startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection direction, ScrollGranularity granularity, RenderBox* renderBox)
@@ -4385,7 +4385,7 @@ bool EventHandler::startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection 
         return false;
 
     auto* animator = scrollableArea->scrollAnimator().keyboardScrollingAnimator();
-    return beginKeyboardScrollGesture(animator, direction, granularity);
+    return beginKeyboardScrollGesture(animator, direction, granularity, *scrollableArea);
 }
 
 bool EventHandler::startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(ScrollDirection direction, ScrollGranularity granularity, RenderBox* renderBox)

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -388,7 +388,7 @@ private:
     bool handleMousePressEventDoubleClick(const MouseEventWithHitTestResults&);
     bool handleMousePressEventTripleClick(const MouseEventWithHitTestResults&);
 
-    bool beginKeyboardScrollGesture(KeyboardScrollingAnimator*, ScrollDirection, ScrollGranularity);
+    bool beginKeyboardScrollGesture(KeyboardScrollingAnimator*, ScrollDirection, ScrollGranularity, ScrollableArea&);
     void stopKeyboardScrolling();
     bool startKeyboardScrollAnimationOnDocument(ScrollDirection, ScrollGranularity);
     bool startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection, ScrollGranularity, RenderBox*);

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2958,6 +2958,14 @@ bool FrameView::isRubberBandInProgress() const
     return false;
 }
 
+bool FrameView::requestStartKeyboardAnimation(ScrollDirection direction, ScrollGranularity granularity)
+{
+    if (auto scrollingCoordinator = this->scrollingCoordinator())
+        return scrollingCoordinator->requestStartKeyboardAnimation(*this, direction, granularity);
+
+    return false;
+}
+
 bool FrameView::requestScrollPositionUpdate(const ScrollPosition& position, ScrollType scrollType, ScrollClamping clamping)
 {
     LOG_WITH_STREAM(Scrolling, stream << "FrameView::requestScrollPositionUpdate " << position);

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -269,6 +269,8 @@ public:
     void updateCompositingLayersAfterScrolling() final;
     static WEBCORE_EXPORT bool scrollRectToVisible(const LayoutRect& absoluteRect, const RenderObject&, bool insideFixed, const ScrollRectToVisibleOptions&);
 
+    bool requestStartKeyboardAnimation(ScrollDirection, ScrollGranularity)
+
     bool requestScrollPositionUpdate(const ScrollPosition&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped) final;
     bool requestAnimatedScrollToPosition(const ScrollPosition&, ScrollClamping = ScrollClamping::Clamped) final;
     void stopAsyncAnimatedScroll() final;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -254,6 +254,24 @@ void AsyncScrollingCoordinator::frameViewRootLayerDidChange(FrameView& frameView
     node->setHorizontalScrollbarLayer(frameView.layerForHorizontalScrollbar());
 }
 
+bool AsyncScrollingCoordinator::requestStartKeyboardAnimation(ScrollableArea& scrollableArea, ScrollDirection, ScrollGranularity)
+{
+    ASSERT(isMainThread());
+    ASSERT(m_page);
+    auto scrollingNodeID = scrollableArea.scrollingNodeID();
+    if (!scrollingNodeID)
+        return false;
+
+    auto* stateNode = downcast<ScrollingStateScrollingNode>(m_scrollingStateTree->stateNodeForID(scrollingNodeID));
+    if (!stateNode)
+        return false;
+
+    stateNode->setKeyboardScrollData({ });
+    // FIXME: This should schedule a rendering update
+    commitTreeStateIfNeeded();
+    return true;
+}
+
 bool AsyncScrollingCoordinator::requestScrollPositionUpdate(ScrollableArea& scrollableArea, const ScrollPosition& scrollPosition, ScrollType scrollType, ScrollClamping clamping)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -103,6 +103,7 @@ private:
     WEBCORE_EXPORT void frameViewWillBeDetached(FrameView&) override;
 
     WEBCORE_EXPORT bool requestScrollPositionUpdate(ScrollableArea&, const ScrollPosition&, ScrollType, ScrollClamping) final;
+    WEBCORE_EXPORT bool requestStartKeyboardAnimation(ScrollableArea&, ScrollDirection, ScrollGranularity) final;
     WEBCORE_EXPORT bool requestAnimatedScrollToPosition(ScrollableArea&, const ScrollPosition&, ScrollClamping) final;
     WEBCORE_EXPORT void stopAnimatedScroll(ScrollableArea&) final;
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -121,6 +121,7 @@ public:
 
     virtual bool requestScrollPositionUpdate(ScrollableArea&, const ScrollPosition&, ScrollType = ScrollType::Programmatic, ScrollClamping = ScrollClamping::Clamped) { return false; }
     virtual bool requestAnimatedScrollToPosition(ScrollableArea&, const ScrollPosition&, ScrollClamping) { return false; }
+    virtual bool requestStartKeyboardAnimation(ScrollableArea&, const ScrollDirection, ScrollGranularity) { return false; }
     virtual void stopAnimatedScroll(ScrollableArea&) { }
 
     virtual bool handleWheelEventForScrolling(const PlatformWheelEvent&, ScrollingNodeID, std::optional<WheelScrollGestureState>) { return false; }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -115,6 +115,24 @@ enum class ScrollRequestType : uint8_t {
     CancelAnimatedScroll
 };
 
+struct KeyboardScrollData {
+    FloatSize offset; // Points per increment.
+    FloatSize maximumVelocity; // Points per second.
+    FloatSize force;
+
+    ScrollGranularity granularity;
+    ScrollDirection direction;
+
+    bool operator==(const KeyboardScrollData& other) const
+    {
+        return offset == other.offset
+            && maximumVelocity == other.maximumVelocity
+            && force == other.force
+            && granularity == other.granularity
+            && direction == other.direction;
+    }
+};
+
 struct RequestedScrollData {
     ScrollRequestType requestType { ScrollRequestType::PositionUpdate };
     FloatPoint scrollPosition;

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -268,6 +268,7 @@ public:
         ViewportConstraints                         = 1LLU << 42,
         // ScrollingStateOverflowScrollProxyNode
         OverflowScrollingNode                       = 1LLU << 43,
+        KeyboardScrollData = 1LLU << 44,
     };
     
     bool hasChangedProperties() const { return !m_changedProperties.isEmpty(); }

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -53,6 +53,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
 #endif
     , m_scrollableAreaParameters(stateNode.scrollableAreaParameters())
     , m_requestedScrollData(stateNode.requestedScrollData())
+    , m_keyboardScrollData(stateNode.keyboardScrollData())
 #if ENABLE(SCROLLING_THREAD)
     , m_synchronousScrollingReasons(stateNode.synchronousScrollingReasons())
 #endif
@@ -198,6 +199,12 @@ void ScrollingStateScrollingNode::setSynchronousScrollingReasons(OptionSet<Synch
     setPropertyChanged(Property::ReasonsForSynchronousScrolling);
 }
 #endif
+
+void ScrollingStateScrollingNode::setKeyboardScrollData(const KeyboardScrollData& scrollData)
+{
+    m_keyboardScrollData = scrollData;
+    setPropertyChanged(Property::KeyboardScrollData);
+}
 
 void ScrollingStateScrollingNode::setRequestedScrollData(const RequestedScrollData& scrollData)
 {

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -76,7 +76,10 @@ public:
 #endif
 
     const RequestedScrollData& requestedScrollData() const { return m_requestedScrollData; }
+    const KeyboardScrollData& keyboardScrollData() const { return m_keyboardScrollData; }
     WEBCORE_EXPORT void setRequestedScrollData(const RequestedScrollData&);
+
+    WEBCORE_EXPORT void setKeyboardScrollData(const KeyboardScrollData&);
 
     WEBCORE_EXPORT bool hasScrollPositionRequest() const;
 
@@ -132,6 +135,7 @@ private:
 
     ScrollableAreaParameters m_scrollableAreaParameters;
     RequestedScrollData m_requestedScrollData;
+    KeyboardScrollData m_keyboardScrollData;
 #if ENABLE(SCROLLING_THREAD)
     OptionSet<SynchronousScrollingReason> m_synchronousScrollingReasons;
 #endif

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -106,6 +106,9 @@ void ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNo
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition))
         handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
 
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::KeyboardScrollData))
+        handleKeyboardScrollRequest(scrollingStateNode.keyboardScrollData());
+
     // This synthetic bit is added back in ScrollingTree::propagateSynchronousScrollingReasons().
 #if ENABLE(SCROLLING_THREAD)
     m_synchronousScrollingReasons.remove(SynchronousScrollingReason::DescendantScrollersHaveSynchronousScrolling);
@@ -259,6 +262,12 @@ void ScrollingTreeScrollingNode::serviceScrollAnimation(MonotonicTime currentTim
 void ScrollingTreeScrollingNode::setScrollAnimationInProgress(bool animationInProgress)
 {
     scrollingTree().setScrollAnimationInProgressForNode(scrollingNodeID(), animationInProgress);
+}
+
+void ScrollingTreeScrollingNode::handleKeyboardScrollRequest(const KeyboardScrollData& scrollData)
+{
+    if (m_delegate)
+        m_delegate->handleKeyboardScrollRequest(scrollData);
 }
 
 void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScrollData& requestedScrollData)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -59,6 +59,8 @@ class WEBCORE_EXPORT ScrollingTreeScrollingNode : public ScrollingTreeNode {
 public:
     virtual ~ScrollingTreeScrollingNode();
 
+    void handleKeyboardScrollRequest(const KeyboardScrollData&);
+
     void commitStateBeforeChildren(const ScrollingStateNode&) override;
     void commitStateAfterChildren(const ScrollingStateNode&) override;
     void didCompleteCommitForNode() final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -146,6 +146,11 @@ bool ScrollingTreeScrollingNodeDelegateMac::isRubberBandInProgress() const
     return m_scrollController.isRubberBandInProgress();
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::handleKeyboardScrollRequest(const KeyboardScrollData& scrollData)
+{
+    m_scrollController.setKeyboardScrollData(scrollData);
+}
+
 bool ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching(const PlatformWheelEvent& wheelEvent) const
 {
     switch (horizontalScrollElasticity()) {

--- a/Source/WebCore/platform/KeyboardScroll.h
+++ b/Source/WebCore/platform/KeyboardScroll.h
@@ -32,15 +32,6 @@ namespace WebCore {
 
 WEBCORE_EXPORT FloatSize unitVectorForScrollDirection(ScrollDirection);
 
-struct KeyboardScroll {
-    FloatSize offset; // Points per increment.
-    FloatSize maximumVelocity; // Points per second.
-    FloatSize force;
-
-    ScrollGranularity granularity;
-    ScrollDirection direction;
-};
-
 struct KeyboardScrollParameters {
     float springMass { 1 };
     float springStiffness { 109 };

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -54,20 +54,20 @@ class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimato
 public:
     KeyboardScrollingAnimator(ScrollAnimator&, ScrollingEffectsController&);
 
-    bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity);
-    void handleKeyUpEvent();
-    void updateKeyboardScrollPosition(MonotonicTime);
-    WEBCORE_EXPORT void stopScrollingImmediately();
+    // bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity);
+    // void handleKeyUpEvent();
+    // void updateKeyboardScrollPosition(MonotonicTime);
+    // WEBCORE_EXPORT void stopScrollingImmediately();
 
 private:
     void stopKeyboardScrollAnimation();
     RectEdges<bool> scrollableDirectionsFromPosition(FloatPoint) const;
-    std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection, ScrollGranularity) const;
-    float scrollDistance(ScrollDirection, ScrollGranularity) const;
+//    std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection, ScrollGranularity) const;
+//    float scrollDistance(ScrollDirection, ScrollGranularity) const;
 
     ScrollAnimator& m_scrollAnimator;
     ScrollingEffectsController& m_scrollController;
-    std::optional<WebCore::KeyboardScroll> m_currentKeyboardScroll;
+//    std::optional<WebCore::KeyboardScroll> m_currentKeyboardScroll;
     bool m_scrollTriggeringKeyIsPressed { false };
     FloatSize m_velocity;
     MonotonicTime m_timeAtLastFrame;

--- a/Source/WebCore/platform/KeyboardScrollingState.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingState.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "KeyboardScrollingState.h"
+
+#include "Logging.h"
+#include "ScrollExtents.h"
+#include "ScrollingEffectsController.h"
+#include <wtf/MathExtras.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+KeyboardScrollingState::~KeyboardScrollingState() = default;
+
+} // namespace WebCore

--- a/Source/WebCore/platform/KeyboardScrollingState.h
+++ b/Source/WebCore/platform/KeyboardScrollingState.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014-2015 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatPoint.h"
+#include "FloatSize.h"
+#include "LayoutPoint.h"
+#include "PlatformWheelEvent.h"
+#include "ScrollAnimationMomentum.h"
+#include "ScrollSnapOffsetsInfo.h"
+#include "ScrollTypes.h"
+#include <wtf/MonotonicTime.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+class Page;
+class ScrollingEffectsController;
+struct ScrollExtents;
+
+class KeyboardScrollingState {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    KeyboardScrollingState(ScrollingEffectsController& scrollController)
+        : m_scrollController(scrollController)
+    { }
+    virtual ~KeyboardScrollingState();
+
+private:
+    ScrollingEffectsController& m_scrollController;
+};
+
+WTF::TextStream& operator<<(WTF::TextStream&, const ScrollSnapAnimatorState&);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ScrollAnimation.cpp
+++ b/Source/WebCore/platform/ScrollAnimation.cpp
@@ -37,6 +37,7 @@ TextStream& operator<<(TextStream& ts, ScrollAnimation::Type animationType)
     case ScrollAnimation::Type::Kinetic: ts << "kinetic"; break;
     case ScrollAnimation::Type::Momentum: ts << "momentum"; break;
     case ScrollAnimation::Type::RubberBand: ts << "rubber-band"; break;
+    case ScrollAnimation::Type::Keyboard: ts << "keyboard"; break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/ScrollAnimation.h
+++ b/Source/WebCore/platform/ScrollAnimation.h
@@ -57,6 +57,7 @@ public:
         Kinetic,
         Momentum,
         RubberBand,
+        Keyboard,
     };
 
     ScrollAnimation(Type animationType, ScrollAnimationClient& client)

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollAnimationKeyboard.h"
+
+#include "FloatPoint.h"
+#include "GeometryUtilities.h"
+#include "ScrollExtents.h"
+#include "ScrollableArea.h"
+#include "TimingFunction.h"
+#include "platform/KeyboardScroll.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+static float scrollDistance(ScrollDirection direction, ScrollGranularity granularity) const
+{
+    auto scrollbar = m_scrollAnimator.scrollableArea().scrollbarForDirection(direction);
+    if (!scrollbar)
+        return false;
+
+    float step = 0;
+    switch (granularity) {
+    case ScrollGranularity::Line:
+        step = scrollbar->lineStep();
+        break;
+    case ScrollGranularity::Page:
+        step = scrollbar->pageStep();
+        break;
+    case ScrollGranularity::Document:
+        step = scrollbar->totalSize();
+        break;
+    case ScrollGranularity::Pixel:
+        step = scrollbar->pixelStep();
+        break;
+    }
+
+    auto axis = axisFromDirection(direction);
+    if (granularity == ScrollGranularity::Page && axis == ScrollEventAxis::Vertical)
+        step = m_scrollAnimator.scrollableArea().adjustVerticalPageScrollStepForFixedContent(step);
+
+    return step;
+}
+
+static std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection direction, ScrollGranularity granularity) const
+{
+    float distance = scrollDistance(direction, granularity);
+
+    if (!distance)
+        return std::nullopt;
+
+    KeyboardScroll scroll;
+
+    scroll.offset = unitVectorForScrollDirection(direction).scaled(distance);
+    scroll.granularity = granularity;
+    scroll.direction = direction;
+    scroll.maximumVelocity = scroll.offset.scaled(KeyboardScrollParameters::parameters().maximumVelocityMultiplier);
+    scroll.force = scroll.maximumVelocity.scaled(KeyboardScrollParameters::parameters().springMass / KeyboardScrollParameters::parameters().timeToMaximumVelocity);
+
+    return scroll;
+}
+
+ScrollAnimationKeyboard::ScrollAnimationKeyboard(ScrollAnimationClient& client)
+    : ScrollAnimation(Type::Keyboard, client)
+    // , m_timingFunction(CubicBezierTimingFunction::create())
+{
+}
+
+ScrollAnimationKeyboard::~ScrollAnimationKeyboard() = default;
+
+bool ScrollAnimationKeyboard::retargetActiveAnimation(const FloatPoint&)
+{
+    return true;
+}
+
+String ScrollAnimationKeyboard::debugDescription() const
+{
+    return ""_s;
+}
+
+/*
+ //    auto scroll = makeKeyboardScroll(direction, granularity);
+ //    if (!scroll)
+ //        return false;
+
+ //    m_currentKeyboardScroll = scroll;
+
+ //    auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollAnimator.currentPosition());
+ //    if (!scrollableDirections.at(boxSideForDirection(direction))) {
+ //        stopScrollingImmediately();
+ //        return false;
+ //    }
+
+ //    if (m_scrollTriggeringKeyIsPressed)
+ //        return true;
+
+ //    if (granularity == ScrollGranularity::Document) {
+ //        m_velocity = { };
+ //        stopKeyboardScrollAnimation();
+ //        auto newPosition = IntPoint(m_scrollAnimator.currentPosition() + m_currentKeyboardScroll->offset);
+ //        m_scrollAnimator.scrollToPositionWithAnimation(newPosition);
+ //        return true;
+ //    }
+
+ //    m_timeAtLastFrame = MonotonicTime::now();
+ //    m_scrollTriggeringKeyIsPressed = true;
+
+ //    m_idealPositionForMinimumTravel = m_scrollAnimator.currentPosition() + m_currentKeyboardScroll->offset;
+ //    m_scrollController.willBeginKeyboardScrolling();
+
+ //    return true;
+ */
+
+bool ScrollAnimationKeyboard::startKeyboardScroll(ScrollDirection, ScrollGranularity)
+{
+//    ALWAYS_LOG_WITH_STREAM(stream << "RR_CODES ScrollAnimationKeyboard::startKeyboardScroll fromOffset = " << fromOffset);
+//
+//    auto extents = m_client.scrollExtentsForAnimation(*this);
+//
+//    m_currentOffset = m_startOffset = fromOffset;
+//    m_destinationOffset = destinationOffset.constrainedBetween(extents.minimumScrollOffset(), extents.maximumScrollOffset());
+//
+//    if (!isActive() && fromOffset == m_destinationOffset)
+//        return false;
+//
+//    m_duration = durationFromDistance(m_destinationOffset - m_startOffset);
+//    if (!m_duration)
+//        return false;
+//
+//    downcast<CubicBezierTimingFunction>(*m_timingFunction).setTimingFunctionPreset(CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut);
+//
+//    if (!isActive())
+//        didStart(MonotonicTime::now());
+
+    return true;
+}
+
+//bool ScrollAnimationSmooth::startKeyboardScroll(const FloatPoint& fromOffset)
+//{
+////    auto extents = m_client.scrollExtentsForAnimation(*this);
+////
+////    m_currentOffset = m_startOffset = fromOffset;
+////    m_destinationOffset = destinationOffset.constrainedBetween(extents.minimumScrollOffset(), extents.maximumScrollOffset());
+////
+////    if (!isActive() && fromOffset == m_destinationOffset)
+////        return false;
+////
+////    m_duration = durationFromDistance(m_destinationOffset - m_startOffset);
+////    if (!m_duration)
+////        return false;
+////
+////    downcast<CubicBezierTimingFunction>(*m_timingFunction).setTimingFunctionPreset(CubicBezierTimingFunction::TimingFunctionPreset::EaseInOut);
+////
+////    if (!isActive())
+////        didStart(MonotonicTime::now());
+////
+////    return true;
+//
+//    auto scroll = makeKeyboardScroll(direction, granularity);
+//    if (!scroll)
+//        return false;
+//
+//    m_currentKeyboardScroll = scroll;
+//
+//    auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollAnimator.currentPosition());
+//    if (!scrollableDirections.at(boxSideForDirection(direction))) {
+//        stopScrollingImmediately();
+//        return false;
+//    }
+//
+//    if (m_scrollTriggeringKeyIsPressed)
+//        return true;
+//
+//    if (granularity == ScrollGranularity::Document) {
+//        m_velocity = { };
+//        stopKeyboardScrollAnimation();
+//        auto newPosition = IntPoint(m_scrollAnimator.currentPosition() + m_currentKeyboardScroll->offset);
+//        m_scrollAnimator.scrollToPositionWithAnimation(newPosition);
+//        return true;
+//    }
+//
+//    m_timeAtLastFrame = MonotonicTime::now();
+//    m_scrollTriggeringKeyIsPressed = true;
+//
+//    m_idealPositionForMinimumTravel = m_scrollAnimator.currentPosition() + m_currentKeyboardScroll->offset;
+//    m_scrollController.willBeginKeyboardScrolling();
+//
+//    return true;
+//}
+
+static RectEdges<bool> scrollableDirectionsFromPosition(FloatPoint position, ScrollExtents extents)
+{
+    auto minimumScrollPosition = extents.minimumScrollOffset();
+    auto maximumScrollPosition = extents.maximumScrollOffset();
+
+    RectEdges<bool> edges;
+
+    edges.setTop(position.y() > minimumScrollPosition.y());
+    edges.setBottom(position.y() < maximumScrollPosition.y());
+    edges.setLeft(position.x() > minimumScrollPosition.x());
+    edges.setRight(position.x() < maximumScrollPosition.x());
+
+    return edges;
+}
+
+static BoxSide boxSideForDirection(ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+        return BoxSide::Top;
+    case ScrollDirection::ScrollDown:
+        return BoxSide::Bottom;
+    case ScrollDirection::ScrollLeft:
+        return BoxSide::Left;
+    case ScrollDirection::ScrollRight:
+        return BoxSide::Right;
+    }
+    ASSERT_NOT_REACHED();
+    return BoxSide::Top;
+}
+
+static FloatSize perpendicularAbsoluteUnitVector(ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+    case ScrollDirection::ScrollDown:
+        return { 1, 0 };
+    case ScrollDirection::ScrollLeft:
+    case ScrollDirection::ScrollRight:
+        return { 0, 1 };
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+bool ScrollAnimationKeyboard::animateScroll(MonotonicTime currentTime)
+{
+    ALWAYS_LOG_WITH_STREAM(stream << "RR_CODES ScrollAnimationKeyboard::animateScroll");
+
+    auto extents = m_client.scrollExtentsForAnimation(*this);
+
+     auto force = FloatSize { };
+     auto axesToApplySpring = FloatSize { 1, 1 };
+     KeyboardScrollParameters params = KeyboardScrollParameters::parameters();
+ 
+    auto scrollableDirections = scrollableDirectionsFromPosition(m_currentOffset, extents);
+
+    if (scrollableDirections.at(boxSideForDirection(m_direction))) {
+        // Apply the scrolling force. Only apply the spring in the perpendicular axis,
+        // otherwise it drags against the direction of motion.
+        axesToApplySpring = perpendicularAbsoluteUnitVector(m_direction);
+        force = m_currentForce;
+    } else {
+        // The scroll view cannot scroll in this direction, and is rubber-banding.
+        // Apply a constant and significant force; otherwise, the force for a
+        // single-line increment is not strong enough to rubber-band perceptibly.
+        force = unitVectorForScrollDirection(m_direction).scaled(params.rubberBandForce);
+    }
+
+    if (fabs(m_velocity.width()) >= fabs(m_maximumVelocity.width()))
+        force.setWidth(0);
+
+    if (fabs(m_velocity.height()) >= fabs(m_maximumVelocity.height()))
+        force.setHeight(0);
+
+
+    auto idealPosition = m_currentOffset.constrainedBetween(extents.minimumScrollOffset(), extents.maximumScrollOffset());
+
+//     ScrollPosition idealPosition = m_scrollAnimator.scrollableArea().constrainedScrollPosition(IntPoint(m_currentKeyboardScroll ? m_scrollAnimator.currentPosition() : m_idealPosition));
+     FloatPoint displacement = idealPosition;
+
+     // auto springForce = -displacement.scaled(params.springStiffness) - m_velocity.scaled(params.springDamping);
+     // force += springForce * axesToApplySpring;
+
+     float frameDuration = (currentTime - m_timeAtLastFrame).value();
+     m_timeAtLastFrame = currentTime;
+
+     FloatSize acceleration = force.scaled(1. / params.springMass);
+     m_velocity += acceleration.scaled(frameDuration);
+     m_currentOffset = m_currentOffset + m_velocity.scaled(frameDuration);
+
+//     m_scrollAnimator.scrollToPositionWithoutAnimation(newPosition);
+
+    m_client.scrollAnimationDidUpdate(*this, m_currentOffset);
+
+     // Stop the spring if it reaches the ideal position.
+     FloatSize newDisplacement = m_currentOffset - idealPosition;
+     if (axesToApplySpring.width() && displacement.x() * newDisplacement.width() < 0)
+         m_velocity.setWidth(0);
+     if (axesToApplySpring.height() && displacement.y() * newDisplacement.height() < 0)
+         m_velocity.setHeight(0);
+
+     return true;
+}
+
+void ScrollAnimationKeyboard::serviceAnimation(MonotonicTime currentTime)
+{
+    bool animationActive = animateScroll(currentTime);
+//    m_client.scrollAnimationDidUpdate(*this, m_currentOffset);
+    if (!animationActive)
+        didEnd();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.h
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScrollAnimation.h"
+#include "platform/ScrollTypes.h"
+#include "platform/graphics/FloatSize.h"
+
+namespace WebCore {
+
+class FloatPoint;
+class TimingFunction;
+
+class ScrollAnimationKeyboard final: public ScrollAnimation {
+public:
+    ScrollAnimationKeyboard(ScrollAnimationClient&);
+    virtual ~ScrollAnimationKeyboard();
+
+    bool retargetActiveAnimation(const FloatPoint&) final;
+
+    bool animateScroll(MonotonicTime);
+
+    bool startKeyboardScroll(ScrollDirection, ScrollGranularity);
+
+private:
+    void serviceAnimation(MonotonicTime) final;
+
+    String debugDescription() const final;
+
+    WebCore::FloatSize m_velocity;
+    MonotonicTime m_timeAtLastFrame;
+    WebCore::ScrollDirection m_direction;
+    WebCore::FloatSize m_currentForce;
+    WebCore::FloatSize m_maximumVelocity;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_SCROLL_ANIMATION(WebCore::ScrollAnimationKeyboard, type() == WebCore::ScrollAnimation::Type::Keyboard)

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -54,7 +54,6 @@ std::unique_ptr<ScrollAnimator> ScrollAnimator::create(ScrollableArea& scrollabl
 ScrollAnimator::ScrollAnimator(ScrollableArea& scrollableArea)
     : m_scrollableArea(scrollableArea)
     , m_scrollController(*this)
-    , m_keyboardScrollingAnimator(makeUnique<KeyboardScrollingAnimator>(*this, m_scrollController))
 {
 }
 
@@ -110,6 +109,11 @@ bool ScrollAnimator::scrollToPositionWithoutAnimation(const FloatPoint& position
 
     setCurrentPosition(adjustedPosition, NotifyScrollableArea::Yes);
     return true;
+}
+
+bool ScrollAnimator::keyboardScrollToPosition(ScrollDirection direction, ScrollGranularity granularity)
+{
+    return m_scrollController.startKeyboardScroll(direction, granularity);
 }
 
 bool ScrollAnimator::scrollToPositionWithAnimation(const FloatPoint& position, ScrollClamping clamping)

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -76,8 +76,11 @@ public:
     // The base class implementation always scrolls immediately, never animates.
     bool singleAxisScroll(ScrollEventAxis, float delta, OptionSet<ScrollBehavior>);
 
+    bool keyboardScrollToPosition(ScrollDirection, ScrollGranularity);
+
     bool scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     bool scrollToPositionWithAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
+    bool beginKeyboardScroll(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
 
     void retargetRunningAnimation(const FloatPoint& newPosition);
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -138,6 +138,16 @@ void ScrollableArea::scrollToPositionWithoutAnimation(const FloatPoint& position
     scrollAnimator().scrollToPositionWithoutAnimation(position, clamping);
 }
 
+void ScrollableArea::beginKeyboardScroll(ScrollDirection direction, ScrollGranularity granularity)
+{
+    bool startedAnimation = requestStartKeyboardAnimation(direction, granularity);
+    if (!startedAnimation)
+        startedAnimation = scrollAnimator().keyboardScrollToPosition(direction, granularity);
+
+    if (startedAnimation)
+      setScrollAnimationStatus(ScrollAnimationStatus::Animating);
+}
+
 void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, ScrollClamping clamping)
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithAnimation " << position);

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -69,6 +69,7 @@ public:
     virtual bool isListBox() const { return false; }
 
     WEBCORE_EXPORT bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1);
+    WEBCORE_EXPORT void beginKeyboardScroll(ScrollDirection, ScrollGranularity);
     WEBCORE_EXPORT void scrollToPositionWithAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     WEBCORE_EXPORT void scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
 
@@ -84,6 +85,7 @@ public:
     // expect it to happen sometime in the future.
     virtual bool requestScrollPositionUpdate(const ScrollPosition&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped) { return false; }
     virtual bool requestAnimatedScrollToPosition(const ScrollPosition&, ScrollClamping = ScrollClamping::Clamped) { return false; }
+    virtual bool requestStartKeyboardAnimation(ScrollDirection, ScrollGranularity) { return false; }
     virtual void stopAsyncAnimatedScroll() { }
 
     WEBCORE_EXPORT virtual bool handleWheelEventForScrolling(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>);

--- a/Source/WebCore/platform/ScrollingEffectsController.cpp
+++ b/Source/WebCore/platform/ScrollingEffectsController.cpp
@@ -32,6 +32,7 @@
 #include "PlatformWheelEvent.h"
 #include "ScrollAnimationMomentum.h"
 #include "ScrollAnimationSmooth.h"
+#include "ScrollAnimationKeyboard.h"
 #include "ScrollExtents.h"
 #include "ScrollableArea.h"
 #include <wtf/text/TextStream.h>
@@ -91,6 +92,21 @@ void ScrollingEffectsController::willBeginKeyboardScrolling()
 void ScrollingEffectsController::didStopKeyboardScrolling()
 {
     setIsAnimatingKeyboardScrolling(false);
+}
+
+bool ScrollingEffectsController::startKeyboardScroll(ScrollDirection direction, ScrollGranularity granularity)
+{
+    if (m_currentAnimation)
+        m_currentAnimation->stop();
+
+    m_currentAnimation = makeUnique<ScrollAnimationKeyboard>(*this);
+    bool started = downcast<ScrollAnimationKeyboard>(*m_currentAnimation).startKeyboardScroll(direction, granularity);
+    LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController " << this << " startAnimatedScrollToDestination " << *m_currentAnimation << " started " << started);
+    return started;
+}
+
+void ScrollingEffectsController::setKeyboardScrollData(const KeyboardScrollData&)
+{
 }
 
 bool ScrollingEffectsController::startAnimatedScrollToDestination(FloatPoint startOffset, FloatPoint destinationOffset)
@@ -210,7 +226,7 @@ void ScrollingEffectsController::stopKeyboardScrolling()
     if (!m_isAnimatingKeyboardScrolling)
         return;
 
-    m_client.keyboardScrollingAnimator()->handleKeyUpEvent();
+    // m_client.keyboardScrollingAnimator()->handleKeyUpEvent();
 }
 
 void ScrollingEffectsController::contentsSizeChanged()
@@ -483,12 +499,12 @@ void ScrollingEffectsController::stopScrollSnapAnimation()
     setIsAnimatingScrollSnap(false);
 }
 
-void ScrollingEffectsController::updateKeyboardScrollingAnimatingState(MonotonicTime currentTime)
+void ScrollingEffectsController::updateKeyboardScrollingAnimatingState(MonotonicTime)
 {
-    if (!m_isAnimatingKeyboardScrolling)
-        return;
-
-    m_client.keyboardScrollingAnimator()->updateKeyboardScrollPosition(currentTime);
+//    if (!m_isAnimatingKeyboardScrolling)
+//        return;
+//
+//    m_client.keyboardScrollingAnimator()->updateKeyboardScrollPosition(currentTime);
 }
 
 void ScrollingEffectsController::scrollAnimationDidUpdate(ScrollAnimation& animation, const FloatPoint& scrollOffset)

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -31,6 +31,7 @@
 #include "RectEdges.h"
 #include "ScrollAnimation.h"
 #include "ScrollSnapAnimatorState.h"
+#include "KeyboardScrollingState.h"
 #include "ScrollSnapOffsetsInfo.h"
 #include "ScrollTypes.h"
 #include "WheelEventTestMonitor.h"
@@ -173,6 +174,10 @@ public:
     bool isScrollSnapInProgress() const;
     bool isUserScrollInProgress() const;
 
+    bool startKeyboardScroll(ScrollDirection, ScrollGranularity);
+
+    void setKeyboardScrollData(const KeyboardScrollData& scrollData);
+
 #if PLATFORM(MAC)
     static FloatSize wheelDeltaBiasingTowardsVertical(const FloatSize&);
 
@@ -259,6 +264,8 @@ private:
     bool m_inScrollGesture { false };
 
 #if PLATFORM(MAC)
+    std::unique_ptr<KeyboardScrollingState> m_keyboardScrollingState;
+
     WallTime m_lastMomentumScrollTimestamp;
     FloatSize m_unappliedOverscrollDelta;
     FloatSize m_stretchScrollForce;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -257,6 +257,14 @@ bool RenderLayerScrollableArea::requestScrollPositionUpdate(const ScrollPosition
     return false;
 }
 
+bool RenderLayerScrollableArea::requestStartKeyboardAnimation(ScrollDirection direction, ScrollGranularity granularity)
+{
+  if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
+      return scrollingCoordinator->requestStartKeyboardAnimation(*this, direction, granularity);
+
+  return false;
+}
+
 bool RenderLayerScrollableArea::requestAnimatedScrollToPosition(const ScrollPosition& destinationPosition, ScrollClamping clamping)
 {
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -208,6 +208,7 @@ public:
 
     bool requestScrollPositionUpdate(const ScrollPosition&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped) final;
     bool requestAnimatedScrollToPosition(const ScrollPosition&, ScrollClamping = ScrollClamping::Clamped) final;
+    bool requestStartKeyboardAnimation(ScrollDirection, ScrollGranularity) final;
     void stopAsyncAnimatedScroll() final;
 
     bool containsDirtyOverlayScrollbars() const { return m_containsDirtyOverlayScrollbars; }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -100,14 +100,14 @@ void EventDispatcher::internalWheelEvent(PageIdentifier pageID, const WebWheelEv
 {
     auto processingSteps = OptionSet<WebCore::WheelEventProcessingSteps> { WheelEventProcessingSteps::MainThreadForScrolling, WheelEventProcessingSteps::MainThreadForBlockingDOMEventDispatch };
 
-    ensureOnMainRunLoop([pageID] {
-        if (auto* webPage = WebProcess::singleton().webPage(pageID)) {
-            if (auto* corePage = webPage->corePage()) {
-                if (auto* keyboardScrollingAnimator = corePage->currentKeyboardScrollingAnimator())
-                    keyboardScrollingAnimator->stopScrollingImmediately();
-            }
-        }
-    });
+    // ensureOnMainRunLoop([pageID] {
+    //     if (auto* webPage = WebProcess::singleton().webPage(pageID)) {
+    //         if (auto* corePage = webPage->corePage()) {
+    //             if (auto* keyboardScrollingAnimator = corePage->currentKeyboardScrollingAnimator())
+    //                 keyboardScrollingAnimator->stopScrollingImmediately();
+    //         }
+    //     }
+    // });
     
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
     do {


### PR DESCRIPTION
#### b0f4981f866ed138e47f9dce34634727ac2d1314
<pre>
Scrolling by pressing space bar has regressed in trunk, is choppy (not 120Hz)
Need the bug URL (OOPS!).
rdar://101052130

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::stopKeyboardScrolling):
(WebCore::EventHandler::beginKeyboardScrollGesture):
(WebCore::EventHandler::startKeyboardScrollAnimationOnDocument):
(WebCore::EventHandler::startKeyboardScrollAnimationOnRenderBoxLayer):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestStartKeyboardAnimation):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::requestStartKeyboardAnimation):
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::boxSideForDirection): Deleted.
(WebCore::perpendicularAbsoluteUnitVector): Deleted.
(WebCore::KeyboardScrollingAnimator::updateKeyboardScrollPosition): Deleted.
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture): Deleted.
(WebCore::farthestPointInDirection): Deleted.
(WebCore::KeyboardScrollingAnimator::stopKeyboardScrollAnimation): Deleted.
(WebCore::KeyboardScrollingAnimator::handleKeyUpEvent): Deleted.
(WebCore::KeyboardScrollingAnimator::stopScrollingImmediately): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.h:
* Source/WebCore/platform/KeyboardScrollingState.cpp: Copied from Source/WebCore/platform/ScrollAnimation.cpp.
* Source/WebCore/platform/KeyboardScrollingState.h: Copied from Source/WebCore/platform/ScrollAnimation.cpp.
(WebCore::KeyboardScrollingState::KeyboardScrollingState):
* Source/WebCore/platform/ScrollAnimation.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollAnimation.h:
* Source/WebCore/platform/ScrollAnimationKeyboard.cpp: Added.
(WebCore::ScrollAnimationKeyboard::ScrollAnimationKeyboard):
(WebCore::ScrollAnimationKeyboard::retargetActiveAnimation):
(WebCore::ScrollAnimationKeyboard::debugDescription const):
(WebCore::ScrollAnimationKeyboard::startKeyboardScroll):
(WebCore::scrollableDirectionsFromPosition):
(WebCore::boxSideForDirection):
(WebCore::perpendicularAbsoluteUnitVector):
(WebCore::ScrollAnimationKeyboard::animateScroll):
(WebCore::ScrollAnimationKeyboard::serviceAnimation):
* Source/WebCore/platform/ScrollAnimationKeyboard.h: Copied from Source/WebCore/platform/ScrollAnimation.cpp.
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::ScrollAnimator):
(WebCore::ScrollAnimator::keyboardScrollToPosition):
* Source/WebCore/platform/ScrollAnimator.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::beginKeyboardScroll):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::requestStartKeyboardAnimation):
* Source/WebCore/platform/ScrollingEffectsController.cpp:
(WebCore::ScrollingEffectsController::startKeyboardScroll):
(WebCore::ScrollingEffectsController::stopKeyboardScrolling):
(WebCore::ScrollingEffectsController::updateKeyboardScrollingAnimatingState):
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::requestStartKeyboardAnimation):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::internalWheelEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0f4981f866ed138e47f9dce34634727ac2d1314

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93185 "39 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2386 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23838 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102893 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163180 "Hash b0f4981f for PR 5389 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97188 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2390 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30708 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85576 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99005 "Hash b0f4981f for PR 5389 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98854 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/2390 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79655 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/85576 "Hash b0f4981f for PR 5389 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/2390 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/23838 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/85576 "Hash b0f4981f for PR 5389 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37099 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/23838 "Hash b0f4981f for PR 5389 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34915 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/23838 "Hash b0f4981f for PR 5389 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38786 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/79655 "Hash b0f4981f for PR 5389 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40715 "Hash b0f4981f for PR 5389 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/23838 "Hash b0f4981f for PR 5389 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->