### PR TITLE
CSS Keyframes names can't be CSS wide keywords

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL invalid: @keyframes none { } assert_equals: expected 0 but got 1
-FAIL invalid: @keyframes default { } assert_equals: expected 0 but got 1
-FAIL invalid: @keyframes initial { } assert_equals: expected 0 but got 1
-FAIL invalid: @keyframes inherit { } assert_equals: expected 0 but got 1
-FAIL invalid: @keyframes unset { } assert_equals: expected 0 but got 1
-FAIL invalid: @keyframes revert { } assert_equals: expected 0 but got 1
-FAIL invalid: @keyframes revert-layer { } assert_equals: expected 0 but got 1
+PASS invalid: @keyframes none { }
+PASS invalid: @keyframes default { }
+PASS invalid: @keyframes initial { }
+PASS invalid: @keyframes inherit { }
+PASS invalid: @keyframes unset { }
+PASS invalid: @keyframes revert { }
+PASS invalid: @keyframes revert-layer { }
 PASS invalid: @keyframes 12 { }
 PASS invalid: @keyframes -12 { }
 PASS invalid: @keyframes 12foo { }


### PR DESCRIPTION
#### d71fb1b829e793d50dc0d909865611cdb22e5589
<pre>
CSS Keyframes names can&apos;t be CSS wide keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=246596">https://bugs.webkit.org/show_bug.cgi?id=246596</a>
rdar://101226253

Reviewed by Tim Nguyen.

The CSS Animations and CSS Values specifications require identifier-based
keyframes names to not be CSS wide keywords, nor &quot;default&quot;, nor &quot;none&quot;.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeKeyframesRule): Forbid the invalid names.

Canonical link: <a href="https://commits.webkit.org/255640@main">https://commits.webkit.org/255640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6172654cbf77b4e0557d4c5cbcb4653776a45a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102858 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2355 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30679 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98978 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98818 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79624 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37068 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34882 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3906 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38753 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37649 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->