### PR TITLE
Fix unqualified calls to std::move in PlayStation MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/playstation/MainWindow.cpp
+++ b/Tools/MiniBrowser/playstation/MainWindow.cpp
@@ -148,7 +148,7 @@ WebViewWindow* MainWindow::createNewWebView(WKPageConfigurationRef configuration
     webViewWindow->fill(WHITE);
 
     WebViewWindow* rawWebViewWindow = webViewWindow.get();
-    m_webviewFrame->appendChild(move(webViewWindow));
+    m_webviewFrame->appendChild(std::move(webViewWindow));
 
     // Acrivate the new window.
     rawWebViewWindow->setActive(true);

--- a/Tools/MiniBrowser/playstation/ToolkittenUtils.h
+++ b/Tools/MiniBrowser/playstation/ToolkittenUtils.h
@@ -74,6 +74,6 @@ WidgetT* createAndAppendChild(toolkitten::Widget* parent, const toolkitten::IntS
     WidgetT* ptr = widget.get();
     ptr->setSize(size);
     ptr->setPosition(position);
-    parent->appendChild(move(widget));
+    parent->appendChild(std::move(widget));
     return ptr;
 }

--- a/Tools/MiniBrowser/playstation/main.cpp
+++ b/Tools/MiniBrowser/playstation/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 
     auto mainWindow = std::make_unique<MainWindow>(argc > 1 ? argv[1] : nullptr);
     mainWindow->setFocused();
-    app.setRootWidget(move(mainWindow));
+    app.setRootWidget(std::move(mainWindow));
 
     // Request the first frame to start the application loop.
     applicationClient.requestNextFrame();


### PR DESCRIPTION
#### 4fd600202386856f17d83d1d3f493905c0e4eed4
<pre>
Fix unqualified calls to std::move in PlayStation MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=246546">https://bugs.webkit.org/show_bug.cgi?id=246546</a>

Reviewed by Fujii Hironori.

A number of `move` calls didn&apos;t have `std::` in front of them. Fix this
warning `-Wunqualified-std-cast-call` from Clang 15.

* Tools/MiniBrowser/playstation/MainWindow.cpp:
* Tools/MiniBrowser/playstation/ToolkittenUtils.h:
* Tools/MiniBrowser/playstation/main.cpp:

Canonical link: <a href="https://commits.webkit.org/255581@main">https://commits.webkit.org/255581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a43c362ad7f9922a13047e29e8ff02a8a00f2ee9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102654 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2148 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30476 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98781 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1471 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79414 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28381 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83384 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71500 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36876 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17003 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38551 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40797 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37373 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->