### PR TITLE
REGRESSION (254359@main): Yellow highlight for lookup doesn't show text

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -370,6 +370,7 @@ list(APPEND WebCore_SOURCES
     platform/mac/PlatformScreenMac.mm
     platform/mac/PowerObserverMac.cpp
     platform/mac/PublicSuffixMac.mm
+    platform/mac/RevealUtilities.mm
     platform/mac/SSLKeyGeneratorMac.mm
     platform/mac/ScrollAnimatorMac.mm
     platform/mac/ScrollingEffectsController.mm
@@ -708,6 +709,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mac/PlaybackSessionInterfaceMac.h
     platform/mac/PluginBlocklist.h
     platform/mac/PowerObserverMac.h
+    platform/mac/RevealUtilities.h
     platform/mac/SerializedPlatformDataCueMac.h
     platform/mac/ScrollbarThemeMac.h
     platform/mac/StringUtilities.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -527,6 +527,7 @@ platform/mac/PlaybackSessionInterfaceMac.mm @no-unify
 platform/mac/PluginBlocklist.mm
 platform/mac/PowerObserverMac.cpp
 platform/mac/PublicSuffixMac.mm
+platform/mac/RevealUtilities.mm
 platform/mac/SSLKeyGeneratorMac.mm
 platform/mac/ScrollAnimatorMac.mm @no-unify
 platform/mac/ScrollAnimationRubberBand.mm

--- a/Source/WebCore/editing/cocoa/DictionaryLookup.mm
+++ b/Source/WebCore/editing/cocoa/DictionaryLookup.mm
@@ -43,6 +43,7 @@
 #import "Page.h"
 #import "Range.h"
 #import "RenderObject.h"
+#import "RevealUtilities.h"
 #import "TextIterator.h"
 #import "VisiblePosition.h"
 #import "VisibleSelection.h"
@@ -75,8 +76,7 @@ SOFT_LINK(UIKitMacHelper, UINSSharedRevealController, id<UINSRevealController>, 
 @property (nonatomic, readonly) BOOL useDefaultHighlight;
 @property (nonatomic, readonly) RetainPtr<NSAttributedString> attributedString;
 
-- (instancetype)initWithHighlightRect:(NSRect)highlightRect useDefaultHighlight:(BOOL)useDefaultHighlight attributedString:(NSAttributedString *) attributedString;
-- (void)setClearTextIndicator:(Function<void()>&&)clearTextIndicator;
+- (instancetype)initWithHighlightRect:(NSRect)highlightRect useDefaultHighlight:(BOOL)useDefaultHighlight attributedString:(NSAttributedString *)attributedString clearTextIndicatorCallback:(Function<void()>&&)clearTextIndicatorCallback;
 
 @end
 
@@ -84,7 +84,7 @@ SOFT_LINK(UIKitMacHelper, UINSSharedRevealController, id<UINSRevealController>, 
     Function<void()> _clearTextIndicator;
 }
 
-- (instancetype)initWithHighlightRect:(NSRect)highlightRect useDefaultHighlight:(BOOL)useDefaultHighlight attributedString:(NSAttributedString *) attributedString
+- (instancetype)initWithHighlightRect:(NSRect)highlightRect useDefaultHighlight:(BOOL)useDefaultHighlight attributedString:(NSAttributedString *)attributedString clearTextIndicatorCallback:(Function<void()>&&)clearTextIndicatorCallback
 {
     if (!(self = [super init]))
         return nil;
@@ -92,13 +92,9 @@ SOFT_LINK(UIKitMacHelper, UINSSharedRevealController, id<UINSRevealController>, 
     _highlightRect = highlightRect;
     _useDefaultHighlight = useDefaultHighlight;
     _attributedString = adoptNS([attributedString copy]);
+    _clearTextIndicator = WTFMove(clearTextIndicatorCallback);
     
     return self;
-}
-
-- (void)setClearTextIndicator:(Function<void()>&&)clearTextIndicator
-{
-    _clearTextIndicator = WTFMove(clearTextIndicator);
 }
 
 - (NSArray<NSValue *> *)revealContext:(RVPresentingContext *)context rectsForItem:(RVItem *)item
@@ -461,16 +457,9 @@ static WKRevealController showPopupOrCreateAnimationController(bool createAnimat
         pointerLocation = [view convertPoint:textBaselineOrigin toView:nil];
     }
 
-    auto webHighlight =  adoptNS([[WebRevealHighlight alloc] initWithHighlightRect: highlightRect useDefaultHighlight:!textIndicator.get().contentImage() attributedString:dictionaryPopupInfo.platformData.attributedString.get()]);
-    auto context = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:pointerLocation inView:view highlightDelegate:webHighlight.get()]);
+    auto webHighlight = adoptNS([[WebRevealHighlight alloc] initWithHighlightRect:highlightRect useDefaultHighlight:!textIndicator.get().contentImage() attributedString:dictionaryPopupInfo.platformData.attributedString.get() clearTextIndicatorCallback:WTFMove(clearTextIndicator)]);
     auto item = adoptNS([PAL::allocRVItemInstance() initWithText:dictionaryPopupInfo.platformData.attributedString.get().string selectedRange:NSMakeRange(0, dictionaryPopupInfo.platformData.attributedString.get().string.length)]);
-
-    if (clearTextIndicator) {
-        [webHighlight setClearTextIndicator:[clearTextIndicator = WTFMove(clearTextIndicator)] {
-            clearTextIndicator();
-        }];
-    }
-
+    auto context = createRVPresentingContextWithRetainedDelegate(pointerLocation, view, webHighlight.get());
     if (createAnimationController)
         return [presenter animationControllerForItem:item.get() documentContext:nil presentingContext:context.get() options:nil];
 

--- a/Source/WebCore/editing/mac/DictionaryLookup.h
+++ b/Source/WebCore/editing/mac/DictionaryLookup.h
@@ -66,10 +66,9 @@ public:
     
 #if PLATFORM(MAC)
     WEBCORE_EXPORT static WKRevealController animationControllerForPopup(const DictionaryPopupInfo&, NSView *, const Function<void(TextIndicator&)>& textIndicatorInstallationCallback, const Function<FloatRect(FloatRect)>& rootViewToViewConversionCallback = nullptr, Function<void()>&& clearTextIndicator = nullptr);
-#endif // PLATFORM(MAC)
-    
+#endif
 };
 
 } // namespace WebCore
 
-#endif
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/mac/RevealUtilities.h
+++ b/Source/WebCore/platform/mac/RevealUtilities.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#import <wtf/RetainPtr.h>
+
+@class NSView;
+@class RVPresentingContext;
+@protocol RVPresenterHighlightDelegate;
+
+namespace WebCore {
+
+WEBCORE_EXPORT RetainPtr<RVPresentingContext> createRVPresentingContextWithRetainedDelegate(NSPoint, NSView *, id<RVPresenterHighlightDelegate>);
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/RevealUtilities.mm
+++ b/Source/WebCore/platform/mac/RevealUtilities.mm
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RevealUtilities.h"
+
+#if PLATFORM(MAC)
+
+#import <objc/runtime.h>
+#import <pal/cocoa/RevealSoftLink.h>
+
+namespace WebCore {
+
+RetainPtr<RVPresentingContext> createRVPresentingContextWithRetainedDelegate(NSPoint point, NSView *view, id<RVPresenterHighlightDelegate> delegate)
+{
+    auto context = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:point inView:view highlightDelegate:delegate]);
+    static char retainedDelegateKey;
+    objc_setAssociatedObject(context.get(), &retainedDelegateKey, delegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return context;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -25,12 +25,12 @@
 
 #import "config.h"
 #import "MenuUtilities.h"
-#import <pal/cocoa/RevealSoftLink.h>
 
 #if PLATFORM(MAC)
 
 #import "StringUtilities.h"
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/RevealUtilities.h>
 
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
 #import <pal/spi/mac/TelephonyUtilitiesSPI.h>
@@ -41,6 +41,7 @@ SOFT_LINK_CLASS(TelephonyUtilities, TUCall)
 #endif
 
 #import <pal/cocoa/DataDetectorsCoreSoftLink.h>
+#import <pal/cocoa/RevealSoftLink.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 
 @interface WKEmptyPresenterHighlightDelegate : NSObject <RVPresenterHighlightDelegate>
@@ -141,9 +142,7 @@ RetainPtr<NSMenu> menuForTelephoneNumber(const String& telephoneNumber, NSView *
     auto item = adoptNS([PAL::allocRVItemInstance() initWithURL:[urlComponents URL] rangeInContext:NSMakeRange(0, telephoneNumber.length())]);
     auto presenter = adoptNS([PAL::allocRVPresenterInstance() init]);
     auto delegate = adoptNS([[WKEmptyPresenterHighlightDelegate alloc] initWithRect:rect]);
-    auto context = adoptNS([PAL::allocRVPresentingContextInstance() initWithPointerLocationInView:NSZeroPoint inView:webView highlightDelegate:delegate.get()]);
-    static char wkRevealDelegateKey;
-    objc_setAssociatedObject(context.get(), &wkRevealDelegateKey, delegate.get(), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    auto context = WebCore::createRVPresentingContextWithRetainedDelegate(NSZeroPoint, webView, delegate.get());
     NSArray *proposedMenuItems = [presenter menuItemsForItem:item.get() documentContext:nil presentingContext:context.get() options:nil];
     
     [menu setItemArray:proposedMenuItems];

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
@@ -56,6 +56,10 @@ WK_AUTHKIT_LDFLAGS_IOS_SINCE_13 = -framework AuthKit;
 WK_AUTHKIT_LDFLAGS_macosx = $(WK_AUTHKIT_LDFLAGS$(WK_MACOS_1015));
 WK_AUTHKIT_LDFLAGS_MACOS_SINCE_1015 = -framework AuthKit;
 
+WK_REVEAL_LDFLAGS = $(WK_REVEAL_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_REVEAL_LDFLAGS_macosx = $(WK_REVEAL_LDFLAGS$(WK_MACOS_1015));
+WK_REVEAL_LDFLAGS_MACOS_SINCE_1015 = -framework Reveal;
+
 WK_HID_LDFLAGS = $(WK_HID_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_HID_LDFLAGS_macosx = $(WK_HID_LDFLAGS$(WK_MACOS_1015));
 WK_HID_LDFLAGS_MACOS_SINCE_1015 = -framework HID;
@@ -98,7 +102,7 @@ WK_WEBCORE_LDFLAGS_watchsimulator = -framework WebCore
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
 OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
 
 // FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.


### PR DESCRIPTION
#### d34e00e6207ce86589cf77dd2f91a1d905fddd3f
<pre>
REGRESSION (254359@main): Yellow highlight for lookup doesn&apos;t show text
<a href="https://bugs.webkit.org/show_bug.cgi?id=246586">https://bugs.webkit.org/show_bug.cgi?id=246586</a>
rdar://100828328

Reviewed by Aditya Keerthi.

After 254359@main, we no longer have a retain cycle between the `WebRevealHighlight` and the
`_clearTextIndicator` callback block data. However, this means that nothing currently holds on to
`WebRevealHighlight` after we return from `showPopupOrCreateAnimationController`, which causes the
text indicator snapshot and data to not show up when looking up a word (e.g. via force click).

To fix this without reintroducing the retain cycle, we instead tie the lifetime of the
`WebRevealHighlight` to the `RVPresentingContext` itself, which only has a weak pointer back to the
reveal highlight (via `-highlightDelegate`). This ensures that the highlight information will never
prematurely disappear from underneath the presenting context.

Note that this technique is already used in `MenuUtilities.mm` inside `menuForTelephoneNumber`,
which handles context menu presentation when force clicking on a data detected phone number. To
avoid repeating this code in both places, we move it into a new helper function in `RevealUtilities`
and call it from both places.

See below for more details.

Test: ImmediateActionTests.ImmediateActionOverText

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/cocoa/DictionaryLookup.mm:
(-[WebRevealHighlight initWithHighlightRect:useDefaultHighlight:attributedString:clearTextIndicatorCallback:]):

Drive-by refactoring: remove `setClearTextIndicator:`, and just pass it in when creating the reveal
highlight. Currently, this method is only called right after initialization anyways.

(WebCore::showPopupOrCreateAnimationController):

Use the new `createRVPresentingContextWithRetainedDelegate` method to create the presenting context.

(-[WebRevealHighlight initWithHighlightRect:useDefaultHighlight:attributedString:]): Deleted.
(-[WebRevealHighlight setClearTextIndicator:]): Deleted.
* Source/WebCore/editing/mac/DictionaryLookup.h:
* Source/WebCore/platform/mac/RevealUtilities.h: Added.
* Source/WebCore/platform/mac/RevealUtilities.mm: Added.

Add a new file that contains a helper method (`createRVPresentingContextWithRetainedDelegate`) that
allocates a new `RVPresentingContext` with the given parameters, and ties the lifetime of the
delegate to the context.

(WebCore::createRVPresentingContextWithRetainedDelegate):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::menuForTelephoneNumber):

Use the new helper method here, too.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:

Additionally link against Reveal in TestWebKitAPI on macOS, so that it&apos;s simpler to intercept and
replace the call to `-initWithPointerLocationInView:inView:highlightDelegate:`.

* Tools/TestWebKitAPI/Tests/mac/ImmediateActionTests.mm:
(-[NSObject swizzled_initWithPointerLocationInView:inView:highlightDelegate:]):
(TestWebKitAPI::swizzlePresentingContextInitialization):

Augment a test to verify that the `RVPresentingContext`&apos;s highlight delegate doesn&apos;t vanish right
after triggering Look Up via a force click.

Canonical link: <a href="https://commits.webkit.org/255642@main">https://commits.webkit.org/255642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00306e14e229bb8b4dcd86309069c2ac2e15cd2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102749 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/162975 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2254 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30571 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98867 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1549 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79516 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28464 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/36965 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17084 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18290 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3909 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40884 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37481 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->