### PR TITLE
WKNavigationAction should expose _WKHitTestResult

### DIFF
--- a/Source/WebKit/Shared/NavigationActionData.cpp
+++ b/Source/WebKit/Shared/NavigationActionData.cpp
@@ -56,6 +56,7 @@ void NavigationActionData::encode(IPC::Encoder& encoder) const
     encoder << clientRedirectSourceForHistory;
     encoder << effectiveSandboxFlags;
     encoder << privateClickMeasurement;
+    encoder << webHitTestResultData;
 }
 
 std::optional<NavigationActionData> NavigationActionData::decode(IPC::Decoder& decoder)
@@ -159,10 +160,15 @@ std::optional<NavigationActionData> NavigationActionData::decode(IPC::Decoder& d
     if (!privateClickMeasurement)
         return std::nullopt;
 
+    std::optional<std::optional<WebKit::WebHitTestResultData>> webHitTestResultData;
+    decoder >> webHitTestResultData;
+    if (!webHitTestResultData)
+        return std::nullopt;
+
     return { { WTFMove(navigationType), modifiers, WTFMove(*mouseButton), WTFMove(*syntheticClickType), WTFMove(*userGestureTokenIdentifier),
         WTFMove(*canHandleRequest), WTFMove(shouldOpenExternalURLsPolicy), WTFMove(*downloadAttribute), WTFMove(clickLocationInRootViewCoordinates),
         WTFMove(*isRedirect), *treatAsSameOriginNavigation, *hasOpenedFrames, *openedByDOMWithOpener, WTFMove(*requesterOrigin),
-        WTFMove(*targetBackForwardItemIdentifier), WTFMove(*sourceBackForwardItemIdentifier), lockHistory, lockBackForwardList, WTFMove(*clientRedirectSourceForHistory), *effectiveSandboxFlags, WTFMove(*privateClickMeasurement) } };
+        WTFMove(*targetBackForwardItemIdentifier), WTFMove(*sourceBackForwardItemIdentifier), lockHistory, lockBackForwardList, WTFMove(*clientRedirectSourceForHistory), *effectiveSandboxFlags, WTFMove(*privateClickMeasurement), WTFMove(*webHitTestResultData) } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WebHitTestResultData.h"
 #include "WebMouseEvent.h"
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatPoint.h>
@@ -68,6 +69,7 @@ struct NavigationActionData {
     WTF::String clientRedirectSourceForHistory;
     WebCore::SandboxFlags effectiveSandboxFlags { 0 };
     std::optional<WebCore::PrivateClickMeasurement> privateClickMeasurement;
+    std::optional<WebKit::WebHitTestResultData> webHitTestResultData;
 };
 
 }

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -30,6 +30,7 @@
 #include "APIObject.h"
 #include "APIUserInitiatedAction.h"
 #include "NavigationActionData.h"
+#include "WebHitTestResultData.h"
 #include <WebCore/ResourceRequest.h>
 #include <wtf/URL.h>
 
@@ -53,6 +54,7 @@ public:
     OptionSet<WebKit::WebEventModifier> modifiers() const { return m_navigationActionData.modifiers; }
     WebKit::WebMouseEventButton mouseButton() const { return m_navigationActionData.mouseButton; }
     WebKit::WebMouseEventSyntheticClickType syntheticClickType() const { return m_navigationActionData.syntheticClickType; }
+    const std::optional<WebKit::WebHitTestResultData>& webHitTestResultData() const { return m_navigationActionData.webHitTestResultData; }
     WebCore::FloatPoint clickLocationInRootViewCoordinates() const { return m_navigationActionData.clickLocationInRootViewCoordinates; }
     bool canHandleRequest() const { return m_navigationActionData.canHandleRequest; }
     bool shouldOpenExternalSchemes() const { return m_navigationActionData.shouldOpenExternalURLsPolicy == WebCore::ShouldOpenExternalURLsPolicy::ShouldAllow || m_navigationActionData.shouldOpenExternalURLsPolicy == WebCore::ShouldOpenExternalURLsPolicy::ShouldAllowExternalSchemesButNotAppLinks; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -26,10 +26,12 @@
 #import "config.h"
 #import "WKNavigationActionInternal.h"
 
+#import "APIHitTestResult.h"
 #import "NavigationActionData.h"
 #import "WKFrameInfoInternal.h"
 #import "WKNavigationInternal.h"
 #import "WebEventFactory.h"
+#import "_WKHitTestResultInternal.h"
 #import "_WKUserInitiatedActionInternal.h"
 #import <WebCore/FloatPoint.h>
 #import <WebCore/WebCoreObjCExtras.h>
@@ -235,6 +237,16 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
     if (!page)
         return;
     page->websiteDataStore().storePrivateClickMeasurement(*privateClickMeasurement);
+}
+
+- (_WKHitTestResult *)_hitTestResult
+{
+    auto webHitTestResultData = _navigationAction->webHitTestResultData();
+    if (!webHitTestResultData)
+        return nil;
+
+    auto apiHitTestResult = API::HitTestResult::create(webHitTestResultData.value());
+    return retainPtr(wrapper(apiHitTestResult)).autorelease();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h
@@ -26,6 +26,7 @@
 #import <WebKit/WKNavigationAction.h>
 
 @class WKNavigation;
+@class _WKHitTestResult;
 @class _WKUserInitiatedAction;
 
 #if TARGET_OS_IPHONE
@@ -61,5 +62,7 @@ typedef NS_ENUM(NSInteger, WKSyntheticClickType) {
 @property (nonatomic, readonly) BOOL _isRedirect WK_API_AVAILABLE(macos(10.13), ios(11.0));
 @property (nonatomic, readonly) WKNavigation *_mainFrameNavigation WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (void)_storeSKAdNetworkAttribution WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+@property (nonatomic, readonly) _WKHitTestResult *_hitTestResult WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -53,6 +53,7 @@
 #include "WebFrame.h"
 #include "WebFrameNetworkingContext.h"
 #include "WebFullScreenManager.h"
+#include "WebHitTestResultData.h"
 #include "WebLoaderStrategy.h"
 #include "WebNavigationDataStore.h"
 #include "WebPage.h"
@@ -68,6 +69,7 @@
 #include <WebCore/Chrome.h>
 #include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/DocumentLoader.h>
+#include <WebCore/EventHandler.h>
 #include <WebCore/FormState.h>
 #include <WebCore/Frame.h>
 #include <WebCore/FrameLoader.h>
@@ -984,6 +986,13 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     navigationActionData.lockHistory = navigationAction.lockHistory();
     navigationActionData.lockBackForwardList = navigationAction.lockBackForwardList();
     navigationActionData.privateClickMeasurement = navigationAction.privateClickMeasurement();
+    if (auto mouseEventData = navigationAction.mouseEventData()) {
+        constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
+        HitTestResult hitTestResult = m_frame->coreFrame()->eventHandler().hitTestResultAtPoint(mouseEventData->absoluteLocation, hitType);
+
+        WebKit::WebHitTestResultData webHitTestResultData(hitTestResult, false);
+        navigationActionData.webHitTestResultData = std::make_optional(webHitTestResultData);
+    }
 
     auto* coreFrame = m_frame->coreFrame();
     if (!coreFrame)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm
@@ -33,6 +33,7 @@
 #import "TestProtocol.h"
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/_WKHitTestResult.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
@@ -306,6 +307,7 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
     EXPECT_EQ(webView.get(), [[action sourceFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+    EXPECT_NULL([action _hitTestResult]);
 
     // Wait for newWebView to ask to load its initial document.
     decidedPolicy = false;
@@ -325,6 +327,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedHyperlink)
     EXPECT_EQ(newWebView.get(), [[action targetFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+
+    _WKHitTestResult *hitTestResult = [action _hitTestResult];
+    EXPECT_NOT_NULL(hitTestResult);
+
+    CGRect elementBoundingBox = hitTestResult.elementBoundingBox;
+    EXPECT_FALSE(CGSizeEqualToSize(elementBoundingBox.size, CGSizeZero));
 
     newWebView = nullptr;
     action = nullptr;
@@ -393,6 +401,7 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedWindowOpen)
     EXPECT_EQ(webView.get(), [[action sourceFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+    EXPECT_NULL([action _hitTestResult]);
 
     // Wait for newWebView to ask to load its initial document.
     decidedPolicy = false;
@@ -412,6 +421,7 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedWindowOpen)
     EXPECT_EQ(newWebView.get(), [[action targetFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+    EXPECT_NULL([action _hitTestResult]);
 
     newWebView = nullptr;
     action = nullptr;
@@ -442,6 +452,7 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedFormSubmission)
     EXPECT_EQ(webView.get(), [[action sourceFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+    EXPECT_NULL([action _hitTestResult]);
 
     // Wait for newWebView to ask to load its initial document.
     decidedPolicy = false;
@@ -460,6 +471,12 @@ TEST(WebKit, DecidePolicyForNavigationActionForTargetedFormSubmission)
     EXPECT_EQ(newWebView.get(), [[action targetFrame] webView]);
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
+
+    _WKHitTestResult *hitTestResult = [action _hitTestResult];
+    EXPECT_NOT_NULL(hitTestResult);
+
+    CGRect elementBoundingBox = hitTestResult.elementBoundingBox;
+    EXPECT_FALSE(CGSizeEqualToSize(elementBoundingBox.size, CGSizeZero));
 
     newWebView = nullptr;
     action = nullptr;
@@ -504,6 +521,12 @@ static void runDecidePolicyForNavigationActionForHyperlinkThatRedirects(ShouldEn
     EXPECT_WK_STREQ("http", [[[action sourceFrame] securityOrigin] protocol]);
     EXPECT_WK_STREQ("webkit.org", [[[action sourceFrame] securityOrigin] host]);
     EXPECT_FALSE([action _isRedirect]);
+
+    _WKHitTestResult *hitTestResult = [action _hitTestResult];
+    EXPECT_NOT_NULL(hitTestResult);
+
+    CGRect elementBoundingBox = hitTestResult.elementBoundingBox;
+    EXPECT_FALSE(CGSizeEqualToSize(elementBoundingBox.size, CGSizeZero));
 
     // Wait to decide policy for redirect.
     decidedPolicy = false;


### PR DESCRIPTION
#### aa7212cf528efc2761077a4c03b0d27ac7178bd9
<pre>
WKNavigationAction should expose _WKHitTestResult
<a href="https://bugs.webkit.org/show_bug.cgi?id=246539">https://bugs.webkit.org/show_bug.cgi?id=246539</a>
&lt;rdar://100526247&gt;

Reviewed by NOBODY (OOPS!).

Add a _hitTestResult property to WKNavigationAction. This property can be nil.

* Source/WebKit/Shared/NavigationActionData.cpp:
(WebKit::NavigationActionData::encode const):
Encode webHitTestResultData.

(WebKit::NavigationActionData::decode):
Decode webHitTestResultData.

* Source/WebKit/Shared/NavigationActionData.h:
Add an optional webHitTestResultData.

* Source/WebKit/UIProcess/API/APINavigationAction.h:
Add webHitTestResultData().

* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction _hitTestResult]):
Added.

* Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionPrivate.h:
Added _hitTestResult property.

* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
Create webHitTestResultData if there is associated mouse event data.

(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
Add _hitTestResult tests to tests that generate mouse event data. The only data that&apos;s populated in
_hitTestResult is the elementBoundingBox, so verify that it&apos;s not empty.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa7212cf528efc2761077a4c03b0d27ac7178bd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102647 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2139 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30470 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85319 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98593 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79407 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28388 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83379 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36870 "Hash aa7212cf for PR 5393 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34674 "Hash aa7212cf for PR 5393 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18196 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38544 "Hash aa7212cf for PR 5393 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40794 "Passed tests") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40465 "Hash aa7212cf for PR 5393 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37376 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->