### PR TITLE
IPC::Connection cannot be bound to arbitrary run loop

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -79,6 +79,7 @@ struct Connection::WaitForMessageState {
 class Connection::SyncMessageState {
 public:
     static std::unique_ptr<SyncMessageState, SyncMessageStateRelease> get(RunLoop&);
+    RunLoop& runLoop() { return m_runLoop; }
 
     void wakeUpClientRunLoop()
     {
@@ -313,8 +314,6 @@ Connection::Connection(Identifier identifier, bool isServer)
     , m_isServer(isServer)
     , m_connectionQueue(WorkQueue::create("com.apple.IPC.ReceiveQueue"))
 {
-    ASSERT(RunLoop::isMain());
-
     {
         Locker locker { s_connectionMapLock };
         connectionMap().add(m_uniqueID, this);
@@ -336,12 +335,10 @@ Connection::~Connection()
     clearAsyncReplyHandlers(*this);
 }
 
-// WTF_IGNORES_THREAD_SAFETY_ANALYSIS because this function accesses connectionMap() without locking.
-// It is safe because this function is only called on the main thread and Connection objects are only
-// constructed / destroyed on the main thread.
-Connection* Connection::connection(UniqueID uniqueID) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+RefPtr<Connection> Connection::connection(UniqueID uniqueID)
 {
-    ASSERT(RunLoop::isMain());
+    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=238493): Removing with lock in destructor is not thread-safe.
+    Locker locker { s_connectionMapLock };
     return connectionMap().get(uniqueID);
 }
 
@@ -452,16 +449,16 @@ void Connection::setDidCloseOnConnectionWorkQueueCallback(DidCloseOnConnectionWo
 {
     ASSERT(!m_isConnected);
 
-    m_didCloseOnConnectionWorkQueueCallback = callback;    
+    m_didCloseOnConnectionWorkQueueCallback = callback;
 }
 
-bool Connection::open(Client& client)
+bool Connection::open(Client& client, RunLoop& runLoop)
 {
     ASSERT(!m_client);
     if (!platformPrepareForOpen())
         return false;
     m_client = &client;
-    m_syncState = SyncMessageState::get(RunLoop::main());
+    m_syncState = SyncMessageState::get(runLoop);
     platformOpen();
     return true;
 }
@@ -475,10 +472,10 @@ bool Connection::platformPrepareForOpen()
 
 void Connection::invalidate()
 {
-    ASSERT(RunLoop::isMain());
     m_isValid = false;
     if (!m_client)
         return;
+    assertIsCurrent(runLoop());
     m_client = nullptr;
     [this] {
         Locker locker { m_incomingMessagesLock };
@@ -549,7 +546,7 @@ bool Connection::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOption>
         Locker locker { m_outgoingMessagesLock };
         m_outgoingMessages.append(WTFMove(encoder));
     }
-    
+
     // FIXME: We should add a boolean flag so we don't call this when work has already been scheduled.
     auto sendOutgoingMessages = [protectedThis = Ref { *this }]() mutable {
         protectedThis->sendOutgoingMessages();
@@ -575,7 +572,9 @@ Timeout Connection::timeoutRespectingIgnoreTimeoutsForTesting(Timeout timeout) c
 
 std::unique_ptr<Decoder> Connection::waitForMessage(MessageName messageName, uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
-    ASSERT(RunLoop::isMain());
+    if (!isValid())
+        return nullptr;
+    assertIsCurrent(runLoop());
     Ref protectedThis { *this };
 
     timeout = timeoutRespectingIgnoreTimeoutsForTesting(timeout);
@@ -689,12 +688,11 @@ void Connection::popPendingSyncRequestID(SyncRequestID syncRequestID)
 std::unique_ptr<Decoder> Connection::sendSyncMessage(SyncRequestID syncRequestID, UniqueRef<Encoder>&& encoder, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
 {
     ASSERT(syncRequestID);
-    ASSERT(RunLoop::isMain());
-
     if (!isValid()) {
         didFailToSendSyncMessage();
         return nullptr;
     }
+    assertIsCurrent(runLoop());
     if (!pushPendingSyncRequestID(syncRequestID)) {
         didFailToSendSyncMessage();
         return nullptr;
@@ -732,21 +730,21 @@ std::unique_ptr<Decoder> Connection::waitForSyncReply(SyncRequestID syncRequestI
     timeout = timeoutRespectingIgnoreTimeoutsForTesting(timeout);
 
     willSendSyncMessage(sendSyncOptions);
-    
+
     bool timedOut = false;
     while (!timedOut) {
         // First, check if we have any messages that we need to process.
         m_syncState->dispatchMessages();
-        
+
         {
             Locker locker { m_syncReplyStateLock };
 
             // Second, check if there is a sync reply at the top of the stack.
             ASSERT(!m_pendingSyncReplies.isEmpty());
-            
+
             PendingSyncReply& pendingSyncReply = m_pendingSyncReplies.last();
             ASSERT_UNUSED(syncRequestID, pendingSyncReply.syncRequestID == syncRequestID);
-            
+
             // We found the sync reply, or the connection was closed.
             if (pendingSyncReply.didReceiveReply || !m_shouldWaitForSyncReplies) {
                 didReceiveSyncReply(sendSyncOptions);
@@ -920,7 +918,7 @@ bool Connection::hasIncomingSyncMessage()
         if (message->isSyncMessage())
             return true;
     }
-    
+
     return false;
 }
 
@@ -944,13 +942,6 @@ void Connection::dispatchIncomingMessageForTesting(std::unique_ptr<Decoder>&& de
     });
 }
 #endif
-
-void Connection::postConnectionDidCloseOnConnectionWorkQueue()
-{
-    m_connectionQueue->dispatch([protectedThis = Ref { *this }]() mutable {
-        protectedThis->connectionDidClose();
-    });
-}
 
 void Connection::connectionDidClose()
 {
@@ -988,15 +979,7 @@ void Connection::connectionDidClose()
     if (m_didCloseOnConnectionWorkQueueCallback)
         m_didCloseOnConnectionWorkQueueCallback(this);
 
-    RunLoop::main().dispatch([protectedThis = Ref { *this }]() mutable {
-        // If the connection has been explicitly invalidated before dispatchConnectionDidClose was called,
-        // then the connection client will be nullptr here.
-        if (!protectedThis->m_client)
-            return;
-        auto client = std::exchange(protectedThis->m_client, nullptr);
-        client->didClose(protectedThis.get());
-        clearAsyncReplyHandlers(protectedThis.get());
-    });
+    dispatchDidCloseAndInvalidate();
 }
 
 bool Connection::canSendOutgoingMessages() const
@@ -1030,7 +1013,7 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
     // FIXME: If the message is invalid, we should send back a SyncMessageError.
     // Currently we just wait for a timeout to happen, which will block the WebContent process.
 
-    ASSERT(isMainRunLoop());
+    assertIsCurrent(runLoop());
     ASSERT(decoder.isSyncMessage());
 
     SyncRequestID syncRequestID;
@@ -1074,10 +1057,22 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
 
 void Connection::dispatchDidReceiveInvalidMessage(MessageName messageName)
 {
-    RunLoop::main().dispatch([this, protectedThis = Ref { *this }, messageName]() mutable {
-        if (!isValid())
+    dispatchToClient([protectedThis = Ref { *this }, messageName] {
+        if (!protectedThis->isValid())
             return;
-        m_client->didReceiveInvalidMessage(*this, messageName);
+        protectedThis->m_client->didReceiveInvalidMessage(protectedThis, messageName);
+    });
+}
+
+void Connection::dispatchDidCloseAndInvalidate()
+{
+    dispatchToClient([protectedThis = Ref { *this }] {
+        // If the connection has been explicitly invalidated before dispatchConnectionDidClose was called,
+        // then the connection client will be nullptr here.
+        if (!protectedThis->m_client)
+            return;
+        protectedThis->m_client->didClose(protectedThis);
+        protectedThis->invalidate();
     });
 }
 
@@ -1124,17 +1119,22 @@ void Connection::enqueueIncomingMessage(std::unique_ptr<Decoder> incomingMessage
             return;
     }
 
-    RunLoop::main().dispatch([protectedThis = Ref { *this }]() mutable {
-        if (protectedThis->isIncomingMessagesThrottlingEnabled())
+    if (!m_syncState)
+        return;
+    if (isIncomingMessagesThrottlingEnabled()) {
+        runLoop().dispatch([protectedThis = Ref { *this }] {
             protectedThis->dispatchIncomingMessages();
-        else
+        });
+    } else {
+        runLoop().dispatch([protectedThis = Ref { *this }] {
             protectedThis->dispatchOneIncomingMessage();
-    });
+        });
+    }
 }
 
 void Connection::dispatchMessage(Decoder& decoder)
 {
-    ASSERT(RunLoop::isMain());
+    assertIsCurrent(runLoop());
     RELEASE_ASSERT(m_client);
     if (decoder.messageReceiverName() == ReceiverName::AsyncReply) {
         auto handler = takeAsyncReplyHandler(*this, decoder.destinationID());
@@ -1170,10 +1170,9 @@ void Connection::dispatchMessage(Decoder& decoder)
 
 void Connection::dispatchMessage(std::unique_ptr<Decoder> message)
 {
-    ASSERT(RunLoop::isMain());
     if (!isValid())
         return;
-
+    assertIsCurrent(runLoop());
     {
         // FIXME: The matches here come from
         // m_messagesToDispatchWhileWaitingForSyncReply. This causes message
@@ -1197,7 +1196,7 @@ void Connection::dispatchMessage(std::unique_ptr<Decoder> message)
     }
 
     m_inDispatchMessageCount++;
-    
+
     bool isDispatchingMessageWhileWaitingForSyncReply = (message->shouldDispatchMessageWhenWaitingForSyncReply() == ShouldDispatchWhenWaitingForSyncReply::Yes)
         || (message->shouldDispatchMessageWhenWaitingForSyncReply() == ShouldDispatchWhenWaitingForSyncReply::YesDuringUnboundedIPC && UnboundedSynchronousIPCScope::hasOngoingUnboundedSyncIPC());
 
@@ -1245,6 +1244,21 @@ size_t Connection::numberOfMessagesToProcess(size_t totalMessages)
     return std::min(totalMessages, batchSize);
 }
 
+RunLoop& Connection::runLoop()
+{
+    // RunLoop can only be accessed while the connection is valid,
+    // and must have the incoming message lock held if not being
+    // called from the RunLoop.
+    RELEASE_ASSERT(m_syncState);
+    if (!m_incomingMessagesLock.isLocked())
+        assertIsCurrent(m_syncState->runLoop());
+
+    // Our syncState is specific to the RunLoop we have been
+    // bound to during open(), so we can retrieve the RunLoop
+    // from it (rather than storing another pointer on this class).
+    return m_syncState->runLoop();
+}
+
 void Connection::dispatchOneIncomingMessage()
 {
     std::unique_ptr<Decoder> message;
@@ -1261,14 +1275,16 @@ void Connection::dispatchOneIncomingMessage()
 
 void Connection::dispatchSyncStateMessages()
 {
-    ASSERT(RunLoop::isMain());
-    if (m_syncState)
+    if (m_syncState) {
+        assertIsCurrent(runLoop());
         m_syncState->dispatchMessagesAndResetDidScheduleDispatchMessagesForConnection(*this);
+    }
 }
 
 void Connection::dispatchIncomingMessages()
 {
-    ASSERT(RunLoop::isMain());
+    if (!isValid())
+        return;
 
     std::unique_ptr<Decoder> message;
 
@@ -1293,7 +1309,7 @@ void Connection::dispatchIncomingMessages()
         // Re-schedule ourselves *before* we dispatch the messages because we want to process follow-up messages if the client
         // spins a nested run loop while we're dispatching a message. Note that this means we can re-enter this method.
         if (!m_incomingMessages.isEmpty()) {
-            RunLoop::main().dispatch([protectedThis = Ref { *this }] {
+            runLoop().dispatch([protectedThis = Ref { *this }] {
                 protectedThis->dispatchIncomingMessages();
             });
         }
@@ -1356,7 +1372,18 @@ CompletionHandler<void(Decoder*)> takeAsyncReplyHandler(Connection& connection, 
 
 void Connection::wakeUpRunLoop()
 {
-    RunLoop::main().wakeUp();
+    if (!isValid())
+        return;
+    runLoop().wakeUp();
+}
+
+template<typename F>
+void Connection::dispatchToClient(F&& clientRunLoopTask)
+{
+    Locker lock { m_incomingMessagesLock };
+    if (!m_syncState)
+        return;
+    runLoop().dispatch(WTFMove(clientRunLoopTask));
 }
 
 #if !USE(UNIX_DOMAIN_SOCKETS) && !OS(DARWIN) && !OS(WINDOWS)

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -50,6 +50,24 @@ struct MockTestMessage1 {
     std::tuple<> arguments() { return { }; }
 };
 
+struct MockTestMessageWithAsyncReply1 {
+    static constexpr bool isSync = false;
+    static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(124); }
+    // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
+    // If WebPage_GetBytecodeProfileReply is removed, just use another one.
+    static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
+    std::tuple<> arguments() { return { }; }
+    static void callReply(IPC::Decoder& decoder, CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        auto value = decoder.decode<uint64_t>();
+        completionHandler(*value);
+    }
+    static void cancelReply(CompletionHandler<void(uint64_t)>&& completionHandler)
+    {
+        completionHandler(0);
+    }
+};
+
 class MockConnectionClient final : public IPC::Connection::Client {
 public:
     ~MockConnectionClient()
@@ -87,7 +105,7 @@ public:
     }
 
     // Handler returns false if the message should be just recorded.
-    void setAsyncMessageHandler(Function<bool(MessageInfo&)>&& handler)
+    void setAsyncMessageHandler(Function<bool(IPC::Decoder&)>&& handler)
     {
         m_asyncMessageHandler = WTFMove(handler);
     }
@@ -95,10 +113,9 @@ public:
     // IPC::Connection::Client overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder& decoder) override
     {
-        MessageInfo messageInfo { decoder.messageName(), decoder.destinationID() };
-        if (m_asyncMessageHandler && m_asyncMessageHandler(messageInfo))
+        if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
             return;
-        m_messages.append(WTFMove(messageInfo));
+        m_messages.append({ decoder.messageName(), decoder.destinationID() });
         m_continueWaitForMessage = true;
     }
 
@@ -122,7 +139,7 @@ private:
     std::optional<IPC::MessageName> m_didReceiveInvalidMessage;
     Deque<MessageInfo> m_messages;
     bool m_continueWaitForMessage { false };
-    Function<bool(MessageInfo&)> m_asyncMessageHandler;
+    Function<bool(IPC::Decoder&)> m_asyncMessageHandler;
 };
 
 }
@@ -441,7 +458,7 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingWorks)
     std::array<size_t, 18> messageCounts { 600, 300, 200, 150, 120, 100, 85, 75, 66, 60, 60, 66, 75, 85, 100, 120, 37, 1 };
     for (size_t i = 0; i < messageCounts.size(); ++i) {
         SCOPED_TRACE(i);
-        RunLoop::current().dispatch([&otherRunLoopTasksRun] { 
+        RunLoop::current().dispatch([&otherRunLoopTasksRun] {
             otherRunLoopTasksRun++;
         });
         Util::spinRunLoop();
@@ -475,18 +492,19 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
         b()->send(MockTestMessage1 { }, i);
     while (a()->pendingMessageCountForTesting() < testedCount)
         sleep(0.1_s);
-    
+
     // Two messages invoke nested run loop. The handler skips total 4 messages for the
     // proofs of logic that the test was ran.
     bool isProcessing = false;
-    aClient().setAsyncMessageHandler([&] (MessageInfo& message) -> bool {
-        if (message.destinationID == 888 || message.destinationID == 1299) {
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto destinationID = decoder.destinationID();
+        if (destinationID == 888 || destinationID == 1299) {
             isProcessing = true;
             Util::spinRunLoop();
             isProcessing = false;
             return true; // Skiping the message is the proof that the message was processed.
         }
-        if (message.destinationID == 889 || message.destinationID == 1300) {
+        if (destinationID == 889 || destinationID == 1300) {
             EXPECT_TRUE(isProcessing); // Passing the EXPECT is the proof that we ran the message in a nested event loop.
             return true; // Skipping the message is the proof that above EXPECT was ran.
         }
@@ -497,7 +515,7 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
     std::array<size_t, 16> messageCounts { 600, 498, 150, 218, 85, 75, 66, 60, 60, 66, 75, 85, 100, 120, 37, 1 };
     for (size_t i = 0; i < messageCounts.size(); ++i) {
         SCOPED_TRACE(i);
-        RunLoop::current().dispatch([&otherRunLoopTasksRun] { 
+        RunLoop::current().dispatch([&otherRunLoopTasksRun] {
             otherRunLoopTasksRun++;
         });
         Util::spinRunLoop();
@@ -516,8 +534,259 @@ TEST_P(ConnectionTestABBA, IncomingMessageThrottlingNestedRunLoopDispatches)
     }
 }
 
+
+template<typename C>
+static void dispatchSync(RunLoop& runLoop, C&& function)
+{
+    BinarySemaphore semaphore;
+    runLoop.dispatch([&] () mutable {
+        function();
+        semaphore.signal();
+    });
+    semaphore.wait();
+}
+
+template<typename C>
+static void dispatchAndWait(RunLoop& runLoop, C&& function)
+{
+    std::atomic<bool> done = false;
+    runLoop.dispatch([&] () mutable {
+        function();
+        done = true;
+    });
+    while (!done)
+        RunLoop::current().cycle();
+}
+
+class ConnectionRunLoopTest : public ConnectionTestABBA {
+public:
+    void TearDown() override
+    {
+        ConnectionTestABBA::TearDown();
+        // Remember to call localReferenceBarrier() in test scope.
+        // Otherwise run loops might be executing code that uses variables
+        // that went out of scope.
+        EXPECT_EQ(m_runLoops.size(), 0u);
+    }
+
+    Ref<RunLoop> createRunLoop(const char* name)
+    {
+        auto runLoop = RunLoop::create(name, ThreadType::Unknown);
+        m_runLoops.append(runLoop);
+        return runLoop;
+    }
+
+    void localReferenceBarrier()
+    {
+        // Since we need to send sync to create a barrier to run loops,
+        // we might as well destroy the run loops in this function.
+        Vector<Ref<Thread>> threadsToWait;
+        // FIXME: Cannot wait for RunLoop to really exit.
+        for (auto& runLoop : std::exchange(m_runLoops, { })) {
+            dispatchSync(runLoop, [&] {
+                threadsToWait.append(Thread::current());
+                RunLoop::current().stop();
+            });
+        }
+        while (true) {
+            sleep(0.1_s);
+            Locker lock { Thread::allThreadsLock() };
+            for (auto& thread : threadsToWait) {
+                if (Thread::allThreads().contains(thread.ptr()))
+                    continue;
+            }
+            break;
+        }
+    }
+
+protected:
+    Vector<Ref<RunLoop>> m_runLoops;
+};
+
+#define LOCAL_STRINGIFY(x) #x
+#define RUN_LOOP_NAME "RunLoop at ConnectionTests.cpp:" LOCAL_STRINGIFY(__LINE__)
+
+TEST_P(ConnectionRunLoopTest, RunLoopOpen)
+{
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        bClient().waitForDidClose(kDefaultWaitForTimeout);
+        semaphore.signal();
+    });
+    a()->invalidate();
+    semaphore.wait();
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopInvalidate)
+{
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        b()->invalidate();
+    });
+    aClient().waitForDidClose(kDefaultWaitForTimeout);
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopSend)
+{
+    ASSERT_TRUE(openA());
+    for (uint64_t i = 0u; i < 55u; ++i)
+        a()->send(MockTestMessage1 { }, i);
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        for (uint64_t i = 100u; i < 160u; ++i)
+            b()->send(MockTestMessage1 { }, i);
+        for (uint64_t i = 0u; i < 55u; ++i) {
+            auto message = bClient().waitForMessage(kDefaultWaitForTimeout);
+            EXPECT_EQ(message.messageName, MockTestMessage1::name());
+            EXPECT_EQ(message.destinationID, i);
+        }
+        semaphore.wait(); // FIXME: We cannot yet invalidate() and expect all messages get delivered.
+        b()->invalidate();
+    });
+    for (uint64_t i = 100u; i < 160u; ++i) {
+        auto message = aClient().waitForMessage(kDefaultWaitForTimeout);
+        EXPECT_EQ(message.messageName, MockTestMessage1::name());
+        EXPECT_EQ(message.destinationID, i);
+    }
+    semaphore.signal();
+
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
+{
+    ASSERT_TRUE(openA());
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto listenerID = decoder.decode<uint64_t>();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        encoder.get() << decoder.destinationID();
+        a()->sendSyncReply(WTFMove(encoder));
+        return true;
+    });
+    HashSet<uint64_t> replies;
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    dispatchAndWait(runLoop, [&] {
+        ASSERT_TRUE(openB());
+        for (uint64_t i = 100u; i < 160u; ++i) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
+                if (!value)
+                    WTFLogAlways("GOT: %llu", j);
+                EXPECT_GE(value, 100u);
+                replies.add(value);
+            }, i);
+        }
+        while (replies.size() < 60u)
+            RunLoop::current().cycle();
+        b()->invalidate();
+    });
+
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
+// This API contract does not make sense. Not only that, but there is no good way currently
+// to capture this in a thread-safe way (construct completion handler in a thread-safe way
+// so that it would assert that it would execute in the run loop thread). This is disabled
+// until the API contract is changed.
+TEST_P(ConnectionRunLoopTest, DISABLED_RunLoopSendAsyncOnAnotherRunLoopDispatchesOnConnectionRunLoop)
+{
+    ASSERT_TRUE(openA());
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto listenerID = decoder.decode<uint64_t>();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        encoder.get() << decoder.destinationID();
+        a()->sendSyncReply(WTFMove(encoder));
+        return true;
+    });
+    HashSet<uint64_t> replies;
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    dispatchSync(runLoop, [&] {
+        ASSERT_TRUE(openB());
+    });
+
+    BinarySemaphore semaphore;
+    auto otherRunLoop = createRunLoop(RUN_LOOP_NAME);
+    otherRunLoop->dispatch([&] {
+        for (uint64_t i = 100u; i < 160u; ++i) {
+            b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&] (uint64_t value) {
+                EXPECT_GE(value, 100u);
+                // These should be dispatched on `runLoop` above, which does not make much sense.
+                replies.add(value);
+            }, i);
+        }
+        // Halt the runloop for a proof that the async replies are not processed on
+        // this run loop.
+        semaphore.wait();
+    });
+    dispatchAndWait(runLoop, [&] {
+        while (replies.size() < 60u)
+            RunLoop::current().cycle();
+    });
+
+    for (uint64_t i = 100u; i < 160u; ++i)
+        EXPECT_TRUE(replies.contains(i));
+    semaphore.signal();
+    localReferenceBarrier();
+}
+
+// This makes no sense:
+//  - async reply handlers are dispatched on the connection run loop
+//  - async reply handlers are dispatched as cancelled on connection run loop during invalidate
+//  - async reply handlers that are sent to already invalid connection are dispatched on main run loop
+// We have to make the discrepancy as the Connection is not bound to any run loop if it is invalid, e.g.
+// prior to open() and after invalidate().
+// Previously Connection was bound only to main run loop. In that scenario also the invalid send could cancel the reply handler
+// on main run loop, as that is guaranteed to exist. After Connection could be bound to an arbitrary run loop, we cannot
+// cancel the reply handler on a run loop we do not know about.
+// Will be fixed later. Likely this needs an API contract change, where async reply handlers are dispatched on the
+// calling run loop.
+TEST_P(ConnectionRunLoopTest, InvalidSendWithAsyncReplyDispatchesCancelHandlerOnMainThread)
+{
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    uint64_t reply = 1u;
+    BinarySemaphore semaphore;
+    runLoop->dispatch([&] {
+        ASSERT_TRUE(openB());
+        b()->invalidate();
+        b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&] (uint64_t value) {
+            reply = value;
+            }, 77);
+        // Halt the runloop for a proof that the async replies are not processed on
+        // this run loop.
+        semaphore.wait();
+    });
+    EXPECT_EQ(reply, 1u);
+    while (reply == 1u)
+        RunLoop::current().cycle();
+    EXPECT_EQ(reply, 0u);
+    semaphore.signal();
+    localReferenceBarrier();
+}
+
+#undef RUN_LOOP_NAME
+#undef LOCAL_STRINGIFY
+
 INSTANTIATE_TEST_SUITE_P(ConnectionTest,
     ConnectionTestABBA,
+    testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
+    TestParametersToStringFormatter());
+
+INSTANTIATE_TEST_SUITE_P(ConnectionTest,
+    ConnectionRunLoopTest,
     testing::Values(ConnectionTestDirection::ServerIsA, ConnectionTestDirection::ClientIsA),
     TestParametersToStringFormatter());
 


### PR DESCRIPTION
#### e23c41101c83695756b09b8741c7529e7b007212
<pre>
IPC::Connection cannot be bound to arbitrary run loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=246336">https://bugs.webkit.org/show_bug.cgi?id=246336</a>
rdar://problem/101030022

Reviewed by Chris Dumez.

Make it possible to bind IPC::Connection::Client to a particular
run loop via Connection::open(Client&amp;, RunLoop&amp;). The messages
will be dispatched to the passed run loop.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::runLoop):
(IPC::Connection::Connection):
(IPC::Connection::~Connection):
(IPC::Connection::connection):
(IPC::Connection::open):
(IPC::Connection::invalidate):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::connectionDidClose):
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::dispatchDidReceiveInvalidMessage):
(IPC::Connection::dispatchDidCloseAndInvalidate):
(IPC::Connection::enqueueIncomingMessage):
(IPC::Connection::dispatchMessage):
(IPC::Connection::dispatchSyncStateMessages):
(IPC::Connection::dispatchIncomingMessages):
(IPC::Connection::wakeUpRunLoop):
(IPC::Connection::dispatchClient):
(IPC::Connection::postConnectionDidCloseOnConnectionWorkQueue): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncCallbackAndDispatchImmediately):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/255814@main">https://commits.webkit.org/255814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b92e12c30195aac7a03300df89eb087408f050a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2852 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103308 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163631 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2863 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31130 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86009 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99319 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80101 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37515 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35357 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4014 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39233 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41168 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->