### PR TITLE
WebPush.ITPCleanup test always fails

### DIFF
--- a/Tools/TestWebKitAPI/TestNotificationProvider.cpp
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.cpp
@@ -131,12 +131,17 @@ void TestNotificationProvider::showWebNotification(WKPageRef page, WKNotificatio
     m_pendingNotification = std::make_pair(notificationManager, identifier);
 }
 
-void TestNotificationProvider::simulateNotificationClick()
+bool TestNotificationProvider::simulateNotificationClick()
 {
+    if (!m_pendingNotification.first)
+        return false;
+
     callOnMainThread([pair = std::exchange(m_pendingNotification, { })] {
         WKNotificationManagerProviderDidClickNotification(pair.first, pair.second);
         WKRelease(pair.first);
     });
+
+    return true;
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/TestNotificationProvider.h
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.h
@@ -45,7 +45,7 @@ public:
 
     WKDictionaryRef notificationPermissions() const;
     void showWebNotification(WKPageRef, WKNotificationRef);
-    void simulateNotificationClick();
+    bool simulateNotificationClick();
 
     bool hasReceivedNotification() const { return m_hasReceivedNotification; }
     void resetHasReceivedNotification() { m_hasReceivedNotification = false; }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -718,7 +718,7 @@ TEST(PushAPI, fireNotificationClickEvent)
 
     terminateNetworkProcessWhileRegistrationIsStored(configuration.get());
 
-    provider.simulateNotificationClick();
+    EXPECT_TRUE(provider.simulateNotificationClick());
 
     done = false;
     expectedMessage = "Received notificationclick"_s;


### PR DESCRIPTION
#### bd280775effe920408259d38f459197afd9e0aac
<pre>
WebPush.ITPCleanup test always fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=246601">https://bugs.webkit.org/show_bug.cgi?id=246601</a>
rdar://problem/101228159

Reviewed by Alex Christensen.

The WebPush.ITPCleanup test always fails. This fixes that and also refactors the code so it is
easier to test further interactions between Web Push and ITP (e.g. 246468):

- We now enable an ITP database as part of WebPushDTest test setup.
- The ITP tests now use the same initialization as all the other Web Push tests (by building off of
  the WebPushDTest class).
- Added a test case (NotificationClickExtendsITPCleanupTimerBy30Days) that should pass once 246468
  is resolved; for now, the part that fails is commented out.

* Tools/TestWebKitAPI/TestNotificationProvider.cpp:
(TestWebKitAPI::TestNotificationProvider::simulateNotificationClick):
* Tools/TestWebKitAPI/TestNotificationProvider.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:

Canonical link: <a href="https://commits.webkit.org/255648@main">https://commits.webkit.org/255648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05d872d278db7a69cb813e7a1245ec45c6bca26c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93078 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102786 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163103 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2287 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30606 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98903 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1576 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79552 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28494 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37000 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17136 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18362 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3913 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40912 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37565 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->