### PR TITLE
[iPadOS] screen.orientation.lock() promise should get rejected when the app supports multiple scenes

### DIFF
--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -89,6 +89,11 @@ void WebScreenOrientationManagerProxy::lock(WebCore::ScreenOrientationLockType l
     if (m_currentLockRequest)
         m_currentLockRequest(WebCore::Exception { WebCore::AbortError, "A new lock request was started"_s });
 
+    if (auto exception = platformShouldRejectLockRequest()) {
+        completionHandler(*exception);
+        return;
+    }
+
     m_currentLockRequest = WTFMove(completionHandler);
     auto currentOrientation = m_provider->currentOrientation();
     auto resolvedLockedOrientation = resolveScreenOrientationLockType(currentOrientation, lockType);
@@ -166,6 +171,11 @@ void WebScreenOrientationManagerProxy::platformInitialize()
 
 void WebScreenOrientationManagerProxy::platformDestroy()
 {
+}
+
+std::optional<WebCore::Exception> WebScreenOrientationManagerProxy::platformShouldRejectLockRequest() const
+{
+    return std::nullopt;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -68,6 +68,8 @@ private:
     void platformInitialize();
     void platformDestroy();
 
+    std::optional<WebCore::Exception> platformShouldRejectLockRequest() const;
+
     // IPC message handlers.
     void currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&&);
     void lock(WebCore::ScreenOrientationLockType, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&&);

--- a/Source/WebKit/UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm
@@ -30,6 +30,7 @@
 
 #import "WKWebView.h"
 #import "WebPageProxy.h"
+#import <WebCore/Exception.h>
 
 namespace WebKit {
 
@@ -52,6 +53,13 @@ void WebScreenOrientationManagerProxy::setWindow(UIWindow *window)
 void WebScreenOrientationManagerProxy::webViewDidMoveToWindow()
 {
     setWindow([m_page.cocoaView() window]);
+}
+
+std::optional<WebCore::Exception> WebScreenOrientationManagerProxy::platformShouldRejectLockRequest() const
+{
+    if (UIApplication.sharedApplication.supportsMultipleScenes)
+        return WebCore::Exception { WebCore::NotSupportedError, "Apps supporting multiple scenes (multitask) cannot lock their orientation"_s };
+    return std::nullopt;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 62f3048961681f0361a5d596280c91485e72c44e
<pre>
[iPadOS] screen.orientation.lock() promise should get rejected when the app supports multiple scenes
<a href="https://bugs.webkit.org/show_bug.cgi?id=246556">https://bugs.webkit.org/show_bug.cgi?id=246556</a>

Reviewed by Wenson Hsieh.

screen.orientation.lock() promise should get rejected when the app supports
multiple scenes (multitasks / split-view) on iPad OS. Such apps are not
currently able to lock their orientation.

* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::lock):
(WebKit::WebScreenOrientationManagerProxy::platformShouldRejectLockRequest const):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/ios/WebScreenOrientationManagerProxyIOS.mm:
(WebKit::WebScreenOrientationManagerProxy::platformShouldRejectLockRequest const):

Canonical link: <a href="https://commits.webkit.org/255657@main">https://commits.webkit.org/255657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ce39b05b3474e2fde5eedb5a70414b3bfed9a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102681 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2180 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30498 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98800 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1493 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79442 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28402 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71521 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36897 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17026 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34708 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18216 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3919 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40821 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37399 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->