### PR TITLE
Have WKUIDelegate._webViewLockScreenOrientation return a boolean

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -265,7 +265,7 @@ struct UIEdgeInsets;
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDropSession:(id <UIDropSession>)session WK_API_AVAILABLE(ios(11.0));
 - (NSInteger)_webView:(WKWebView *)webView dataOwnerForDragSession:(id <UIDragSession>)session WK_API_AVAILABLE(ios(11.0));
 
-- (void)_webViewLockScreenOrientation:(WKWebView *)webView lockType:(_WKScreenOrientationType)lockType WK_API_AVAILABLE(ios(WK_IOS_TBA));
+- (BOOL)_webViewLockScreenOrientation:(WKWebView *)webView lockType:(_WKScreenOrientationType)lockType WK_API_AVAILABLE(ios(WK_IOS_TBA));
 - (void)_webViewUnlockScreenOrientation:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -612,8 +612,7 @@ bool UIDelegate::UIClient::lockScreenOrientation(WebPageProxy&, WebCore::ScreenO
     if (!delegate)
         return false;
 
-    [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:m_uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationType(orientation)];
-    return true;
+    return [(id<WKUIDelegatePrivate>)delegate _webViewLockScreenOrientation:m_uiDelegate->m_webView.get().get() lockType:toWKScreenOrientationType(orientation)];
 #else
     UNUSED_PARAM(orientation);
     return false;


### PR DESCRIPTION
#### 5ec7c256f77fab5a7dcf7a4ca4531d7c61ab0751
<pre>
Have WKUIDelegate._webViewLockScreenOrientation return a boolean
<a href="https://bugs.webkit.org/show_bug.cgi?id=246545">https://bugs.webkit.org/show_bug.cgi?id=246545</a>

Reviewed by Geoffrey Garen.

Have WKUIDelegate._webViewLockScreenOrientation return a boolean so the client
application can communicate if it was help to lock the orientation or not.

* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::lockScreenOrientation):

Canonical link: <a href="https://commits.webkit.org/255588@main">https://commits.webkit.org/255588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a75c4e6d87d248ee902a3e0b8854bac61587770e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102652 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2146 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30474 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98779 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1470 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79412 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28380 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83383 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71499 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36874 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18191 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40795 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1784 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37371 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->