### PR TITLE
Support loading Web Extension URLs and load the background page or service worker.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -76,6 +76,12 @@
 /* The domain and application using the camera and/or microphone. The first argument is domain, the second is the application name (iOS only). */
 "%@ in %%@" = "%@ in %%@";
 
+/* Label for an inspectable Web Extension background page */
+"%@ — Extension Background Page" = "%@ — Extension Background Page";
+
+/* Label for an inspectable Web Extension service worker */
+"%@ — Extension Service Worker" = "%@ — Extension Service Worker";
+
 /* Label to describe the number of files selected in a file upload control that allows multiple files */
 "%d files" = "%d files";
 
@@ -204,6 +210,9 @@
 
 /* WKWebExtensionErrorUnknown description */
 "An unknown error has occurred." = "An unknown error has occurred.";
+
+/* WKWebExtensionContextErrorUnknown description */
+"An unknown error has occurred. (WKWebExtensionContext)" = "An unknown error has occurred.";
 
 /* WKErrorUnknown description */
 "An unknown error occurred" = "An unknown error occurred";

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -145,6 +145,9 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << iceCandidateFilteringEnabled;
     encoder << enumeratingAllNetworkInterfacesEnabled;
     encoder << userContentControllerParameters;
+#if ENABLE(WK_WEB_EXTENSIONS)
+    encoder << webExtensionControllerParameters;
+#endif
     encoder << backgroundColor;
     encoder << oldPageID;
     encoder << overriddenMediaType;
@@ -483,6 +486,14 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
     if (!userContentControllerParameters)
         return std::nullopt;
     parameters.userContentControllerParameters = WTFMove(*userContentControllerParameters);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    std::optional<std::optional<WebExtensionControllerParameters>> webExtensionControllerParameters;
+    decoder >> webExtensionControllerParameters;
+    if (!webExtensionControllerParameters)
+        return std::nullopt;
+    parameters.webExtensionControllerParameters = WTFMove(*webExtensionControllerParameters);
+#endif
 
     std::optional<std::optional<WebCore::Color>> backgroundColor;
     decoder >> backgroundColor;

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -57,6 +57,10 @@
 #include <WebCore/ApplicationManifest.h>
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionControllerParameters.h"
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -215,6 +219,10 @@ struct WebPageCreationParameters {
     bool enumeratingAllNetworkInterfacesEnabled { false };
 
     UserContentControllerParameters userContentControllerParameters;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    std::optional<WebExtensionControllerParameters> webExtensionControllerParameters;
+#endif
 
     std::optional<WebCore::Color> backgroundColor;
 

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -39,6 +39,10 @@
 #include "APIApplicationManifest.h"
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionController.h"
+#endif
+
 namespace API {
 using namespace WebKit;
 
@@ -59,6 +63,9 @@ Ref<PageConfiguration> PageConfiguration::copy() const
 
     copy->m_processPool = this->m_processPool;
     copy->m_userContentController = this->m_userContentController;
+#if ENABLE(WK_WEB_EXTENSIONS)
+    copy->m_webExtensionController = this->m_webExtensionController;
+#endif
     copy->m_pageGroup = this->m_pageGroup;
     copy->m_preferences = this->m_preferences;
     copy->m_relatedPage = this->m_relatedPage;
@@ -129,6 +136,18 @@ void PageConfiguration::setUserContentController(WebUserContentControllerProxy* 
 {
     m_userContentController = userContentController;
 }
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+WebExtensionController* PageConfiguration::webExtensionController()
+{
+    return m_webExtensionController.get();
+}
+
+void PageConfiguration::setWebExtensionController(WebExtensionController* webExtensionController)
+{
+    m_webExtensionController = webExtensionController;
+}
+#endif // ENABLE(WK_WEB_EXTENSIONS)
 
 WebPageGroup* PageConfiguration::pageGroup()
 {

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -49,6 +49,10 @@ class WebURLSchemeHandler;
 class WebUserContentControllerProxy;
 class WebsiteDataStore;
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+class WebExtensionController;
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 enum class AttributionOverrideTesting : uint8_t {
     NoOverride,
@@ -81,6 +85,11 @@ public:
 
     WebKit::WebUserContentControllerProxy* userContentController();
     void setUserContentController(WebKit::WebUserContentControllerProxy*);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    WebKit::WebExtensionController* webExtensionController();
+    void setWebExtensionController(WebKit::WebExtensionController*);
+#endif
 
     WebKit::WebPageGroup* pageGroup();
     void setPageGroup(WebKit::WebPageGroup*);
@@ -203,6 +212,9 @@ private:
 
     RefPtr<WebKit::WebProcessPool> m_processPool;
     RefPtr<WebKit::WebUserContentControllerProxy> m_userContentController;
+#if ENABLE(WK_WEB_EXTENSIONS)
+    RefPtr<WebKit::WebExtensionController> m_webExtensionController;
+#endif
     RefPtr<WebKit::WebPageGroup> m_pageGroup;
     RefPtr<WebKit::WebPreferences> m_preferences;
     RefPtr<WebKit::WebPageProxy> m_relatedPage;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -161,6 +161,10 @@
 #import "WKDataDetectorTypesInternal.h"
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#import "_WKWebExtensionControllerInternal.h"
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteScrollingCoordinatorProxy.h"
@@ -455,6 +459,11 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     pageConfiguration->setVisitedLinkStore([_configuration _visitedLinkStore]->_visitedLinkStore.get());
     pageConfiguration->setWebsiteDataStore([_configuration websiteDataStore]->_websiteDataStore.get());
     pageConfiguration->setDefaultWebsitePolicies([_configuration defaultWebpagePreferences]->_websitePolicies.get());
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (auto *controller = _configuration.get()._webExtensionControllerIfExists)
+        pageConfiguration->setWebExtensionController(&controller._webExtensionController);
+#endif
 
 #if PLATFORM(MAC)
     if (auto pageGroup = WebKit::toImpl([_configuration _pageGroup]))
@@ -1729,12 +1738,6 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 - (NakedPtr<WebKit::WebPageProxy>)_page
 {
     return _page.get();
-}
-
-- (id <WKURLSchemeHandler>)urlSchemeHandlerForURLScheme:(NSString *)urlScheme
-{
-    auto* handler = static_cast<WebKit::WebURLSchemeHandlerCocoa*>(_page->urlSchemeHandlerForScheme(urlScheme));
-    return handler ? handler->apiHandler() : nil;
 }
 
 - (std::optional<BOOL>)_resolutionForShareSheetImmediateCompletionForTesting

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @class WKWebView;
 @class _WKApplicationManifest;
 @class _WKVisitedLinkStore;
+@class _WKWebExtensionController;
 
 @interface WKWebViewConfiguration (WKPrivate)
 
@@ -58,6 +59,9 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, copy, setter=_setGroupIdentifier:) NSString *_groupIdentifier;
 
 @property (nonatomic, strong, setter=_setVisitedLinkStore:) _WKVisitedLinkStore *_visitedLinkStore;
+
+@property (nonatomic, readonly) _WKWebExtensionController *_webExtensionControllerIfExists;
+@property (nonatomic, strong, setter=_setWebExtensionController:) _WKWebExtensionController *_webExtensionController;
 
 @property (nonatomic, weak, setter=_setAlternateWebViewForNavigationGestures:) WKWebView *_alternateWebViewForNavigationGestures;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -42,6 +42,7 @@ typedef NS_ERROR_ENUM(_WKWebExtensionContextErrorDomain, _WKWebExtensionContextE
     _WKWebExtensionContextErrorUnknown = 1,
     _WKWebExtensionContextErrorAlreadyLoaded,
     _WKWebExtensionContextErrorNotLoaded,
+    _WKWebExtensionContextErrorBaseURLTaken,
 } NS_SWIFT_NAME(_WKWebExtensionContext.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 typedef NS_ENUM(NSInteger, _WKWebExtensionContextPermissionState) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -31,6 +31,7 @@
 #import "_WKWebExtensionContextInternal.h"
 
 #import "CocoaHelpers.h"
+#import "WKWebView.h"
 #import "WebExtension.h"
 #import "WebExtensionContext.h"
 #import "_WKWebExtensionControllerInternal.h"
@@ -38,6 +39,7 @@
 #import "_WKWebExtensionMatchPatternInternal.h"
 #import "_WKWebExtensionTab.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/URLParser.h>
 
 NSErrorDomain const _WKWebExtensionContextErrorDomain = @"_WKWebExtensionContextErrorDomain";
 
@@ -108,6 +110,9 @@ _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotifi
 - (void)setBaseURL:(NSURL *)baseURL
 {
     NSParameterAssert(baseURL);
+    NSAssert1(WTF::URLParser::maybeCanonicalizeScheme(String(baseURL.scheme)), @"Invalid parameter: '%@' is not a valid URL scheme", baseURL.scheme);
+    NSAssert1(![WKWebView handlesURLScheme:baseURL.scheme], @"Invalid parameter: '%@' is a URL scheme that WKWebView handles natively and cannot be used for extensions", baseURL.scheme);
+    NSAssert(!baseURL.path.length || [baseURL.path isEqualToString:@"/"], @"Invalid parameter: a URL with a path cannot be used");
 
     _webExtensionContext->setBaseURL(baseURL);
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -95,7 +95,7 @@
 - (_WKWebExtensionContext *)extensionContextForExtension:(_WKWebExtension *)extension
 {
     if (auto extensionContext = _webExtensionController->extensionContext(extension._webExtension))
-        return extensionContext.value()->wrapper();
+        return extensionContext->wrapper();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -32,13 +32,82 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "WKNavigationActionPrivate.h"
+#import "WKNavigationDelegatePrivate.h"
+#import "WKPreferencesPrivate.h"
+#import "WKUIDelegatePrivate.h"
+#import "WKWebViewConfigurationInternal.h"
+#import "WKWebViewInternal.h"
+#import "WebExtensionURLSchemeHandler.h"
+#import "WebPageProxy.h"
 #import "_WKWebExtensionContextInternal.h"
 #import "_WKWebExtensionPermission.h"
 #import "_WKWebExtensionTab.h"
 #import <WebCore/LocalizedStrings.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/URLParser.h>
 
 // This number was chosen arbitrarily based on testing with some popular extensions.
 static constexpr size_t maximumCachedPermissionResults = 256;
+
+@interface _WKWebExtensionContextDelegate : NSObject <WKNavigationDelegate, WKUIDelegate> {
+    WeakPtr<WebKit::WebExtensionContext> _webExtensionContext;
+}
+
+- (instancetype)initWithWebExtensionContext:(WebKit::WebExtensionContext&)context;
+
+@end
+
+@implementation _WKWebExtensionContextDelegate
+
+- (instancetype)initWithWebExtensionContext:(WebKit::WebExtensionContext&)context
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _webExtensionContext = context;
+
+    return self;
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+{
+    if (!_webExtensionContext)
+        return;
+
+    if (_webExtensionContext->decidePolicyForNavigationAction(webView, navigationAction)) {
+        decisionHandler(WKNavigationActionPolicyAllow);
+        return;
+    }
+
+    decisionHandler(WKNavigationActionPolicyCancel);
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
+{
+    if (!_webExtensionContext)
+        return;
+
+    _webExtensionContext->didFinishNavigation(webView, navigation);
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
+{
+    if (!_webExtensionContext)
+        return;
+
+    _webExtensionContext->didFailNavigation(webView, navigation, error);
+}
+
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
+{
+    if (!_webExtensionContext)
+        return;
+
+    _webExtensionContext->webViewWebContentProcessDidTerminate(webView);
+}
+
+@end
 
 namespace WebKit {
 
@@ -51,27 +120,44 @@ WebExtensionContext::WebExtensionContext(Ref<WebExtension>&& extension)
     baseURLBuilder.append("webkit-extension://", uniqueIdentifier(), "/");
 
     m_baseURL = URL { baseURLBuilder.toString() };
+
+    m_delegate = [[_WKWebExtensionContextDelegate alloc] initWithWebExtensionContext:*this];
+}
+
+static _WKWebExtensionContextError toAPI(WebExtensionContext::Error error)
+{
+    switch (error) {
+    case WebExtensionContext::Error::Unknown:
+        return _WKWebExtensionContextErrorUnknown;
+    case WebExtensionContext::Error::AlreadyLoaded:
+        return _WKWebExtensionContextErrorAlreadyLoaded;
+    case WebExtensionContext::Error::NotLoaded:
+        return _WKWebExtensionContextErrorNotLoaded;
+    case WebExtensionContext::Error::BaseURLTaken:
+        return _WKWebExtensionContextErrorBaseURLTaken;
+    }
 }
 
 NSError *WebExtensionContext::createError(Error error, NSString *customLocalizedDescription, NSError *underlyingError)
 {
-    _WKWebExtensionContextError errorCode;
+    auto errorCode = toAPI(error);
     NSString *localizedDescription;
 
     switch (error) {
     case Error::Unknown:
-        errorCode = _WKWebExtensionContextErrorUnknown;
-        localizedDescription = WEB_UI_STRING("An unknown error has occurred.", "WKWebExtensionContextErrorUnknown description");
+        localizedDescription = WEB_UI_STRING_KEY("An unknown error has occurred.", "An unknown error has occurred. (WKWebExtensionContext)", "WKWebExtensionContextErrorUnknown description");
         break;
 
     case Error::AlreadyLoaded:
-        errorCode = _WKWebExtensionContextErrorAlreadyLoaded;
         localizedDescription = WEB_UI_STRING("Extension context is already loaded.", "WKWebExtensionContextErrorAlreadyLoaded description");
         break;
 
     case Error::NotLoaded:
-        errorCode = _WKWebExtensionContextErrorNotLoaded;
         localizedDescription = WEB_UI_STRING("Extension context is not loaded.", "WKWebExtensionContextErrorNotLoaded description");
+        break;
+
+    case Error::BaseURLTaken:
+        localizedDescription = WEB_UI_STRING("Another extension context is loaded with the same base URL.", "WKWebExtensionContextErrorBaseURLTaken description");
         break;
     }
 
@@ -98,7 +184,9 @@ bool WebExtensionContext::load(WebExtensionController& controller, NSError **out
 
     m_extensionController = controller;
 
-    // FIXME: Load background page, inject content, etc.
+    loadBackgroundWebViewDuringLoad();
+
+    // FIXME: <https://webkit.org/b/246486> Inject content, move local storage (if base URL changed), etc.
 
     return true;
 }
@@ -116,7 +204,9 @@ bool WebExtensionContext::unload(NSError **outError)
 
     m_extensionController = nil;
 
-    // FIXME: Unload background page, remove injected content, etc.
+    unloadBackgroundWebView();
+
+    // FIXME: <https://webkit.org/b/246486> Remove injected content, etc.
 
     return true;
 }
@@ -130,8 +220,13 @@ void WebExtensionContext::setBaseURL(URL&& url)
     if (!url.isValid())
         return;
 
+    auto canonicalScheme = WTF::URLParser::maybeCanonicalizeScheme(url.protocol());
+    ASSERT(canonicalScheme);
+    if (!canonicalScheme)
+        return;
+
     StringBuilder baseURLBuilder;
-    baseURLBuilder.append(url.protocol(), "://", url.host(), "/");
+    baseURLBuilder.append(canonicalScheme.value(), "://", url.host(), "/");
 
     m_baseURL = URL { baseURLBuilder.toString() };
 }
@@ -288,9 +383,9 @@ void WebExtensionContext::postAsyncNotification(NSNotificationName notificationN
     if (permissions.isEmpty())
         return;
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&, protectedThis = Ref { *this }]() {
         [NSNotificationCenter.defaultCenter postNotificationName:notificationName object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyPermissions: toAPI(permissions) }];
-    });
+    }).get());
 }
 
 void WebExtensionContext::postAsyncNotification(NSNotificationName notificationName, MatchPatternSet& matchPatterns)
@@ -298,9 +393,9 @@ void WebExtensionContext::postAsyncNotification(NSNotificationName notificationN
     if (matchPatterns.isEmpty())
         return;
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&, protectedThis = Ref { *this }]() {
         [NSNotificationCenter.defaultCenter postNotificationName:notificationName object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns: toAPI(matchPatterns) }];
-    });
+    }).get());
 }
 
 void WebExtensionContext::grantPermissions(PermissionsSet&& permissions, WallTime expirationDate)
@@ -887,6 +982,141 @@ void WebExtensionContext::cancelUserGesture(_WKWebExtensionTab *tab)
         return;
 
     [m_temporaryTabPermissionMatchPatterns removeObjectForKey:tab];
+}
+
+WKWebViewConfiguration *WebExtensionContext::webViewConfiguration()
+{
+    ASSERT(isLoaded());
+
+    WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
+
+    configuration._webExtensionController = m_extensionController->wrapper();
+    configuration._processDisplayName = extension().webProcessDisplayName();
+
+    WKPreferences *preferences = configuration.preferences;
+#if PLATFORM(MAC)
+    preferences._domTimersThrottlingEnabled = NO;
+#endif
+    preferences._pageVisibilityBasedProcessSuppressionEnabled = NO;
+
+    // FIXME: Configure other extension web view configuration properties.
+
+    return configuration;
+}
+
+URL WebExtensionContext::backgroundContentURL()
+{
+    ASSERT(extension().hasBackgroundContent());
+    return URL { m_baseURL, extension().backgroundContentPath() };
+}
+
+void WebExtensionContext::loadBackgroundWebViewDuringLoad()
+{
+    ASSERT(isLoaded());
+
+    if (!extension().hasBackgroundContent())
+        return;
+
+    // FIXME: <https://webkit.org/b/246483> Handle non-persistent background pages differently here.
+    loadBackgroundWebView();
+}
+
+void WebExtensionContext::loadBackgroundWebView()
+{
+    ASSERT(isLoaded());
+
+    if (!extension().hasBackgroundContent())
+        return;
+
+    ASSERT(!m_backgroundWebView);
+    m_backgroundWebView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:webViewConfiguration()];
+
+    m_backgroundWebView.get().UIDelegate = m_delegate.get();
+    m_backgroundWebView.get().navigationDelegate = m_delegate.get();
+
+    if (extension().backgroundContentIsServiceWorker())
+        m_backgroundWebView.get()._remoteInspectionNameOverride = WEB_UI_FORMAT_CFSTRING("%@ — Extension Service Worker", "Label for an inspectable Web Extension service worker", (__bridge CFStringRef)extension().displayShortName());
+    else
+        m_backgroundWebView.get()._remoteInspectionNameOverride = WEB_UI_FORMAT_CFSTRING("%@ — Extension Background Page", "Label for an inspectable Web Extension background page", (__bridge CFStringRef)extension().displayShortName());
+
+    extension().removeError(WebExtension::Error::BackgroundContentFailedToLoad);
+
+    if (!extension().backgroundContentIsServiceWorker()) {
+        [m_backgroundWebView loadRequest:[NSURLRequest requestWithURL:backgroundContentURL()]];
+        return;
+    }
+
+    [m_backgroundWebView _loadServiceWorker:backgroundContentURL() completionHandler:makeBlockPtr([&, protectedThis = Ref { *this }](BOOL success) {
+        if (!success) {
+            extension().recordError(extension().createError(WebExtension::Error::BackgroundContentFailedToLoad), WebExtension::SuppressNotification::No);
+            return;
+        }
+
+        performTasksAfterBackgroundContentLoads();
+    }).get()];
+}
+
+void WebExtensionContext::unloadBackgroundWebView()
+{
+    if (!m_backgroundWebView)
+        return;
+
+    // FIXME: <https://webkit.org/b/246484> Disconnect message ports for the background web view.
+
+    [m_backgroundWebView _close];
+    m_backgroundWebView = nil;
+}
+
+void WebExtensionContext::performTasksAfterBackgroundContentLoads()
+{
+    // FIXME: <https://webkit.org/b/246483> Implement. Fire setup and install events (if needed), perform pending actions, schedule non-persistent page to unload (if needed), etc.
+}
+
+bool WebExtensionContext::decidePolicyForNavigationAction(WKWebView *webView, WKNavigationAction *navigationAction)
+{
+    // FIXME: <https://webkit.org/b/246485> Handle inspector background pages in the assert.
+    ASSERT(webView == m_backgroundWebView);
+
+    NSURL *url = navigationAction.request.URL;
+    if (!navigationAction.targetFrame.isMainFrame || isURLForThisExtension(url))
+        return true;
+
+    return false;
+}
+
+void WebExtensionContext::didFinishNavigation(WKWebView *webView, WKNavigation *)
+{
+    if (webView != m_backgroundWebView)
+        return;
+
+    // When didFinishNavigation fires for a service worker, the service worker has not executed yet.
+    // The service worker will notify the load via a completion handler instead.
+    if (extension().backgroundContentIsServiceWorker())
+        return;
+
+    performTasksAfterBackgroundContentLoads();
+}
+
+void WebExtensionContext::didFailNavigation(WKWebView *webView, WKNavigation *, NSError *error)
+{
+    if (webView != m_backgroundWebView)
+        return;
+
+    extension().recordError(extension().createError(WebExtension::Error::BackgroundContentFailedToLoad, nil, error), WebExtension::SuppressNotification::No);
+}
+
+void WebExtensionContext::webViewWebContentProcessDidTerminate(WKWebView *webView)
+{
+    // FIXME: <https://webkit.org/b/246484> Disconnect message ports for the crashed web view.
+
+    if (webView == m_backgroundWebView) {
+        loadBackgroundWebView();
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/246485> Handle inspector background pages too.
+
+    ASSERT_NOT_REACHED();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionURLSchemeHandler.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "APIFrameInfo.h"
+#import "WKURLSchemeTaskInternal.h"
+#import "WebExtension.h"
+#import "WebExtensionContext.h"
+#import "WebExtensionController.h"
+#import "WebURLSchemeTask.h"
+#import <UniformTypeIdentifiers/UTType.h>
+#import <wtf/BlockPtr.h>
+
+namespace WebKit {
+
+class WebPageProxy;
+
+constexpr NSInteger noPermissionErrorCode = NSURLErrorNoPermissionsToReadFile;
+
+WebExtensionURLSchemeHandler::WebExtensionURLSchemeHandler(WebExtensionController& controller)
+    : m_webExtensionController(controller)
+{
+}
+
+void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLSchemeTask& task)
+{
+    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([&, protectedThis = Ref { *this }]() {
+        // If a frame is loading, the frame request URL will be an empty string, since the request is actually the frame URL being loaded.
+        // In this case, consider the firstPartyForCookies() to be the document including the frame. This fails for nested frames, since
+        // it is always the main frame URL, not the immediate parent frame.
+        // FIXME: <rdar://problem/59193765> Remove this workaround when there is a way to know the proper parent frame.
+        URL frameDocumentURL = task.frameInfo().request().url().isEmpty() ? task.request().firstPartyForCookies() : task.frameInfo().request().url();
+        URL requestURL = task.request().url();
+
+        auto extensionContext = m_webExtensionController->extensionContext(requestURL);
+        if (!extensionContext) {
+            // We need to return the same error here, as we do below for URLs that don't match web_accessible_resources.
+            // Otherwise, a page tracking extension injected content and watching extension UUIDs across page loads can fingerprint
+            // the user and know the same set of extensions are installed and enabled for this user and that website.
+            task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:noPermissionErrorCode userInfo:nil]);
+            return;
+        }
+
+        // FIXME: <https://webkit.org/b/246485> Support devtools' exception to web accessible resources.
+
+        if (!protocolHostAndPortAreEqual(frameDocumentURL, requestURL)) {
+            if (!extensionContext->extension().isAccessibleResourcePath(requestURL.path().toString(), frameDocumentURL)) {
+                task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:noPermissionErrorCode userInfo:nil]);
+                return;
+            }
+        }
+
+        NSData *fileData = extensionContext->extension().resourceDataForPath(requestURL.path().toString());
+        if (!fileData) {
+            task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil]);
+            return;
+        }
+
+        NSString *mimeType = [UTType typeWithFilenameExtension:((NSURL *)requestURL).pathExtension].preferredMIMEType;
+        if (!mimeType)
+            mimeType = @"application/octet-stream";
+
+        // FIXME: <https://webkit.org/b/246488> Support localization of CSS files.
+
+        // FIXME: <https://webkit.org/b/246490> Include the Content-Security-Policy header for the extension.
+        NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:requestURL statusCode:200 HTTPVersion:nil headerFields:@{
+            @"Access-Control-Allow-Origin": @"*",
+            @"Content-Length": [NSString stringWithFormat:@"%zu", (size_t)fileData.length],
+            @"Content-Type": mimeType
+        }];
+
+        task.didReceiveResponse(urlResponse);
+        task.didReceiveData(WebCore::SharedBuffer::create(fileData));
+        task.didComplete({ });
+    }).get()];
+
+    m_operations.set(task, operation);
+
+    [NSOperationQueue.mainQueue addOperation:operation];
+}
+
+void WebExtensionURLSchemeHandler::platformStopTask(WebPageProxy& page, WebURLSchemeTask& task)
+{
+    auto operation = m_operations.take(task);
+    [operation cancel];
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -154,6 +154,8 @@ public:
     bool validateResourceData(NSURL *, NSData *, NSError **);
 #endif
 
+    bool isAccessibleResourcePath(NSString *, NSURL *frameDocumentURL);
+
     NSURL *resourceFileURLForPath(NSString *);
     NSData *resourceDataForPath(NSString *, CacheResult = CacheResult::No);
 
@@ -181,6 +183,7 @@ public:
     bool backgroundContentIsPersistent();
     bool backgroundContentIsServiceWorker();
 
+    NSString *backgroundContentPath();
     NSString *generatedBackgroundContent();
 
     const InjectedContentVector& injectedContents();
@@ -206,6 +209,7 @@ public:
     // If an error can't be synchronously determined by one of the populate methods in the errors() getter,
     // then the caller of recordError() should pass SuppressNotification::No.
     void recordError(NSError *, SuppressNotification = SuppressNotification::Yes);
+    void removeError(Error, SuppressNotification = SuppressNotification::No);
 
     NSArray *errors();
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -49,7 +49,12 @@ OBJC_CLASS NSMapTable;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
 OBJC_CLASS NSUUID;
+OBJC_CLASS WKNavigation;
+OBJC_CLASS WKNavigationAction;
+OBJC_CLASS WKWebView;
+OBJC_CLASS WKWebViewConfiguration;
 OBJC_CLASS _WKWebExtensionContext;
+OBJC_CLASS _WKWebExtensionContextDelegate;
 OBJC_PROTOCOL(_WKWebExtensionTab);
 #endif
 
@@ -87,6 +92,7 @@ public:
         Unknown = 1,
         AlreadyLoaded,
         NotLoaded,
+        BaseURLTaken,
     };
 
     enum class PermissionState : int8_t {
@@ -177,6 +183,11 @@ public:
     bool hasActiveUserGesture(_WKWebExtensionTab *) const;
     void cancelUserGesture(_WKWebExtensionTab *);
 
+    bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);
+    void didFinishNavigation(WKWebView *, WKNavigation *);
+    void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
+    void webViewWebContentProcessDidTerminate(WKWebView *);
+
     _WKWebExtensionContext *wrapper() const { return (_WKWebExtensionContext *)API::ObjectImpl<API::Object::Type::WebExtensionContext>::wrapper(); }
 #endif
 
@@ -192,6 +203,16 @@ private:
 
     PermissionsMap& removeExpired(PermissionsMap&, NSString *notificationName = nil);
     PermissionMatchPatternsMap& removeExpired(PermissionMatchPatternsMap&, NSString *notificationName = nil);
+
+    WKWebViewConfiguration *webViewConfiguration();
+
+    URL backgroundContentURL();
+
+    void loadBackgroundWebViewDuringLoad();
+    void loadBackgroundWebView();
+    void unloadBackgroundWebView();
+
+    void performTasksAfterBackgroundContentLoads();
 #endif
 
     // IPC::MessageReceiver.
@@ -218,6 +239,9 @@ private:
     RetainPtr<NSMapTable> m_temporaryTabPermissionMatchPatterns;
 
     bool m_requestedOptionalAccessToAllHosts = false;
+
+    RetainPtr<WKWebView> m_backgroundWebView;
+    RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,31 +25,36 @@
 
 #pragma once
 
-#include "WebURLSchemeHandler.h"
-#include <wtf/RetainPtr.h>
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-@protocol WKURLSchemeHandler;
+#include "WebURLSchemeHandler.h"
+#include <wtf/Forward.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
+
+OBJC_CLASS NSBlockOperation;
 
 namespace WebKit {
 
-class WebURLSchemeTask;
+class WebExtensionController;
 
-class WebURLSchemeHandlerCocoa : public WebURLSchemeHandler {
+class WebExtensionURLSchemeHandler : public WebURLSchemeHandler {
 public:
-    static Ref<WebURLSchemeHandlerCocoa> create(id <WKURLSchemeHandler>);
-
-    id <WKURLSchemeHandler> apiHandler() const { return m_apiHandler.get(); }
-
-    bool isAPIHandler() final { return true; }
+    static Ref<WebExtensionURLSchemeHandler> create(WebExtensionController& controller)
+    {
+        return adoptRef(*new WebExtensionURLSchemeHandler(controller));
+    }
 
 private:
-    WebURLSchemeHandlerCocoa(id <WKURLSchemeHandler>);
+    WebExtensionURLSchemeHandler(WebExtensionController&);
 
     void platformStartTask(WebPageProxy&, WebURLSchemeTask&) final;
     void platformStopTask(WebPageProxy&, WebURLSchemeTask&) final;
 
-    RetainPtr<id <WKURLSchemeHandler>> m_apiHandler;
-
-}; // class WebURLSchemeHandler
+    WeakPtr<WebExtensionController> m_webExtensionController;
+    HashMap<Ref<WebURLSchemeTask>, RetainPtr<NSBlockOperation>> m_operations;
+}; // class WebExtensionURLSchemeHandler
 
 } // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -325,6 +325,10 @@
 #include <WebCore/PreviewConverter.h>
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionController.h"
+#endif
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_COMPLETION(process, assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, process->connection(), completion)
@@ -487,6 +491,9 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     , m_pageGroup(*m_configuration->pageGroup())
     , m_preferences(*m_configuration->preferences())
     , m_userContentController(*m_configuration->userContentController())
+#if ENABLE(WK_WEB_EXTENSIONS)
+    , m_webExtensionController(m_configuration->webExtensionController())
+#endif
     , m_visitedLinkStore(*m_configuration->visitedLinkStore())
     , m_websiteDataStore(*m_configuration->websiteDataStore())
     , m_userAgent(standardUserAgent())
@@ -551,6 +558,11 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 
     m_preferences->addPage(*this);
     m_pageGroup->addPage(*this);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (m_webExtensionController)
+        m_webExtensionController->addPage(*this);
+#endif
 
     m_inspector = WebInspectorUIProxy::create(*this);
 
@@ -1202,6 +1214,11 @@ void WebPageProxy::close()
         if (auto* automationSession = process().processPool().automationSession())
             automationSession->willClosePage(*this);
     }
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (m_webExtensionController)
+        m_webExtensionController->removePage(*this);
+#endif
 
 #if ENABLE(CONTEXT_MENUS)
     m_activeContextMenu = nullptr;
@@ -8699,6 +8716,11 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
         userContentController = *userContentControllerFromWebsitePolicies;
     process.addWebUserContentControllerProxy(userContentController);
     parameters.userContentControllerParameters = userContentController.get().parameters();
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (m_webExtensionController)
+        parameters.webExtensionControllerParameters = m_webExtensionController->parameters();
+#endif
 
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
     parameters.shouldCaptureAudioInUIProcess = preferences().captureAudioInUIProcessEnabled();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -390,6 +390,10 @@ class WebWheelEvent;
 class WebWheelEventCoalescer;
 class WebsiteDataStore;
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+class WebExtensionController;
+#endif
+
 struct AppPrivacyReportTestingData;
 struct DataDetectionResult;
 struct DocumentEditingContext;
@@ -2765,6 +2769,11 @@ private:
     Ref<WebPreferences> m_preferences;
 
     Ref<WebUserContentControllerProxy> m_userContentController;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    RefPtr<WebExtensionController> m_webExtensionController;
+#endif
+
     Ref<VisitedLinkStore> m_visitedLinkStore;
     Ref<WebsiteDataStore> m_websiteDataStore;
 

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.h
@@ -57,6 +57,8 @@ public:
     void stopAllTasksForPage(WebPageProxy&, WebProcessProxy*);
     void taskCompleted(WebPageProxyIdentifier, WebURLSchemeTask&);
 
+    virtual bool isAPIHandler() { return false; }
+
 protected:
     WebURLSchemeHandler();
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -436,6 +436,8 @@
 		1C8E2A361277852400BC7BD0 /* WebInspectorMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C8E2A321277852400BC7BD0 /* WebInspectorMessages.h */; };
 		1CA8B945127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CA8B943127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp */; };
 		1CA8B946127C882A00576C2B /* WebInspectorUIProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CA8B944127C882A00576C2B /* WebInspectorUIProxyMessages.h */; };
+		1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1CAB9B8728F746AA00E6C77E /* WebExtensionURLSchemeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */; };
 		1CAECB6527465AE400AB78D0 /* UnifiedSource109.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB5D27465AE300AB78D0 /* UnifiedSource109.cpp */; };
 		1CAECB6627465AE400AB78D0 /* UnifiedSource111.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB5E27465AE300AB78D0 /* UnifiedSource111.cpp */; };
 		1CAECB6727465AE400AB78D0 /* UnifiedSource108.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CAECB5F27465AE300AB78D0 /* UnifiedSource108.cpp */; };
@@ -3743,6 +3745,8 @@
 		1CA8B935127C774E00576C2B /* WebInspectorUIProxyMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebInspectorUIProxyMac.mm; sourceTree = "<group>"; };
 		1CA8B943127C882A00576C2B /* WebInspectorUIProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebInspectorUIProxyMessageReceiver.cpp; path = DerivedSources/WebKit/WebInspectorUIProxyMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CA8B944127C882A00576C2B /* WebInspectorUIProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebInspectorUIProxyMessages.h; path = DerivedSources/WebKit/WebInspectorUIProxyMessages.h; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionURLSchemeHandler.h; sourceTree = "<group>"; };
+		1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionURLSchemeHandlerCocoa.mm; sourceTree = "<group>"; };
 		1CAECB5D27465AE300AB78D0 /* UnifiedSource109.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource109.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource109.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CAECB5E27465AE300AB78D0 /* UnifiedSource111.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource111.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource111.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CAECB5F27465AE300AB78D0 /* UnifiedSource108.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource108.cpp; path = "DerivedSources/WebKit/unified-sources/UnifiedSource108.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -8645,6 +8649,7 @@
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
+				1CAB9B8528F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm */,
 			);
 			path = Cocoa;
 			sourceTree = "<group>";
@@ -8950,6 +8955,7 @@
 				1CC23B1C288732A800D0A65A /* WebExtensionController.h */,
 				1CC23B1B288732A800D0A65A /* WebExtensionController.messages.in */,
 				1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */,
+				1CAB9B8428F7427F00E6C77E /* WebExtensionURLSchemeHandler.h */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -15178,6 +15184,7 @@
 				1C3BEB7D2888A01600E66E38 /* WebExtensionControllerProxy.h in Headers */,
 				1C3BEB512887492F00E66E38 /* WebExtensionControllerProxyMessages.h in Headers */,
 				1C3BEB542887492F00E66E38 /* WebExtensionControllerProxyMessagesReplies.h in Headers */,
+				1CAB9B8728F746AA00E6C77E /* WebExtensionURLSchemeHandler.h in Headers */,
 				DDA0A35D27E55E4F005E086E /* WebFeature.h in Headers */,
 				9354242C2703BDCB005CA72C /* WebFileSystemStorageConnection.h in Headers */,
 				93E799882756FAC20074008A /* WebFileSystemStorageConnectionMessages.h in Headers */,
@@ -17745,6 +17752,7 @@
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,
+				1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */,
 				93E799852756FA550074008A /* WebFileSystemStorageConnectionMessageReceiver.cpp in Sources */,
 				CD73BA4E131ACDB700EEDED2 /* WebFullScreenManagerMessageReceiver.cpp in Sources */,
 				CD73BA47131ACC9A00EEDED2 /* WebFullScreenManagerProxyMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -662,6 +662,11 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.deviceOrientationUpdateProvider = WebDeviceOrientationUpdateProvider::create(*this);
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (parameters.webExtensionControllerParameters)
+        m_webExtensionController = WebExtensionControllerProxy::getOrCreate(parameters.webExtensionControllerParameters.value().identifier);
+#endif
+
     m_corsDisablingPatterns = WTFMove(parameters.corsDisablingPatterns);
     if (!m_corsDisablingPatterns.isEmpty())
         synchronizeCORSDisablingPatternsWithNetworkProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -156,6 +156,10 @@
 #include "PlatformXRSystemProxy.h"
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#include "WebExtensionControllerProxy.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include <WebCore/VisibleSelection.h>
 #include <wtf/RetainPtr.h>
@@ -2213,6 +2217,11 @@ private:
     RefPtr<NotificationPermissionRequestManager> m_notificationPermissionRequestManager;
 
     Ref<WebUserContentController> m_userContentController;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    RefPtr<WebExtensionControllerProxy> m_webExtensionController;
+#endif
+
     UniqueRef<WebScreenOrientationManager> m_screenOrientationManager;
 
 #if ENABLE(GEOLOCATION)


### PR DESCRIPTION
#### 62160da965fce1b9c4054c0f212660ccfb05726e
<pre>
Support loading Web Extension URLs and load the background page or service worker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246409">https://bugs.webkit.org/show_bug.cgi?id=246409</a>

Reviewed by Brian Weinstein.

This also adds _WKWebExtensionController to WKWebViewConfiguration and propagate through to WebPage.

* Source/WebCore/en.lproj/Localizable.strings: Updated with update-webkit-localizable-strings.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView urlSchemeHandlerForURLScheme:]): Deleted. Dead code, not used or exposed in any header.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration urlSchemeHandlerForURLScheme:]): Only return API handlers.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext setBaseURL:]): Added more assertions.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController extensionContextForExtension:]): Added baseURL version.
* Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::isAccessibleResourcePath): Added with FIXME.
(WebKit::WebExtension::resourceDataForPath): Remove &quot;/&quot; prefix.
(WebKit::toAPI): Added.
(WebKit::WebExtension::createError): Use toAPI.
(WebKit::WebExtension::removeError): Added.
(WebKit::WebExtension::recordError): Dispatch notifications async to avoid reentrancy.
(WebKit::WebExtension::backgroundContentPath): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(-[_WKWebExtensionContextDelegate initWithWebExtensionContext:]): Added.
(-[_WKWebExtensionContextDelegate webView:decidePolicyForNavigationAction:decisionHandler:]): Added.
(-[_WKWebExtensionContextDelegate webView:didFinishNavigation:]): Added.
(-[_WKWebExtensionContextDelegate webView:didFailNavigation:withError:]): Added.
(-[_WKWebExtensionContextDelegate webViewWebContentProcessDidTerminate:]): Added.
(WebKit::WebExtensionContext::WebExtensionContext): Create m_delegate.
(WebKit::toAPI): Added.
(WebKit::WebExtensionContext::createError): Use toAPI and added BaseURLTaken case.
(WebKit::WebExtensionContext::load): Call loadBackgroundWebViewDuringLoad.
(WebKit::WebExtensionContext::unload): Call unloadBackgroundWebView.
(WebKit::WebExtensionContext::setBaseURL): Canonicalize URL scheme.
(WebKit::WebExtensionContext::postAsyncNotification): Use makeBlockPtr to be safe in C++.
(WebKit::WebExtensionContext::webViewConfiguration): Added.
(WebKit::WebExtensionContext::backgroundContentURL): Added.
(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad): Added.
(WebKit::WebExtensionContext::loadBackgroundWebView): Added.
(WebKit::WebExtensionContext::unloadBackgroundWebView): Added.
(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads): Added.
(WebKit::WebExtensionContext::decidePolicyForNavigationAction): Added.
(WebKit::WebExtensionContext::didFinishNavigation): Added.
(WebKit::WebExtensionContext::didFailNavigation): Added.
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load): Added scheme handling more more error reporting.
(WebKit::WebExtensionController::unload): Update the baseURL map.
(WebKit::WebExtensionController::addPage): Added. Register the scheme handlers.
(WebKit::WebExtensionController::removePage): Added.
(WebKit::WebExtensionController::extensionContext const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm: Added.
(WebKit::WebExtensionURLSchemeHandler::WebExtensionURLSchemeHandler):
(WebKit::WebExtensionURLSchemeHandler::platformStartTask):
(WebKit::WebExtensionURLSchemeHandler::platformStopTask):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::wrapper const):
* Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::WebPageProxy): Call addPage on the WebExtensionController.
(WebKit::WebPageProxy::close): Call removePage on the WebExtensionController.
* Source/WebKit/UIProcess/WebURLSchemeHandler.h:
(WebKit::WebURLSchemeHandler::isAPIHandler): Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added new files.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundPageLoading)): Added.
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const): Encode WebExtensionControllerParameters.
(WebKit::WebPageCreationParameters::decode): Decode WebExtensionControllerParameters.
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::copy const): Copy _webExtensionController.
(API::PageConfiguration::webExtensionController): Added.
(API::PageConfiguration::setWebExtensionController): Added.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setupPageConfiguration:]): Copy _webExtensionController.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration encodeWithCoder:]): Encode _webExtensionController.
(-[WKWebViewConfiguration initWithCoder:]): Decode _webExtensionController.
(-[WKWebViewConfiguration copyWithZone:]): Copy _webExtensionController.
(-[WKWebViewConfiguration _webExtensionController]): Added.
(-[WKWebViewConfiguration _setWebExtensionController:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
Added _webExtensionController property.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::WebPageProxy): Set m_webExtensionController.
(WebKit::WebPageProxy::creationParameters): Set webExtensionControllerParameters.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/255568@main">https://commits.webkit.org/255568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/731fb857cb0c581e1361d4064d51802ff2a50a25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92933 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102651 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2145 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30473 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85323 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98599 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79411 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28391 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36873 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34678 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37378 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->