### PR TITLE
[Fetch API] Headers iteration should not happen on cached headers list

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any-expected.txt
@@ -18,4 +18,8 @@ PASS Check values method
 PASS Check entries method
 PASS Check Symbol.iterator method
 PASS Check forEach method
+PASS Iteration skips elements removed while iterating
+PASS Removing elements already iterated over causes an element to be skipped during iteration
+PASS Appending a value pair during iteration causes it to be reached during iteration
+PASS Prepending a value pair before the current element position causes it to be skipped during iteration and adds the current element a second time
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.js
@@ -218,3 +218,58 @@ test(function() {
   });
   assert_true(reference.next().done);
 }, "Check forEach method");
+
+test(() => {
+  const headers = new Headers({"foo": "2", "baz": "1", "BAR": "0"});
+  const actualKeys = [];
+  const actualValues = [];
+  for (const [header, value] of headers) {
+    actualKeys.push(header);
+    actualValues.push(value);
+    headers.delete("foo");
+  }
+  assert_array_equals(actualKeys, ["bar", "baz"]);
+  assert_array_equals(actualValues, ["0", "1"]);
+}, "Iteration skips elements removed while iterating");
+
+test(() => {
+  const headers = new Headers({"foo": "2", "baz": "1", "BAR": "0", "quux": "3"});
+  const actualKeys = [];
+  const actualValues = [];
+  for (const [header, value] of headers) {
+    actualKeys.push(header);
+    actualValues.push(value);
+    if (header === "baz")
+      headers.delete("bar");
+  }
+  assert_array_equals(actualKeys, ["bar", "baz", "quux"]);
+  assert_array_equals(actualValues, ["0", "1", "3"]);
+}, "Removing elements already iterated over causes an element to be skipped during iteration");
+
+test(() => {
+  const headers = new Headers({"foo": "2", "baz": "1", "BAR": "0", "quux": "3"});
+  const actualKeys = [];
+  const actualValues = [];
+  for (const [header, value] of headers) {
+    actualKeys.push(header);
+    actualValues.push(value);
+    if (header === "baz")
+      headers.append("X-yZ", "4");
+  }
+  assert_array_equals(actualKeys, ["bar", "baz", "foo", "quux", "x-yz"]);
+  assert_array_equals(actualValues, ["0", "1", "2", "3", "4"]);
+}, "Appending a value pair during iteration causes it to be reached during iteration");
+
+test(() => {
+  const headers = new Headers({"foo": "2", "baz": "1", "BAR": "0", "quux": "3"});
+  const actualKeys = [];
+  const actualValues = [];
+  for (const [header, value] of headers) {
+    actualKeys.push(header);
+    actualValues.push(value);
+    if (header === "baz")
+      headers.append("abc", "-1");
+  }
+  assert_array_equals(actualKeys, ["bar", "baz", "baz", "foo", "quux"]);
+  assert_array_equals(actualValues, ["0", "1", "1", "2", "3"]);
+}, "Prepending a value pair before the current element position causes it to be skipped during iteration and adds the current element a second time");

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.worker-expected.txt
@@ -18,4 +18,8 @@ PASS Check values method
 PASS Check entries method
 PASS Check Symbol.iterator method
 PASS Check forEach method
+PASS Iteration skips elements removed while iterating
+PASS Removing elements already iterated over causes an element to be skipped during iteration
+PASS Appending a value pair during iteration causes it to be reached during iteration
+PASS Prepending a value pair before the current element position causes it to be skipped during iteration and adds the current element a second time
 

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -150,6 +150,7 @@ ExceptionOr<void> FetchHeaders::fill(const FetchHeaders& otherHeaders)
 
 ExceptionOr<void> FetchHeaders::append(const String& name, const String& value)
 {
+    ++m_updateCounter;
     return appendToHeaderMap(name, value, m_headers, m_guard);
 }
 
@@ -167,6 +168,7 @@ ExceptionOr<void> FetchHeaders::remove(const String& name)
     if (m_guard == FetchHeaders::Guard::Response && isForbiddenResponseHeaderName(name))
         return { };
 
+    ++m_updateCounter;
     m_headers.remove(name);
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
@@ -198,6 +200,7 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
     if (!canWriteResult.releaseReturnValue())
         return { };
 
+    ++m_updateCounter;
     m_headers.set(name, normalizedValue);
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
@@ -224,6 +227,14 @@ void FetchHeaders::filterAndFill(const HTTPHeaderMap& headers, Guard guard)
 
 std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
 {
+    if (m_keys.isEmpty() || m_updateCounter != m_headers->m_updateCounter) {
+        m_keys.resize(0);
+        m_keys.reserveCapacity(m_headers->m_headers.size());
+        for (auto& header : m_headers->m_headers)
+            m_keys.uncheckedAppend(header.key.convertToASCIILowercase());
+        std::sort(m_keys.begin(), m_keys.end(), WTF::codePointCompareLessThan);
+        m_updateCounter = m_headers->m_updateCounter;
+    }
     while (m_currentIndex < m_keys.size()) {
         auto key = m_keys[m_currentIndex++];
         auto value = m_headers->m_headers.get(key);
@@ -236,10 +247,6 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
 FetchHeaders::Iterator::Iterator(FetchHeaders& headers)
     : m_headers(headers)
 {
-    m_keys.reserveInitialCapacity(headers.m_headers.size());
-    for (auto& header : headers.m_headers)
-        m_keys.uncheckedAppend(header.key.convertToASCIILowercase());
-    std::sort(m_keys.begin(), m_keys.end(), WTF::codePointCompareLessThan);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -75,6 +75,7 @@ public:
         Ref<FetchHeaders> m_headers;
         size_t m_currentIndex { 0 };
         Vector<String> m_keys;
+        size_t m_updateCounter { 0 };
     };
     Iterator createIterator() { return Iterator { *this }; }
 
@@ -90,6 +91,7 @@ private:
 
     Guard m_guard;
     HTTPHeaderMap m_headers;
+    uint64_t m_updateCounter { 0 };
 };
 
 inline FetchHeaders::FetchHeaders(Guard guard, HTTPHeaderMap&& headers)


### PR DESCRIPTION
#### 68f5a2f24c94431e60a9517543ad28b25e5809c3
<pre>
[Fetch API] Headers iteration should not happen on cached headers list
<a href="https://bugs.webkit.org/show_bug.cgi?id=246526">https://bugs.webkit.org/show_bug.cgi?id=246526</a>
rdar://problem/101235580

Reviewed by Chris Dumez.

We introduce a change counter that is incremented anytime a JS API is mutating the headers (append, delete, set).
We recreate the header list as needed, either on the first time or if the change counter tells us to do so.

Covered by resynced WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/headers-basic.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::FetchHeaders::append):
(WebCore::FetchHeaders::remove):
(WebCore::FetchHeaders::set):
(WebCore::FetchHeaders::Iterator::next):
(WebCore::FetchHeaders::Iterator::Iterator):
* Source/WebCore/Modules/fetch/FetchHeaders.h:

Canonical link: <a href="https://commits.webkit.org/255639@main">https://commits.webkit.org/255639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80778856c2941df68b9fe32fb3c8cc80f2a2db70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102805 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2306 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30626 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98923 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1590 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79572 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28511 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83269 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71620 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37019 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17154 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18388 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3907 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38702 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40929 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37592 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->