### PR TITLE
[git-webkit] Handle invalid commit reference

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.22',
+    version='5.6.23',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 22)
+version = Version(5, 6, 23)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
@@ -181,7 +181,10 @@ class Trace(Command):
                 if commits_story:
                     found = commits_story.by_ref.get(ref, None)
                 if not found:
-                    found = repository.find(ref)
+                    try:
+                        found = repository.find(ref)
+                    except ValueError:
+                        continue
                 if not found:
                     continue
                 if commits_story:


### PR DESCRIPTION
#### 06adbe55de54c8d74614a19015c7bb78e495457c
<pre>
[git-webkit] Handle invalid commit reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=246549">https://bugs.webkit.org/show_bug.cgi?id=246549</a>
rdar://101191143

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py:
(Trace.relationships): Catch exception in case the commit reference is invalid.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestTrace.test_invalid_revert):

Canonical link: <a href="https://commits.webkit.org/255683@main">https://commits.webkit.org/255683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0f0bdb430d5b42b1201de5fbd500ba946dbb418

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93321 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/2518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/23969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97324 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/2525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/30830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98991 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/2525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/79781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/96899 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/2525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/23969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/23969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/92349 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/35038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/23969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/38912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/79781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1829 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/40842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/23969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->