### PR TITLE
Fire error event when link preload fails synchronously.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1039,8 +1039,6 @@ imported/w3c/web-platform-tests/content-security-policy/svg/including.sub.svg [ 
 
 # Skip Content Security Policy tests that time out
 imported/w3c/web-platform-tests/content-security-policy/child-src/child-src-cross-origin-load.sub.html [ Skip ]
-imported/w3c/web-platform-tests/content-security-policy/font-src/font-mismatch-blocked.sub.html [ Skip ]
-imported/w3c/web-platform-tests/content-security-policy/font-src/font-none-blocked.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-none-block.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-self-block.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/frame-ancestors/frame-ancestors-nested-cross-in-cross-star-allow.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-mismatch-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-mismatch-blocked.sub-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Test font does not load if it does not match font-src. Test timed out
+PASS Test font does not load if it does not match font-src.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-none-blocked.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-none-blocked.sub-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Test font does not load if it does not match font-src. Test timed out
+PASS Test font does not load if it does not match font-src.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Reporting endpoints received credentials. assert_equals: expected 2 but got 1
+PASS Reporting endpoints received credentials.
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -84,6 +84,11 @@ void LinkLoader::triggerEvents(const CachedResource& resource)
         m_client.linkLoaded();
 }
 
+void LinkLoader::triggerError()
+{
+    m_client.linkLoadingErrored();
+}
+
 void LinkLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
     ASSERT_UNUSED(resource, m_cachedLinkResource.get() == &resource);
@@ -321,6 +326,9 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
 
     if (cachedLinkResource && loader)
         return createLinkPreloadResourceClient(*cachedLinkResource, *loader, document);
+
+    if (loader)
+        loader->triggerError();
     return nullptr;
 }
 

--- a/Source/WebCore/loader/LinkLoader.h
+++ b/Source/WebCore/loader/LinkLoader.h
@@ -70,6 +70,7 @@ public:
     static bool isSupportedType(CachedResource::Type, const String& mimeType, Document&);
 
     void triggerEvents(const CachedResource&);
+    void triggerError();
     void cancelLoad();
 
 private:


### PR DESCRIPTION
#### 6bab27e2e35e1637493df40e8d4c296586b23f73
<pre>
Fire error event when link preload fails synchronously.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246663">https://bugs.webkit.org/show_bug.cgi?id=246663</a>
rdar://101269688

Reviewed by Youenn Fablet.

This fires an error event when fetch fails before scheduling with the
Network process when preloading a resource specified by a link element.

The code path for firing error events in case of a network error is to return
a CachedResource with an error state to a LinkPreloadResourceClient. The client
then calls the LinkLoader with the resource and the loader in turn has the
HTMLLinkElement fire an event depending on the state of the resource returned.

This code path never executes when we block due to CSP since we do not get to the
point of scheduling the load with the Network process or even creating the
LinkPreloadResourceClient. This change detects that condition and has the HTMLLinkElement
fire an error event.

See the spec for The fetch and process the linked resource steps here:
<a href="https://html.spec.whatwg.org/multipage/links.html#preload">https://html.spec.whatwg.org/multipage/links.html#preload</a>

In particular, we are supposed to return a &quot;network error&quot; when blocking due to
CSP and so we should fire an error event:
<a href="https://fetch.spec.whatwg.org/#main-fetch">https://fetch.spec.whatwg.org/#main-fetch</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-mismatch-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/font-src/font-none-blocked.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https-expected.txt:

* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::triggerError):
(WebCore::LinkLoader::preloadIfNeeded):
* Source/WebCore/loader/LinkLoader.h:

Canonical link: <a href="https://commits.webkit.org/255740@main">https://commits.webkit.org/255740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ad2cada5090091d1e166f68610dd6049d4a1031

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103020 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163350 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2548 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30846 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99125 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1785 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79797 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28733 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37229 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35055 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18569 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3973 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41099 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37789 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->