### PR TITLE
AudioSourceProviderAVFObjC::m_client should be Weak

### DIFF
--- a/Source/WebCore/platform/audio/AudioSourceProvider.h
+++ b/Source/WebCore/platform/audio/AudioSourceProvider.h
@@ -26,8 +26,9 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef AudioSourceProvider_h
-#define AudioSourceProvider_h
+#pragma once
+
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -41,7 +42,7 @@ public:
     virtual void provideInput(AudioBus* bus, size_t framesToProcess) = 0;
 
     // If a client is set, we call it back when the audio format is available or changes.
-    virtual void setClient(AudioSourceProviderClient*) { };
+    virtual void setClient(WeakPtr<AudioSourceProviderClient>&&) { };
 
     virtual bool isHandlingAVPlayer() const { return false; }
 
@@ -49,5 +50,3 @@ public:
 };
 
 } // WebCore
-
-#endif // AudioSourceProvider_h

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -248,16 +248,16 @@ GstFlowReturn AudioSourceProviderGStreamer::handleSample(GstAppSink* sink, bool 
     return GST_FLOW_OK;
 }
 
-void AudioSourceProviderGStreamer::setClient(AudioSourceProviderClient* newClient)
+void AudioSourceProviderGStreamer::setClient(WeakPtr<AudioSourceProviderClient>&& newClient)
 {
-    if (client() == newClient)
+    if (client() == newClient.get())
         return;
 
 #if ENABLE(MEDIA_STREAM)
     GST_DEBUG_OBJECT(m_pipeline.get(), "Setting up client %p (previous: %p)", newClient, client());
 #endif
     bool previousClientWasValid = !!m_client;
-    m_client = newClient;
+    m_client = WTFMove(newClient);
 
     // The volume element is used to mute audio playback towards the
     // autoaudiosink. This is needed to avoid double playback of audio

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h
@@ -61,7 +61,7 @@ public:
     void configureAudioBin(GstElement* audioBin, GstElement* audioSink);
 
     void provideInput(AudioBus*, size_t framesToProcess) override;
-    void setClient(AudioSourceProviderClient*) override;
+    void setClient(WeakPtr<AudioSourceProviderClient>&&) override;
     const AudioSourceProviderClient* client() const { return m_client.get(); }
 
     void handleNewDeinterleavePad(GstPad*);

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -75,7 +75,7 @@ private:
 
     // AudioSourceProvider
     void provideInput(AudioBus*, size_t framesToProcess) override;
-    void setClient(AudioSourceProviderClient*) override;
+    void setClient(WeakPtr<AudioSourceProviderClient>&&) override;
     bool isHandlingAVPlayer() const final { return true; }
 
     static void initCallback(MTAudioProcessingTapRef, void*, void**);
@@ -105,7 +105,7 @@ private:
     enum { NoSeek = std::numeric_limits<uint64_t>::max() };
     uint64_t m_seekTo { NoSeek };
     bool m_paused { true };
-    AudioSourceProviderClient* m_client { nullptr };
+    WeakPtr<AudioSourceProviderClient> m_client;
     WeakPtrFactory<AudioSourceProviderAVFObjC> m_weakFactory;
 
     class TapStorage;

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -146,12 +146,12 @@ void AudioSourceProviderAVFObjC::provideInput(AudioBus* bus, size_t framesToProc
         PAL::AudioConverterConvertComplexBuffer(m_converter.get(), framesToProcess, m_list.get(), m_list.get());
 }
 
-void AudioSourceProviderAVFObjC::setClient(AudioSourceProviderClient* client)
+void AudioSourceProviderAVFObjC::setClient(WeakPtr<AudioSourceProviderClient>&& client)
 {
     if (m_client == client)
         return;
     destroyMixIfNeeded();
-    m_client = client;
+    m_client = WTFMove(client);
     createMixIfNeeded();
 }
 

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h
@@ -70,12 +70,12 @@ private:
 
     // AudioSourceProvider
     void provideInput(AudioBus*, size_t) final;
-    void setClient(AudioSourceProviderClient*) final;
+    void setClient(WeakPtr<AudioSourceProviderClient>&&) final;
 
     void prepare(const AudioStreamBasicDescription&);
 
     Lock m_lock;
-    AudioSourceProviderClient* m_client { nullptr };
+    WeakPtr<AudioSourceProviderClient> m_client;
 
     std::optional<CAAudioStreamDescription> m_inputDescription;
     std::optional<CAAudioStreamDescription> m_outputDescription;

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
@@ -55,12 +55,12 @@ WebAudioSourceProviderCocoa::~WebAudioSourceProviderCocoa()
 {
 }
 
-void WebAudioSourceProviderCocoa::setClient(AudioSourceProviderClient* client)
+void WebAudioSourceProviderCocoa::setClient(WeakPtr<AudioSourceProviderClient>&& client)
 {
     if (m_client == client)
         return;
-    m_client = client;
-    hasNewClient(client);
+    m_client = WTFMove(client);
+    hasNewClient(m_client.get());
 }
 
 void WebAudioSourceProviderCocoa::provideInput(AudioBus* bus, size_t framesToProcess)


### PR DESCRIPTION
#### 9290cdbf360c8d5a6a04d6eacf026891fbc07e94
<pre>
AudioSourceProviderAVFObjC::m_client should be Weak
<a href="https://bugs.webkit.org/show_bug.cgi?id=246634">https://bugs.webkit.org/show_bug.cgi?id=246634</a>
rdar://100804084

Reviewed by Eric Carlson.

Make the API contract explicit by having AudioSourceProvider::setClient() take a WeakPtr.

* Source/WebCore/platform/audio/AudioSourceProvider.h:
(WebCore::AudioSourceProvider::setClient):
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::setClient):
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm:
(WebCore::WebAudioSourceProviderCocoa::setClient):

Canonical link: <a href="https://commits.webkit.org/255745@main">https://commits.webkit.org/255745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d59931c78b05a83de2672b5a3833934c16ee1e6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102993 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163330 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2509 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30816 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99101 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98975 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1754 "Found 1 new test failure: media/video-object-fit.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79766 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71786 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37202 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3976 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41077 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37768 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->