### PR TITLE
Add a codepath to adjust URLs and plain text before writing to the system pasteboard

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -57,9 +57,9 @@ private:
     using BufferOrString = std::variant<String, Ref<SharedBuffer>>;
     class ClipboardItemTypeLoader : public FileReaderLoaderClient, public RefCounted<ClipboardItemTypeLoader> {
     public:
-        static Ref<ClipboardItemTypeLoader> create(const String& type, CompletionHandler<void()>&& completionHandler)
+        static Ref<ClipboardItemTypeLoader> create(Clipboard& writingDestination, const String& type, CompletionHandler<void()>&& completionHandler)
         {
-            return adoptRef(*new ClipboardItemTypeLoader(type, WTFMove(completionHandler)));
+            return adoptRef(*new ClipboardItemTypeLoader(writingDestination, type, WTFMove(completionHandler)));
         }
 
         ~ClipboardItemTypeLoader();
@@ -72,10 +72,12 @@ private:
         const BufferOrString& data() { return m_data; }
 
     private:
-        ClipboardItemTypeLoader(const String& type, CompletionHandler<void()>&&);
+        ClipboardItemTypeLoader(Clipboard&, const String& type, CompletionHandler<void()>&&);
 
         void sanitizeDataIfNeeded();
         void invokeCompletionHandler();
+
+        String dataAsString() const;
 
         // FileReaderLoaderClient methods.
         void didStartLoading() final { }
@@ -87,6 +89,7 @@ private:
         BufferOrString m_data;
         std::unique_ptr<FileReaderLoader> m_blobLoader;
         CompletionHandler<void()> m_completionHandler;
+        WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_writingDestination;
     };
 
     unsigned m_numberOfPendingClipboardTypes { 0 };

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -71,8 +71,8 @@ public:
     String getData(Document&, const String& type) const;
     String getDataForItem(Document&, const String& type) const;
 
-    void setData(const String& type, const String& data);
-    void setDataFromItemList(const String& type, const String& data);
+    void setData(Document&, const String& type, const String& data);
+    void setDataFromItemList(Document&, const String& type, const String& data);
 
     void setDragImage(Element&, int x, int y);
 

--- a/Source/WebCore/dom/DataTransfer.idl
+++ b/Source/WebCore/dom/DataTransfer.idl
@@ -41,7 +41,7 @@
 
     readonly attribute FrozenArray<DOMString> types;
     [CallWith=CurrentDocument] DOMString getData(DOMString format);
-    undefined setData(DOMString format, DOMString data);
+    [CallWith=CurrentDocument] undefined setData(DOMString format, DOMString data);
     undefined clearData(optional DOMString format);
     [SameObject, CallWith=CurrentDocument] readonly attribute FileList files;
 };

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -65,7 +65,7 @@ static bool shouldExposeTypeInItemList(const String& type)
     return DeprecatedGlobalSettings::customPasteboardDataEnabled() || Pasteboard::isSafeTypeForDOMToReadAndWrite(type);
 }
 
-ExceptionOr<RefPtr<DataTransferItem>> DataTransferItemList::add(const String& data, const String& type)
+ExceptionOr<RefPtr<DataTransferItem>> DataTransferItemList::add(Document& document, const String& data, const String& type)
 {
     if (!m_dataTransfer.canWriteData())
         return nullptr;
@@ -80,7 +80,7 @@ ExceptionOr<RefPtr<DataTransferItem>> DataTransferItemList::add(const String& da
     if (!shouldExposeTypeInItemList(lowercasedType))
         return nullptr;
 
-    m_dataTransfer.setDataFromItemList(lowercasedType, data);
+    m_dataTransfer.setDataFromItemList(document, lowercasedType, data);
     ASSERT(m_items);
     m_items->append(DataTransferItem::create(*this, lowercasedType));
     return m_items->last().ptr();

--- a/Source/WebCore/dom/DataTransferItemList.h
+++ b/Source/WebCore/dom/DataTransferItemList.h
@@ -43,6 +43,7 @@
 namespace WebCore {
 
 class DataTransferItem;
+class Document;
 class File;
 
 class DataTransferItemList final : public ScriptWrappable, public ContextDestructionObserver, public CanMakeWeakPtr<DataTransferItemList> {
@@ -60,7 +61,7 @@ public:
     // DOM API
     unsigned length() const;
     RefPtr<DataTransferItem> item(unsigned index);
-    ExceptionOr<RefPtr<DataTransferItem>> add(const String& data, const String& type);
+    ExceptionOr<RefPtr<DataTransferItem>> add(Document&, const String& data, const String& type);
     RefPtr<DataTransferItem> add(Ref<File>&&);
     ExceptionOr<void> remove(unsigned index);
     void clear();

--- a/Source/WebCore/dom/DataTransferItemList.idl
+++ b/Source/WebCore/dom/DataTransferItemList.idl
@@ -38,7 +38,7 @@
     readonly attribute long length;
     getter DataTransferItem item(unsigned long index);
 
-    DataTransferItem? add(DOMString data, DOMString type);
+    [CallWith=CurrentDocument] DataTransferItem? add(DOMString data, DOMString type);
     DataTransferItem? add(File file);
 
     undefined remove(unsigned long index);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1647,12 +1647,16 @@ void Editor::copyURL(const URL& url, const String& title)
 
 void Editor::copyURL(const URL& url, const String& title, Pasteboard& pasteboard)
 {
+    auto sanitizedURL = url;
+    if (auto* page = m_document.page())
+        sanitizedURL = page->sanitizeForCopyOrShare(url);
+
     PasteboardURL pasteboardURL;
-    pasteboardURL.url = url;
+    pasteboardURL.url = sanitizedURL;
     pasteboardURL.title = title;
 
 #if PLATFORM(MAC)
-    pasteboardURL.userVisibleForm = userVisibleString(url);
+    pasteboardURL.userVisibleForm = userVisibleString(sanitizedURL);
 #endif
 
     pasteboard.write(pasteboardURL);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -58,6 +58,7 @@
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Seconds.h>
+#include <wtf/URL.h>
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 #include "MediaPlaybackTargetContext.h"
@@ -539,8 +540,10 @@ public:
     virtual void handleSelectionServiceClick(FrameSelection&, const Vector<String>&, const IntPoint&) { }
     virtual bool hasRelevantSelectionServices(bool /*isTextOnly*/) const { return false; }
     virtual void handleImageServiceClick(const IntPoint&, Image&, HTMLImageElement&) { }
-    virtual void handlePDFServiceClick(const IntPoint&, HTMLAttachmentElement&) { };
+    virtual void handlePDFServiceClick(const IntPoint&, HTMLAttachmentElement&) { }
 #endif
+
+    virtual URL sanitizeForCopyOrShare(const URL& url) const { return url; }
 
     virtual bool shouldDispatchFakeMouseMoveEvents() const { return true; }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4032,4 +4032,16 @@ ScreenOrientationManager* Page::screenOrientationManager() const
     return m_screenOrientationManager.get();
 }
 
+URL Page::sanitizeForCopyOrShare(const URL& url) const
+{
+    return chrome().client().sanitizeForCopyOrShare(url);
+}
+
+String Page::sanitizeForCopyOrShare(const String& urlString) const
+{
+    if (auto url = URL { urlString }; url.isValid())
+        return sanitizeForCopyOrShare(WTFMove(url)).string();
+    return urlString;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -945,6 +945,9 @@ public:
 
     bool httpsUpgradeEnabled() const { return m_httpsUpgradeEnabled; }
 
+    URL sanitizeForCopyOrShare(const URL&) const;
+    String sanitizeForCopyOrShare(const String&) const;
+
     LoadSchedulingMode loadSchedulingMode() const { return m_loadSchedulingMode; }
     void setLoadSchedulingMode(LoadSchedulingMode);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1496,6 +1496,11 @@ void WebChromeClient::requestTextRecognition(Element& element, TextRecognitionOp
 
 #endif
 
+URL WebChromeClient::sanitizeForCopyOrShare(const URL& url) const
+{
+    return m_page.sanitizeForCopyOrShare(url);
+}
+
 #if ENABLE(TEXT_AUTOSIZING)
 
 void WebChromeClient::textAutosizingUsesIdempotentModeChanged()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -454,6 +454,8 @@ private:
     void textAutosizingUsesIdempotentModeChanged() final;
 #endif
 
+    URL sanitizeForCopyOrShare(const URL&) const final;
+
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
     void showMediaControlsContextMenu(WebCore::FloatRect&&, Vector<WebCore::MediaControlsContextMenuItem>&&, CompletionHandler<void(WebCore::MediaControlsContextMenuItem::ID)>&&) final;
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -648,6 +648,15 @@ void WebPage::readSelectionFromPasteboard(const String& pasteboardName, Completi
     completionHandler(true);
 }
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPageCocoaAdditions.mm>)
+#include <WebKitAdditions/WebPageCocoaAdditions.mm>
+#else
+URL WebPage::sanitizeForCopyOrShare(const URL& url) const
+{
+    return url;
+}
+#endif
+
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1479,6 +1479,8 @@ public:
 
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
 
+    URL sanitizeForCopyOrShare(const URL&) const;
+
 #if ENABLE(IMAGE_ANALYSIS)
     void requestTextRecognition(WebCore::Element&, WebCore::TextRecognitionOptions&&, CompletionHandler<void(RefPtr<WebCore::Element>&&)>&& = { });
     void updateWithTextRecognitionResult(const WebCore::TextRecognitionResult&, const WebCore::ElementContext&, const WebCore::FloatPoint& location, CompletionHandler<void(TextRecognitionUpdateResult)>&&);
@@ -2544,6 +2546,10 @@ inline void WebPage::prepareToRunModalJavaScriptDialog() { }
 
 #if !PLATFORM(MAC)
 inline bool WebPage::shouldAvoidComputingPostLayoutDataForEditorState() const { return false; }
+#endif
+
+#if !PLATFORM(COCOA)
+inline URL WebPage::sanitizeForCopyOrShare(const URL& url) const { return url; }
 #endif
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 3f8ad758a672f42d1d38eb5789dee634da4c545e
<pre>
Add a codepath to adjust URLs and plain text before writing to the system pasteboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=246635">https://bugs.webkit.org/show_bug.cgi?id=246635</a>
rdar://101212078

Reviewed by Aditya Keerthi.

Add codepaths to adjust URLs written via either programmatic clipboard APIs (i.e. DataTransfer,
async clipboard) or via the &quot;Copy Link&quot; context menu action. See below for more details.

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::collectDataForWriting):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::ClipboardItemTypeLoader):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::dataAsString const):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::create):

For the programmatic clipboard APIs, we treat this URL sanitization in the same way as sanitized
markup, by writing the original unsanitized URL to pickled clipboard data, while writing the
sanitized URL to the pasteboard, but only in the case where the two differ.

* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::setData):
(WebCore::DataTransfer::setDataFromItemList):

Add a `Document&amp;` argument to codepaths that can be used to programmatically write URL data to the
pasteboard.

* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/DataTransfer.idl:

Add `[CallWith=CurrentDocument]` so that we can easily call into `Page` to sanitize URL data when
writing data to the pasteboard.

* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::add):
* Source/WebCore/dom/DataTransferItemList.h:
* Source/WebCore/dom/DataTransferItemList.idl:

Add `[CallWith=CurrentDocument]` here as well, so that we can easily call into `Page`.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::copyURL):

Additionally sanitize URLs when copying a link via the context menu.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::handlePDFServiceClick):
(WebCore::ChromeClient::sanitizeForCopyOrShare const):

Add a platform client hook to call &quot;sanitize&quot; the given URL.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::sanitizeForCopyOrShare const):

Add a couple of helper methods on Page to sanitize either a given URL, or a given URL string.

* Source/WebCore/page/Page.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::sanitizeForCopyOrShare const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::sanitizeForCopyOrShare const):

Add a new additions extension point.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::sanitizeForCopyOrShare const):

Add a no-op stub implementation for non-Cocoa builds.

Canonical link: <a href="https://commits.webkit.org/255708@main">https://commits.webkit.org/255708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87d72a3580f0e00d1db854b57b677f45348fbb7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102854 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163151 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2352 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30676 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/98975 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1632 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79621 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28552 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71661 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37065 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17197 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34879 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18438 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3950 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/40972 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37647 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->