### PR TITLE
[WGSL] Use UniqueRefVector to simplify working with AST

### DIFF
--- a/Source/WebGPU/WGSL/AST/Attribute.h
+++ b/Source/WebGPU/WGSL/AST/Attribute.h
@@ -26,14 +26,17 @@
 #pragma once
 
 #include "ASTNode.h"
-#include <wtf/text/StringView.h>
+
 #include <wtf/UniqueRef.h>
+#include <wtf/UniqueRefVector.h>
 #include <wtf/Vector.h>
+#include <wtf/text/StringView.h>
 
 namespace WGSL::AST {
 
 class Attribute : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     enum class Kind {
         Group,
@@ -43,6 +46,8 @@ public:
         Builtin,
     };
 
+    using List = UniqueRefVector<Attribute, 2>;
+
     Attribute(SourceSpan span)
         : ASTNode(span)
     {
@@ -50,7 +55,7 @@ public:
 
     virtual ~Attribute() {};
 
-    virtual Kind kind() const = 0 ;
+    virtual Kind kind() const = 0;
     bool isGroup() const { return kind() == Kind::Group; }
     bool isBinding() const { return kind() == Kind::Binding; }
     bool isStage() const { return kind() == Kind::Stage; }
@@ -60,6 +65,7 @@ public:
 
 class GroupAttribute final : public Attribute {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     GroupAttribute(SourceSpan span, unsigned group)
         : Attribute(span)
@@ -76,6 +82,7 @@ private:
 
 class BindingAttribute final : public Attribute {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     BindingAttribute(SourceSpan span, unsigned binding)
         : Attribute(span)
@@ -92,6 +99,7 @@ private:
 
 class StageAttribute final : public Attribute {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     enum class Stage : uint8_t {
         Compute,
@@ -114,6 +122,7 @@ private:
 
 class BuiltinAttribute final : public Attribute {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     BuiltinAttribute(SourceSpan span, StringView name)
         : Attribute(span)
@@ -130,6 +139,7 @@ private:
 
 class LocationAttribute final : public Attribute {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     LocationAttribute(SourceSpan span, unsigned value)
         : Attribute(span)
@@ -144,8 +154,6 @@ private:
     unsigned m_value;
 };
 
-using Attributes = Vector<UniqueRef<Attribute>, 2>;
-
 } // namespace WGSL::AST
 
 #define SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(ToValueTypeName, predicate) \
@@ -158,4 +166,3 @@ SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(BindingAttribute, isBinding())
 SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(StageAttribute, isStage())
 SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(LocationAttribute, isLocation())
 SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(BuiltinAttribute, isBuiltin())
-

--- a/Source/WebGPU/WGSL/AST/Decl.h
+++ b/Source/WebGPU/WGSL/AST/Decl.h
@@ -26,18 +26,23 @@
 #pragma once
 
 #include "ASTNode.h"
+
 #include <wtf/TypeCasts.h>
+#include <wtf/UniqueRefVector.h>
 
 namespace WGSL::AST {
 
 class Decl : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     enum class Kind {
         Variable,
         Struct,
         Function,
     };
+
+    using List = UniqueRefVector<Decl>;
 
     Decl(SourceSpan span)
         : ASTNode(span)

--- a/Source/WebGPU/WGSL/AST/Expression.h
+++ b/Source/WebGPU/WGSL/AST/Expression.h
@@ -26,12 +26,15 @@
 #pragma once
 
 #include "ASTNode.h"
+
 #include <wtf/TypeCasts.h>
+#include <wtf/UniqueRefVector.h>
 
 namespace WGSL::AST {
 
 class Expression : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
     enum class Kind {
         BoolLiteral,
@@ -47,6 +50,8 @@ public:
         UnaryExpression,
     };
 
+    using List = UniqueRefVector<Expression>;
+
     Expression(SourceSpan span)
         : ASTNode(span)
     {
@@ -54,7 +59,7 @@ public:
 
     virtual ~Expression() {}
 
-    virtual Kind kind() const  = 0;
+    virtual Kind kind() const = 0;
     bool isBoolLiteral() const { return kind() == Kind::BoolLiteral; }
     bool isInt32Literal() const { return kind() == Kind::Int32Literal; }
     bool isUInt32Literal() const { return kind() == Kind::Uint32Literal; }

--- a/Source/WebGPU/WGSL/AST/Expressions/ArrayAccess.h
+++ b/Source/WebGPU/WGSL/AST/Expressions/ArrayAccess.h
@@ -41,8 +41,8 @@ public:
     }
 
     Kind kind() const override { return Kind::ArrayAccess; }
-    UniqueRef<Expression>& base() { return m_base; }
-    UniqueRef<Expression>& index() { return m_index; }
+    Expression& base() { return m_base.get(); }
+    Expression& index() { return m_index.get(); }
 
 private:
     UniqueRef<Expression> m_base;

--- a/Source/WebGPU/WGSL/AST/Expressions/CallableExpression.h
+++ b/Source/WebGPU/WGSL/AST/Expressions/CallableExpression.h
@@ -38,8 +38,9 @@ namespace WGSL::AST {
 // kind of expression can only be resolved during semantic analysis.
 class CallableExpression final : public Expression {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    CallableExpression(SourceSpan span, UniqueRef<TypeDecl>&& target, Vector<UniqueRef<Expression>>&& arguments)
+    CallableExpression(SourceSpan span, UniqueRef<TypeDecl>&& target, Expression::List&& arguments)
         : Expression(span)
         , m_target(WTFMove(target))
         , m_arguments(WTFMove(arguments))
@@ -48,15 +49,7 @@ public:
 
     Kind kind() const override { return Kind::CallableExpression; }
     const TypeDecl& target() const { return m_target; }
-    Vector<std::reference_wrapper<const Expression>> arguments() const 
-    {
-        Vector<std::reference_wrapper<const Expression>> arguments;
-
-        for (const auto& argument : m_arguments)
-            arguments.append(std::cref(argument.get()));
-
-        return arguments;
-    }
+    const Expression::List& arguments() const { return m_arguments; }
 
 private:
     // If m_target is a NamedType, it could either be a:
@@ -64,7 +57,7 @@ private:
     //   * Identifier that refers to a type alias.
     //   * Identifier that refers to a function.
     UniqueRef<TypeDecl> m_target;
-    Vector<UniqueRef<Expression>> m_arguments;
+    Expression::List m_arguments;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/FunctionDecl.h
+++ b/Source/WebGPU/WGSL/AST/FunctionDecl.h
@@ -32,12 +32,17 @@
 #include "Statements/CompoundStatement.h"
 #include "TypeDecl.h"
 
+#include <wtf/UniqueRefVector.h>
+
 namespace WGSL::AST {
 
 class Parameter final : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    Parameter(SourceSpan span, StringView name, UniqueRef<TypeDecl>&& type, Attributes&& attributes)
+    using List = UniqueRefVector<Parameter>;
+
+    Parameter(SourceSpan span, StringView name, UniqueRef<TypeDecl>&& type, Attribute::List&& attributes)
         : ASTNode(span)
         , m_name(WTFMove(name))
         , m_type(WTFMove(type))
@@ -47,18 +52,21 @@ public:
 
     const StringView& name() const { return m_name; }
     TypeDecl& type() { return m_type; }
-    Attributes& attributes() { return m_attributes; }
+    Attribute::List& attributes() { return m_attributes; }
 
 private:
     StringView m_name;
     UniqueRef<TypeDecl> m_type;
-    Attributes m_attributes;
+    Attribute::List m_attributes;
 };
 
 class FunctionDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    FunctionDecl(SourceSpan sourceSpan, StringView name, Vector<UniqueRef<Parameter>>&& parameters, std::unique_ptr<TypeDecl>&& returnType, CompoundStatement&& body, Attributes&& attributes, Attributes&& returnAttributes)
+    using List = UniqueRefVector<FunctionDecl>;
+
+    FunctionDecl(SourceSpan sourceSpan, StringView name, Parameter::List&& parameters, std::unique_ptr<TypeDecl>&& returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
         : Decl(sourceSpan)
         , m_name(name)
         , m_parameters(WTFMove(parameters))
@@ -71,17 +79,17 @@ public:
 
     Kind kind() const override { return Kind::Function; }
     const StringView& name() const { return m_name; }
-    Vector<UniqueRef<Parameter>>& parameters() { return m_parameters; }
-    Attributes& attributes() { return m_attributes; }
-    Attributes& returnAttributes() { return m_returnAttributes; }
+    Parameter::List& parameters() { return m_parameters; }
+    Attribute::List& attributes() { return m_attributes; }
+    Attribute::List& returnAttributes() { return m_returnAttributes; }
     TypeDecl* maybeReturnType() { return m_returnType.get(); }
     CompoundStatement& body() { return m_body; }
 
 private:
     StringView m_name;
-    Vector<UniqueRef<Parameter>> m_parameters;
-    Attributes m_attributes;
-    Attributes m_returnAttributes;
+    Parameter::List m_parameters;
+    Attribute::List m_attributes;
+    Attribute::List m_returnAttributes;
     std::unique_ptr<TypeDecl> m_returnType;
     CompoundStatement m_body;
 };

--- a/Source/WebGPU/WGSL/AST/GlobalDirective.h
+++ b/Source/WebGPU/WGSL/AST/GlobalDirective.h
@@ -32,7 +32,10 @@ namespace WGSL::AST {
 
 class GlobalDirective : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
+    using List = UniqueRefVector<GlobalDirective>;
+
     GlobalDirective(SourceSpan span, StringView name)
         : ASTNode(span)
         , m_name(name)

--- a/Source/WebGPU/WGSL/AST/Statement.h
+++ b/Source/WebGPU/WGSL/AST/Statement.h
@@ -41,6 +41,8 @@ public:
         Variable,
     };
 
+    using List = UniqueRefVector<Statement>;
+
     Statement(SourceSpan span)
         : ASTNode(span)
     {

--- a/Source/WebGPU/WGSL/AST/Statements/CompoundStatement.h
+++ b/Source/WebGPU/WGSL/AST/Statements/CompoundStatement.h
@@ -31,18 +31,19 @@ namespace WGSL::AST {
 
 class CompoundStatement final : public Statement {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    CompoundStatement(SourceSpan span, Vector<UniqueRef<Statement>>&& statements)
+    CompoundStatement(SourceSpan span, Statement::List&& statements)
         : Statement(span)
         , m_statements(WTFMove(statements))
     {
     }
 
     Kind kind() const override { return Kind::Compound; }
-    Vector<UniqueRef<Statement>>& statements() { return m_statements; }
+    Statement::List& statements() { return m_statements; }
 
 private:
-    Vector<UniqueRef<Statement>> m_statements;
+    Statement::List m_statements;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/StructureDecl.h
+++ b/Source/WebGPU/WGSL/AST/StructureDecl.h
@@ -30,17 +30,19 @@
 #include "CompilationMessage.h"
 #include "Decl.h"
 #include "TypeDecl.h"
-#include <wtf/text/StringView.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/UniqueRef.h>
-
+#include <wtf/text/StringView.h>
 
 namespace WGSL::AST {
 
 class StructMember final : public ASTNode {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    StructMember(SourceSpan span, StringView name, UniqueRef<TypeDecl>&& type, Attributes&& attributes)
+    using List = UniqueRefVector<StructMember>;
+
+    StructMember(SourceSpan span, StringView name, UniqueRef<TypeDecl>&& type, Attribute::List&& attributes)
         : ASTNode(span)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
@@ -50,18 +52,21 @@ public:
 
     const StringView& name() const { return m_name; }
     TypeDecl& type() { return m_type; }
-    Attributes& attributes() { return m_attributes; }
+    Attribute::List& attributes() { return m_attributes; }
 
 private:
     StringView m_name;
-    Attributes m_attributes;
+    Attribute::List m_attributes;
     UniqueRef<TypeDecl> m_type;
 };
 
 class StructDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    StructDecl(SourceSpan sourceSpan, StringView name, Vector<UniqueRef<StructMember>>&& members, Attributes&& attributes)
+    using List = UniqueRefVector<StructDecl>;
+
+    StructDecl(SourceSpan sourceSpan, StringView name, StructMember::List&& members, Attribute::List&& attributes)
         : Decl(sourceSpan)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
@@ -71,13 +76,13 @@ public:
 
     Kind kind() const override { return Kind::Struct; }
     const StringView& name() const { return m_name; }
-    Attributes& attributes() { return m_attributes; }
-    Vector<UniqueRef<StructMember>>& members() { return m_members; }
+    Attribute::List& attributes() { return m_attributes; }
+    StructMember::List& members() { return m_members; }
 
 private:
     StringView m_name;
-    Attributes m_attributes;
-    Vector<UniqueRef<StructMember>> m_members;
+    Attribute::List m_attributes;
+    StructMember::List m_members;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/VariableDecl.h
+++ b/Source/WebGPU/WGSL/AST/VariableDecl.h
@@ -37,8 +37,11 @@ namespace WGSL::AST {
 
 class VariableDecl final : public Decl {
     WTF_MAKE_FAST_ALLOCATED;
+
 public:
-    VariableDecl(SourceSpan span, StringView name, std::unique_ptr<VariableQualifier>&& qualifier, std::unique_ptr<TypeDecl>&& type, std::unique_ptr<Expression>&& initializer, Attributes&& attributes)
+    using List = UniqueRefVector<VariableDecl>;
+
+    VariableDecl(SourceSpan span, StringView name, std::unique_ptr<VariableQualifier>&& qualifier, std::unique_ptr<TypeDecl>&& type, std::unique_ptr<Expression>&& initializer, Attribute::List&& attributes)
         : Decl(span)
         , m_name(name)
         , m_attributes(WTFMove(attributes))
@@ -51,14 +54,14 @@ public:
 
     Kind kind() const override { return Kind::Variable; }
     const StringView& name() const { return m_name; }
-    Attributes& attributes() { return m_attributes; }
+    Attribute::List& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier.get(); }
     TypeDecl* maybeTypeDecl() { return m_type.get(); }
     Expression* maybeInitializer() { return m_initializer.get(); }
 
 private:
     StringView m_name;
-    Attributes m_attributes;
+    Attribute::List m_attributes;
     // Each of the following may be null
     // But at least one of type and initializer must be non-null
     std::unique_ptr<VariableQualifier> m_qualifier;

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -48,19 +48,19 @@ public:
 
     // UniqueRef whenever it can return multiple types.
     Expected<UniqueRef<AST::Decl>, Error> parseGlobalDecl();
-    Expected<AST::Attributes, Error> parseAttributes();
+    Expected<AST::Attribute::List, Error> parseAttributes();
     Expected<UniqueRef<AST::Attribute>, Error> parseAttribute();
-    Expected<AST::StructDecl, Error> parseStructDecl(AST::Attributes&&);
+    Expected<AST::StructDecl, Error> parseStructDecl(AST::Attribute::List&&);
     Expected<AST::StructMember, Error> parseStructMember();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDecl();
     Expected<UniqueRef<AST::TypeDecl>, Error> parseTypeDeclAfterIdentifier(StringView&&, SourcePosition start);
     Expected<UniqueRef<AST::TypeDecl>, Error> parseArrayType();
     Expected<AST::VariableDecl, Error> parseVariableDecl();
-    Expected<AST::VariableDecl, Error> parseVariableDeclWithAttributes(AST::Attributes&&);
+    Expected<AST::VariableDecl, Error> parseVariableDeclWithAttributes(AST::Attribute::List&&);
     Expected<AST::VariableQualifier, Error> parseVariableQualifier();
     Expected<AST::StorageClass, Error> parseStorageClass();
     Expected<AST::AccessMode, Error> parseAccessMode();
-    Expected<AST::FunctionDecl, Error> parseFunctionDecl(AST::Attributes&&);
+    Expected<AST::FunctionDecl, Error> parseFunctionDecl(AST::Attribute::List&&);
     Expected<AST::Parameter, Error> parseParameter();
     Expected<UniqueRef<AST::Statement>, Error> parseStatement();
     Expected<AST::CompoundStatement, Error> parseCompoundStatement();
@@ -77,7 +77,7 @@ public:
     Expected<UniqueRef<AST::Expression>, Error> parseExpression();
     Expected<UniqueRef<AST::Expression>, Error> parseLHSExpression();
     Expected<UniqueRef<AST::Expression>, Error> parseCoreLHSExpression();
-    Expected<Vector<UniqueRef<AST::Expression>>, Error> parseArgumentExpressionList();
+    Expected<AST::Expression::List, Error> parseArgumentExpressionList();
 
 private:
     Expected<Token, TokenType> consumeType(TokenType);

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -100,14 +100,14 @@ TEST(WGSLParserTests, Struct)
     EXPECT_EQ(shader->structs().size(), 1u);
     EXPECT_TRUE(shader->globalVars().isEmpty());
     EXPECT_TRUE(shader->functions().isEmpty());
-    auto& str = shader->structs()[0].get();
+    auto& str = shader->structs()[0];
     EXPECT_EQ(str.name(), "B"_s);
     EXPECT_TRUE(str.attributes().isEmpty());
     EXPECT_EQ(str.members().size(), 1u);
-    EXPECT_TRUE(str.members()[0]->attributes().isEmpty());
-    EXPECT_EQ(str.members()[0]->name(), "a"_s);
-    EXPECT_TRUE(str.members()[0]->type().isNamed());
-    auto& memberType = downcast<WGSL::AST::NamedType>(str.members()[0]->type());
+    EXPECT_TRUE(str.members()[0].attributes().isEmpty());
+    EXPECT_EQ(str.members()[0].name(), "a"_s);
+    EXPECT_TRUE(str.members()[0].type().isNamed());
+    auto& memberType = downcast<WGSL::AST::NamedType>(str.members()[0].type());
     EXPECT_EQ(memberType.name(), "i32"_s);
 }
 
@@ -123,12 +123,12 @@ TEST(WGSLParserTests, GlobalVariable)
     EXPECT_TRUE(shader->structs().isEmpty());
     EXPECT_EQ(shader->globalVars().size(), 1u);
     EXPECT_TRUE(shader->functions().isEmpty());
-    auto& var = shader->globalVars()[0].get();
+    auto& var = shader->globalVars()[0];
     EXPECT_EQ(var.attributes().size(), 2u);
-    EXPECT_TRUE(var.attributes()[0]->isGroup());
-    EXPECT_FALSE(downcast<WGSL::AST::GroupAttribute>(var.attributes()[0].get()).group());
-    EXPECT_TRUE(var.attributes()[1]->isBinding());
-    EXPECT_FALSE(downcast<WGSL::AST::BindingAttribute>(var.attributes()[1].get()).binding());
+    EXPECT_TRUE(var.attributes()[0].isGroup());
+    EXPECT_FALSE(downcast<WGSL::AST::GroupAttribute>(var.attributes()[0]).group());
+    EXPECT_TRUE(var.attributes()[1].isBinding());
+    EXPECT_FALSE(downcast<WGSL::AST::BindingAttribute>(var.attributes()[1]).binding());
     EXPECT_EQ(var.name(), "x"_s);
     EXPECT_TRUE(var.maybeQualifier());
     EXPECT_EQ(var.maybeQualifier()->storageClass(), WGSL::AST::StorageClass::Storage);
@@ -154,17 +154,17 @@ TEST(WGSLParserTests, FunctionDecl)
     EXPECT_TRUE(shader->structs().isEmpty());
     EXPECT_TRUE(shader->globalVars().isEmpty());
     EXPECT_EQ(shader->functions().size(), 1u);
-    auto& func = shader->functions()[0].get();
+    auto& func = shader->functions()[0];
     EXPECT_EQ(func.attributes().size(), 1u);
-    EXPECT_TRUE(func.attributes()[0]->isStage());
-    EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Compute);
+    EXPECT_TRUE(func.attributes()[0].isStage());
+    EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Compute);
     EXPECT_EQ(func.name(), "main"_s);
     EXPECT_TRUE(func.parameters().isEmpty());
     EXPECT_TRUE(func.returnAttributes().isEmpty());
     EXPECT_FALSE(func.maybeReturnType());
     EXPECT_EQ(func.body().statements().size(), 1u);
-    EXPECT_TRUE(func.body().statements()[0]->isAssignment());
-    auto& stmt = downcast<WGSL::AST::AssignmentStatement>(func.body().statements()[0].get());
+    EXPECT_TRUE(func.body().statements()[0].isAssignment());
+    auto& stmt = downcast<WGSL::AST::AssignmentStatement>(func.body().statements()[0]);
     EXPECT_TRUE(stmt.maybeLhs());
     EXPECT_TRUE(stmt.maybeLhs()->isStructureAccess());
     auto& structAccess = downcast<WGSL::AST::StructureAccess>(*stmt.maybeLhs());
@@ -197,56 +197,56 @@ TEST(WGSLParserTests, TrivialGraphicsShader)
     EXPECT_EQ(shader->functions().size(), 2u);
 
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         EXPECT_EQ(func.attributes().size(), 1u);
-        EXPECT_TRUE(func.attributes()[0]->isStage());
-        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
+        EXPECT_TRUE(func.attributes()[0].isStage());
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
         EXPECT_EQ(func.name(), "vertexShader"_s);
         EXPECT_EQ(func.parameters().size(), 1u);
-        EXPECT_EQ(func.parameters()[0]->name(), "x"_s);
-        EXPECT_EQ(func.parameters()[0]->attributes().size(), 1u);
-        EXPECT_TRUE(func.parameters()[0]->attributes()[0]->isLocation());
-        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.parameters()[0]->attributes()[0].get()).location());
-        EXPECT_TRUE(func.parameters()[0]->type().isParameterized());
-        auto& paramType = downcast<WGSL::AST::ParameterizedType>(func.parameters()[0]->type());
+        EXPECT_EQ(func.parameters()[0].name(), "x"_s);
+        EXPECT_EQ(func.parameters()[0].attributes().size(), 1u);
+        EXPECT_TRUE(func.parameters()[0].attributes()[0].isLocation());
+        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.parameters()[0].attributes()[0]).location());
+        EXPECT_TRUE(func.parameters()[0].type().isParameterized());
+        auto& paramType = downcast<WGSL::AST::ParameterizedType>(func.parameters()[0].type());
         EXPECT_EQ(paramType.base(), WGSL::AST::ParameterizedType::Base::Vec4);
         EXPECT_TRUE(paramType.elementType().isNamed());
         EXPECT_EQ(downcast<WGSL::AST::NamedType>(paramType.elementType()).name(), "f32"_s);
         EXPECT_EQ(func.returnAttributes().size(), 1u);
-        checkBuiltin(func.returnAttributes()[0].get(), "position"_s);
+        checkBuiltin(func.returnAttributes()[0], "position"_s);
         EXPECT_TRUE(func.maybeReturnType());
         EXPECT_TRUE(func.maybeReturnType()->isParameterized());
         EXPECT_EQ(func.body().statements().size(), 1u);
-        EXPECT_TRUE(func.body().statements()[0]->isReturn());
-        auto& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(func.body().statements()[0].isReturn());
+        auto& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0]);
         EXPECT_TRUE(stmt.maybeExpression());
         EXPECT_TRUE(stmt.maybeExpression()->isIdentifier());
     }
 
     {
-        auto& func = shader->functions()[1].get();
+        auto& func = shader->functions()[1];
         EXPECT_EQ(func.attributes().size(), 1u);
-        EXPECT_TRUE(func.attributes()[0]->isStage());
-        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Fragment);
+        EXPECT_TRUE(func.attributes()[0].isStage());
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Fragment);
         EXPECT_EQ(func.name(), "fragmentShader"_s);
         EXPECT_TRUE(func.parameters().isEmpty());
         EXPECT_EQ(func.returnAttributes().size(), 1u);
-        EXPECT_TRUE(func.returnAttributes()[0]->isLocation());
-        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.returnAttributes()[0].get()).location());
+        EXPECT_TRUE(func.returnAttributes()[0].isLocation());
+        EXPECT_FALSE(downcast<WGSL::AST::LocationAttribute>(func.returnAttributes()[0]).location());
         EXPECT_TRUE(func.maybeReturnType());
         EXPECT_TRUE(func.maybeReturnType()->isParameterized());
         EXPECT_EQ(func.body().statements().size(), 1u);
-        EXPECT_TRUE(func.body().statements()[0]->isReturn());
-        auto& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(func.body().statements()[0].isReturn());
+        auto& stmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0]);
         EXPECT_TRUE(stmt.maybeExpression());
         EXPECT_TRUE(stmt.maybeExpression()->isCallableExpression());
         auto& expr = downcast<WGSL::AST::CallableExpression>(*stmt.maybeExpression());
         EXPECT_TRUE(expr.target().isParameterized());
         EXPECT_EQ(expr.arguments().size(), 4u);
-        EXPECT_TRUE(expr.arguments()[0].get().isAbstractFloatLiteral());
-        EXPECT_TRUE(expr.arguments()[1].get().isAbstractFloatLiteral());
-        EXPECT_TRUE(expr.arguments()[2].get().isAbstractFloatLiteral());
-        EXPECT_TRUE(expr.arguments()[3].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[0].isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[1].isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[2].isAbstractFloatLiteral());
+        EXPECT_TRUE(expr.arguments()[3].isAbstractFloatLiteral());
     }
 }
 
@@ -270,11 +270,11 @@ TEST(WGSLParserTests, LocalVariable)
     EXPECT_EQ(shader->functions().size(), 1u);
 
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         // @vertex
         EXPECT_EQ(func.attributes().size(), 1u);
-        EXPECT_TRUE(func.attributes()[0]->isStage());
-        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0].get()).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
+        EXPECT_TRUE(func.attributes()[0].isStage());
+        EXPECT_EQ(downcast<WGSL::AST::StageAttribute>(func.attributes()[0]).stage(), WGSL::AST::StageAttribute::Stage::Vertex);
 
         // fn main() -> vec4<f32> {
         EXPECT_EQ(func.name(), "main"_s);
@@ -285,8 +285,8 @@ TEST(WGSLParserTests, LocalVariable)
         EXPECT_EQ(func.body().statements().size(), 2u);
 
         // var x = vec4<f32>(0.4, 0.4, 0.8, 1.0);
-        EXPECT_TRUE(func.body().statements()[0]->isVariable());
-        auto& varStmt = downcast<WGSL::AST::VariableStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(func.body().statements()[0].isVariable());
+        auto& varStmt = downcast<WGSL::AST::VariableStatement>(func.body().statements()[0]);
         auto& varDecl = downcast<WGSL::AST::VariableDecl>(varStmt.declaration());
         EXPECT_EQ(varDecl.name(), "x"_s);
         EXPECT_TRUE(varDecl.attributes().isEmpty());
@@ -296,14 +296,14 @@ TEST(WGSLParserTests, LocalVariable)
         auto& varInitExpr = downcast<WGSL::AST::CallableExpression>(*varDecl.maybeInitializer());
         EXPECT_TRUE(varInitExpr.target().isParameterized());
         EXPECT_EQ(varInitExpr.arguments().size(), 4u);
-        EXPECT_TRUE(varInitExpr.arguments()[0].get().isAbstractFloatLiteral());
-        EXPECT_TRUE(varInitExpr.arguments()[1].get().isAbstractFloatLiteral());
-        EXPECT_TRUE(varInitExpr.arguments()[2].get().isAbstractFloatLiteral());
-        EXPECT_TRUE(varInitExpr.arguments()[3].get().isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[0].isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[1].isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[2].isAbstractFloatLiteral());
+        EXPECT_TRUE(varInitExpr.arguments()[3].isAbstractFloatLiteral());
 
         // return x;
-        EXPECT_TRUE(func.body().statements()[1]->isReturn());
-        auto& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[1].get());
+        EXPECT_TRUE(func.body().statements()[1].isReturn());
+        auto& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[1]);
         EXPECT_TRUE(retStmt.maybeExpression());
         EXPECT_TRUE(retStmt.maybeExpression()->isIdentifier());
         auto& retExpr = downcast<WGSL::AST::IdentifierExpression>(*retStmt.maybeExpression());
@@ -326,7 +326,7 @@ TEST(WGSLParserTests, ArrayAccess)
     EXPECT_EQ(shader->functions().size(), 1u);
 
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         // fn test() { ... }
         EXPECT_EQ(func.name(), "test"_s);
         EXPECT_TRUE(func.parameters().isEmpty());
@@ -335,16 +335,16 @@ TEST(WGSLParserTests, ArrayAccess)
 
         EXPECT_EQ(func.body().statements().size(), 1u);
         // return x[42];
-        EXPECT_TRUE(func.body().statements()[0]->isReturn());
-        auto& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(func.body().statements()[0].isReturn());
+        auto& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0]);
         EXPECT_TRUE(retStmt.maybeExpression());
         EXPECT_TRUE(retStmt.maybeExpression()->isArrayAccess());
         auto& arrayAccess = downcast<WGSL::AST::ArrayAccess>(*retStmt.maybeExpression());
-        EXPECT_TRUE(arrayAccess.base()->isIdentifier());
-        auto& base = downcast<WGSL::AST::IdentifierExpression>(arrayAccess.base().get());
+        EXPECT_TRUE(arrayAccess.base().isIdentifier());
+        auto& base = downcast<WGSL::AST::IdentifierExpression>(arrayAccess.base());
         EXPECT_EQ(base.identifier(), "x"_s);
-        EXPECT_TRUE(arrayAccess.index()->isInt32Literal());
-        auto& index = downcast<WGSL::AST::Int32Literal>(arrayAccess.index().get());
+        EXPECT_TRUE(arrayAccess.index().isInt32Literal());
+        auto& index = downcast<WGSL::AST::Int32Literal>(arrayAccess.index());
         EXPECT_EQ(index.value(), 42);
     }
 }
@@ -364,7 +364,7 @@ TEST(WGSLParserTests, UnaryExpression)
     EXPECT_EQ(shader->functions().size(), 1u);
 
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         // @vertex
         EXPECT_TRUE(func.attributes().isEmpty());
 
@@ -377,8 +377,8 @@ TEST(WGSLParserTests, UnaryExpression)
 
         EXPECT_EQ(func.body().statements().size(), 1u);
         // return x;
-        EXPECT_TRUE(func.body().statements()[0]->isReturn());
-        auto& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0].get());
+        EXPECT_TRUE(func.body().statements()[0].isReturn());
+        auto& retStmt = downcast<WGSL::AST::ReturnStatement>(func.body().statements()[0]);
         EXPECT_TRUE(retStmt.maybeExpression());
         EXPECT_TRUE(retStmt.maybeExpression()->isUnaryExpression());
         auto& retExpr = downcast<WGSL::AST::UnaryExpression>(*retStmt.maybeExpression());
@@ -416,7 +416,7 @@ TEST(WGSLParserTests, TriangleVert)
 
     // fn main(...)
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         // @vertex
         EXPECT_EQ(func.attributes().size(), 1u);
 
@@ -432,11 +432,11 @@ TEST(WGSLParserTests, TriangleVert)
 
     // var pos = array<vec2<f32>, 3>(...);
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         EXPECT_GE(func.body().statements().size(), 1u);
-        auto& stmt = func.body().statements()[0].get();
+        auto& stmt = func.body().statements()[0];
         EXPECT_TRUE(stmt.isVariable());
-        auto& varStmt = downcast<WGSL::AST::VariableStatement>(func.body().statements()[0].get());
+        auto& varStmt = downcast<WGSL::AST::VariableStatement>(func.body().statements()[0]);
         auto& varDecl = downcast<WGSL::AST::VariableDecl>(varStmt.declaration());
         EXPECT_EQ(varDecl.name(), "pos"_s);
         EXPECT_TRUE(varDecl.attributes().isEmpty());
@@ -455,9 +455,9 @@ TEST(WGSLParserTests, TriangleVert)
 
     // return vec4<f32>(..);
     {
-        auto& func = shader->functions()[0].get();
+        auto& func = shader->functions()[0];
         EXPECT_GE(func.body().statements().size(), 1u);
-        auto& stmt = func.body().statements()[1].get();
+        auto& stmt = func.body().statements()[1];
         EXPECT_TRUE(stmt.isReturn());
         auto& retStmt = downcast<WGSL::AST::ReturnStatement>(stmt);
         EXPECT_TRUE(retStmt.maybeExpression());


### PR DESCRIPTION
#### 8b4319ba38ad79d0a796d5e1c0dab1efd8a1616d
<pre>
[WGSL] Use UniqueRefVector to simplify working with AST
<a href="https://bugs.webkit.org/show_bug.cgi?id=246560">https://bugs.webkit.org/show_bug.cgi?id=246560</a>
rdar://problem/101198284

Reviewed by Dean Jackson.

Use UniqueRefVector for lists of AST nodes to eliminate the need to unwrap
UniqueRef&lt;&gt; with .get().

Tested by TestWebKitAPI/Tests/WGSL/ParserTests.cpp

* Source/WebGPU/WGSL/AST/Attribute.h:
* Source/WebGPU/WGSL/AST/Decl.h:
(WGSL::AST::Decl::~Decl):
* Source/WebGPU/WGSL/AST/Expression.h:
* Source/WebGPU/WGSL/AST/Expressions/ArrayAccess.h:
* Source/WebGPU/WGSL/AST/Expressions/CallableExpression.h:
* Source/WebGPU/WGSL/AST/FunctionDecl.h:
* Source/WebGPU/WGSL/AST/GlobalDirective.h:
* Source/WebGPU/WGSL/AST/ShaderModule.h:
* Source/WebGPU/WGSL/AST/Statement.h:
* Source/WebGPU/WGSL/AST/Statements/CompoundStatement.h:
* Source/WebGPU/WGSL/AST/StructureDecl.h:
* Source/WebGPU/WGSL/AST/VariableDecl.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseShader):
(WGSL::Parser&lt;Lexer&gt;::parseAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseStructDecl):
(WGSL::Parser&lt;Lexer&gt;::parseVariableDecl):
(WGSL::Parser&lt;Lexer&gt;::parseVariableDeclWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseFunctionDecl):
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseCompoundStatement):
(WGSL::Parser&lt;Lexer&gt;::parseArgumentExpressionList):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TestWGSLAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255597@main">https://commits.webkit.org/255597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6133916fe9396326411e9757fa289db2d77b8e7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/92982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102695 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162941 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/96984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2194 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30512 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85367 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98809 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1500 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79456 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28412 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83413 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71526 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36911 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34721 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3876 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40830 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37417 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->