### PR TITLE
Remove longstanding iOS-specific image painting antialiasing quirk

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -330,15 +330,6 @@ void GraphicsContextCG::drawNativeImage(NativeImage& nativeImage, const FloatSiz
     if (subImage == image && currentImageSize.height() < imageSize.height())
         adjustedDestRect.setHeight(adjustedDestRect.height() * currentImageSize.height() / imageSize.height());
 
-#if PLATFORM(IOS_FAMILY)
-    bool wasAntialiased = CGContextGetShouldAntialias(context);
-    // Anti-aliasing is on by default on the iPhone. Need to turn it off when drawing images.
-    CGContextSetShouldAntialias(context, false);
-
-    // Align to pixel boundaries
-    adjustedDestRect = roundToDevicePixels(adjustedDestRect);
-#endif
-
     auto oldCompositeOperator = compositeOperation();
     auto oldBlendMode = blendMode();
     setCGBlendMode(context, options.compositeOperator(), options.blendMode());
@@ -365,9 +356,6 @@ void GraphicsContextCG::drawNativeImage(NativeImage& nativeImage, const FloatSiz
 
     if (!stateSaver.didSave()) {
         CGContextSetCTM(context, transform);
-#if PLATFORM(IOS_FAMILY)
-        CGContextSetShouldAntialias(context, wasAntialiased);
-#endif
         setCGBlendMode(context, oldCompositeOperator, oldBlendMode);
     }
 


### PR DESCRIPTION
#### ef3ae0b1e9717221ac7c094161fa75cae8fd99b4
<pre>
Remove longstanding iOS-specific image painting antialiasing quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=246551">https://bugs.webkit.org/show_bug.cgi?id=246551</a>
rdar://100183888

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImage):
In the interests of platform unity, remove this longstanding iOS image painting
quirk; it can cause pixel cracks in some cases, and there is no reason for iOS
image painting to differ from macOS at this point (it was originally introduced
for performance on very early hardware).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef3ae0b1e9717221ac7c094161fa75cae8fd99b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102665 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162925 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2164 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30487 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98790 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98618 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1483 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-cover.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79427 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28399 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36886 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17018 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18208 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40811 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37389 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->