### PR TITLE
[git-webkit] Improve 'trace' regexes

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.24',
+    version='5.6.25',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 24)
+version = Version(5, 6, 25)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
@@ -31,13 +31,21 @@ from webkitbugspy import Tracker
 COMMIT_REF_BASE = r'r?R?[a-f0-9A-F]+.?\d*@?[0-9a-zA-z\-/]*'
 COMPOUND_COMMIT_REF = r'(?P<primary>{})(?P<secondary> \({}\))?'.format(COMMIT_REF_BASE, COMMIT_REF_BASE)
 CHERRY_PICK_RE = re.compile(r'[Cc]herry[- ][Pp]ick {}'.format(COMPOUND_COMMIT_REF))
-REVERT_RE = re.compile(r'Reverts? {}'.format(COMPOUND_COMMIT_REF))
+REVERT_RE = [
+    re.compile(r'Reverts? {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'Reverts? \[{}\]'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'Reverts? \({}\)'.format(COMPOUND_COMMIT_REF)),
+]
 FOLLOW_UP_FIXES_RE = [
     re.compile(r'Fix following {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'Follow-? ?up fix to {}'.format(COMPOUND_COMMIT_REF)),
     re.compile(r'Follow-? ?up fix {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'Follow-? ?up to {}'.format(COMPOUND_COMMIT_REF)),
     re.compile(r'Follow-? ?up {}'.format(COMPOUND_COMMIT_REF)),
-    re.compile(r'\[?[Gg]ardening\]?:? REGRESSION \(?{}\)?'.format(COMPOUND_COMMIT_REF)),
-    re.compile(r'REGRESSION ?\(?{}\)?'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\[?[Gg]ardening\]?:? REGRESSION \({}\)'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\[?[Gg]ardening\]?:? REGRESSION {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'REGRESSION ?\({}\)'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'REGRESSION ?{}'.format(COMPOUND_COMMIT_REF)),
     re.compile(r'\[?[Gg]ardening\]?:? [Tt]est-? ?[Aa]ddition \(?{}\)?'.format(COMPOUND_COMMIT_REF)),
     re.compile(r'[Tt]est-? ?[Aa]ddition \(?{}\)?'.format(COMPOUND_COMMIT_REF)),
 ]
@@ -49,7 +57,7 @@ class Relationship(object):
         'references', 'referenced by',
         'cherry-picked', 'original',
         'reverts', 'reverted by',
-        'follow-up', 'follow-up by',
+        'follow-up to', 'followed-up by',
     )
     REFERENCES, REFERENCED_BY, \
         CHERRY_PICK, ORIGINAL, \
@@ -79,7 +87,7 @@ class Relationship(object):
 
         for type, regexes in {
             cls.ORIGINAL: [CHERRY_PICK_RE],
-            cls.REVERTS: [REVERT_RE],
+            cls.REVERTS: REVERT_RE,
             cls.FOLLOW_UP: FOLLOW_UP_FIXES_RE,
         }.items():
             for regex in regexes:


### PR DESCRIPTION
#### 1fe7fc8f2bd03d46db4f2deebbf10b11c0455a33
<pre>
[git-webkit] Improve &apos;trace&apos; regexes
<a href="https://bugs.webkit.org/show_bug.cgi?id=246543">https://bugs.webkit.org/show_bug.cgi?id=246543</a>
rdar://101188306

Rubber-stamped by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py:
(Relationship): Improve regexes for follow-up fixes.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestRelationship.test_follow_up): Update relationship name.
(TestCommitsStory.test_follow_up): Ditto.
(TestTrace.test_revert_a):
(TestTrace.test_revert_b):
(TestTrace.test_revert): Renamed test_revert_a.
(TestTrace.test_follow_up_a):
(TestTrace.test_follow_up_b):
(TestTrace.test_follow_up_c):
(TestTrace.test_regression):
(TestTrace.test_gardening):

Canonical link: <a href="https://commits.webkit.org/255687@main">https://commits.webkit.org/255687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99fda9fd52b2bfa36c40132db8149c2909af7159

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2529 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/23979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/97334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2536 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/30839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/99000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/79789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/96910 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/23979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/23979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/92360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/35047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/23979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/38921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/79789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1835 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/40853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/23979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->