### PR TITLE
[WGSL] AST Visitor helper

### DIFF
--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -25,42 +25,25 @@
 
 #pragma once
 
+#include "ASTArrayAccess.h"
+#include "ASTAssignmentStatement.h"
+#include "ASTAttribute.h"
+#include "ASTCallableExpression.h"
+#include "ASTCompoundStatement.h"
+#include "ASTDecl.h"
 #include "ASTExpression.h"
+#include "ASTFunctionDecl.h"
+#include "ASTGlobalDirective.h"
+#include "ASTIdentifierExpression.h"
+#include "ASTLiteralExpressions.h"
+#include "ASTNode.h"
+#include "ASTReturnStatement.h"
+#include "ASTShaderModule.h"
+#include "ASTStatement.h"
+#include "ASTStructureAccess.h"
+#include "ASTStructureDecl.h"
 #include "ASTTypeDecl.h"
-
-#include <wtf/UniqueRef.h>
-#include <wtf/Vector.h>
-
-namespace WGSL::AST {
-
-// A CallableExpression expresses a "function" call, which consists of a target to be called,
-// and a list of arguments. The target does not necesserily have to be a function identifier,
-// but can also be a type, in which the whole call is a type conversion expression. The exact
-// kind of expression can only be resolved during semantic analysis.
-class CallableExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    CallableExpression(SourceSpan span, UniqueRef<TypeDecl>&& target, Expression::List&& arguments)
-        : Expression(span)
-        , m_target(WTFMove(target))
-        , m_arguments(WTFMove(arguments))
-    {
-    }
-
-    Kind kind() const override { return Kind::CallableExpression; }
-    TypeDecl& target() { return m_target; }
-    Expression::List& arguments() { return m_arguments; }
-
-private:
-    // If m_target is a NamedType, it could either be a:
-    //   * Type that does not accept parameters (bool, i32, u32, ...)
-    //   * Identifier that refers to a type alias.
-    //   * Identifier that refers to a function.
-    UniqueRef<TypeDecl> m_target;
-    Expression::List m_arguments;
-};
-
-} // namespace WGSL::AST
-
-SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(CallableExpression, isCallableExpression())
+#include "ASTUnaryExpression.h"
+#include "ASTVariableDecl.h"
+#include "ASTVariableQualifier.h"
+#include "ASTVariableStatement.h"

--- a/Source/WebGPU/WGSL/AST/ASTArrayAccess.h
+++ b/Source/WebGPU/WGSL/AST/ASTArrayAccess.h
@@ -27,6 +27,7 @@
 
 #include "ASTExpression.h"
 
+#include <wtf/UniqueRef.h>
 #include <wtf/text/StringView.h>
 
 namespace WGSL::AST {

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -25,42 +25,52 @@
 
 #pragma once
 
-#include "ASTExpression.h"
-#include "ASTTypeDecl.h"
-
-#include <wtf/UniqueRef.h>
-#include <wtf/Vector.h>
-
 namespace WGSL::AST {
 
-// A CallableExpression expresses a "function" call, which consists of a target to be called,
-// and a list of arguments. The target does not necesserily have to be a function identifier,
-// but can also be a type, in which the whole call is a type conversion expression. The exact
-// kind of expression can only be resolved during semantic analysis.
-class CallableExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+class ShaderModule;
+class GlobalDirective;
 
-public:
-    CallableExpression(SourceSpan span, UniqueRef<TypeDecl>&& target, Expression::List&& arguments)
-        : Expression(span)
-        , m_target(WTFMove(target))
-        , m_arguments(WTFMove(arguments))
-    {
-    }
+class Attribute;
+class BindingAttribute;
+class BuiltinAttribute;
+class GroupAttribute;
+class LocationAttribute;
+class StageAttribute;
 
-    Kind kind() const override { return Kind::CallableExpression; }
-    TypeDecl& target() { return m_target; }
-    Expression::List& arguments() { return m_arguments; }
+class Decl;
+class FunctionDecl;
+class StructDecl;
+class VariableDecl;
 
-private:
-    // If m_target is a NamedType, it could either be a:
-    //   * Type that does not accept parameters (bool, i32, u32, ...)
-    //   * Identifier that refers to a type alias.
-    //   * Identifier that refers to a function.
-    UniqueRef<TypeDecl> m_target;
-    Expression::List m_arguments;
-};
+class Expression;
+class AbstractFloatLiteral;
+class AbstractIntLiteral;
+class ArrayAccess;
+class BoolLiteral;
+class CallableExpression;
+class Float32Literal;
+class IdentifierExpression;
+class Int32Literal;
+class StructureAccess;
+class Uint32Literal;
+class UnaryExpression;
+
+class Statement;
+class AssignmentStatement;
+class CompoundStatement;
+class ReturnStatement;
+class VariableStatement;
+
+class TypeDecl;
+class ArrayType;
+class NamedType;
+class ParameterizedType;
+
+class Parameter;
+class StructMember;
+class VariableQualifier;
+
+enum class AccessMode : uint8_t;
+enum class StorageClass : uint8_t;
 
 } // namespace WGSL::AST
-
-SPECIALIZE_TYPE_TRAITS_WGSL_EXPRESSION(CallableExpression, isCallableExpression())

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ASTVisitor.h"
+
+#include "AST.h"
+
+namespace WGSL::AST {
+
+bool Visitor::hasError() const
+{
+    return !m_expectedError;
+}
+
+Expected<void, Error> Visitor::result()
+{
+    return m_expectedError;
+}
+
+template<typename T> void Visitor::checkErrorAndVisit(T& x)
+{
+    if (!hasError())
+        visit(x);
+}
+
+template<typename T> void Visitor::maybeCheckErrorAndVisit(T* x)
+{
+    if (!hasError() && x)
+        visit(*x);
+}
+
+// Shader Module
+
+void Visitor::visit(AST::ShaderModule& shaderModule)
+{
+    for (auto& directive : shaderModule.directives())
+        checkErrorAndVisit(directive);
+    for (auto& structDecl : shaderModule.structs())
+        checkErrorAndVisit(structDecl);
+    for (auto& variableDecl : shaderModule.globalVars())
+        checkErrorAndVisit(variableDecl);
+    for (auto& functionDecl : shaderModule.functions())
+        checkErrorAndVisit(functionDecl);
+}
+
+void Visitor::visit(AST::GlobalDirective&)
+{
+}
+
+// Attribute
+
+void Visitor::visit(AST::Attribute& attribute)
+{
+    switch (attribute.kind()) {
+    case AST::Attribute::Kind::Binding:
+        checkErrorAndVisit(downcast<AST::BindingAttribute>(attribute));
+        break;
+    case AST::Attribute::Kind::Builtin:
+        checkErrorAndVisit(downcast<AST::BuiltinAttribute>(attribute));
+        break;
+    case AST::Attribute::Kind::Group:
+        checkErrorAndVisit(downcast<AST::GroupAttribute>(attribute));
+        break;
+    case AST::Attribute::Kind::Location:
+        checkErrorAndVisit(downcast<AST::LocationAttribute>(attribute));
+        break;
+    case AST::Attribute::Kind::Stage:
+        checkErrorAndVisit(downcast<AST::StageAttribute>(attribute));
+        break;
+    }
+}
+
+void Visitor::visit(AST::BindingAttribute&)
+{
+}
+
+void Visitor::visit(AST::BuiltinAttribute&)
+{
+}
+
+void Visitor::visit(AST::GroupAttribute&)
+{
+}
+
+void Visitor::visit(AST::LocationAttribute&)
+{
+}
+
+void Visitor::visit(AST::StageAttribute&)
+{
+}
+
+// Declaration
+
+void Visitor::visit(AST::Decl& declaration)
+{
+    switch (declaration.kind()) {
+    case AST::Decl::Kind::Function:
+        checkErrorAndVisit(downcast<AST::FunctionDecl>(declaration));
+        break;
+    case AST::Decl::Kind::Struct:
+        checkErrorAndVisit(downcast<AST::StructDecl>(declaration));
+        break;
+    case AST::Decl::Kind::Variable:
+        checkErrorAndVisit(downcast<AST::VariableDecl>(declaration));
+        break;
+    }
+}
+
+void Visitor::visit(AST::FunctionDecl& functionDeclaration)
+{
+    for (auto& attribute : functionDeclaration.attributes())
+        checkErrorAndVisit(attribute);
+    for (auto& parameter : functionDeclaration.parameters())
+        checkErrorAndVisit(parameter);
+    for (auto& attribute : functionDeclaration.returnAttributes())
+        checkErrorAndVisit(attribute);
+    maybeCheckErrorAndVisit(functionDeclaration.maybeReturnType());
+    checkErrorAndVisit(functionDeclaration.body());
+}
+
+void Visitor::visit(AST::StructDecl& structDeclaration)
+{
+    for (auto& attribute : structDeclaration.attributes())
+        checkErrorAndVisit(attribute);
+    for (auto& member : structDeclaration.members())
+        checkErrorAndVisit(member);
+}
+
+void Visitor::visit(AST::VariableDecl& varDeclaration)
+{
+    for (auto& attribute : varDeclaration.attributes())
+        checkErrorAndVisit(attribute);
+    maybeCheckErrorAndVisit(varDeclaration.maybeQualifier());
+    maybeCheckErrorAndVisit(varDeclaration.maybeTypeDecl());
+    maybeCheckErrorAndVisit(varDeclaration.maybeInitializer());
+}
+
+// Expression
+
+void Visitor::visit(AST::Expression& expression)
+{
+    switch (expression.kind()) {
+    case AST::Expression::Kind::AbstractFloatLiteral:
+        checkErrorAndVisit(downcast<AST::AbstractFloatLiteral>(expression));
+        break;
+    case AST::Expression::Kind::AbstractIntLiteral:
+        checkErrorAndVisit(downcast<AST::AbstractIntLiteral>(expression));
+        break;
+    case AST::Expression::Kind::ArrayAccess:
+        checkErrorAndVisit(downcast<AST::ArrayAccess>(expression));
+        break;
+    case AST::Expression::Kind::BoolLiteral:
+        checkErrorAndVisit(downcast<AST::BoolLiteral>(expression));
+        break;
+    case AST::Expression::Kind::CallableExpression:
+        checkErrorAndVisit(downcast<AST::CallableExpression>(expression));
+        break;
+    case AST::Expression::Kind::Float32Literal:
+        checkErrorAndVisit(downcast<AST::Float32Literal>(expression));
+        break;
+    case AST::Expression::Kind::Identifier:
+        checkErrorAndVisit(downcast<AST::IdentifierExpression>(expression));
+        break;
+    case AST::Expression::Kind::Int32Literal:
+        checkErrorAndVisit(downcast<AST::Int32Literal>(expression));
+        break;
+    case AST::Expression::Kind::StructureAccess:
+        checkErrorAndVisit(downcast<AST::StructureAccess>(expression));
+        break;
+    case AST::Expression::Kind::Uint32Literal:
+        checkErrorAndVisit(downcast<AST::Uint32Literal>(expression));
+        break;
+    case AST::Expression::Kind::UnaryExpression:
+        checkErrorAndVisit(downcast<AST::UnaryExpression>(expression));
+        break;
+    }
+}
+
+void Visitor::visit(AST::AbstractFloatLiteral&)
+{
+}
+
+void Visitor::visit(AST::AbstractIntLiteral&)
+{
+}
+
+void Visitor::visit(AST::ArrayAccess& arrayAccess)
+{
+    checkErrorAndVisit(arrayAccess.base());
+    checkErrorAndVisit(arrayAccess.index());
+}
+
+void Visitor::visit(AST::BoolLiteral&)
+{
+}
+
+void Visitor::visit(AST::CallableExpression& callableExpression)
+{
+    checkErrorAndVisit(callableExpression.target());
+    for (auto& argument : callableExpression.arguments())
+        checkErrorAndVisit(argument);
+}
+
+void Visitor::visit(AST::Float32Literal&)
+{
+}
+
+void Visitor::visit(AST::IdentifierExpression&)
+{
+}
+
+void Visitor::visit(AST::Int32Literal&)
+{
+}
+
+void Visitor::visit(AST::StructureAccess& structureAccess)
+{
+    checkErrorAndVisit(structureAccess.base());
+}
+
+void Visitor::visit(AST::Uint32Literal&)
+{
+}
+
+void Visitor::visit(AST::UnaryExpression& unaryExpression)
+{
+    checkErrorAndVisit(unaryExpression.expression());
+}
+
+// Statement
+
+void Visitor::visit(AST::Statement& statement)
+{
+    switch (statement.kind()) {
+    case AST::Statement::Kind::Assignment:
+        checkErrorAndVisit(downcast<AST::AssignmentStatement>(statement));
+        break;
+    case AST::Statement::Kind::Compound:
+        checkErrorAndVisit(downcast<AST::CompoundStatement>(statement));
+        break;
+    case AST::Statement::Kind::Return:
+        checkErrorAndVisit(downcast<AST::ReturnStatement>(statement));
+        break;
+    case AST::Statement::Kind::Variable:
+        checkErrorAndVisit(downcast<AST::VariableStatement>(statement));
+        break;
+    }
+}
+
+void Visitor::visit(AST::AssignmentStatement& assignStatement)
+{
+    maybeCheckErrorAndVisit(assignStatement.maybeLhs());
+    checkErrorAndVisit(assignStatement.rhs());
+}
+
+void Visitor::visit(AST::CompoundStatement& compoundStatement)
+{
+    for (auto& statement : compoundStatement.statements())
+        checkErrorAndVisit(statement);
+}
+
+void Visitor::visit(AST::ReturnStatement& returnStatement)
+{
+    maybeCheckErrorAndVisit(returnStatement.maybeExpression());
+}
+
+void Visitor::visit(AST::VariableStatement& varStatement)
+{
+    checkErrorAndVisit(varStatement.declaration());
+}
+
+// Types
+
+void Visitor::visit(AST::TypeDecl& typeDecl)
+{
+    switch (typeDecl.kind()) {
+    case AST::TypeDecl::Kind::Array:
+        checkErrorAndVisit(downcast<AST::ArrayType>(typeDecl));
+        break;
+    case AST::TypeDecl::Kind::Named:
+        checkErrorAndVisit(downcast<AST::NamedType>(typeDecl));
+        break;
+    case AST::TypeDecl::Kind::Parameterized:
+        checkErrorAndVisit(downcast<AST::ParameterizedType>(typeDecl));
+        break;
+    }
+}
+
+void Visitor::visit(AST::ArrayType& arrayType)
+{
+    maybeCheckErrorAndVisit(arrayType.maybeElementType());
+    maybeCheckErrorAndVisit(arrayType.maybeElementCount());
+}
+
+void Visitor::visit(AST::NamedType&)
+{
+}
+
+void Visitor::visit(AST::ParameterizedType& parameterizedType)
+{
+    checkErrorAndVisit(parameterizedType.elementType());
+}
+
+//
+
+void Visitor::visit(AST::Parameter& parameter)
+{
+    for (auto& attribute : parameter.attributes())
+        checkErrorAndVisit(attribute);
+    checkErrorAndVisit(parameter.type());
+}
+
+void Visitor::visit(AST::StructMember& structMember)
+{
+    for (auto& attribute : structMember.attributes())
+        checkErrorAndVisit(attribute);
+    checkErrorAndVisit(structMember.type());
+}
+
+void Visitor::visit(AST::VariableQualifier&)
+{
+}
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTForward.h"
+#include "CompilationMessage.h"
+
+#include <wtf/Expected.h>
+
+namespace WGSL::AST {
+
+class Visitor {
+public:
+    virtual ~Visitor() = default;
+
+    // Shader Module
+    virtual void visit(AST::ShaderModule&);
+    virtual void visit(AST::GlobalDirective&);
+
+    // Attribute
+    virtual void visit(AST::Attribute&);
+    virtual void visit(AST::BindingAttribute&);
+    virtual void visit(AST::BuiltinAttribute&);
+    virtual void visit(AST::GroupAttribute&);
+    virtual void visit(AST::LocationAttribute&);
+    virtual void visit(AST::StageAttribute&);
+
+    // Declaration
+    virtual void visit(AST::Decl&);
+    virtual void visit(AST::FunctionDecl&);
+    virtual void visit(AST::StructDecl&);
+    virtual void visit(AST::VariableDecl&);
+
+    // Expression
+    virtual void visit(AST::Expression&);
+    virtual void visit(AST::AbstractFloatLiteral&);
+    virtual void visit(AST::AbstractIntLiteral&);
+    virtual void visit(AST::ArrayAccess&);
+    virtual void visit(AST::BoolLiteral&);
+    virtual void visit(AST::CallableExpression&);
+    virtual void visit(AST::Float32Literal&);
+    virtual void visit(AST::IdentifierExpression&);
+    virtual void visit(AST::Int32Literal&);
+    virtual void visit(AST::StructureAccess&);
+    virtual void visit(AST::Uint32Literal&);
+    virtual void visit(AST::UnaryExpression&);
+
+    // Statement
+    virtual void visit(AST::Statement&);
+    virtual void visit(AST::AssignmentStatement&);
+    virtual void visit(AST::CompoundStatement&);
+    virtual void visit(AST::ReturnStatement&);
+    virtual void visit(AST::VariableStatement&);
+
+    // Types
+    virtual void visit(AST::TypeDecl&);
+    virtual void visit(AST::ArrayType&);
+    virtual void visit(AST::NamedType&);
+    virtual void visit(AST::ParameterizedType&);
+
+    virtual void visit(AST::Parameter&);
+    virtual void visit(AST::StructMember&);
+    virtual void visit(AST::VariableQualifier&);
+    
+    bool hasError() const;
+    Expected<void, Error> result();
+
+    template<typename T> void checkErrorAndVisit(T&);
+    template<typename T> void maybeCheckErrorAndVisit(T*);
+
+protected:
+    void setError(Error error)
+    {
+        ASSERT(!hasError());
+        m_expectedError = makeUnexpected(error);
+    }
+
+private:
+    Expected<void, Error> m_expectedError;
+};
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -74,8 +74,12 @@
 		33EA188427BC268600A1DD52 /* ASTStructureAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188327BC268600A1DD52 /* ASTStructureAccess.h */; };
 		33EA188627BC26DF00A1DD52 /* ASTCallableExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188527BC26DF00A1DD52 /* ASTCallableExpression.h */; };
 		33EA188827BC361E00A1DD52 /* ASTLiteralExpressions.h in Headers */ = {isa = PBXBuildFile; fileRef = 33EA188727BC361E00A1DD52 /* ASTLiteralExpressions.h */; };
+		3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A1337E528FBD56300F29B73 /* ASTVisitor.cpp */; };
+		3A1337E828FBD56400F29B73 /* ASTVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1337E628FBD56400F29B73 /* ASTVisitor.h */; };
+		3A1337EA28FBD56E00F29B73 /* ASTForward.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1337E928FBD56E00F29B73 /* ASTForward.h */; };
 		3A7E164C28C57BB8003F49C9 /* ASTArrayAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7E164B28C57BB7003F49C9 /* ASTArrayAccess.h */; };
 		3AAE4EB428C56E9A00DA484B /* ASTUnaryExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AAE4EB328C56E9A00DA484B /* ASTUnaryExpression.h */; };
+		3ACCE80628FE1872004A0914 /* AST.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ACCE80528FE1872004A0914 /* AST.h */; };
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
@@ -319,8 +323,12 @@
 		33EA188327BC268600A1DD52 /* ASTStructureAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASTStructureAccess.h; sourceTree = "<group>"; };
 		33EA188527BC26DF00A1DD52 /* ASTCallableExpression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASTCallableExpression.h; sourceTree = "<group>"; };
 		33EA188727BC361E00A1DD52 /* ASTLiteralExpressions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ASTLiteralExpressions.h; sourceTree = "<group>"; };
+		3A1337E528FBD56300F29B73 /* ASTVisitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTVisitor.cpp; sourceTree = "<group>"; };
+		3A1337E628FBD56400F29B73 /* ASTVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVisitor.h; sourceTree = "<group>"; };
+		3A1337E928FBD56E00F29B73 /* ASTForward.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTForward.h; sourceTree = "<group>"; };
 		3A7E164B28C57BB7003F49C9 /* ASTArrayAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTArrayAccess.h; sourceTree = "<group>"; };
 		3AAE4EB328C56E9A00DA484B /* ASTUnaryExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTUnaryExpression.h; sourceTree = "<group>"; };
+		3ACCE80528FE1872004A0914 /* AST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AST.h; sourceTree = "<group>"; };
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
@@ -658,6 +666,7 @@
 		33EA185C27BC193D00A1DD52 /* AST */ = {
 			isa = PBXGroup;
 			children = (
+				3ACCE80528FE1872004A0914 /* AST.h */,
 				3A7E164B28C57BB7003F49C9 /* ASTArrayAccess.h */,
 				33EA187F27BC24E200A1DD52 /* ASTAssignmentStatement.h */,
 				33EA186927BC1BE600A1DD52 /* ASTAttribute.h */,
@@ -665,6 +674,7 @@
 				33EA187A27BC230E00A1DD52 /* ASTCompoundStatement.h */,
 				33EA186127BC19C100A1DD52 /* ASTDecl.h */,
 				33EA186B27BC1CBC00A1DD52 /* ASTExpression.h */,
+				3A1337E928FBD56E00F29B73 /* ASTForward.h */,
 				33EA187527BC216B00A1DD52 /* ASTFunctionDecl.h */,
 				33EA185F27BC198100A1DD52 /* ASTGlobalDirective.h */,
 				33EA188127BC25D000A1DD52 /* ASTIdentifierExpression.h */,
@@ -680,6 +690,8 @@
 				33EA186327BC1A1D00A1DD52 /* ASTVariableDecl.h */,
 				33EA187127BC1FE100A1DD52 /* ASTVariableQualifier.h */,
 				3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */,
+				3A1337E528FBD56300F29B73 /* ASTVisitor.cpp */,
+				3A1337E628FBD56400F29B73 /* ASTVisitor.h */,
 			);
 			path = AST;
 			sourceTree = "<group>";
@@ -705,6 +717,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3ACCE80628FE1872004A0914 /* AST.h in Headers */,
 				3A7E164C28C57BB8003F49C9 /* ASTArrayAccess.h in Headers */,
 				33EA188027BC24E200A1DD52 /* ASTAssignmentStatement.h in Headers */,
 				33EA186A27BC1BE600A1DD52 /* ASTAttribute.h in Headers */,
@@ -712,6 +725,7 @@
 				33EA187B27BC230E00A1DD52 /* ASTCompoundStatement.h in Headers */,
 				33EA186227BC19C100A1DD52 /* ASTDecl.h in Headers */,
 				33EA186C27BC1CBC00A1DD52 /* ASTExpression.h in Headers */,
+				3A1337EA28FBD56E00F29B73 /* ASTForward.h in Headers */,
 				33EA187627BC216B00A1DD52 /* ASTFunctionDecl.h in Headers */,
 				33EA186027BC198100A1DD52 /* ASTGlobalDirective.h in Headers */,
 				33EA188227BC25D000A1DD52 /* ASTIdentifierExpression.h in Headers */,
@@ -727,6 +741,7 @@
 				33EA186427BC1A1D00A1DD52 /* ASTVariableDecl.h in Headers */,
 				33EA187227BC1FE100A1DD52 /* ASTVariableQualifier.h in Headers */,
 				3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */,
+				3A1337E828FBD56400F29B73 /* ASTVisitor.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
 				338BB2D427B6B66C00E066AB /* Lexer.h in Headers */,
 				339B7B1827D7FFA40072BF9A /* Parser.h in Headers */,
@@ -953,6 +968,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,
 				339B7B1B27D800090072BF9A /* Parser.cpp in Sources */,


### PR DESCRIPTION
#### bbdc3617fa55e95db6b63934f8929aef08ddd639
<pre>
[WGSL] AST Visitor helper
<a href="https://bugs.webkit.org/show_bug.cgi?id=246660">https://bugs.webkit.org/show_bug.cgi?id=246660</a>
rdar://problem/101268329

Reviewed by Antti Koivisto.

Many analysis passes in the compiler need to work with the subtrees of the
AST. AST::Visitor provides the boilerplate for performing a preorder traversal
of an AST; analyzers derived from AST::Visitor can override visit methods for
just the kinds of nodes for its task.

* Source/WebGPU/WGSL/AST/AST.h: Copied from Source/WebGPU/WGSL/AST/ASTArrayAccess.h.
* Source/WebGPU/WGSL/AST/ASTArrayAccess.h:
* Source/WebGPU/WGSL/AST/ASTCallableExpression.h:
* Source/WebGPU/WGSL/AST/ASTForward.h: Copied from Source/WebGPU/WGSL/AST/ASTArrayAccess.h.
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp: Added.
(WGSL::Visitor::hasError const):
(WGSL::Visitor::result):
(WGSL::Visitor::checkErrorAndVisit):
(WGSL::Visitor::maybeCheckErrorAndVisit):
(WGSL::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h: Added.
(WGSL::Visitor::setError):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/255725@main">https://commits.webkit.org/255725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38879f7be74d7c98b1fd52ce15e37cdcf196f807

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102939 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2453 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30761 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99054 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1706 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79711 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28614 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71727 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37150 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17257 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3963 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41032 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37714 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->