### PR TITLE
[libpas] Support MallocStackLogging

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -130,6 +130,7 @@ set(bmalloc_SOURCES
     libpas/src/libpas/pas_lock.c
     libpas/src/libpas/pas_lock_free_read_ptr_ptr_hashtable.c
     libpas/src/libpas/pas_log.c
+    libpas/src/libpas/pas_malloc_stack_logging.c
     libpas/src/libpas/pas_medium_megapage_cache.c
     libpas/src/libpas/pas_megapage_cache.c
     libpas/src/libpas/pas_monotonic_time.c
@@ -517,6 +518,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/pas_lock_free_read_ptr_ptr_hashtable.h
     libpas/src/libpas/pas_lock.h
     libpas/src/libpas/pas_log.h
+    libpas/src/libpas/pas_malloc_stack_logging.h
     libpas/src/libpas/pas_medium_megapage_cache.h
     libpas/src/libpas/pas_megapage_cache.h
     libpas/src/libpas/pas_min_heap.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -653,6 +653,8 @@
 		E32EBB1F28C72456009E5EB5 /* pas_darwin_spi.h in Headers */ = {isa = PBXBuildFile; fileRef = E32EBB1E28C72456009E5EB5 /* pas_darwin_spi.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35B7BCA27ADB44E00C3498F /* pas_thread_suspend_lock.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B7BC827ADB44E00C3498F /* pas_thread_suspend_lock.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35B7BCB27ADB44E00C3498F /* pas_thread_suspend_lock.c in Sources */ = {isa = PBXBuildFile; fileRef = E35B7BC927ADB44E00C3498F /* pas_thread_suspend_lock.c */; };
+		E3696A3C28F6C48B00C2F2D4 /* pas_malloc_stack_logging.c in Sources */ = {isa = PBXBuildFile; fileRef = E3696A3A28F6C48B00C2F2D4 /* pas_malloc_stack_logging.c */; };
+		E3696A3D28F6C48B00C2F2D4 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = E3696A3B28F6C48B00C2F2D4 /* pas_malloc_stack_logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E378A9DF246B68720029C2BB /* ObjectTypeTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E378A9DE246B686A0029C2BB /* ObjectTypeTable.cpp */; };
 		E378A9E0246B68750029C2BB /* ObjectTypeTable.h in Headers */ = {isa = PBXBuildFile; fileRef = E378A9DD246B686A0029C2BB /* ObjectTypeTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38A9E3C27426514000BBD49 /* pas_platform.h in Headers */ = {isa = PBXBuildFile; fileRef = E38A9E3B27426514000BBD49 /* pas_platform.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1325,6 +1327,8 @@
 		E32EBB1E28C72456009E5EB5 /* pas_darwin_spi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_darwin_spi.h; path = libpas/src/libpas/pas_darwin_spi.h; sourceTree = "<group>"; };
 		E35B7BC827ADB44E00C3498F /* pas_thread_suspend_lock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_thread_suspend_lock.h; path = libpas/src/libpas/pas_thread_suspend_lock.h; sourceTree = "<group>"; };
 		E35B7BC927ADB44E00C3498F /* pas_thread_suspend_lock.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_thread_suspend_lock.c; path = libpas/src/libpas/pas_thread_suspend_lock.c; sourceTree = "<group>"; };
+		E3696A3A28F6C48B00C2F2D4 /* pas_malloc_stack_logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pas_malloc_stack_logging.c; path = libpas/src/libpas/pas_malloc_stack_logging.c; sourceTree = "<group>"; };
+		E3696A3B28F6C48B00C2F2D4 /* pas_malloc_stack_logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_malloc_stack_logging.h; path = libpas/src/libpas/pas_malloc_stack_logging.h; sourceTree = "<group>"; };
 		E378A9DD246B686A0029C2BB /* ObjectTypeTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ObjectTypeTable.h; path = bmalloc/ObjectTypeTable.h; sourceTree = "<group>"; };
 		E378A9DE246B686A0029C2BB /* ObjectTypeTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ObjectTypeTable.cpp; path = bmalloc/ObjectTypeTable.cpp; sourceTree = "<group>"; };
 		E38A9E3B27426514000BBD49 /* pas_platform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pas_platform.h; path = libpas/src/libpas/pas_platform.h; sourceTree = "<group>"; };
@@ -1756,6 +1760,8 @@
 				0FC40AA42451498E00876DA0 /* pas_lock_free_read_ptr_ptr_hashtable.h */,
 				0FC40AD72451499100876DA0 /* pas_log.c */,
 				0FC40AC12451499000876DA0 /* pas_log.h */,
+				E3696A3A28F6C48B00C2F2D4 /* pas_malloc_stack_logging.c */,
+				E3696A3B28F6C48B00C2F2D4 /* pas_malloc_stack_logging.h */,
 				0F87004B25AF8A19000E1ABF /* pas_medium_megapage_cache.c */,
 				0F87004825AF8A19000E1ABF /* pas_medium_megapage_cache.h */,
 				0FC40A812451498B00876DA0 /* pas_megapage_cache.c */,
@@ -2445,6 +2451,7 @@
 				0FC40B672451499400876DA0 /* pas_lock.h in Headers */,
 				0FC40B7F2451499400876DA0 /* pas_lock_free_read_ptr_ptr_hashtable.h in Headers */,
 				0FC40B9C2451499400876DA0 /* pas_log.h in Headers */,
+				E3696A3D28F6C48B00C2F2D4 /* pas_malloc_stack_logging.h in Headers */,
 				0F87006525AF8A1B000E1ABF /* pas_medium_megapage_cache.h in Headers */,
 				0FC40B042451499400876DA0 /* pas_megapage_cache.h in Headers */,
 				0FC40B5A2451499400876DA0 /* pas_min_heap.h in Headers */,
@@ -2806,6 +2813,7 @@
 				0FC40BDA245243A400876DA0 /* pas_lock.c in Sources */,
 				0FC40B342451499400876DA0 /* pas_lock_free_read_ptr_ptr_hashtable.c in Sources */,
 				0FC40BB22451499400876DA0 /* pas_log.c in Sources */,
+				E3696A3C28F6C48B00C2F2D4 /* pas_malloc_stack_logging.c in Sources */,
 				0F87006825AF8A1B000E1ABF /* pas_medium_megapage_cache.c in Sources */,
 				0FC40B5D2451499400876DA0 /* pas_megapage_cache.c in Sources */,
 				0FC40B6A2451499400876DA0 /* pas_monotonic_time.c in Sources */,

--- a/Source/bmalloc/bmalloc/Environment.cpp
+++ b/Source/bmalloc/bmalloc/Environment.cpp
@@ -67,7 +67,6 @@ static bool isMallocEnvironmentVariableImplyingSystemMallocSet()
         "MallocGuardEdges",
         "MallocDoNotProtectPrelude",
         "MallocDoNotProtectPostlude",
-        "MallocStackLoggingNoCompact",
         "MallocScribble",
         "MallocCheckHeapStart",
         "MallocCheckHeapEach",
@@ -83,12 +82,6 @@ static bool isMallocEnvironmentVariableImplyingSystemMallocSet()
         if (getenv(list[i]))
             return true;
     }
-
-    // Use system malloc anytime MallocStackLogging is enabled, except when the "vm" or "vmlite" logging modes are enabled.
-    // Those modes only intercept syscalls rather than mallocs, so they don't necessarily imply the use of system malloc.
-    const char* mallocStackLogging = getenv("MallocStackLogging");
-    if (mallocStackLogging && strncmp(mallocStackLogging, "vm", 2))
-        return true;
 
     return false;
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h
@@ -41,6 +41,45 @@ int pthread_self_is_exiting_np(void);
 PAS_END_EXTERN_C;
 #define PAS_HAVE_PTHREAD_PRIVATE 0
 #endif
-#endif
+
+PAS_BEGIN_EXTERN_C;
+
+/* From OSS libmalloc stack_logging.h
+   https://github.com/apple-oss-distributions/libmalloc/blob/main/private/stack_logging.h */
+/*********    MallocStackLogging permanant SPIs  ************/
+
+#define pas_stack_logging_type_free                           0
+#define pas_stack_logging_type_generic                        1    /* anything that is not allocation/deallocation */
+#define pas_stack_logging_type_alloc                          2    /* malloc, realloc, etc... */
+#define pas_stack_logging_type_dealloc                        4    /* free, realloc, etc... */
+#define pas_stack_logging_type_vm_allocate                   16    /* vm_allocate or mmap */
+#define pas_stack_logging_type_vm_deallocate                 32    /* vm_deallocate or munmap */
+#define pas_stack_logging_type_mapped_file_or_shared_mem    128
+
+// The valid flags include those from VM_FLAGS_ALIAS_MASK, which give the user_tag of allocated VM regions.
+#define pas_stack_logging_valid_type_flags ( \
+pas_stack_logging_type_generic | \
+pas_stack_logging_type_alloc | \
+pas_stack_logging_type_dealloc | \
+pas_stack_logging_type_vm_allocate | \
+pas_stack_logging_type_vm_deallocate | \
+pas_stack_logging_type_mapped_file_or_shared_mem | \
+VM_FLAGS_ALIAS_MASK);
+
+// Following flags are absorbed by stack_logging_log_stack()
+#define pas_stack_logging_flag_zone        8    /* NSZoneMalloc, etc... */
+#define pas_stack_logging_flag_cleared    64    /* for NewEmptyHandle */
+
+typedef void(malloc_logger_t)(uint32_t type,
+                              uintptr_t arg1,
+                              uintptr_t arg2,
+                              uintptr_t arg3,
+                              uintptr_t result,
+                              uint32_t num_hot_frames_to_skip);
+extern malloc_logger_t* malloc_logger;
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_OS(DARWIN) */
 
 #endif /* PAS_DARWIN_SPI_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.c
@@ -30,6 +30,7 @@
 #include "pas_deallocate.h"
 
 #include "pas_debug_heap.h"
+#include "pas_malloc_stack_logging.h"
 #include "pas_scavenger.h"
 #include "pas_segregated_page_inlines.h"
 
@@ -106,6 +107,7 @@ bool pas_try_deallocate_slow_no_cache(void* ptr,
         pas_debug_heap_free(ptr);
         return true;
     }
+    pas_msl_free_logging(ptr);
 
     if (verbose)
         pas_log("Deallocating %p normally.\n", ptr);

--- a/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_deallocate.h
@@ -34,6 +34,7 @@
 #include "pas_heap_lock.h"
 #include "pas_heap_ref.h"
 #include "pas_large_heap.h"
+#include "pas_malloc_stack_logging.h"
 #include "pas_segregated_page_inlines.h"
 #include "pas_thread_local_cache.h"
 #include "pas_utils.h"
@@ -103,6 +104,7 @@ static PAS_ALWAYS_INLINE bool pas_try_deallocate_not_small_exclusive_segregated(
         pas_debug_heap_free((void*)begin);
         return true;
     }
+    pas_msl_free_logging((void*)begin);
 
     page_base = config.page_header_func(begin);
     if (page_base) {

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -34,6 +34,7 @@
 #include "pas_debug_heap.h"
 #include "pas_epoch.h"
 #include "pas_full_alloc_bits_inlines.h"
+#include "pas_malloc_stack_logging.h"
 #include "pas_scavenger.h"
 #include "pas_segregated_exclusive_view_inlines.h"
 #include "pas_segregated_size_directory_inlines.h"

--- a/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "bmalloc_heap_config.h"
+#include "bmalloc_heap_inlines.h"
+#include "pas_darwin_spi.h"
+#include "pas_malloc_stack_logging.h"
+#include <stdlib.h>
+
+PAS_BEGIN_EXTERN_C;
+
+pas_msl_is_enabled_flag pas_msl_is_enabled_flag_value = pas_msl_is_enabled_flag_indeterminate;
+static void compute_msl_status(void)
+{
+    pas_msl_is_enabled_flag_value = getenv("MallocStackLogging") ? pas_msl_is_enabled_flag_enabled : pas_msl_is_enabled_flag_disabled;
+}
+
+bool pas_compute_msl_is_enabled(void)
+{
+    static pthread_once_t key = PTHREAD_ONCE_INIT;
+    pthread_once(&key, compute_msl_status);
+    return pas_msl_is_enabled_flag_value == pas_msl_is_enabled_flag_enabled;
+}
+
+#if PAS_OS(DARWIN)
+
+PAS_NEVER_INLINE pas_allocation_result pas_msl_malloc_logging_slow(size_t size, pas_allocation_result result)
+{
+    PAS_TESTING_ASSERT(malloc_logger);
+    if (result.did_succeed && pas_msl_is_enabled())
+        malloc_logger(pas_stack_logging_type_alloc, (uintptr_t)0, (uintptr_t)size, 0, (uintptr_t)result.begin, 0);
+    return result;
+}
+
+PAS_NEVER_INLINE void pas_msl_free_logging_slow(void* ptr)
+{
+    PAS_TESTING_ASSERT(malloc_logger);
+    if (ptr && pas_msl_is_enabled())
+        malloc_logger(pas_stack_logging_type_dealloc, (uintptr_t)0, (uintptr_t)ptr, 0, 0, 0);
+}
+
+#endif
+
+PAS_END_EXTERN_C;
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PAS_MALLOC_STACK_LOGGING_H
+#define PAS_MALLOC_STACK_LOGGING_H
+
+#include "pas_allocation_result.h"
+#include "pas_darwin_spi.h"
+#include "pas_heap_config.h"
+#include "pas_root.h"
+#include "pas_utils.h"
+
+PAS_BEGIN_EXTERN_C;
+
+enum pas_msl_is_enabled_flag {
+    pas_msl_is_enabled_flag_enabled,
+    pas_msl_is_enabled_flag_disabled,
+    pas_msl_is_enabled_flag_indeterminate,
+};
+typedef enum pas_msl_is_enabled_flag pas_msl_is_enabled_flag;
+
+extern pas_msl_is_enabled_flag pas_msl_is_enabled_flag_value;
+PAS_API bool pas_compute_msl_is_enabled(void);
+
+#if PAS_OS(DARWIN)
+PAS_API PAS_NEVER_INLINE pas_allocation_result pas_msl_malloc_logging_slow(size_t size, pas_allocation_result result);
+PAS_API PAS_NEVER_INLINE void pas_msl_free_logging_slow(void*);
+#endif
+
+static PAS_ALWAYS_INLINE bool pas_msl_is_enabled(void)
+{
+    switch (pas_msl_is_enabled_flag_value) {
+    case pas_msl_is_enabled_flag_indeterminate:
+        return pas_compute_msl_is_enabled();
+    case pas_msl_is_enabled_flag_enabled:
+        return true;
+    case pas_msl_is_enabled_flag_disabled:
+        return false;
+    }
+    return false;
+}
+
+static PAS_ALWAYS_INLINE pas_allocation_result pas_msl_malloc_logging(size_t size, pas_allocation_result result)
+{
+#if PAS_OS(DARWIN)
+    if (PAS_UNLIKELY(malloc_logger))
+        return pas_msl_malloc_logging_slow(size, result); /* Keep it tail-call to avoid messing up the fast path code. */
+#else
+    PAS_UNUSED_PARAM(size);
+#endif
+    return result;
+}
+
+static PAS_ALWAYS_INLINE void pas_msl_free_logging(void* ptr)
+{
+#if PAS_OS(DARWIN)
+    if (PAS_UNLIKELY(malloc_logger))
+        return pas_msl_free_logging_slow(ptr); /* Keep it tail-call to avoid messing up the fast path code. */
+#else
+    PAS_UNUSED_PARAM(ptr);
+#endif
+}
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_MALLOC_STACK_LOGGING_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h
@@ -35,6 +35,7 @@
 #include "pas_internal_config.h"
 #include "pas_local_allocator.h"
 #include "pas_local_allocator_result.h"
+#include "pas_malloc_stack_logging.h"
 #include "pas_segregated_page_config_kind_and_role.h"
 #include "pas_utils.h"
 #include <pthread.h>
@@ -106,7 +107,7 @@ static inline pas_thread_local_cache* pas_thread_local_cache_try_get(void)
 static inline bool pas_thread_local_cache_can_set(void)
 {
 #if PAS_OS(DARWIN)
-    return !pthread_self_is_exiting_np();
+    return !pthread_self_is_exiting_np() && !pas_msl_is_enabled();
 #else
     return ((uintptr_t)pas_thread_local_cache_try_get_impl()) != PAS_THREAD_LOCAL_CACHE_DESTROYED;
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h
@@ -30,6 +30,7 @@
 #include "pas_heap_inlines.h"
 #include "pas_allocation_result.h"
 #include "pas_local_allocator_inlines.h"
+#include "pas_malloc_stack_logging.h"
 #include "pas_primitive_heap_ref.h"
 #include "pas_segregated_heap_inlines.h"
 #include "pas_utils.h"
@@ -173,7 +174,7 @@ pas_try_allocate_common_impl_slow(
         
         pas_scavenger_notify_eligibility_if_needed();
         
-        return result;
+        return pas_msl_malloc_logging(size, result);
     }
     
     if (verbose)
@@ -195,7 +196,7 @@ pas_try_allocate_common_impl_slow(
     if (baseline_allocator_result.lock)
         pas_lock_unlock(baseline_allocator_result.lock);
 
-    return result;
+    return pas_msl_malloc_logging(size, result);
 }
 
 static PAS_ALWAYS_INLINE pas_allocation_result

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -29,6 +29,7 @@
 #include "pas_bitfit_directory.h"
 #include "pas_deallocate.h"
 #include "pas_large_map.h"
+#include "pas_malloc_stack_logging.h"
 #include "pas_reallocate_free_mode.h"
 #include "pas_reallocate_heap_teleport_rule.h"
 #include "pas_try_allocate.h"
@@ -180,8 +181,10 @@ pas_try_reallocate_table_bitfit_case(pas_page_base* page_base,
     result = pas_try_allocate_for_reallocate_and_copy(
         old_heap, heap, (void*)begin, old_size, new_size, teleport_rule,
         allocate_callback, allocate_callback_arg);
-    if (result.begin || free_mode == pas_reallocate_free_always)
+    if (result.begin || free_mode == pas_reallocate_free_always) {
         bitfit_config.specialized_page_deallocate_with_page(page, begin);
+        pas_msl_free_logging((void*)begin); /* This will not go to TLC, thus, we need to record deallocation here. */
+    }
     return result;
 }
 
@@ -347,8 +350,10 @@ pas_try_reallocate(void* old_ptr,
             source_heap, heap, old_ptr, old_size, new_size, teleport_rule,
             allocate_callback, allocate_callback_arg);
         
-        if (result.begin || free_mode == pas_reallocate_free_always)
+        if (result.begin || free_mode == pas_reallocate_free_always) {
             pas_deallocate_known_large(old_ptr, config.config_ptr);
+            pas_msl_free_logging(old_ptr); /* This will not go to TLC, thus, we need to record deallocation here. */
+        }
         
         return result;
     } }


### PR DESCRIPTION
#### 5d192fe3d632fdaec9371af3f54db375cd9afe95
<pre>
[libpas] Support MallocStackLogging
<a href="https://bugs.webkit.org/show_bug.cgi?id=246581">https://bugs.webkit.org/show_bug.cgi?id=246581</a>
rdar://101210195

Reviewed by Darin Adler.

This patch adds MallocStackLogging (MSL) support to libpas. After this change, bmalloc will not fallback to system malloc with
MallocStackLogging environment variable (Malloc environment variable etc. fallbacks), and enable libpas MSL.
The limitation is that libpas is not supporting on-demand enablement of MSL. If we would like to collect data,
MallocStackLogging environment variable needs to be set (or use system malloc as before, right now).

libmalloc is invoking malloc_logger hook function on allocations and deallocations. The other framework implements MSL&apos;s actual
stacktrace capturing and it configures malloc_logger hook function, and this is how MSL is implemented in libmalloc. We do the
same thing in libpas: calling malloc_logger hook function on allocations and deallocations.

The challenge is that how to avoid adding these code into the hottest fast path in libpas: libpas allocation path is super tightly
optimized and any additional load etc. regress performance severely. We took similar approach to our system malloc enablement in
libpas: when libpas found MallocStackLogging, it disables thread-local-cache completely. This enforces all allocations and deallocations
go to the slow path. Then, we inserted this hook in the slow path so that we insert this logging without performance penalty when
MSL is not enabled.

We ensured that MSL works and no performance penalty is observed from A/B tests.

* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/bmalloc/Environment.cpp:
(bmalloc::isMallocEnvironmentVariableImplyingSystemMallocSet):
* Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h:
* Source/bmalloc/libpas/src/libpas/pas_deallocate.c:
(pas_try_deallocate_slow_no_cache):
* Source/bmalloc/libpas/src/libpas/pas_deallocate.h:
(pas_try_deallocate_not_small_exclusive_segregated):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
* Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.c: Copied from Source/bmalloc/libpas/src/libpas/pas_darwin_spi.h.
(compute_msl_status):
(pas_compute_msl_is_enabled):
(pas_msl_malloc_logging_slow):
(pas_msl_free_logging_slow):
* Source/bmalloc/libpas/src/libpas/pas_malloc_stack_logging.h: Added.
(pas_msl_is_enabled):
(pas_msl_malloc_logging):
(pas_msl_free_logging):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.h:
(pas_thread_local_cache_can_set):
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_common.h:
(pas_try_allocate_common_impl_slow):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate_table_bitfit_case):
(pas_try_reallocate):

Canonical link: <a href="https://commits.webkit.org/255601@main">https://commits.webkit.org/255601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63ec2975db9d6baeb8cd3aa903e0ab0b77227a7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93056 "16 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102765 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/162990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2267 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30585 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85439 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98881 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98721 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79530 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36979 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/79444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34791 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/79444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/82077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1788 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40590 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/37510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/82077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->