### PR TITLE
[git-webkit] Ring terminal bell if input hangs

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -35,6 +35,7 @@ from webkitcorepy.timeout import Timeout
 from webkitcorepy.subprocess_utils import TimeoutExpired, CompletedProcess, run, Thread
 from webkitcorepy.output_capture import LoggerCapture, OutputCapture, OutputDuplicate
 from webkitcorepy.task_pool import TaskPool
+from webkitcorepy.timer import Timer
 from webkitcorepy.terminal import Terminal
 from webkitcorepy.environment import Environment
 from webkitcorepy.credentials import credentials, delete_credentials
@@ -45,7 +46,7 @@ from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
 from webkitcorepy.null_context import NullContext
 
-version = Version(0, 13, 18)
+version = Version(0, 13, 19)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py
@@ -27,7 +27,7 @@ import sys
 if not sys.platform.startswith('win'):
     import readline
 
-from webkitcorepy import StringIO, run
+from webkitcorepy import StringIO, run, Timer
 
 if sys.version_info > (3, 0):
     file = io.IOBase
@@ -37,17 +37,30 @@ class Terminal(object):
     _atty_overrides = {}
     colors = True
     URL_PREFIXES = ('file://', 'http://', 'https://', 'radar://', 'rdar://')
+    RING_INTERVAL = 30
 
     @classmethod
     def input(cls, *args, **kwargs):
+        alert_after = kwargs.pop('alert_after', None)
+
         try:
-            return (input if sys.version_info > (3, 0) else raw_input)(*args, **kwargs)
+            if alert_after and cls.isatty(sys.stdout):
+                with Timer(alert_after, lambda: cls.ring(sys.stdout)):
+                    return (input if sys.version_info > (3, 0) else raw_input)(*args, **kwargs)
+            else:
+                return (input if sys.version_info > (3, 0) else raw_input)(*args, **kwargs)
         except KeyboardInterrupt:
             sys.stderr.write('\nUser interrupted program\n')
             sys.exit(1)
 
     @classmethod
-    def choose(cls, prompt, options=None, default=None, strict=False, numbered=False):
+    def ring(cls, file=sys.stdout):
+        if file:
+            file.write('\a')
+            file.flush()
+
+    @classmethod
+    def choose(cls, prompt, options=None, default=None, strict=False, numbered=False, alert_after=RING_INTERVAL):
         options = options or ('Yes', 'No')
 
         response = None
@@ -63,7 +76,7 @@ class Terminal(object):
                     '[{}]'.format(option) if option == default else option for option in options
                 ])))
             sys.stdout.flush()
-            response = cls.input(': ')
+            response = cls.input(': ', alert_after=alert_after)
 
             if numbered and response.isdigit():
                 index = int(response) - 1
@@ -88,7 +101,7 @@ class Terminal(object):
         if not isinstance(target, (io.IOBase, file, StringIO)):
             raise ValueError('{} is not an IO object'.format(target))
         if not isinstance(target, StringIO) and not (getattr(target, 'writable', None) and target.writable()) and 'w' not in getattr(target, 'mode', 'r'):
-            raise ValueError('{} is an IO object, but is not writable {}'.format(target, ))
+            raise ValueError('{} is an IO object, but is not writable'.format(target))
 
     @classmethod
     def supports_color(cls, file):
@@ -126,7 +139,7 @@ class Terminal(object):
                 cls._atty_overrides[key] = previous
 
     @classmethod
-    def open_url(cls, url, prompt=None):
+    def open_url(cls, url, prompt=None, alert_after=RING_INTERVAL):
         if all(not url.startswith(prefix) for prefix in cls.URL_PREFIXES):
             sys.stderr.write("'{}' is not a valid URL\n")
             return False
@@ -135,7 +148,7 @@ class Terminal(object):
 
         if prompt:
             try:
-                cls.input(prompt)
+                cls.input(prompt, alert_after=alert_after)
             except SystemExit:
                 sys.stderr.write('User aborted URL open\n')
                 return False

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timer.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,46 +20,22 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup
+import sys
+
+if sys.version_info > (3, 0):
+    from threading import Timer as _Timer
+else:
+    from threading import _Timer
 
 
-def readme():
-    with open('README.md') as f:
-        return f.read()
+class Timer(_Timer):
+    def __init__(self, interval, callback):
+        super(Timer, self).__init__(interval, callback)
+        self.daemon = True
 
+    def __enter__(self):
+        self.start()
+        return self
 
-setup(
-    name='webkitcorepy',
-    version='0.13.19',
-    description='Library containing various Python support classes and functions.',
-    long_description=readme(),
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: Other/Proprietary License',
-        'Operating System :: MacOS',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    keywords='python unicode',
-    url='https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy',
-    author='Jonathan Bedard',
-    author_email='jbedard@apple.com',
-    license='Modified BSD',
-    packages=[
-        'webkitcorepy',
-        'webkitcorepy.mocks',
-        'webkitcorepy.tests',
-        'webkitcorepy.tests.mocks',
-    ],
-    install_requires=[
-        'mock',
-        'requests',
-        'six',
-        'tblib',
-        'whichcraft',
-    ],
-    include_package_data=True,
-    zip_safe=False,
-)
+    def __exit__(self, *args, **kwargs):
+        self.cancel()

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.21',
+    version='5.6.22',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 21)
+version = Version(5, 6, 22)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -114,7 +114,7 @@ class Branch(Command):
                 prompt = '{}nter issue URL or title of new issue: '.format('{}, e'.format(why) if why else 'E')
             else:
                 prompt = '{}nter name of new branch (or issue URL): '.format('{}, e'.format(why) if why else 'E')
-            args.issue = Terminal.input(prompt)
+            args.issue = Terminal.input(prompt, alert_after=2 * Terminal.RING_INTERVAL)
 
         if string_utils.decode(args.issue).isnumeric() and Tracker.instance() and not redact:
             issue = Tracker.instance().issue(int(args.issue))


### PR DESCRIPTION
#### 1f96c91d66dc4d0724ac14e58b3394a17e5c1556
<pre>
[git-webkit] Ring terminal bell if input hangs
<a href="https://bugs.webkit.org/show_bug.cgi?id=244625">https://bugs.webkit.org/show_bug.cgi?id=244625</a>
&lt;rdar://problem/99397362&gt;

Reviewed by Darin Adler.

* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Add Timer object, bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/terminal.py:
(Terminal):
(Terminal.input): Support ring timer through alert_after.
(Terminal.ring): Add.
(Terminal.choose): Add alert_after.
(Terminal.open_url): Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timer.py:
(Timer): Added.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.main): Add alert_after.

Canonical link: <a href="https://commits.webkit.org/255650@main">https://commits.webkit.org/255650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d96da0605813ac075fac51107af594eb4aa9f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93174 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102880 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2378 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30697 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85564 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/98996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98843 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79644 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/96752 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37088 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/92206 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34904 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/40989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1800 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40704 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/37669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->