### PR TITLE
[WK2] Provide a variadic-template ArgumentCoder specialization for IPC::ArrayReferenceTuple

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -215,100 +215,53 @@ GCGLSpan<T, Extent> makeGCGLSpan(T* data)
 }
 
 template<typename... Types>
-struct GCGLSpanTuple;
+struct GCGLSpanTuple {
+    GCGLSpanTuple(Types*... dataPointers, size_t bufSize)
+        : bufSize { bufSize }
+        , dataTuple { dataPointers... }
+    { }
 
-template<typename T0, typename T1>
-struct GCGLSpanTuple<T0, T1> {
-    GCGLSpanTuple(T0* data0_, T1* data1_, size_t bufSize_)
-        : bufSize(bufSize_)
-        , data0(data0_)
-        , data1(data1_)
+    template<typename... VectorTypes>
+    GCGLSpanTuple(const Vector<VectorTypes>&... dataVectors)
+        : bufSize(
+            [](auto& firstVector, auto&... otherVectors) {
+                auto size = firstVector.size();
+                RELEASE_ASSERT(((otherVectors.size() == size) && ...));
+                return size;
+            }(dataVectors...))
+        , dataTuple { dataVectors.data()... }
+    { }
+
+    template<unsigned I>
+    auto data() const
     {
+        return std::get<I>(dataTuple);
     }
-    template<typename U0, typename U1>
-    GCGLSpanTuple(const Vector<U0>& data0_, const Vector<U1>& data1_)
-        : bufSize(data0_.size())
-        , data0(data0_.data())
-        , data1(data1_.data())
-    {
-        ASSERT(data0_.size() == data1_.size());
-    }
+
     const size_t bufSize;
-    T0* const data0;
-    T1* const data1;
-};
-
-template<typename T0, typename T1, typename T2>
-struct GCGLSpanTuple<T0, T1, T2> : public GCGLSpanTuple<T0, T1> {
-    GCGLSpanTuple(T0* data0_, T1* data1_, T2* data2_, size_t bufSize_)
-        : GCGLSpanTuple<T0, T1>(data0_, data1_, bufSize_)
-        , data2(data2_)
-    {
-    }
-    template<typename U0, typename U1, typename U2>
-    GCGLSpanTuple(const Vector<U0>& data0_, const Vector<U1>& data1_, const Vector<U2>& data2_)
-        : GCGLSpanTuple<T0, T1>(data0_, data1_)
-        , data2(data2_.data())
-    {
-        ASSERT(data2_.size() == data0_.size());
-    }
-    T2* const data2;
-};
-
-template<typename T0, typename T1, typename T2, typename T3>
-struct GCGLSpanTuple<T0, T1, T2, T3> : public GCGLSpanTuple<T0, T1, T2> {
-    GCGLSpanTuple(T0* data0_, T1* data1_, T2* data2_, T3* data3_, size_t bufSize_)
-        : GCGLSpanTuple<T0, T1, T2>(data0_, data1_, data2_, bufSize_)
-        , data3(data3_)
-    {
-    }
-    template<typename U0, typename U1, typename U2, typename U3>
-    GCGLSpanTuple(const Vector<U0>& data0_, const Vector<U1>& data1_, const Vector<U2>& data2_, const Vector<U3>& data3_)
-        : GCGLSpanTuple<T0, T1, T2>(data0_, data1_, data2_)
-        , data3(data3_.data())
-    {
-        ASSERT(data3_.size() == data0_.size());
-    }
-    T3* const data3;
-};
-
-template<typename T0, typename T1, typename T2, typename T3, typename T4>
-struct GCGLSpanTuple<T0, T1, T2, T3, T4> : public GCGLSpanTuple<T0, T1, T2, T3> {
-    GCGLSpanTuple(T0* data0_, T1* data1_, T2* data2_, T3* data3_, T4* data4_, size_t bufSize_)
-        : GCGLSpanTuple<T0, T1, T2, T3>(data0_, data1_, data2_, data3_, bufSize_)
-        , data4(data4_)
-    {
-    }
-    template<typename U0, typename U1, typename U2, typename U3, typename U4>
-    GCGLSpanTuple(const Vector<U0>& data0_, const Vector<U1>& data1_, const Vector<U2>& data2_, const Vector<U3>& data3_, const Vector<U4>& data4_)
-        : GCGLSpanTuple<T0, T1, T2, T3>(data0_, data1_, data2_, data3_)
-        , data4(data4_.data())
-    {
-        ASSERT(data4_.size() == data0_.size());
-    }
-    T4* const data4;
+    std::tuple<Types*...> dataTuple;
 };
 
 template<typename T0, typename T1>
 GCGLSpanTuple(T0*, T1*, size_t) -> GCGLSpanTuple<T0, T1>;
 
-template<typename T0, typename T1>
-GCGLSpanTuple(const Vector<T0>&, const Vector<T1>&) -> GCGLSpanTuple<const T0, const T1>;
-
 template<typename T0, typename T1, typename T2>
 GCGLSpanTuple(T0*, T1*, T2*, size_t) -> GCGLSpanTuple<T0, T1, T2>;
+
+template<typename T0, typename T1, typename T2, typename T3>
+GCGLSpanTuple(T0*, T1*, T2*, T3*, size_t) -> GCGLSpanTuple<T0, T1, T2, T3>;
+
+template<typename T0, typename T1, typename T2, typename T3, typename T4>
+GCGLSpanTuple(T0*, T1*, T2*, T3*, T4*, size_t) -> GCGLSpanTuple<T0, T1, T2, T3, T4>;
+
+template<typename T0, typename T1>
+GCGLSpanTuple(const Vector<T0>&, const Vector<T1>&) -> GCGLSpanTuple<const T0, const T1>;
 
 template<typename T0, typename T1, typename T2>
 GCGLSpanTuple(const Vector<T0>&, const Vector<T1>&, const Vector<T2>&) -> GCGLSpanTuple<const T0, const T1, const T2>;
 
 template<typename T0, typename T1, typename T2, typename T3>
-GCGLSpanTuple(T0*, T1*, T2*, T3*, size_t) -> GCGLSpanTuple<T0, T1, T2, T3>;
-
-template<typename T0, typename T1, typename T2, typename T3>
 GCGLSpanTuple(const Vector<T0>&, const Vector<T1>&, const Vector<T2>&, const Vector<T3>&) -> GCGLSpanTuple<const T0, const T1, const T2, const T3>;
-
-template<typename T0, typename T1, typename T2, typename T3, typename T4>
-GCGLSpanTuple(T0*, T1*, T2*, T3*, T4*, size_t) -> GCGLSpanTuple<T0, T1, T2, T3, T4>;
 
 template<typename T0, typename T1, typename T2, typename T3, typename T4>
 GCGLSpanTuple(const Vector<T0>&, const Vector<T1>&, const Vector<T2>&, const Vector<T3>&, const Vector<T4>&) -> GCGLSpanTuple<const T0, const T1, const T2, const T3, const T4>;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2855,7 +2855,7 @@ void GraphicsContextGLANGLE::multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<c
     if (!makeContextCurrent())
         return;
 
-    GL_MultiDrawArraysANGLE(mode, firstsAndCounts.data0, firstsAndCounts.data1, firstsAndCounts.bufSize);
+    GL_MultiDrawArraysANGLE(mode, firstsAndCounts.data<0>(), firstsAndCounts.data<1>(), firstsAndCounts.bufSize);
     checkGPUStatus();
 }
 
@@ -2864,7 +2864,7 @@ void GraphicsContextGLANGLE::multiDrawArraysInstancedANGLE(GCGLenum mode, GCGLSp
     if (!makeContextCurrent())
         return;
 
-    GL_MultiDrawArraysInstancedANGLE(mode, firstsCountsAndInstanceCounts.data0, firstsCountsAndInstanceCounts.data1, firstsCountsAndInstanceCounts.data2, firstsCountsAndInstanceCounts.bufSize);
+    GL_MultiDrawArraysInstancedANGLE(mode, firstsCountsAndInstanceCounts.data<0>(), firstsCountsAndInstanceCounts.data<1>(), firstsCountsAndInstanceCounts.data<2>(), firstsCountsAndInstanceCounts.bufSize);
     checkGPUStatus();
 }
 
@@ -2877,9 +2877,9 @@ void GraphicsContextGLANGLE::multiDrawElementsANGLE(GCGLenum mode, GCGLSpanTuple
     Vector<void*> offsetsPointers;
     offsetsPointers.reserveInitialCapacity(countsAndOffsets.bufSize);
     for (size_t i = 0; i < countsAndOffsets.bufSize; ++i)
-        offsetsPointers.append(reinterpret_cast<void*>(countsAndOffsets.data1[i]));
+        offsetsPointers.append(reinterpret_cast<void*>(countsAndOffsets.data<1>()[i]));
 
-    GL_MultiDrawElementsANGLE(mode, countsAndOffsets.data0, type, offsetsPointers.data(), countsAndOffsets.bufSize);
+    GL_MultiDrawElementsANGLE(mode, countsAndOffsets.data<0>(), type, offsetsPointers.data(), countsAndOffsets.bufSize);
     checkGPUStatus();
 }
 
@@ -2892,9 +2892,9 @@ void GraphicsContextGLANGLE::multiDrawElementsInstancedANGLE(GCGLenum mode, GCGL
     Vector<void*> offsetsPointers;
     offsetsPointers.reserveInitialCapacity(countsOffsetsAndInstanceCounts.bufSize);
     for (size_t i = 0; i < countsOffsetsAndInstanceCounts.bufSize; ++i)
-        offsetsPointers.append(reinterpret_cast<void*>(countsOffsetsAndInstanceCounts.data1[i]));
+        offsetsPointers.append(reinterpret_cast<void*>(countsOffsetsAndInstanceCounts.data<1>()[i]));
 
-    GL_MultiDrawElementsInstancedANGLE(mode, countsOffsetsAndInstanceCounts.data0, type, offsetsPointers.data(), countsOffsetsAndInstanceCounts.data2, countsOffsetsAndInstanceCounts.bufSize);
+    GL_MultiDrawElementsInstancedANGLE(mode, countsOffsetsAndInstanceCounts.data<0>(), type, offsetsPointers.data(), countsOffsetsAndInstanceCounts.data<2>(), countsOffsetsAndInstanceCounts.bufSize);
     checkGPUStatus();
 }
 
@@ -3030,7 +3030,7 @@ void GraphicsContextGLANGLE::multiDrawArraysInstancedBaseInstanceANGLE(GCGLenum 
     if (!makeContextCurrent())
         return;
 
-    GL_MultiDrawArraysInstancedBaseInstanceANGLE(mode, firstsCountsInstanceCountsAndBaseInstances.data0, firstsCountsInstanceCountsAndBaseInstances.data1, firstsCountsInstanceCountsAndBaseInstances.data2, firstsCountsInstanceCountsAndBaseInstances.data3, firstsCountsInstanceCountsAndBaseInstances.bufSize);
+    GL_MultiDrawArraysInstancedBaseInstanceANGLE(mode, firstsCountsInstanceCountsAndBaseInstances.data<0>(), firstsCountsInstanceCountsAndBaseInstances.data<1>(), firstsCountsInstanceCountsAndBaseInstances.data<2>(), firstsCountsInstanceCountsAndBaseInstances.data<3>(), firstsCountsInstanceCountsAndBaseInstances.bufSize);
     checkGPUStatus();
 }
 
@@ -3043,9 +3043,9 @@ void GraphicsContextGLANGLE::multiDrawElementsInstancedBaseVertexBaseInstanceANG
     Vector<void*> offsetsPointers;
     offsetsPointers.reserveInitialCapacity(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.bufSize);
     for (size_t i = 0; i < countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.bufSize; ++i)
-        offsetsPointers.append(reinterpret_cast<void*>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data1[i]));
+        offsetsPointers.append(reinterpret_cast<void*>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<1>()[i]));
 
-    GL_MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data0, type, offsetsPointers.data(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data2, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data3, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data4, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.bufSize);
+    GL_MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<0>(), type, offsetsPointers.data(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<2>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<3>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.data<4>(), countsOffsetsInstanceCountsBaseVerticesAndBaseInstances.bufSize);
     checkGPUStatus();
 }
 

--- a/Source/WebKit/Platform/IPC/ArrayReferenceTuple.h
+++ b/Source/WebKit/Platform/IPC/ArrayReferenceTuple.h
@@ -29,107 +29,30 @@
 
 namespace IPC {
 
-template <typename... Types> class ArrayReferenceTuple;
-
-template<typename T0, typename T1>
-class ArrayReferenceTuple<T0, T1> {
+template<typename... Types>
+class ArrayReferenceTuple {
 public:
     ArrayReferenceTuple() = default;
-    ArrayReferenceTuple(const T0* data0, const T1* data1, size_t size)
+
+    ArrayReferenceTuple(const Types*... data, size_t size)
         : m_size(size)
-        , m_data0(size ? data0 : nullptr)
-        , m_data1(size ? data1 : nullptr)
     {
+        if (m_size)
+            m_data = { data... };
     }
+
     bool isEmpty() const { return !m_size; }
     size_t size() const { return m_size; }
-    template<int I>
+
+    template<unsigned I>
     auto data() const
     {
-        if constexpr(I)
-            return m_data1;
-        else if constexpr(!I)
-            return m_data0;
+        return std::get<I>(m_data);
     }
+
 private:
     size_t m_size { 0 };
-    const T0* m_data0 { nullptr };
-    const T1* m_data1 { nullptr };
+    std::tuple<const Types*...> m_data;
 };
-
-template<typename T0, typename T1, typename T2>
-class ArrayReferenceTuple<T0, T1, T2> : public ArrayReferenceTuple<T0, T1> {
-public:
-    ArrayReferenceTuple() = default;
-    ArrayReferenceTuple(const T0* data0, const T1* data1, const T2* data2, size_t size)
-        : ArrayReferenceTuple<T0, T1>(data0, data1, size)
-        , m_data2(size ? data2 : nullptr)
-    {
-    }
-    template<int I>
-    auto data() const
-    {
-        if constexpr(I == 2)
-            return m_data2;
-        else
-            return ArrayReferenceTuple<T0, T1>::template data<I>();
-    }
-private:
-    const T2* m_data2 { nullptr };
-};
-
-template<typename T0, typename T1, typename T2, typename T3>
-class ArrayReferenceTuple<T0, T1, T2, T3> : public ArrayReferenceTuple<T0, T1, T2> {
-public:
-    ArrayReferenceTuple() = default;
-    ArrayReferenceTuple(const T0* data0, const T1* data1, const T2* data2, const T3* data3, size_t size)
-        : ArrayReferenceTuple<T0, T1, T2>(data0, data1, data2, size)
-        , m_data3(size ? data3 : nullptr)
-    {
-    }
-    template<int I>
-    auto data() const
-    {
-        if constexpr(I == 3)
-            return m_data3;
-        else
-            return ArrayReferenceTuple<T0, T1, T2>::template data<I>();
-    }
-private:
-    const T3* m_data3 { nullptr };
-};
-
-template<typename T0, typename T1, typename T2, typename T3, typename T4>
-class ArrayReferenceTuple<T0, T1, T2, T3, T4> : public ArrayReferenceTuple<T0, T1, T2, T3> {
-public:
-    ArrayReferenceTuple() = default;
-    ArrayReferenceTuple(const T0* data0, const T1* data1, const T2* data2, const T3* data3, const T4* data4, size_t size)
-        : ArrayReferenceTuple<T0, T1, T2, T3>(data0, data1, data2, data3, size)
-        , m_data4(size ? data4 : nullptr)
-    {
-    }
-    template<int I>
-    auto data() const
-    {
-        if constexpr(I == 4)
-            return m_data4;
-        else
-            return ArrayReferenceTuple<T0, T1, T2, T3>::template data<I>();
-    }
-private:
-    const T4* m_data4 { nullptr };
-};
-
-template<typename T0, typename T1>
-ArrayReferenceTuple(const T0*, const T1*, size_t) -> ArrayReferenceTuple<T0, T1>;
-
-template<typename T0, typename T1, typename T2>
-ArrayReferenceTuple(const T0*, const T1*, const T2*, size_t) -> ArrayReferenceTuple<T0, T1, T2>;
-
-template<typename T0, typename T1, typename T2, typename T3>
-ArrayReferenceTuple(const T0*, const T1*, const T2*, const T3*, size_t) -> ArrayReferenceTuple<T0, T1, T2, T3>;
-
-template<typename T0, typename T1, typename T2, typename T3, typename T4>
-ArrayReferenceTuple(const T0*, const T1*, const T2*, const T3*, const T4*, size_t) -> ArrayReferenceTuple<T0, T1, T2, T3, T4>;
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -48,44 +48,22 @@ using namespace WebCore;
 static constexpr size_t defaultStreamSize = 1 << 21;
 
 namespace {
-template<typename T0, typename T1, typename S0, typename S1>
-IPC::ArrayReferenceTuple<T0, T1> toArrayReferenceTuple(GCGLSpanTuple<const S0, const S1> spanTuple)
+
+template<typename... Types, typename... SpanTupleTypes, size_t... Indices>
+IPC::ArrayReferenceTuple<Types...> toArrayReferenceTuple(const GCGLSpanTuple<SpanTupleTypes...>& spanTuple, std::index_sequence<Indices...>)
 {
-    return IPC::ArrayReferenceTuple {
-        reinterpret_cast<const T0*>(spanTuple.data0),
-        reinterpret_cast<const T1*>(spanTuple.data1),
+    return IPC::ArrayReferenceTuple<Types...> {
+        reinterpret_cast<const std::tuple_element_t<Indices, std::tuple<Types...>>*>(spanTuple.template data<Indices>())...,
         spanTuple.bufSize };
 }
-template<typename T0, typename T1, typename T2, typename S0, typename S1, typename S2>
-IPC::ArrayReferenceTuple<T0, T1, T2> toArrayReferenceTuple(GCGLSpanTuple<const S0, const S1, const S2> spanTuple)
+
+template<typename... Types, typename... SpanTupleTypes>
+IPC::ArrayReferenceTuple<Types...> toArrayReferenceTuple(const GCGLSpanTuple<SpanTupleTypes...>& spanTuple)
 {
-    return IPC::ArrayReferenceTuple {
-        reinterpret_cast<const T0*>(spanTuple.data0),
-        reinterpret_cast<const T1*>(spanTuple.data1),
-        reinterpret_cast<const T2*>(spanTuple.data2),
-        spanTuple.bufSize };
+    static_assert(sizeof...(Types) == sizeof...(SpanTupleTypes));
+    return toArrayReferenceTuple<Types...>(spanTuple, std::index_sequence_for<Types...> { });
 }
-template<typename T0, typename T1, typename T2, typename T3, typename S0, typename S1, typename S2, typename S3>
-IPC::ArrayReferenceTuple<T0, T1, T2, T3> toArrayReferenceTuple(GCGLSpanTuple<const S0, const S1, const S2, const S3> spanTuple)
-{
-    return IPC::ArrayReferenceTuple {
-        reinterpret_cast<const T0*>(spanTuple.data0),
-        reinterpret_cast<const T1*>(spanTuple.data1),
-        reinterpret_cast<const T2*>(spanTuple.data2),
-        reinterpret_cast<const T3*>(spanTuple.data3),
-        spanTuple.bufSize };
-}
-template<typename T0, typename T1, typename T2, typename T3, typename T4, typename S0, typename S1, typename S2, typename S3, typename S4>
-IPC::ArrayReferenceTuple<T0, T1, T2, T3, T4> toArrayReferenceTuple(GCGLSpanTuple<const S0, const S1, const S2, const S3, const S4> spanTuple)
-{
-    return IPC::ArrayReferenceTuple {
-        reinterpret_cast<const T0*>(spanTuple.data0),
-        reinterpret_cast<const T1*>(spanTuple.data1),
-        reinterpret_cast<const T2*>(spanTuple.data2),
-        reinterpret_cast<const T3*>(spanTuple.data3),
-        reinterpret_cast<const T4*>(spanTuple.data4),
-        spanTuple.bufSize };
-}
+
 }
 
 RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy(GPUProcessConnection& gpuProcessConnection, const GraphicsContextGLAttributes& attributes, RenderingBackendIdentifier renderingBackend)


### PR DESCRIPTION
#### 22858076abebf044aa4ff2a5ee68d8ba0069715d
<pre>
[WK2] Provide a variadic-template ArgumentCoder specialization for IPC::ArrayReferenceTuple
<a href="https://bugs.webkit.org/show_bug.cgi?id=246535">https://bugs.webkit.org/show_bug.cgi?id=246535</a>

Reviewed by NOBODY (OOPS!).

Instead of multiple ArgumentCoder specializations for IPC::ArrayReferenceTuple types
of different sizes, provide a single specialization that can handle encoding and
decoding of ArrayReferenceTuple objects of any size.

Encoding is straightforward, leveraging an index sequence to traverse and encode
fixed-length data of each element through a fold expression.

Decoding is constexpr and recursive, decoding fixed-length reference to the element&apos;s
data. Data pointers are forwarded through the final step when the index sequence matches
the ArrayReferenceTuple size, at which point the resulting ArrayReferenceTuple object
can be constructed.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22858076abebf044aa4ff2a5ee68d8ba0069715d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103566 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163904 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3139 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31360 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86254 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99598 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2248 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80356 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29268 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84174 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37751 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17701 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35619 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18965 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41534 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38194 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->