### PR TITLE
Add serializer for struct Cookie, struct VideoFrameMetadata, struct NavigationPreloadState

### DIFF
--- a/Source/WebCore/platform/Cookie.h
+++ b/Source/WebCore/platform/Cookie.h
@@ -43,9 +43,6 @@ namespace WebCore {
 struct Cookie {
     Cookie() = default;
 
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<Cookie> decode(Decoder&);
-
     WEBCORE_EXPORT bool operator==(const Cookie&) const;
     WEBCORE_EXPORT unsigned hash() const;
 
@@ -93,8 +90,30 @@ struct Cookie {
     URL commentURL;
     Vector<uint16_t> ports;
 
-    enum class SameSitePolicy { None, Lax, Strict };
+    enum class SameSitePolicy : uint8_t { 
+        None, 
+        Lax, 
+        Strict 
+    };
+
     SameSitePolicy sameSite { SameSitePolicy::None };
+
+    Cookie(String&& name, String&& value, String&& domain, String&& path, double created, std::optional<double> expires, bool httpOnly, bool secure, bool session, String&& comment, URL&& commentURL, Vector<uint16_t>&& ports, SameSitePolicy sameSite)
+        : name(WTFMove(name))
+        , value(WTFMove(value))
+        , domain(WTFMove(domain))
+        , path(WTFMove(path))
+        , created(created)
+        , expires(expires)
+        , httpOnly(httpOnly)
+        , secure(secure)
+        , session(session)
+        , comment(WTFMove(comment))
+        , commentURL(WTFMove(commentURL))
+        , ports(WTFMove(ports))
+        , sameSite(sameSite)
+    {
+    }
 };
 
 struct CookieHash {
@@ -109,57 +128,6 @@ struct CookieHash {
     }
     static const bool safeToCompareToEmptyOrDeleted = false;
 };
-
-template<class Encoder>
-void Cookie::encode(Encoder& encoder) const
-{
-    encoder << name;
-    encoder << value;
-    encoder << domain;
-    encoder << path;
-    encoder << created;
-    encoder << expires;
-    encoder << httpOnly;
-    encoder << secure;
-    encoder << session;
-    encoder << comment;
-    encoder << commentURL;
-    encoder << ports;
-    encoder << sameSite;
-}
-
-template<class Decoder>
-std::optional<Cookie> Cookie::decode(Decoder& decoder)
-{
-    Cookie cookie;
-    if (!decoder.decode(cookie.name))
-        return std::nullopt;
-    if (!decoder.decode(cookie.value))
-        return std::nullopt;
-    if (!decoder.decode(cookie.domain))
-        return std::nullopt;
-    if (!decoder.decode(cookie.path))
-        return std::nullopt;
-    if (!decoder.decode(cookie.created))
-        return std::nullopt;
-    if (!decoder.decode(cookie.expires))
-        return std::nullopt;
-    if (!decoder.decode(cookie.httpOnly))
-        return std::nullopt;
-    if (!decoder.decode(cookie.secure))
-        return std::nullopt;
-    if (!decoder.decode(cookie.session))
-        return std::nullopt;
-    if (!decoder.decode(cookie.comment))
-        return std::nullopt;
-    if (!decoder.decode(cookie.commentURL))
-        return std::nullopt;
-    if (!decoder.decode(cookie.ports))
-        return std::nullopt;
-    if (!decoder.decode(cookie.sameSite))
-        return std::nullopt;
-    return cookie;
-}
 
 }
 

--- a/Source/WebCore/platform/VideoFrameMetadata.h
+++ b/Source/WebCore/platform/VideoFrameMetadata.h
@@ -45,72 +45,7 @@ struct VideoFrameMetadata {
     std::optional<double> captureTime;
     std::optional<double> receiveTime;
     std::optional<unsigned> rtpTimestamp;
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<VideoFrameMetadata> decode(Decoder&);
 };
-
-template<class Encoder>
-inline void VideoFrameMetadata::encode(Encoder& encoder) const
-{
-    encoder << presentationTime << expectedDisplayTime << width << height << mediaTime << presentedFrames << processingDuration << captureTime << receiveTime << rtpTimestamp;
-}
-
-template<class Decoder>
-inline std::optional<VideoFrameMetadata> VideoFrameMetadata::decode(Decoder& decoder)
-{
-    std::optional<double> presentationTime;
-    decoder >> presentationTime;
-    if (!presentationTime)
-        return std::nullopt;
-
-    std::optional<double> expectedDisplayTime;
-    decoder >> expectedDisplayTime;
-    if (!expectedDisplayTime)
-        return std::nullopt;
-
-    std::optional<unsigned> width;
-    decoder >> width;
-    if (!width)
-        return std::nullopt;
-
-    std::optional<unsigned> height;
-    decoder >> height;
-    if (!height)
-        return std::nullopt;
-
-    std::optional<double> mediaTime;
-    decoder >> mediaTime;
-    if (!mediaTime)
-        return std::nullopt;
-
-    std::optional<unsigned> presentedFrames;
-    decoder >> presentedFrames;
-    if (!presentedFrames)
-        return std::nullopt;
-
-    std::optional<std::optional<double>> processingDuration;
-    decoder >> processingDuration;
-    if (!processingDuration)
-        return std::nullopt;
-
-    std::optional<std::optional<double>> captureTime;
-    decoder >> captureTime;
-    if (!captureTime)
-        return std::nullopt;
-
-    std::optional<std::optional<double>> receiveTime;
-    decoder >> receiveTime;
-    if (!receiveTime)
-        return std::nullopt;
-
-    std::optional<std::optional<unsigned>> rtpTimestamp;
-    decoder >> rtpTimestamp;
-    if (!rtpTimestamp)
-        return std::nullopt;
-
-    return VideoFrameMetadata { *presentationTime, *expectedDisplayTime, *width, *height, *mediaTime, *presentedFrames, *processingDuration, *captureTime, *receiveTime, *rtpTimestamp };
-}
 
 }
 

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -467,12 +467,22 @@ std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(
 #if ENABLE(SERVICE_WORKER)
 void Coder<WebCore::NavigationPreloadState>::encode(Encoder& encoder, const WebCore::NavigationPreloadState& instance)
 {
-    instance.encode(encoder);
+    encoder << instance.enabled;
+    encoder << instance.headerValue;
 }
 
 std::optional<WebCore::NavigationPreloadState> Coder<WebCore::NavigationPreloadState>::decode(Decoder& decoder)
 {
-    return WebCore::NavigationPreloadState::decode(decoder);
+    std::optional<bool> enabled;
+    decoder >> enabled;
+    if (!enabled)
+        return { };
+
+    std::optional<String> headerValue;
+    decoder >> headerValue;
+    if (!headerValue)
+        return { };
+    return { { *enabled, WTFMove(*headerValue) } };
 }
 #endif
 

--- a/Source/WebCore/workers/service/NavigationPreloadState.h
+++ b/Source/WebCore/workers/service/NavigationPreloadState.h
@@ -38,27 +38,9 @@ struct NavigationPreloadState {
     NavigationPreloadState isolatedCopy() const & { return { enabled, headerValue.isolatedCopy() }; }
     NavigationPreloadState isolatedCopy() && { return { enabled, WTFMove(headerValue).isolatedCopy() }; }
 
-    template<class Encoder> void encode(Encoder& encoder) const { encoder << enabled << headerValue; }
-    template<class Decoder> static std::optional<NavigationPreloadState> decode(Decoder&);
-
     bool enabled { false };
     String headerValue;
 };
-
-template<class Decoder>
-std::optional<NavigationPreloadState> NavigationPreloadState::decode(Decoder& decoder)
-{
-    std::optional<bool> enabled;
-    decoder >> enabled;
-    if (!enabled)
-        return { };
-
-    std::optional<String> headerValue;
-    decoder >> headerValue;
-    if (!headerValue)
-        return { };
-    return { { *enabled, WTFMove(*headerValue) } };
-}
 
 } // namespace WebCore
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -954,4 +954,51 @@ struct WebCore::AudioConfiguration {
     std::optional<uint64_t> bitrate;
     std::optional<uint32_t> samplerate;
     std::optional<bool> spatialRendering;
- };
+};
+
+[Nested] enum class WebCore::Cookie::SameSitePolicy : uint8_t {
+    None
+    Lax
+    Strict
+};
+
+struct WebCore::Cookie {
+    String name;
+    String value;
+    String domain;
+    String path;
+    double created;
+    std::optional<double> expires;
+    bool httpOnly;
+    bool secure;
+    bool session;
+    String comment;
+    URL commentURL;
+    Vector<uint16_t> ports;
+    WebCore::Cookie::SameSitePolicy sameSite;
+};
+
+#if ENABLE(VIDEO)
+struct WebCore::VideoFrameMetadata {
+    double presentationTime;
+    double expectedDisplayTime;
+
+    unsigned width;
+    unsigned height;
+    double mediaTime;
+
+    unsigned presentedFrames;
+    std::optional<double> processingDuration;
+
+    std::optional<double> captureTime;
+    std::optional<double> receiveTime;
+    std::optional<unsigned> rtpTimestamp;
+};
+#endif // ENABLE(VIDEO)
+
+#if ENABLE(SERVICE_WORKER)
+struct WebCore::NavigationPreloadState {
+    bool enabled;
+    String headerValue;
+};
+#endif // ENABLE(SERVICE_WORKER)


### PR DESCRIPTION
#### 4cc516b4855a16144a814fea1d9f02a32b8e0259
<pre>
Add serializer for struct Cookie, struct VideoFrameMetadata, struct NavigationPreloadState

rdar://problem/101179936

Reviewed by Alex Christensen.

* Source/WebCore/platform/Cookie.h:
(WebCore::Cookie::encode const): Deleted.
(WebCore::Cookie::decode): Deleted.
* Source/WebCore/platform/VideoFrameMetadata.h:
(WebCore::VideoFrameMetadata::encode const): Deleted.
(WebCore::VideoFrameMetadata::decode): Deleted.
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::NavigationPreloadState&gt;::encode):
(WTF::Persistence::Coder&lt;WebCore::NavigationPreloadState&gt;::decode):
* Source/WebCore/workers/service/NavigationPreloadState.h:
(WebCore::NavigationPreloadState::encode const): Deleted.
(WebCore::NavigationPreloadState::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/255698@main">https://commits.webkit.org/255698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2150477f6de6a195ae300ac42e325e5bb60fdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103014 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2537 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30840 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99120 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99001 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79790 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83688 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71796 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37222 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35048 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3943 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38922 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37785 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->