### PR TITLE
Make delete-stale-build-files python 2 compatible

### DIFF
--- a/Tools/CISupport/delete-stale-build-files
+++ b/Tools/CISupport/delete-stale-build-files
@@ -98,10 +98,10 @@ def deleteWindowsStaleFiles():
                            '/cygdrive/c/Program Files (x86)/Windows Kits/10/Debuggers/x64/sym/DumpRenderTreeLib.pdb']
     for directory in directoriesToDelete:
         try:
-            print(f'Removing: {directory}')
+            print('Removing: {}'.format(directory))
             shutil.rmtree(directory)
         except OSError as e:
-            print(f'Failed to remove: {directory}, error: {e}')
+            print('Failed to remove: {}, error: {}'.format(directory, e))
             continue
         print('Done')
 


### PR DESCRIPTION
#### cd2c58e946f27f26c3b30a7b9180ceecfb948caf
<pre>
Make delete-stale-build-files python 2 compatible
<a href="https://bugs.webkit.org/show_bug.cgi?id=246665">https://bugs.webkit.org/show_bug.cgi?id=246665</a>

Unreviewed fix.

* Tools/CISupport/delete-stale-build-files:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd2c58e946f27f26c3b30a7b9180ceecfb948caf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102929 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163216 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2441 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30750 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99044 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98907 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79699 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28604 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83370 "Found 1 new API test failure: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71717 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37139 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17249 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34960 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18491 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41023 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37704 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->