### PR TITLE
Make fullscreen API use the top layer

### DIFF
--- a/LayoutTests/fullscreen/full-screen-enter-while-exiting-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-enter-while-exiting-expected.txt
@@ -8,8 +8,8 @@ RUN(document.webkitExitFullscreen())
 RUN(internals.webkitWillExitFullScreenForElement(target1))
 Attempt to enter fullscreen with target2
 RUN(target2.webkitRequestFullScreen())
-EVENT(webkitfullscreenchange)
 EVENT(webkitfullscreenerror)
 RUN(internals.webkitDidExitFullScreenForElement(target1))
+EVENT(webkitfullscreenchange)
 END OF TEST
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -475,9 +475,6 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             case CSSSelector::PseudoClassFullScreenControlsHidden:
                 builder.append(":-webkit-full-screen-controls-hidden");
                 break;
-            case CSSSelector::PseudoClassFullScreenParent:
-                builder.append(":-webkit-full-screen-parent");
-                break;
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
             case CSSSelector::PseudoClassPictureInPicture:

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -160,7 +160,6 @@ struct PossiblyQuotedIdentifier {
             PseudoClassFullScreenAncestor,
             PseudoClassAnimatingFullScreenTransition,
             PseudoClassFullScreenControlsHidden,
-            PseudoClassFullScreenParent,
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
             PseudoClassPictureInPicture,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1046,8 +1046,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
         case CSSSelector::PseudoClassFullScreenAncestor:
             return matchesFullScreenAncestorPseudoClass(element);
-        case CSSSelector::PseudoClassFullScreenParent:
-            return matchesFullScreenParentPseudoClass(element);
         case CSSSelector::PseudoClassFullScreenDocument:
             return matchesFullScreenDocumentPseudoClass(element);
         case CSSSelector::PseudoClassFullScreenControlsHidden:

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -408,7 +408,7 @@ ALWAYS_INLINE bool matchesFullScreenPseudoClass(const Element& element)
     // element is an element in the document, the 'full-screen' pseudoclass applies to
     // that element. Also, an <iframe>, <object> or <embed> element whose child browsing
     // context's Document is in the fullscreen state has the 'full-screen' pseudoclass applied.
-    if (is<HTMLFrameElementBase>(element) && element.containsFullScreenElement())
+    if (is<HTMLFrameElementBase>(element) && element.hasFullscreenFlag())
         return true;
     if (!element.document().fullscreenManager().isFullscreen())
         return false;
@@ -422,17 +422,10 @@ ALWAYS_INLINE bool matchesFullScreenAnimatingFullScreenTransitionPseudoClass(con
     return element.document().fullscreenManager().isAnimatingFullscreen();
 }
 
-/* FIXME: Remove when we use top layer, since this won't be needed (webkit.org/b/84798). */
-ALWAYS_INLINE bool matchesFullScreenParentPseudoClass(const Element& element)
-{
-    if (!element.document().fullscreenManager().isFullscreen())
-        return false;
-    return &element == element.document().fullscreenManager().currentFullscreenElement()->parentElement();
-}
-
 ALWAYS_INLINE bool matchesFullScreenAncestorPseudoClass(const Element& element)
 {
-    return element.containsFullScreenElement();
+    auto* currentFullscreenElement = element.document().fullscreenManager().currentFullscreenElement();
+    return currentFullscreenElement && currentFullscreenElement->isDescendantOrShadowDescendantOf(element);
 }
 
 ALWAYS_INLINE bool matchesFullScreenDocumentPseudoClass(const Element& element)

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -79,7 +79,6 @@ window-inactive
 -webkit-full-screen-ancestor
 -webkit-full-screen-document
 -webkit-full-screen-controls-hidden
--webkit-full-screen-parent
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)

--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -24,6 +24,8 @@
 
 #if defined(ENABLE_FULLSCREEN_API) && ENABLE_FULLSCREEN_API
 
+/* https://fullscreen.spec.whatwg.org/#user-agent-level-style-sheet-defaults */
+
 :not(:root):-webkit-full-screen {
   position: fixed !important;
   inset: 0 !important;
@@ -41,41 +43,8 @@
   object-fit:contain;
 }
 
-:-webkit-full-screen {
-    z-index: 2147483647 !important;
-    width: 100%;
-    height: 100%;
-}
-
-:root:-webkit-full-screen-document:not(:-webkit-full-screen), :root:-webkit-full-screen-ancestor {
+:root:-webkit-full-screen-document:not(:-webkit-full-screen) {
     overflow: hidden !important;
-}
-
-:-webkit-full-screen-ancestor:not(iframe) {
-    z-index: auto !important;
-    position: static !important;
-    opacity: 1 !important;
-    transform: none !important;
-    mask: none !important;
-    clip: none !important;
-    filter: none !important;
-    transition: none !important;
-    -webkit-box-reflect: none !important;
-    perspective: none !important;
-    transform-style: flat !important;
-    overflow: visible !important;
-    contain: none !important;
-}
-
-video:-webkit-full-screen, audio:-webkit-full-screen {
-    background-color: transparent !important;
-    position: static !important;
-    margin: 0 !important;
-    height: 100% !important;
-    width: 100% !important;
-    flex: 1 !important;
-    display: block !important;
-    transition: none !important;
 }
 
 :-webkit-full-screen video,
@@ -90,29 +59,12 @@ img:-webkit-full-screen {
 }
 
 iframe:-webkit-full-screen {
-    margin: 0 !important;
+    border: none !important;
     padding: 0 !important;
-    border: 0 !important;
-    position: fixed !important;
-    height: 100% !important;
-    width: 100% !important;
-    left: 0 !important;
-    top: 0 !important;
-    max-width: none !important;
-    max-height: none !important;
 }
 
-/* FIXME: Use top layer backdrop (webkit.org/b/84798). */
-:-webkit-full-screen-parent::before {
-    content: "" !important;
-    position: fixed !important;
-    background: black !important;
-    z-index: 2147483647 !important;
-    width: 100vw !important;
-    height: 100vh !important;
-    margin: 0 !important;
-    inset: 0 !important;
-    box-sizing: border-box !important;
+:not(:root):-webkit-full-screen::backdrop {
+    background: black;
 }
 
 #endif

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -106,7 +106,6 @@ static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesLangPseudo
 #if ENABLE(FULLSCREEN_API)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenDocumentPseudoClass, bool, (const Element&));
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenParentPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAncestorPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenControlsHiddenPseudoClass, bool, (const Element&));
@@ -727,11 +726,6 @@ JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenDocumentPseudoClass, bool, (c
     return matchesFullScreenDocumentPseudoClass(element);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenParentPseudoClass, bool, (const Element& element))
-{
-    return matchesFullScreenParentPseudoClass(element);
-}
-
 JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenAncestorPseudoClass, bool, (const Element& element))
 {
     return matchesFullScreenAncestorPseudoClass(element);
@@ -907,9 +901,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClassFullScreenDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenDocumentPseudoClass));
-        return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFullScreenParent:
-        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenParentPseudoClass));
         return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClassFullScreenAncestor:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAncestorPseudoClass));

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5021,10 +5021,6 @@ void Document::nodeChildrenWillBeRemoved(ContainerNode& container)
     adjustFocusedNodeOnNodeRemoval(container, NodeRemoval::ChildrenOfNode);
     adjustFocusNavigationNodeOnNodeRemoval(container, NodeRemoval::ChildrenOfNode);
 
-#if ENABLE(FULLSCREEN_API)
-    m_fullscreenManager->adjustFullscreenElementOnNodeRemoval(container, NodeRemoval::ChildrenOfNode);
-#endif
-
     for (auto* range : m_ranges)
         range->nodeChildrenWillBeRemoved(container);
 
@@ -5053,10 +5049,6 @@ void Document::nodeWillBeRemoved(Node& node)
 
     adjustFocusedNodeOnNodeRemoval(node);
     adjustFocusNavigationNodeOnNodeRemoval(node);
-
-#if ENABLE(FULLSCREEN_API)
-    m_fullscreenManager->adjustFullscreenElementOnNodeRemoval(node, NodeRemoval::Node);
-#endif
 
     for (auto* it : m_nodeIterators)
         it->nodeWillBeRemoved(node);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -566,9 +566,10 @@ public:
     void removeFromTopLayer();
 
 #if ENABLE(FULLSCREEN_API)
-    bool containsFullScreenElement() const { return hasNodeFlag(NodeFlag::ContainsFullScreenElement); }
-    void setContainsFullScreenElement(bool);
-    void setContainsFullScreenElementOnAncestorsCrossingFrameBoundaries(bool);
+    bool hasFullscreenFlag() const { return hasNodeFlag(NodeFlag::IsFullscreen); }
+    bool hasIFrameFullscreenFlag() const { return hasNodeFlag(NodeFlag::IsIFrameFullscreen); }
+    void setFullscreenFlag(bool);
+    void setIFrameFullscreenFlag(bool);
     WEBCORE_EXPORT void webkitRequestFullscreen();
     virtual void requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&&);
 #endif

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -51,10 +51,11 @@ public:
     Page* page() const { return m_document.page(); }
     Frame* frame() const { return m_document.frame(); }
     Element* documentElement() const { return m_document.documentElement(); }
+    bool isSimpleFullscreenDocument() const;
     Document::BackForwardCacheState backForwardCacheState() const { return m_document.backForwardCacheState(); }
 
-    // W3C Fullscreen API
-    Element* fullscreenElement() const { return !m_fullscreenElementStack.isEmpty() ? m_fullscreenElementStack.last().get() : nullptr; }
+    // WHATWG Fullscreen API
+    WEBCORE_EXPORT Element* fullscreenElement() const;
     WEBCORE_EXPORT bool isFullscreenEnabled() const;
     WEBCORE_EXPORT void exitFullscreen();
 
@@ -77,7 +78,10 @@ public:
 
     void dispatchFullscreenChangeEvents();
 
-    void adjustFullscreenElementOnNodeRemoval(Node&, Document::NodeRemoval = Document::NodeRemoval::Node);
+    enum class ExitMode : bool { Resize, NoResize };
+    void finishExitFullscreen(Document&, ExitMode);
+
+    void exitRemovedFullscreenElementIfNeeded(Element&);
 
     WEBCORE_EXPORT bool isAnimatingFullscreen() const;
     WEBCORE_EXPORT void setAnimatingFullscreen(bool);
@@ -94,9 +98,6 @@ protected:
     enum class EventType : bool { Change, Error };
     void dispatchFullscreenChangeOrErrorEvent(Deque<GCReachableRef<Node>>&, EventType, bool shouldNotifyMediaElement);
     void dispatchEventForNode(Node&, EventType);
-    void clearFullscreenElementStack();
-    void popFullscreenElementStack();
-    void pushFullscreenElementStack(Element&);
     void addDocumentToFullscreenChangeEventQueue(Document&);
 
 private:
@@ -114,7 +115,6 @@ private:
     bool m_pendingExitFullscreen { false };
     RefPtr<Element> m_pendingFullscreenElement;
     RefPtr<Element> m_fullscreenElement;
-    Vector<RefPtr<Element>> m_fullscreenElementStack;
     Deque<GCReachableRef<Node>> m_fullscreenChangeEventTargetQueue;
     Deque<GCReachableRef<Node>> m_fullscreenErrorEventTargetQueue;
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -567,29 +567,27 @@ protected:
 
         // These bits are used by derived classes, pulled up here so they can
         // be stored in the same memory word as the Node bits above.
-        IsDocumentFragmentForInnerOuterHTML = 1 << 14, // DocumentFragment
-        IsEditingText = 1 << 15, // Text
-        IsLink = 1 << 16, // Element
-        IsUserActionElement = 1 << 17,
-        IsParsingChildrenFinished = 1 << 18,
-        HasSyntheticAttrChildNodes = 1 << 19,
-        SelfOrPrecedingNodesAffectDirAuto = 1 << 20,
+        IsDocumentFragmentForInnerOuterHTML = 1 << 13, // DocumentFragment
+        IsEditingText = 1 << 14, // Text
+        IsLink = 1 << 15, // Element
+        IsUserActionElement = 1 << 16,
+        IsParsingChildrenFinished = 1 << 17,
+        HasSyntheticAttrChildNodes = 1 << 18,
+        SelfOrPrecedingNodesAffectDirAuto = 1 << 19,
 
-        HasCustomStyleResolveCallbacks = 1 << 21,
-
-        HasPendingResources = 1 << 22,
-        IsInGCReachableRefMap = 1 << 23,
+        HasCustomStyleResolveCallbacks = 1 << 20,
+        HasPendingResources = 1 << 21,
+        IsInGCReachableRefMap = 1 << 22,
+        IsComputedStyleInvalidFlag = 1 << 23,
+        HasShadowRootContainingSlots = 1 << 24,
+        IsInTopLayer = 1 << 25,
+        NeedsSVGRendererUpdate = 1 << 26,
+        NeedsUpdateQueryContainerDependentStyle = 1 << 27,
+        HasBeenInUserAgentShadowTree = 1 << 28,
 #if ENABLE(FULLSCREEN_API)
-        ContainsFullScreenElement = 1 << 24,
+        IsFullscreen = 1 << 29,
+        IsIFrameFullscreen = 1 << 30,
 #endif
-        IsComputedStyleInvalidFlag = 1 << 25,
-        HasShadowRootContainingSlots = 1 << 26,
-        IsInTopLayer = 1 << 27,
-        NeedsSVGRendererUpdate = 1 << 28,
-        NeedsUpdateQueryContainerDependentStyle = 1 << 29,
-        HasBeenInUserAgentShadowTree = 1 << 30,
-
-        // Bit 31 is free.
     };
 
     enum class TabIndexState : uint8_t {


### PR DESCRIPTION
#### c96dd4f574c01a761f875ce4222725c44693f2b1
<pre>
Make fullscreen API use the top layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=84798">https://bugs.webkit.org/show_bug.cgi?id=84798</a>
rdar://11313423

Reviewed by Darin Adler.

The fullscreen API should use the top layer instead of the fullscreen stack. Some notes:
- Pushing to the top layer causes visual changes, so we need to update the DOM methods to follow spec order to prevent unintended effects.
Visual changes can&apos;t happen before `willEnterFullscreen` and can&apos;t happen before `didExitFullscreen` when fully entering/exiting fullscreen.

- Since top layer handles visual z-ordering, we can remove old style hacks of clobbering the ancestor chain with special styling, and the associated
containsFullscreenElement node flag.

Spec: <a href="https://fullscreen.spec.whatwg.org">https://fullscreen.spec.whatwg.org</a>

* LayoutTests/fullscreen/full-screen-enter-while-exiting-expected.txt:
Events are now scheduled and dispatched in didExitFullscreen instead of exitFullscreen(), hence the order change.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
Remove temporary backdrop workaround that was landed in <a href="https://commits.webkit.org/256226@main">https://commits.webkit.org/256226@main</a> .

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesFullScreenPseudoClass):
(WebCore::matchesFullScreenAncestorPseudoClass):
Rewrite selector checker functions to account for removal of containsFullscreenElement flag.
Since :-webkit-fullscreen-ancestor main usage was for the UA stylesheet, we may be able to remove it in a followup clean up.

(WebCore::matchesFullScreenParentPseudoClass): Deleted. (part of the backdrop workaround)
* Source/WebCore/css/fullscreen.css:
(#if defined(ENABLE_FULLSCREEN_API) &amp;&amp; ENABLE_FULLSCREEN_API):
(:root:-webkit-full-screen-document:not(:-webkit-full-screen)): Only keep overflow: hidden; since top layer does not make the root element unscrollable.
(iframe:-webkit-full-screen): Match the spec.
(:not(:root):-webkit-full-screen::backdrop): Match the spec by making the fullscreen backdrops black.
(:-webkit-full-screen): Deleted. (not needed with top layer)
(:root:-webkit-full-screen-document:not(:-webkit-full-screen), :root:-webkit-full-screen-ancestor): Deleted.
(:-webkit-full-screen-ancestor:not(iframe)): Deleted. (not needed with top layer)
(video:-webkit-full-screen, audio:-webkit-full-screen): Deleted. (to match the spec)
(:-webkit-full-screen-parent::before): Deleted. (fake backdrop workaround)
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::nodeChildrenWillBeRemoved):
(WebCore::Document::nodeWillBeRemoved):
Move element removal handling to `Element::removedFromAncestor()`

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::setFullscreenFlag):
(WebCore::Element::setIframeFullscreenFlag):
(WebCore::parentCrossingFrameBoundaries): Deleted.
(WebCore::Element::setContainsFullScreenElement): Deleted.
(WebCore::Element::setContainsFullScreenElementOnAncestorsCrossingFrameBoundaries): Deleted.
Removed the containsFullscreenElement flag and replace it with fullscreen flag and iframe fullscreen flag.

* Source/WebCore/dom/Element.h: Ditto
(WebCore::Element::hasFullscreenFlag const):
(WebCore::Element::hasIframeFullscreenFlag const):
(WebCore::Element::containsFullScreenElement const): Deleted.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::fullscreenElement const): Rewrite it to iterate through top layer instead of fullscreen stack.
(WebCore::FullscreenManager::requestFullscreenForElement): Removed all fullscreen stack handling. Top layer handling is now in `willEnterFullscreen` since it performs visual changes.
(WebCore::FullscreenManager::cancelFullscreen): Basically exitFullscreen() but always exits everything.
(WebCore::documentsToUnfullscreen): &quot;collecting documents to unfullscreen&quot; algorithm from spec
(WebCore::FullscreenManager::exitFullscreen): Steps 1 - 8 of exit fullscreen algorithm from spec
(WebCore::FullscreenManager::finishExitFullscreen): Steps 12 - 15 of exit fullscreen algorithm from spec
(WebCore::FullscreenManager::willEnterFullscreen): Push documents to top layer, add fullscreen flag &amp; emit events (Step 12 of request fullscreen in spec)
(WebCore::FullscreenManager::didExitFullscreen): Everything else that is needed when fully exiting fullscreen.
(WebCore::FullscreenManager::exitRemovedFullscreenElementIfNeeded): &quot;removing steps&quot; for element from spec (except for top layer removal which is already done later on in Element::removedFromAncestor)
(WebCore::FullscreenManager::isSimpleFullscreenDocument const): &quot;Simple fullscreen document&quot; as defined by the spec, e.g. a document with only one fullscreen element in the top layer.

(WebCore::FullscreenManager::adjustFullscreenElementOnNodeRemoval): Deleted. Replaced by exitRemovedFullscreenElementIfNeeded called from Element::removedFromAncestor().

(WebCore::FullscreenManager::clearFullscreenElementStack): Deleted.
(WebCore::FullscreenManager::popFullscreenElementStack): Deleted.
(WebCore::FullscreenManager::pushFullscreenElementStack): Deleted.
(WebCore::FullscreenManager::clear):
Remove fullscreen stack remainders.

* Source/WebCore/dom/FullscreenManager.h:

* Source/WebCore/dom/Node.h:
Add IsFullscreen/IsIframeFullscreen flags, remove ContainsFullScreenElement.
Shuffle flags around, since Bit 31 is actually not usable (causes integer overflow when using it).

Canonical link: <a href="https://commits.webkit.org/257456@main">https://commits.webkit.org/257456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dad342434ac3e7290cfad31992d4d5229f549d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108482 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8836 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104813 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/91591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/91591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2185 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2077 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5135 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42597 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->