### PR TITLE
Make sure to set bitrate and framerate for VPX encoders

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,7 +1,5 @@
-CONSOLE MESSAGE: TypeError: Config is not valid
-CONSOLE MESSAGE: TypeError: Config is not valid
-CONSOLE MESSAGE: TypeError: Config is not valid
-CONSOLE MESSAGE: TypeError: Config is not valid
+CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Type error
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: TypeError: Config is not valid
-CONSOLE MESSAGE: TypeError: Config is not valid
-CONSOLE MESSAGE: TypeError: Config is not valid
+CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Type error
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
@@ -1,3 +1,21 @@
+CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+
+Harness Error (FAIL), message = InvalidStateError: VideoDecoder is not configured
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
@@ -1,3 +1,21 @@
+CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
+
+Harness Error (FAIL), message = InvalidStateError: VideoDecoder is not configured
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt
@@ -1,7 +1,6 @@
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
 
-Harness Error (FAIL), message = Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
+Harness Error (FAIL), message = Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
 
 FAIL Reconfiguring encoder assert_equals: expected 16 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt
@@ -1,37 +1,37 @@
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 800 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
-CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
 
-Harness Error (FAIL), message = Error: assert_unreached: assert_equals: expected (number) 640 but got (undefined) undefined Reached unreachable code
+Harness Error (FAIL), message = Error: assert_unreached: assert_equals: expected 640 but got 800 Reached unreachable code
 
 PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp8-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
 
-FAIL Reconfiguring encoder assert_equals: expected 16 but got 0
+Harness Error (FAIL), message = Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p0-expected.txt
@@ -1,3 +1,6 @@
+CONSOLE MESSAGE: Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
 
-FAIL Reconfiguring encoder assert_equals: expected 16 but got 0
+Harness Error (FAIL), message = Error: assert_unreached: assert_equals: expected 800 but got 640 Reached unreachable code
+
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_vp8-expected.txt
@@ -1,4 +1,54 @@
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
 
-FAIL SVC L1T2 assert_equals: expected 24 but got 0
-FAIL SVC L1T3 assert_equals: expected 24 but got 0
+Harness Error (FAIL), message = Error: assert_own_property: expected property "svc" missing
+
+FAIL SVC L1T2 assert_equals: expected 12 but got 0
+FAIL SVC L1T3 assert_equals: expected 6 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_vp9-expected.txt
@@ -1,4 +1,54 @@
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
+CONSOLE MESSAGE: Error: assert_own_property: expected property "svc" missing
 
-FAIL SVC L1T2 assert_equals: expected 24 but got 0
-FAIL SVC L1T3 assert_equals: expected 24 but got 0
+Harness Error (FAIL), message = Error: assert_own_property: expected property "svc" missing
+
+FAIL SVC L1T2 assert_equals: expected 12 but got 0
+FAIL SVC L1T3 assert_equals: expected 6 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
@@ -1,44 +1,14 @@
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
-CONSOLE MESSAGE: VideoEncoder encode failed: Frame resolution does not match VPx encoder configured size
 
 PASS Test VideoEncoder construction
 PASS Test VideoEncoder.configure()
-FAIL Test successful configure(), encode(), and flush() assert_not_equals: got disallowed value null
+FAIL Test successful configure(), encode(), and flush() promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'decoderConfig.colorSpace.primaries')"
 FAIL encodeQueueSize test assert_equals: expected 0 but got Infinity
-FAIL Test successful reset() and re-confiugre() assert_unreached: unexpected error Reached unreachable code
-FAIL Test successful encode() after re-configure(). assert_equals: number of chunks expected 2 but got 0
+PASS Test successful reset() and re-confiugre()
+PASS Test successful encode() after re-configure().
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
 FAIL Verify encoding closed frames throws. assert_throws_dom: function "() => {
     encoder.encode(frame);
   }" threw object "TypeError: VideoFrame is detached" that is not a DOMException OperationError: property "code" is equal to undefined, expected 0
-FAIL Encode video with negative timestamp assert_equals: expected 1 but got 0
+PASS Encode video with negative timestamp
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt
@@ -1,5 +1,10 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
 
-Harness Error (TIMEOUT), message = null
+Harness Error (FAIL), message = Unhandled rejection: Type error
+
+TIMEOUT Create ImageBitmap for a VideoFrame from VP9 decoder. Test timed out
+
+Harness Error (FAIL), message = Unhandled rejection: Type error
 
 TIMEOUT Create ImageBitmap for a VideoFrame from VP9 decoder. Test timed out
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "VideoEncoder.h"
 #include "WebCodecsCodecState.h"
+#include "WebCodecsVideoEncoderConfig.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -41,7 +42,6 @@ class WebCodecsErrorCallback;
 class WebCodecsEncodedVideoChunkOutputCallback;
 class WebCodecsVideoFrame;
 struct WebCodecsEncodedVideoChunkMetadata;
-struct WebCodecsVideoEncoderConfig;
 struct WebCodecsVideoEncoderEncodeOptions;
 
 class WebCodecsVideoEncoder
@@ -108,6 +108,7 @@ private:
     bool m_isKeyChunkRequired { false };
     Deque<Function<void()>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
+    WebCodecsVideoEncoderConfig m_baseConfiguration;
     VideoEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };
 };

--- a/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp
@@ -55,14 +55,16 @@ static WorkQueue& vpxQueue()
 
 class LibWebRTCVPXInternalVideoEncoder : public ThreadSafeRefCounted<LibWebRTCVPXInternalVideoEncoder> , public webrtc::EncodedImageCallback {
 public:
-    static Ref<LibWebRTCVPXInternalVideoEncoder> create(LibWebRTCVPXVideoEncoder::Type type, const VideoEncoder::Config& config, VideoEncoder::OutputCallback&& outputCallback, VideoEncoder::PostTaskCallback&& postTaskCallback) { return adoptRef(*new LibWebRTCVPXInternalVideoEncoder(type, config, WTFMove(outputCallback), WTFMove(postTaskCallback))); }
+    static Ref<LibWebRTCVPXInternalVideoEncoder> create(LibWebRTCVPXVideoEncoder::Type type, VideoEncoder::OutputCallback&& outputCallback, VideoEncoder::PostTaskCallback&& postTaskCallback) { return adoptRef(*new LibWebRTCVPXInternalVideoEncoder(type, WTFMove(outputCallback), WTFMove(postTaskCallback))); }
     ~LibWebRTCVPXInternalVideoEncoder() = default;
+
+    int initialize(LibWebRTCVPXVideoEncoder::Type, const VideoEncoder::Config&);
 
     void postTask(Function<void()>&& task) { m_postTaskCallback(WTFMove(task)); }
     void encode(VideoEncoder::RawFrame&&, bool shouldGenerateKeyFrame, VideoEncoder::EncodeCallback&&);
     void close() { m_isClosed = true; }
 private:
-    LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXVideoEncoder::Type, const VideoEncoder::Config&, VideoEncoder::OutputCallback&&, VideoEncoder::PostTaskCallback&&);
+    LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXVideoEncoder::Type, VideoEncoder::OutputCallback&&, VideoEncoder::PostTaskCallback&&);
     webrtc::EncodedImageCallback::Result OnEncodedImage(const webrtc::EncodedImage&, const webrtc::CodecSpecificInfo*) final;
     void OnDroppedFrame(DropReason) final;
 
@@ -74,29 +76,39 @@ private:
     bool m_isClosed { false };
     uint64_t m_width { 0 };
     uint64_t m_height { 0 };
+    bool m_isInitialized { false };
+    bool m_hasEncoded { false };
 };
 
 void LibWebRTCVPXVideoEncoder::create(Type type, const VideoEncoder::Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback)
 {
-    auto encoder = makeUniqueRef<LibWebRTCVPXVideoEncoder>(type, config, WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(postTaskCallback));
-    vpxQueue().dispatch([callback = WTFMove(callback), encoder = WTFMove(encoder)]() mutable {
+    auto encoder = makeUniqueRef<LibWebRTCVPXVideoEncoder>(type, WTFMove(outputCallback), WTFMove(postTaskCallback));
+    auto error = encoder->initialize(type, config);
+    vpxQueue().dispatch([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error, type]() mutable {
         auto internalEncoder = encoder->m_internalEncoder;
-        internalEncoder->postTask([callback = WTFMove(callback), encoder = WTFMove(encoder)]() mutable {
+        internalEncoder->postTask([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error, type]() mutable {
+            if (error) {
+                callback(makeUnexpected(makeString("VPx encoding initialization failed with error ", error)));
+                return;
+            }
             callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
+            descriptionCallback(VideoEncoder::ActiveConfiguration { type == Type::VP8 ? "vp8"_s : "vp9.00"_s, { }, { }, { }, { }, { } });
         });
     });
 }
 
-LibWebRTCVPXVideoEncoder::LibWebRTCVPXVideoEncoder(Type type, const VideoEncoder::Config& config, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback)
-    : m_internalEncoder(LibWebRTCVPXInternalVideoEncoder::create(type, config, WTFMove(outputCallback), WTFMove(postTaskCallback)))
+LibWebRTCVPXVideoEncoder::LibWebRTCVPXVideoEncoder(Type type, OutputCallback&& outputCallback, PostTaskCallback&& postTaskCallback)
+    : m_internalEncoder(LibWebRTCVPXInternalVideoEncoder::create(type, WTFMove(outputCallback), WTFMove(postTaskCallback)))
 {
-    vpxQueue().dispatch([type, descriptionCallback = WTFMove(descriptionCallback)]() mutable {
-        descriptionCallback(VideoEncoder::ActiveConfiguration { type == Type::VP8 ? "vp8"_s : "vp9.00"_s, { }, { }, { }, { }, { } });
-    });
 }
 
 LibWebRTCVPXVideoEncoder::~LibWebRTCVPXVideoEncoder()
 {
+}
+
+int LibWebRTCVPXVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type type, const VideoEncoder::Config& config)
+{
+    return m_internalEncoder->initialize(type, config);
 }
 
 void LibWebRTCVPXVideoEncoder::encode(RawFrame&& frame, bool shouldGenerateKeyFrame, EncodeCallback&& callback)
@@ -123,39 +135,6 @@ void LibWebRTCVPXVideoEncoder::close()
     m_internalEncoder->close();
 }
 
-
-void LibWebRTCVPXInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bool shouldGenerateKeyFrame, VideoEncoder::EncodeCallback&& callback)
-{
-    if (m_width != rawFrame.frame->presentationSize().width() || m_height != rawFrame.frame->presentationSize().height()) {
-        // FIXME: Decide whether to add support, via scaling or cropping for instance.
-        m_postTaskCallback([protectedThis = Ref { *this }, callback = WTFMove(callback)]() mutable {
-            callback("Frame resolution does not match VPx encoder configured size"_s);
-        });
-        return;
-    }
-
-    m_timestamp = rawFrame.timestamp;
-    m_duration = rawFrame.duration;
-
-    auto frameType = shouldGenerateKeyFrame ? webrtc::VideoFrameType::kVideoFrameKey : webrtc::VideoFrameType::kVideoFrameDelta;
-    std::vector<webrtc::VideoFrameType> frameTypes { frameType };
-
-    auto frameBuffer = webrtc::pixelBufferToFrame(rawFrame.frame->pixelBuffer());
-
-    webrtc::VideoFrame frame { frameBuffer, webrtc::kVideoRotation_0, rawFrame.timestamp };
-    auto error = m_internalEncoder->Encode(frame, &frameTypes);
-
-    m_postTaskCallback([protectedThis = Ref { *this }, error, callback = WTFMove(callback)]() mutable {
-        if (protectedThis->m_isClosed)
-            return;
-
-        String result;
-        if (error)
-            result = makeString("VPx encoding failed with error ", error);
-        callback(WTFMove(result));
-    });
-}
-
 static UniqueRef<webrtc::VideoEncoder> createInternalEncoder(LibWebRTCVPXVideoEncoder::Type type)
 {
     if (type == LibWebRTCVPXVideoEncoder::Type::VP8)
@@ -163,19 +142,17 @@ static UniqueRef<webrtc::VideoEncoder> createInternalEncoder(LibWebRTCVPXVideoEn
     return makeUniqueRefFromNonNullUniquePtr(webrtc::VP9Encoder::Create());
 }
 
-LibWebRTCVPXInternalVideoEncoder::LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXVideoEncoder::Type type, const VideoEncoder::Config& config, VideoEncoder::OutputCallback&& outputCallback, VideoEncoder::PostTaskCallback&& postTaskCallback)
+LibWebRTCVPXInternalVideoEncoder::LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXVideoEncoder::Type type, VideoEncoder::OutputCallback&& outputCallback, VideoEncoder::PostTaskCallback&& postTaskCallback)
     : m_outputCallback(WTFMove(outputCallback))
     , m_postTaskCallback(WTFMove(postTaskCallback))
     , m_internalEncoder(createInternalEncoder(type))
-    , m_width(config.width)
-    , m_height(config.height)
 {
-    if (config.bitRate) {
-        webrtc::VideoBitrateAllocation allocation;
-        allocation.SetBitrate(0, 0, config.bitRate);
-        m_internalEncoder->SetRates({ allocation, config.frameRate });
-    }
-    m_internalEncoder->RegisterEncodeCompleteCallback(this);
+}
+
+int LibWebRTCVPXInternalVideoEncoder::initialize(LibWebRTCVPXVideoEncoder::Type type, const VideoEncoder::Config& config)
+{
+    m_width = config.width;
+    m_height = config.height;
 
     const int defaultPayloadSize = 1440;
     webrtc::VideoCodec videoCodec;
@@ -191,8 +168,50 @@ LibWebRTCVPXInternalVideoEncoder::LibWebRTCVPXInternalVideoEncoder(LibWebRTCVPXV
         videoCodec.VP9()->numberOfTemporalLayers = 1;
     }
 
-    // FIXME: Check InitEncode result.
-    m_internalEncoder->InitEncode(&videoCodec, webrtc::VideoEncoder::Settings { webrtc::VideoEncoder::Capabilities { true }, static_cast<int>(webrtc::CpuInfo::DetectNumberOfCores()), defaultPayloadSize });
+    if (auto error = m_internalEncoder->InitEncode(&videoCodec, webrtc::VideoEncoder::Settings { webrtc::VideoEncoder::Capabilities { true }, static_cast<int>(webrtc::CpuInfo::DetectNumberOfCores()), defaultPayloadSize }))
+        return error;
+
+    m_isInitialized = true;
+
+    webrtc::VideoBitrateAllocation allocation;
+    allocation.SetBitrate(0, 0, config.bitRate ? config.bitRate : 3 * config.width * config.height);
+    m_internalEncoder->SetRates({ allocation, config.frameRate ? config.frameRate : 30.0 });
+
+    m_internalEncoder->RegisterEncodeCompleteCallback(this);
+    return 0;
+}
+
+void LibWebRTCVPXInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bool shouldGenerateKeyFrame, VideoEncoder::EncodeCallback&& callback)
+{
+    if (!m_isInitialized)
+        return;
+
+    m_timestamp = rawFrame.timestamp;
+    m_duration = rawFrame.duration;
+
+    auto frameType = (shouldGenerateKeyFrame || !m_hasEncoded) ? webrtc::VideoFrameType::kVideoFrameKey : webrtc::VideoFrameType::kVideoFrameDelta;
+    std::vector<webrtc::VideoFrameType> frameTypes { frameType };
+
+    auto frameBuffer = webrtc::pixelBufferToFrame(rawFrame.frame->pixelBuffer());
+
+    if (m_width != static_cast<size_t>(frameBuffer->width()) || m_height != static_cast<size_t>(frameBuffer->height()))
+        frameBuffer = frameBuffer->Scale(m_width, m_height);
+
+    webrtc::VideoFrame frame { frameBuffer, webrtc::kVideoRotation_0, rawFrame.timestamp };
+    auto error = m_internalEncoder->Encode(frame, &frameTypes);
+
+    if (!m_hasEncoded)
+        m_hasEncoded = !error;
+
+    m_postTaskCallback([protectedThis = Ref { *this }, error, callback = WTFMove(callback)]() mutable {
+        if (protectedThis->m_isClosed)
+            return;
+
+        String result;
+        if (error)
+            result = makeString("VPx encoding failed with error ", error);
+        callback(WTFMove(result));
+    });
 }
 
 webrtc::EncodedImageCallback::Result LibWebRTCVPXInternalVideoEncoder::OnEncodedImage(const webrtc::EncodedImage& encodedImage, const webrtc::CodecSpecificInfo*)

--- a/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.h
+++ b/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.h
@@ -41,10 +41,11 @@ public:
     enum class Type { VP8, VP9 };
     static void create(Type, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
 
-    LibWebRTCVPXVideoEncoder(Type, const Config&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
+    LibWebRTCVPXVideoEncoder(Type, OutputCallback&&, PostTaskCallback&&);
     ~LibWebRTCVPXVideoEncoder();
 
 private:
+    int initialize(LibWebRTCVPXVideoEncoder::Type, const VideoEncoder::Config&);
     void encode(RawFrame&&, bool shouldGenerateKeyFrame, EncodeCallback&&) final;
     void flush(Function<void()>&&) final;
     void reset() final;


### PR DESCRIPTION
#### 449a88665b2df5e298ee863b72b9515bfe8e029e
<pre>
Make sure to set bitrate and framerate for VPX encoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=246626">https://bugs.webkit.org/show_bug.cgi?id=246626</a>
rdar://problem/101245414

Reviewed by Eric Carlson.

Make sure to set bitrate and framerate values if they are not provided.
Make decoder configuration more precise based on the encoder configuration.
Make sure to error the encoder if InitEncode returns an error.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_vp9-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::createEncodedChunkMetadata):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoEncoder::create):
(WebCore::LibWebRTCVPXVideoEncoder::create):
(WebCore::LibWebRTCVPXVideoEncoder::LibWebRTCVPXVideoEncoder):
(WebCore::LibWebRTCVPXVideoEncoder::initialize):
(WebCore::LibWebRTCVPXInternalVideoEncoder::LibWebRTCVPXInternalVideoEncoder):
(WebCore::LibWebRTCVPXInternalVideoEncoder::initialize):
(WebCore::LibWebRTCVPXInternalVideoEncoder::encode):
* Source/WebCore/platform/LibWebRTCVPXVideoEncoder.h:

Canonical link: <a href="https://commits.webkit.org/255666@main">https://commits.webkit.org/255666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/063d2650a250d5ab21be67f69703074f8892cdda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102862 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163157 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2359 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30682 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98981 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1639 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79627 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28558 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83321 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71667 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37071 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17200 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34886 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18442 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3926 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40979 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37651 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->