### PR TITLE
Prepare to start instantiating RemoteFrame for site-isolated iframes

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -46,7 +46,7 @@ const ClassInfo JSDOMWindowProperties::s_info = { "WindowProperties"_s, &Base::s
 static bool jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter(JSDOMWindowProperties* thisObject, DOMWindow& window, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot)
 {
     if (auto* frame = window.frame()) {
-        if (auto* scopedChild = frame->tree().scopedChild(propertyNameToAtomString(propertyName))) {
+        if (auto* scopedChild = dynamicDowncast<LocalFrame>(frame->tree().scopedChild(propertyNameToAtomString(propertyName)))) {
             slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::DontEnum), toJS(lexicalGlobalObject, scopedChild->document()->domWindow()));
             return true;
         }

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -82,9 +82,12 @@ void DeviceOrientationAndMotionAccessController::shouldAllowAccess(const Documen
         if (permissionState != DeviceOrientationOrMotionPermissionState::Granted)
             return;
 
-        for (auto* frame = m_topDocument.frame(); frame && frame->window(); frame = frame->tree().traverseNext()) {
-            frame->window()->startListeningForDeviceOrientationIfNecessary();
-            frame->window()->startListeningForDeviceMotionIfNecessary();
+        for (AbstractFrame* frame = m_topDocument.frame(); frame && frame->window(); frame = frame->tree().traverseNext()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+            if (!localFrame)
+                continue;
+            localFrame->window()->startListeningForDeviceOrientationIfNecessary();
+            localFrame->window()->startListeningForDeviceMotionIfNecessary();
         }
     });
 }

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -195,8 +195,11 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 
         // A descendant browsing context's document has a non-empty fullscreen element stack.
         bool descendentHasNonEmptyStack = false;
-        for (Frame* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
-            if (descendant->document()->fullscreenManager().fullscreenElement()) {
+        for (AbstractFrame* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(descendant);
+            if (!localFrame)
+                continue;
+            if (localFrame->document()->fullscreenManager().fullscreenElement()) {
                 descendentHasNonEmptyStack = true;
                 break;
             }
@@ -328,9 +331,12 @@ void FullscreenManager::exitFullscreen()
     // element stack (if any), ordered so that the child of the doc is last and the document furthest
     // away from the doc is first.
     Deque<RefPtr<Document>> descendants;
-    for (Frame* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
-        if (descendant->document()->fullscreenManager().fullscreenElement())
-            descendants.prepend(descendant->document());
+    for (AbstractFrame* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(descendant);
+        if (!localFrame)
+            continue;
+        if (localFrame->document()->fullscreenManager().fullscreenElement())
+            descendants.prepend(localFrame->document());
     }
 
     // 4. For each descendant in descendants, empty descendant's fullscreen element stack, and queue a

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -473,11 +473,11 @@ Element* TreeScope::findAnchor(StringView name)
     return nullptr;
 }
 
-static Element* focusedFrameOwnerElement(Frame* focusedFrame, Frame* currentFrame)
+static Element* focusedFrameOwnerElement(AbstractFrame* focusedFrame, Frame* currentFrame)
 {
     for (; focusedFrame; focusedFrame = focusedFrame->tree().parent()) {
         if (focusedFrame->tree().parent() == currentFrame)
-            return focusedFrame->ownerElement();
+            return is<LocalFrame>(focusedFrame) ? downcast<LocalFrame>(focusedFrame)->ownerElement() : nullptr;
     }
     return nullptr;
 }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2002,7 +2002,7 @@ void FrameSelection::selectFrameElementInParentIfFullySelected()
     RefPtr frame { document->frame() };
     if (!frame)
         return;
-    RefPtr parent { frame->tree().parent() };
+    RefPtr parent { dynamicDowncast<LocalFrame>(frame->tree().parent()) };
     if (!parent)
         return;
     Page* page = m_document->page();

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -158,8 +158,12 @@ CachedFrame::CachedFrame(Frame& frame)
     m_document->setMayBeDetachedFromFrame(false);
 
     // Create the CachedFrames for all Frames in the FrameTree.
-    for (Frame* child = frame.tree().firstChild(); child; child = child->tree().nextSibling())
-        m_childFrames.append(makeUniqueRef<CachedFrame>(*child));
+    for (auto* child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        auto* localChild = downcast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        m_childFrames.append(makeUniqueRef<CachedFrame>(*localChild));
+    }
 
     RELEASE_ASSERT(m_document->domWindow());
     RELEASE_ASSERT(m_document->frame());

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -83,8 +83,12 @@ static void firePageShowAndPopStateEvents(Page& page)
     // Dispatching JavaScript events can cause frame destruction.
     auto& mainFrame = page.mainFrame();
     Vector<Ref<Frame>> childFrames;
-    for (auto* child = mainFrame.tree().traverseNextInPostOrder(CanWrap::Yes); child; child = child->tree().traverseNextInPostOrder(CanWrap::No))
-        childFrames.append(*child);
+    for (auto* child = mainFrame.tree().traverseNextInPostOrder(CanWrap::Yes); child; child = child->tree().traverseNextInPostOrder(CanWrap::No)) {
+        auto* localChild = downcast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        childFrames.append(*localChild);
+    }
 
     for (auto& child : childFrames) {
         if (!child->tree().isDescendantOf(&mainFrame))

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -531,8 +531,8 @@ void HTMLFormElement::parseAttribute(const QualifiedName& name, const AtomString
         
         if (!m_attributes.action().isEmpty()) {
             if (RefPtr<Frame> f = document().frame()) {
-                Frame& topFrame = f->tree().top();
-                MixedContentChecker::checkFormForMixedContent(topFrame, topFrame.document()->securityOrigin(), document().completeURL(m_attributes.action()));
+                if (auto* topFrame = dynamicDowncast<LocalFrame>(f->tree().top()))
+                    MixedContentChecker::checkFormForMixedContent(*topFrame, topFrame->document()->securityOrigin(), document().completeURL(m_attributes.action()));
             }
         }
     } else if (name == targetAttr)

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -132,8 +132,11 @@ bool HTMLFrameOwnerElement::isProhibitedSelfReference(const URL& completeURL) co
 {
     // We allow one level of self-reference because some websites depend on that, but we don't allow more than one.
     bool foundOneSelfReference = false;
-    for (auto* frame = document().frame(); frame; frame = frame->tree().parent()) {
-        if (equalIgnoringFragmentIdentifier(frame->document()->url(), completeURL)) {
+    for (AbstractFrame* frame = document().frame(); frame; frame = frame->tree().parent()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (equalIgnoringFragmentIdentifier(localFrame->document()->url(), completeURL)) {
             if (foundOneSelfReference)
                 return true;
             foundOneSelfReference = true;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1270,8 +1270,8 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     // In cross-origin iframes it should throw a "SecurityError" DOMException except on file and color. In same-origin iframes it should work fine.
     // https://github.com/whatwg/html/issues/6909#issuecomment-917138991
     if (!m_inputType->allowsShowPickerAcrossFrames()) {
-        Frame& topFrame = frame->tree().top();
-        if (!frame->document()->securityOrigin().isSameOriginAs(topFrame.document()->securityOrigin()))
+        auto* localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
+        if (!localTopFrame || !frame->document()->securityOrigin().isSameOriginAs(localTopFrame->document()->securityOrigin()))
             return Exception { SecurityError, "Input showPicker() called from cross-origin iframe."_s };
     }
 

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -147,8 +147,12 @@ void PageDebugger::reportException(JSGlobalObject* state, JSC::Exception* except
 void PageDebugger::setJavaScriptPaused(const PageGroup& pageGroup, bool paused)
 {
     for (auto& page : pageGroup.pages()) {
-        for (auto* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext())
-            setJavaScriptPaused(*frame, paused);
+        for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+            if (!localFrame)
+                continue;
+            setJavaScriptPaused(*localFrame, paused);
+        }
 
         if (auto* frontendClient = page.inspectorController().inspectorFrontendClient()) {
             if (paused)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -343,8 +343,11 @@ void InspectorDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReaso
 Vector<Document*> InspectorDOMAgent::documents()
 {
     Vector<Document*> result;
-    for (Frame* frame = m_document->frame(); frame; frame = frame->tree().traverseNext()) {
-        Document* document = frame->document();
+    for (AbstractFrame* frame = m_document->frame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        auto* document = localFrame->document();
         if (!document)
             continue;
         result.append(document);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -688,10 +688,11 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
 
     ASSERT(m_frame);
 
-    Frame& topFrame = m_frame->tree().top();
+    auto* topFrame = dynamicDowncast<LocalFrame>(m_frame->tree().top());
 
     ASSERT(m_frame->document());
-    ASSERT(topFrame.document());
+    ASSERT(topFrame);
+    ASSERT(topFrame->document());
     
     // Update cookie policy base URL as URL changes, except for subframes, which use the
     // URL of the main frame which doesn't change when we redirect.
@@ -713,12 +714,12 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
     if (isRedirectToGetAfterPost(m_request, newRequest))
         newRequest.clearHTTPOrigin();
 
-    if (&topFrame != m_frame) {
+    if (topFrame != m_frame) {
         if (!MixedContentChecker::canDisplayInsecureContent(*m_frame, m_frame->document()->securityOrigin(), MixedContentChecker::ContentType::Active, newRequest.url(), MixedContentChecker::AlwaysDisplayInNonStrictMode::Yes)) {
             cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
             return completionHandler(WTFMove(newRequest));
         }
-        if (!MixedContentChecker::canDisplayInsecureContent(*m_frame, topFrame.document()->securityOrigin(), MixedContentChecker::ContentType::Active, newRequest.url())) {
+        if (!topFrame || !MixedContentChecker::canDisplayInsecureContent(*m_frame, topFrame->document()->securityOrigin(), MixedContentChecker::ContentType::Active, newRequest.url())) {
             cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
             return completionHandler(WTFMove(newRequest));
         }

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -202,7 +202,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
             ASSERT(policyContainerFromHistory);
             document->inheritPolicyContainerFrom(*policyContainerFromHistory);
         } else if (url == aboutSrcDocURL()) {
-            auto* parentFrame = m_frame->tree().parent();
+            auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
             if (parentFrame && parentFrame->document()) {
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
                 document->contentSecurityPolicy()->updateSourceSelf(parentFrame->document()->securityOrigin());
@@ -244,7 +244,7 @@ TextResourceDecoder& DocumentWriter::decoder()
         m_decoder = TextResourceDecoder::create(m_mimeType,
             m_frame->settings().defaultTextEncodingName(),
             m_frame->settings().usesEncodingDetector());
-        Frame* parentFrame = m_frame->tree().parent();
+        auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
         // Set the hint encoding to the parent frame encoding only if
         // the parent and the current frames share the security origin.
         // We impose this condition because somebody can make a child frame

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -838,14 +838,17 @@ void FrameLoader::subresourceLoadDone(LoadCompletionType type)
         scheduleCheckLoadComplete();
 }
 
-bool FrameLoader::preventsParentFromBeingComplete(const Frame& frame) const
+bool FrameLoader::preventsParentFromBeingComplete(const AbstractFrame& frame) const
 {
-    return !frame.loader().m_isComplete && (!frame.ownerElement() || !frame.ownerElement()->isLazyLoadObserverActive());
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+    if (!localFrame)
+        return false;
+    return !localFrame->loader().m_isComplete && (!localFrame->ownerElement() || !localFrame->ownerElement()->isLazyLoadObserverActive());
 }
 
 bool FrameLoader::allChildrenAreComplete() const
 {
-    for (Frame* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+    for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
         if (preventsParentFromBeingComplete(*child))
             return false;
     }
@@ -854,8 +857,11 @@ bool FrameLoader::allChildrenAreComplete() const
 
 bool FrameLoader::allAncestorsAreComplete() const
 {
-    for (Frame* ancestor = &m_frame; ancestor; ancestor = ancestor->tree().parent()) {
-        if (!ancestor->loader().m_isComplete)
+    for (AbstractFrame* ancestor = &m_frame; ancestor; ancestor = ancestor->tree().parent()) {
+        auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor);
+        if (!localAncestor)
+            continue;
+        if (!localAncestor->loader().m_isComplete)
             return false;
     }
     return true;
@@ -1032,8 +1038,8 @@ String FrameLoader::outgoingReferrer() const
 {
     // See http://www.whatwg.org/specs/web-apps/current-work/#fetching-resources
     // for why we walk the parent chain for srcdoc documents.
-    Frame* frame = &m_frame;
-    while (frame && frame->document()->isSrcdocDocument()) {
+    AbstractFrame* frame = &m_frame;
+    while (frame && is<LocalFrame>(frame) && downcast<LocalFrame>(frame)->document()->isSrcdocDocument()) {
         frame = frame->tree().parent();
         // Srcdoc documents cannot be top-level documents, by definition,
         // because they need to be contained in iframes with the srcdoc.
@@ -1041,7 +1047,7 @@ String FrameLoader::outgoingReferrer() const
     }
     if (!frame)
         return emptyString();
-    return frame->loader().m_outgoingReferrer;
+    return is<LocalFrame>(frame) ? downcast<LocalFrame>(frame)->loader().m_outgoingReferrer : emptyString();
 }
 
 String FrameLoader::outgoingOrigin() const
@@ -1101,21 +1107,28 @@ void FrameLoader::resetMultipleFormSubmissionProtection()
 
 void FrameLoader::updateFirstPartyForCookies()
 {
-    if (m_frame.tree().parent())
-        setFirstPartyForCookies(m_frame.tree().parent()->document()->firstPartyForCookies());
+    if (auto* localParent = dynamicDowncast<LocalFrame>(m_frame.tree().parent()))
+        setFirstPartyForCookies(localParent->document()->firstPartyForCookies());
     else
         setFirstPartyForCookies(m_frame.document()->url());
 }
 
 void FrameLoader::setFirstPartyForCookies(const URL& url)
 {
-    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame))
-        frame->document()->setFirstPartyForCookies(url);
+    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        localFrame->document()->setFirstPartyForCookies(url);
+    }
 
     RegistrableDomain registrableDomain(url);
-    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
-        if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(frame->document()->url()) || registrableDomain.matches(frame->document()->url()))
-            frame->document()->setSiteForCookies(url);
+    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(localFrame->document()->url()) || registrableDomain.matches(localFrame->document()->url()))
+            localFrame->document()->setSiteForCookies(url);
     }
 }
 
@@ -1210,11 +1223,17 @@ void FrameLoader::completed()
 {
     Ref<Frame> protect(m_frame);
 
-    for (Frame* descendant = m_frame.tree().traverseNext(&m_frame); descendant; descendant = descendant->tree().traverseNext(&m_frame))
-        descendant->navigationScheduler().startTimer();
+    for (AbstractFrame* descendant = m_frame.tree().traverseNext(&m_frame); descendant; descendant = descendant->tree().traverseNext(&m_frame)) {
+        auto* localDescendant = dynamicDowncast<LocalFrame>(descendant);
+        if (!localDescendant)
+            continue;
+        localDescendant->navigationScheduler().startTimer();
+    }
 
-    if (Frame* parent = m_frame.tree().parent())
-        parent->loader().checkCompleted();
+    if (auto* parent = m_frame.tree().parent()) {
+        if (auto* localParent = dynamicDowncast<LocalFrame>(parent))
+            localParent->loader().checkCompleted();
+    }
 
     if (m_frame.view())
         m_frame.view()->maintainScrollPositionAtAnchor(nullptr);
@@ -1222,8 +1241,12 @@ void FrameLoader::completed()
 
 void FrameLoader::started()
 {
-    for (Frame* frame = &m_frame; frame; frame = frame->tree().parent())
-        frame->loader().m_isComplete = false;
+    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().parent()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        localFrame->loader().m_isComplete = false;
+    }
 }
 
 void FrameLoader::prepareForLoadStart()
@@ -1640,7 +1663,7 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
         return;
     }
 
-    if (Frame* parent = m_frame.tree().parent())
+    if (auto* parent = dynamicDowncast<LocalFrame>(m_frame.tree().parent()))
         loader->setOverrideEncoding(parent->loader().documentLoader()->overrideEncoding());
 
     policyChecker().stopCheck();
@@ -1843,8 +1866,12 @@ void FrameLoader::stopAllLoaders(ClearProvisionalItem clearProvisionalItem, Stop
     if (clearProvisionalItem == ClearProvisionalItem::Yes)
         history().setProvisionalItem(nullptr);
 
-    for (RefPtr<Frame> child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling())
-        child->loader().stopAllLoaders(clearProvisionalItem);
+    for (RefPtr<AbstractFrame> child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
+        if (!localChild)
+            continue;
+        localChild->loader().stopAllLoaders(clearProvisionalItem);
+    }
 
     FRAMELOADER_RELEASE_LOG(ResourceLoading, "stopAllLoaders: m_provisionalDocumentLoader=%p, m_documentLoader=%p", m_provisionalDocumentLoader.get(), m_documentLoader.get());
 
@@ -1877,8 +1904,12 @@ void FrameLoader::stopForBackForwardCache()
     if (m_documentLoader)
         m_documentLoader->stopLoading();
 
-    for (RefPtr<Frame> child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling())
-        child->loader().stopForBackForwardCache();
+    for (RefPtr<AbstractFrame> child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
+        if (!localChild)
+            continue;
+        localChild->loader().stopForBackForwardCache();
+    }
 
     // We cancel pending navigations & policy checks *after* cancelling loads because cancelling loads might end up
     // running script, which could schedule new navigations.
@@ -2119,8 +2150,12 @@ void FrameLoader::commitProvisionalLoad()
 
         Vector<Ref<Frame>> targetFrames;
         targetFrames.append(m_frame);
-        for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame))
-            targetFrames.append(*child);
+        for (AbstractFrame* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame)) {
+            auto* localChild = dynamicDowncast<LocalFrame>(child);
+            if (!localChild)
+                continue;
+            targetFrames.append(*localChild);
+        }
 
         for (auto& frame : targetFrames)
             frame->loader().checkCompleted();
@@ -2318,8 +2353,12 @@ void FrameLoader::closeOldDataSources()
     // FIXME: Is it important for this traversal to be postorder instead of preorder?
     // If so, add helpers for postorder traversal, and use them. If not, then lets not
     // use a recursive algorithm here.
-    for (Frame* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling())
-        child->loader().closeOldDataSources();
+    for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        localChild->loader().closeOldDataSources();
+    }
     
     if (m_documentLoader)
         m_client->dispatchWillClose();
@@ -2414,8 +2453,11 @@ void FrameLoader::setReplacing()
 bool FrameLoader::subframeIsLoading() const
 {
     // It's most likely that the last added frame is the last to load so we walk backwards.
-    for (Frame* child = m_frame.tree().lastChild(); child; child = child->tree().previousSibling()) {
-        FrameLoader& childLoader = child->loader();
+    for (auto* child = m_frame.tree().lastChild(); child; child = child->tree().previousSibling()) {
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        FrameLoader& childLoader = localChild->loader();
         DocumentLoader* documentLoader = childLoader.documentLoader();
         if (documentLoader && documentLoader->isLoadingInAPISense())
             return true;
@@ -2452,7 +2494,7 @@ CachePolicy FrameLoader::subresourceCachePolicy(const URL& url) const
     if (m_loadType == FrameLoadType::ReloadFromOrigin)
         return CachePolicy::Reload;
 
-    if (Frame* parentFrame = m_frame.tree().parent()) {
+    if (auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent())) {
         CachePolicy parentCachePolicy = parentFrame->loader().subresourceCachePolicy(url);
         if (parentCachePolicy != CachePolicy::Verify)
             return parentCachePolicy;
@@ -2751,8 +2793,12 @@ void FrameLoader::detachChildren()
 
     Vector<Ref<Frame>, 16> childrenToDetach;
     childrenToDetach.reserveInitialCapacity(m_frame.tree().childCount());
-    for (Frame* child = m_frame.tree().lastChild(); child; child = child->tree().previousSibling())
-        childrenToDetach.uncheckedAppend(*child);
+    for (auto* child = m_frame.tree().lastChild(); child; child = child->tree().previousSibling()) {
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        childrenToDetach.uncheckedAppend(*localChild);
+    }
     for (auto& child : childrenToDetach)
         child->loader().detachFromParent();
 }
@@ -2781,8 +2827,12 @@ void FrameLoader::checkLoadComplete()
     // FIXME: Always traversing the entire frame tree is a bit inefficient, but 
     // is currently needed in order to null out the previous history item for all frames.
     Vector<Ref<Frame>, 16> frames;
-    for (Frame* frame = &m_frame.mainFrame(); frame; frame = frame->tree().traverseNext())
-        frames.append(*frame);
+    for (AbstractFrame* frame = &m_frame.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        frames.append(*localFrame);
+    }
 
     // To process children before their parents, iterate the vector backwards.
     for (auto frame = frames.rbegin(); frame != frames.rend(); ++frame) {
@@ -2797,8 +2847,12 @@ int FrameLoader::numPendingOrLoadingRequests(bool recurse) const
         return m_frame.document()->cachedResourceLoader().requestCount();
 
     int count = 0;
-    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame))
-        count += frame->document()->cachedResourceLoader().requestCount();
+    for (AbstractFrame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        count += localFrame->document()->cachedResourceLoader().requestCount();
+    }
     return count;
 }
 
@@ -2879,7 +2933,7 @@ void FrameLoader::detachFromParent()
 
     m_progressTracker = nullptr;
 
-    if (Frame* parent = m_frame.tree().parent()) {
+    if (auto* parent = dynamicDowncast<LocalFrame>(m_frame.tree().parent())) {
         parent->loader().closeAndRemoveChild(m_frame);
         parent->loader().scheduleCheckCompleted();
         parent->loader().scheduleCheckLoadComplete();
@@ -2953,7 +3007,7 @@ void FrameLoader::updateRequestAndAddExtraFields(ResourceRequest& request, IsMai
         if (!initiator) {
             initiator = m_frame.document();
             if (isMainResource) {
-                auto* ownerFrame = m_frame.tree().parent();
+                auto* ownerFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent());
                 if (!ownerFrame && m_stateMachine.isDisplayingInitialEmptyDocument())
                     ownerFrame = m_opener.get();
                 if (ownerFrame)
@@ -3320,8 +3374,12 @@ bool FrameLoader::shouldClose()
     // Store all references to each subframe in advance since beforeunload's event handler may modify frame
     Vector<Ref<Frame>, 16> targetFrames;
     targetFrames.append(m_frame);
-    for (Frame* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame))
-        targetFrames.append(*child);
+    for (AbstractFrame* child = m_frame.tree().firstChild(); child; child = child->tree().traverseNext(&m_frame)) {
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        targetFrames.append(*localChild);
+    }
 
     bool shouldClose = false;
     {
@@ -3457,7 +3515,7 @@ bool FrameLoader::dispatchBeforeUnloadEvent(Chrome& chrome, FrameLoader* frameLo
     // We should only display the beforeunload dialog for an iframe if its SecurityOrigin matches all
     // ancestor frame SecurityOrigins up through the navigating FrameLoader.
     if (frameLoaderBeingNavigated != this) {
-        Frame* parentFrame = m_frame.tree().parent();
+        auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent());
         while (parentFrame) {
             Document* parentDocument = parentFrame->document();
             if (!parentDocument)
@@ -3470,7 +3528,7 @@ bool FrameLoader::dispatchBeforeUnloadEvent(Chrome& chrome, FrameLoader* frameLo
             if (&parentFrame->loader() == frameLoaderBeingNavigated)
                 break;
             
-            parentFrame = parentFrame->tree().parent();
+            parentFrame = dynamicDowncast<LocalFrame>(parentFrame->tree().parent());
         }
         
         // The navigatingFrameLoader should always be in our ancestory.
@@ -3730,8 +3788,8 @@ void FrameLoader::applyUserAgentIfNeeded(ResourceRequest& request)
 
 bool FrameLoader::shouldInterruptLoadForXFrameOptions(const String& content, const URL& url, ResourceLoaderIdentifier requestIdentifier)
 {
-    Frame& topFrame = m_frame.tree().top();
-    if (&m_frame == &topFrame)
+    auto* topFrame = dynamicDowncast<LocalFrame>(m_frame.tree().top());
+    if (&m_frame == topFrame)
         return false;
 
     XFrameOptionsDisposition disposition = parseXFrameOptionsHeader(content);
@@ -3739,10 +3797,13 @@ bool FrameLoader::shouldInterruptLoadForXFrameOptions(const String& content, con
     switch (disposition) {
     case XFrameOptionsDisposition::SameOrigin: {
         auto origin = SecurityOrigin::create(url);
-        if (!origin->isSameSchemeHostPort(topFrame.document()->securityOrigin()))
+        if (topFrame && !origin->isSameSchemeHostPort(topFrame->document()->securityOrigin()))
             return true;
-        for (Frame* frame = m_frame.tree().parent(); frame; frame = frame->tree().parent()) {
-            if (!origin->isSameSchemeHostPort(frame->document()->securityOrigin()))
+        for (auto* frame = m_frame.tree().parent(); frame; frame = frame->tree().parent()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+            if (!localFrame)
+                continue;
+            if (!origin->isSameSchemeHostPort(localFrame->document()->securityOrigin()))
                 return true;
         }
         return false;
@@ -3812,7 +3873,7 @@ Frame* FrameLoader::findFrameForNavigation(const AtomString& name, Document* act
     if (!activeDocument)
         return nullptr;
 
-    auto* frame = m_frame.tree().find(name, activeDocument->frame() ? *activeDocument->frame() : m_frame);
+    auto* frame = dynamicDowncast<LocalFrame>(m_frame.tree().find(name, activeDocument->frame() ? *activeDocument->frame() : m_frame));
 
     if (!activeDocument->canNavigate(frame))
         return nullptr;
@@ -4034,7 +4095,7 @@ RetainPtr<CFDictionaryRef> FrameLoader::connectionProperties(ResourceLoader* loa
 
 ReferrerPolicy FrameLoader::effectiveReferrerPolicy() const
 {
-    if (auto* parentFrame = m_frame.tree().parent())
+    if (auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent()))
         return parentFrame->document()->referrerPolicy();
     if (m_opener)
         return m_opener->document()->referrerPolicy();
@@ -4081,7 +4142,7 @@ void FrameLoader::dispatchGlobalObjectAvailableInAllWorlds()
 SandboxFlags FrameLoader::effectiveSandboxFlags() const
 {
     SandboxFlags flags = m_forcedSandboxFlags;
-    if (Frame* parentFrame = m_frame.tree().parent())
+    if (auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent()))
         flags |= parentFrame->document()->sandboxFlags();
     if (HTMLFrameOwnerElement* ownerElement = m_frame.ownerElement())
         flags |= ownerElement->sandboxFlags();

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -54,6 +54,7 @@
 
 namespace WebCore {
 
+class AbstractFrame;
 class Archive;
 class CachedFrameBase;
 class CachedPage;
@@ -431,7 +432,7 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
-    bool preventsParentFromBeingComplete(const Frame&) const;
+    bool preventsParentFromBeingComplete(const AbstractFrame&) const;
 
     Frame& m_frame;
     UniqueRef<FrameLoaderClient> m_client;

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -132,9 +132,10 @@ std::optional<String> MixedContentChecker::checkForMixedContentInFrameTree(const
         if (frame->isMainFrame())
             break;
 
-        frame = frame->tree().parent();
-        RELEASE_ASSERT_WITH_MESSAGE(frame, "Should never have a parentless non main frame");
-        document = frame->document();
+        auto* parentFrame = frame->tree().parent();
+        RELEASE_ASSERT_WITH_MESSAGE(parentFrame, "Should never have a parentless non main frame");
+        if (auto* localParentFrame = dynamicDowncast<LocalFrame>(parentFrame))
+            document = localParentFrame->document();
     }
     
     return std::nullopt;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -463,9 +463,12 @@ LockBackForwardList NavigationScheduler::mustLockBackForwardList(Frame& targetFr
     // Navigation of a subframe during loading of an ancestor frame does not create a new back/forward item.
     // The definition of "during load" is any time before all handlers for the load event have been run.
     // See https://bugs.webkit.org/show_bug.cgi?id=14957 for the original motivation for this.
-    for (Frame* ancestor = targetFrame.tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
-        Document* document = ancestor->document();
-        if (!ancestor->loader().isComplete() || (document && document->processingLoadEvent()))
+    for (auto* ancestor = targetFrame.tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+        auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor);
+        if (!localAncestor)
+            continue;
+        Document* document = localAncestor->document();
+        if (!localAncestor->loader().isComplete() || (document && document->processingLoadEvent()))
             return LockBackForwardList::Yes;
     }
     return LockBackForwardList::No;

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -518,7 +518,9 @@ static void logResourceResponseSource(Frame* frame, ResourceResponse::Source sou
 
 bool ResourceLoader::shouldAllowResourceToAskForCredentials() const
 {
-    return m_canCrossOriginRequestsAskUserForCredentials || m_frame->tree().top().document()->securityOrigin().canRequest(m_request.url());
+    auto* topFrame = dynamicDowncast<LocalFrame>(m_frame->tree().top());
+    return m_canCrossOriginRequestsAskUserForCredentials
+        || (topFrame && topFrame->document()->securityOrigin().canRequest(m_request.url()));
 }
 
 void ResourceLoader::didBlockAuthenticationChallenge()

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -455,7 +455,10 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(Frame& frame)
 
     Vector<Ref<LegacyWebArchive>> subframeArchives;
     for (unsigned i = 0; i < frame.tree().childCount(); ++i) {
-        if (auto childFrameArchive = create(*frame.tree().child(i)))
+        auto* localChild = dynamicDowncast<LocalFrame>(frame.tree().child(i));
+        if (!localChild)
+            continue;
+        if (auto childFrameArchive = create(*localChild))
             subframeArchives.append(childFrameArchive.releaseNonNull());
     }
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -447,8 +447,9 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
         if (Frame* frame = this->frame()) {
             if (!MixedContentChecker::canRunInsecureContent(*frame, m_document->securityOrigin(), url))
                 return false;
-            Frame& top = frame->tree().top();
-            if (&top != frame && !MixedContentChecker::canRunInsecureContent(top, top.document()->securityOrigin(), url))
+            auto& top = frame->tree().top();
+            auto* localTop = dynamicDowncast<LocalFrame>(top);
+            if (&top != frame && localTop && !MixedContentChecker::canRunInsecureContent(*localTop, localTop->document()->securityOrigin(), url))
                 return false;
         }
         break;
@@ -468,8 +469,9 @@ bool CachedResourceLoader::checkInsecureContent(CachedResource::Type type, const
         if (Frame* frame = this->frame()) {
             if (!MixedContentChecker::canDisplayInsecureContent(*frame, m_document->securityOrigin(), contentTypeFromResourceType(type), url, MixedContentChecker::AlwaysDisplayInNonStrictMode::Yes))
                 return false;
-            Frame& topFrame = frame->tree().top();
-            if (!MixedContentChecker::canDisplayInsecureContent(topFrame, topFrame.document()->securityOrigin(), contentTypeFromResourceType(type), url))
+            auto& topFrame = frame->tree().top();
+            auto* localTopFrame = dynamicDowncast<LocalFrame>(topFrame);
+            if (!localTopFrame || !MixedContentChecker::canDisplayInsecureContent(*localTopFrame, localTopFrame->document()->securityOrigin(), contentTypeFromResourceType(type), url))
                 return false;
         }
         break;
@@ -1019,7 +1021,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     case Use:
         ASSERT(resource);
         if (request.options().mode == FetchOptions::Mode::Navigate && !frame.isMainFrame()) {
-            if (auto* parentDocument = frame.tree().parent() ? frame.tree().parent()->document() : nullptr) {
+            auto* localParentFrame = dynamicDowncast<LocalFrame>(frame.tree().parent());
+            if (auto* parentDocument = localParentFrame ? localParentFrame->document() : nullptr) {
                 auto coep = parentDocument->crossOriginEmbedderPolicy().value;
                 if (auto error = validateCrossOriginResourcePolicy(coep, parentDocument->securityOrigin(), request.resourceRequest().url(), resource->response(), ForNavigation::Yes))
                     return makeUnexpected(WTFMove(*error));

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1562,8 +1562,11 @@ bool DOMWindow::consumeTransientActivation()
     if (!hasTransientActivation())
         return false;
 
-    for (RefPtr frame = this->frame() ? &this->frame()->tree().top() : nullptr; frame; frame = frame->tree().traverseNext()) {
-        auto* window = frame->window();
+    for (RefPtr<AbstractFrame> frame = this->frame() ? &this->frame()->tree().top() : nullptr; frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
+        if (!localFrame)
+            continue;
+        auto* window = localFrame->window();
         if (!window || window->lastActivationTimestamp() != MonotonicTime::infinity())
             window->setLastActivationTimestamp(-MonotonicTime::infinity());
     }
@@ -1579,7 +1582,10 @@ void DOMWindow::notifyActivated(MonotonicTime activationTime)
         return;
 
     for (RefPtr ancestor = frame() ? frame()->tree().parent() : nullptr; ancestor; ancestor = ancestor->tree().parent()) {
-        if (auto* window = ancestor->window())
+        RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor.get());
+        if (!localAncestor)
+            continue;
+        if (auto* window = localAncestor->window())
             window->setLastActivationTimestamp(activationTime);
     }
 
@@ -1587,9 +1593,12 @@ void DOMWindow::notifyActivated(MonotonicTime activationTime)
     if (!securityOrigin)
         return;
 
-    RefPtr descendant = frame();
+    RefPtr<AbstractFrame> descendant = frame();
     while ((descendant = descendant->tree().traverseNext(frame()))) {
-        auto* descendantWindow = descendant->window();
+        auto* localDescendant = dynamicDowncast<LocalFrame>(descendant.get());
+        if (!localDescendant)
+            continue;
+        auto* descendantWindow = localDescendant->window();
         if (!descendantWindow)
             continue;
 
@@ -2651,10 +2660,10 @@ ExceptionOr<RefPtr<WindowProxy>> DOMWindow::open(DOMWindow& activeWindow, DOMWin
     // In those cases, we schedule a location change right now and return early.
     RefPtr<Frame> targetFrame;
     if (isTopTargetFrameName(frameName))
-        targetFrame = &frame->tree().top();
+        targetFrame = dynamicDowncast<LocalFrame>(&frame->tree().top());
     else if (isParentTargetFrameName(frameName)) {
         if (RefPtr parent = frame->tree().parent())
-            targetFrame = parent;
+            targetFrame = dynamicDowncast<LocalFrame>(parent.get());
         else
             targetFrame = frame;
     }

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -114,12 +114,15 @@ bool MouseWheelRegionOverlay::updateRegion()
 #else
     auto region = makeUnique<Region>();
     
-    for (const Frame* frame = &m_page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (!frame->view() || !frame->document())
+    for (const AbstractFrame* frame = &m_page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (!localFrame->view() || !localFrame->document())
             continue;
 
-        auto frameRegion = frame->document()->absoluteRegionForEventTargets(frame->document()->wheelEventTargets());
-        frameRegion.first.translate(toIntSize(frame->view()->contentsToRootView(IntPoint())));
+        auto frameRegion = localFrame->document()->absoluteRegionForEventTargets(localFrame->document()->wheelEventTargets());
+        frameRegion.first.translate(toIntSize(localFrame->view()->contentsToRootView(IntPoint())));
         region->unite(frameRegion.first);
     }
     

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1271,13 +1271,17 @@ bool EventHandler::scrollRecursively(ScrollDirection direction, ScrollGranularit
     if (scrollOverflow(direction, granularity, startingNode))
         return true;    
     RefPtr frame = &m_frame;
-    RefPtr view = frame->view();
+    RefPtr localFrame = frame;
+    if (!localFrame)
+        return false;
+    RefPtr view = localFrame->view();
     if (view && view->scroll(direction, granularity))
         return true;
-    frame = frame->tree().parent();
-    if (!frame)
+    RefPtr parent = frame->tree().parent();
+    if (!parent)
         return false;
-    return frame->eventHandler().scrollRecursively(direction, granularity, m_frame.ownerElement());
+    RefPtr localParent = dynamicDowncast<LocalFrame>(parent.get());
+    return localParent->eventHandler().scrollRecursively(direction, granularity, m_frame.ownerElement());
 }
 
 bool EventHandler::logicalScrollRecursively(ScrollLogicalDirection direction, ScrollGranularity granularity, Node* startingNode)
@@ -1304,11 +1308,14 @@ bool EventHandler::logicalScrollRecursively(ScrollLogicalDirection direction, Sc
     if (scrolled)
         return true;
 
-    frame = frame->tree().parent();
-    if (!frame)
+    RefPtr parent = frame->tree().parent();
+    if (!parent)
+        return false;
+    RefPtr localParent = dynamicDowncast<LocalFrame>(parent.get());
+    if (!localParent)
         return false;
 
-    return frame->eventHandler().logicalScrollRecursively(direction, granularity, m_frame.ownerElement());
+    return localParent->eventHandler().logicalScrollRecursively(direction, granularity, m_frame.ownerElement());
 }
 
 IntPoint EventHandler::lastKnownMousePosition() const
@@ -4460,11 +4467,14 @@ bool EventHandler::keyboardScrollRecursively(std::optional<ScrollDirection> dire
         return true;
 
     RefPtr frame = &m_frame;
-    frame = frame->tree().parent();
-    if (!frame)
+    RefPtr parent = frame->tree().parent();
+    if (!parent)
+        return false;
+    RefPtr localParent = dynamicDowncast<LocalFrame>(parent.get());
+    if (!localParent)
         return false;
 
-    return frame->eventHandler().keyboardScrollRecursively(direction, granularity, m_frame.ownerElement());
+    return localParent->eventHandler().keyboardScrollRecursively(direction, granularity, m_frame.ownerElement());
 }
 
 void EventHandler::defaultArrowEventHandler(FocusDirection focusDirection, KeyboardEvent& event)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -361,6 +361,11 @@ private:
     UniqueRef<EventHandler> m_eventHandler;
 };
 
+using LocalFrame = Frame;
+
+// FIXME: Remove after WebKitAdditions transitions to this change.
+#define WEBCORE_HAS_LOCAL_FRAME 1
+
 inline NavigationScheduler& Frame::navigationScheduler() const
 {
     return m_navigationScheduler.get();

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -45,58 +45,56 @@ public:
     const AtomString& uniqueName() const { return m_uniqueName; }
     WEBCORE_EXPORT void setName(const AtomString&);
     WEBCORE_EXPORT void clearName();
-    WEBCORE_EXPORT Frame* parent() const;
-    
-    // FIXME: Add type checks and move them to callers instead of these reinterpret_casts.
-    Frame* nextSibling() const { return reinterpret_cast<Frame*>(m_nextSibling.get()); }
-    Frame* previousSibling() const { return reinterpret_cast<Frame*>(m_previousSibling.get()); }
-    Frame* firstChild() const { return reinterpret_cast<Frame*>(m_firstChild.get()); }
-    Frame* lastChild() const { return reinterpret_cast<Frame*>(m_lastChild.get()); }
+    WEBCORE_EXPORT AbstractFrame* parent() const;
 
-    Frame* firstRenderedChild() const;
-    Frame* nextRenderedSibling() const;
+    AbstractFrame* nextSibling() const { return m_nextSibling.get(); }
+    AbstractFrame* previousSibling() const { return m_previousSibling.get(); }
+    AbstractFrame* firstChild() const { return m_firstChild.get(); }
+    AbstractFrame* lastChild() const { return m_lastChild.get(); }
 
-    WEBCORE_EXPORT bool isDescendantOf(const Frame* ancestor) const;
+    AbstractFrame* firstRenderedChild() const;
+    AbstractFrame* nextRenderedSibling() const;
+
+    WEBCORE_EXPORT bool isDescendantOf(const AbstractFrame* ancestor) const;
     
-    WEBCORE_EXPORT Frame* traverseNext(const Frame* stayWithin = nullptr) const;
+    WEBCORE_EXPORT AbstractFrame* traverseNext(const AbstractFrame* stayWithin = nullptr) const;
     // Rendered means being the main frame or having an ownerRenderer. It may not have been parented in the Widget tree yet (see WidgetHierarchyUpdatesSuspensionScope).
-    WEBCORE_EXPORT Frame* traverseNextRendered(const Frame* stayWithin = nullptr) const;
-    WEBCORE_EXPORT Frame* traverseNext(CanWrap, DidWrap* = nullptr) const;
-    WEBCORE_EXPORT Frame* traversePrevious(CanWrap, DidWrap* = nullptr) const;
+    WEBCORE_EXPORT AbstractFrame* traverseNextRendered(const AbstractFrame* stayWithin = nullptr) const;
+    WEBCORE_EXPORT AbstractFrame* traverseNext(CanWrap, DidWrap* = nullptr) const;
+    WEBCORE_EXPORT AbstractFrame* traversePrevious(CanWrap, DidWrap* = nullptr) const;
 
-    Frame* traverseNextInPostOrder(CanWrap) const;
+    AbstractFrame* traverseNextInPostOrder(CanWrap) const;
 
-    WEBCORE_EXPORT void appendChild(Frame&);
+    WEBCORE_EXPORT void appendChild(AbstractFrame&);
     void detachFromParent() { m_parent = nullptr; }
-    void removeChild(Frame&);
+    void removeChild(AbstractFrame&);
 
-    Frame* child(unsigned index) const;
-    Frame* child(const AtomString& name) const;
-    WEBCORE_EXPORT Frame* find(const AtomString& name, Frame& activeFrame) const;
+    AbstractFrame* child(unsigned index) const;
+    AbstractFrame* child(const AtomString& name) const;
+    WEBCORE_EXPORT AbstractFrame* find(const AtomString& name, AbstractFrame& activeFrame) const;
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
-    WEBCORE_EXPORT Frame& top() const;
+    WEBCORE_EXPORT AbstractFrame& top() const;
 
-    WEBCORE_EXPORT Frame* scopedChild(unsigned index) const;
-    WEBCORE_EXPORT Frame* scopedChild(const AtomString& name) const;
+    WEBCORE_EXPORT AbstractFrame* scopedChild(unsigned index) const;
+    WEBCORE_EXPORT AbstractFrame* scopedChild(const AtomString& name) const;
     unsigned scopedChildCount() const;
 
     void resetFrameIdentifiers() { m_frameIDGenerator = 0; }
 
 private:
-    Frame* deepFirstChild() const;
-    Frame* deepLastChild() const;
+    AbstractFrame* deepFirstChild() const;
+    AbstractFrame* deepLastChild() const;
 
     bool scopedBy(TreeScope*) const;
-    Frame* scopedChild(unsigned index, TreeScope*) const;
-    Frame* scopedChild(const AtomString& name, TreeScope*) const;
+    AbstractFrame* scopedChild(unsigned index, TreeScope*) const;
+    AbstractFrame* scopedChild(const AtomString& name, TreeScope*) const;
     unsigned scopedChildCount(TreeScope*) const;
 
     AtomString uniqueChildName(const AtomString& requestedName) const;
     AtomString generateUniqueName() const;
 
-    // FIXME: This should be an AbstractFrame&.
-    Frame& m_thisFrame;
+    AbstractFrame& m_thisFrame;
 
     WeakPtr<AbstractFrame> m_parent;
     AtomString m_name; // The actual frame name (may be empty).
@@ -122,5 +120,5 @@ bool isTopTargetFrameName(StringView);
 
 #if ENABLE(TREE_DEBUGGING)
 // Outside the WebCore namespace for ease of invocation from the debugger.
-WEBCORE_EXPORT void showFrameTree(const WebCore::Frame*);
+WEBCORE_EXPORT void showFrameTree(const WebCore::AbstractFrame*);
 #endif

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -112,8 +112,10 @@ Ref<DOMStringList> Location::ancestorOrigins() const
     auto* frame = this->frame();
     if (!frame)
         return origins;
-    for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent())
-        origins->append(ancestor->document()->securityOrigin().toString());
+    for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+        if (auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor))
+            origins->append(localAncestor->document()->securityOrigin().toString());
+    }
     return origins;
 }
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -229,8 +229,12 @@ void PageSerializer::serializeFrame(Frame* frame)
         }
     }
 
-    for (Frame* childFrame = frame->tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling())
-        serializeFrame(childFrame);
+    for (AbstractFrame* childFrame = frame->tree().firstChild(); childFrame; childFrame = childFrame->tree().nextSibling()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(childFrame);
+        if (!localFrame)
+            continue;
+        serializeFrame(localFrame);
+    }
 }
 
 void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL& url)

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -181,9 +181,12 @@ void SettingsBase::setMinimumDOMTimerInterval(Seconds interval)
     if (!m_page)
         return;
 
-    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (frame->document())
-            frame->document()->adjustMinimumDOMTimerInterval(oldTimerInterval);
+    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (localFrame->document())
+            localFrame->document()->adjustMinimumDOMTimerInterval(oldTimerInterval);
     }
 }
 
@@ -305,10 +308,13 @@ void SettingsBase::setNeedsRelayoutAllFrames()
     if (!m_page)
         return;
 
-    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (!frame->ownerRenderer())
+    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
             continue;
-        frame->ownerRenderer()->setNeedsLayoutAndPrefWidthsRecalc();
+        if (!localFrame->ownerRenderer())
+            continue;
+        localFrame->ownerRenderer()->setNeedsLayoutAndPrefWidthsRecalc();
     }
 }
 
@@ -341,11 +347,14 @@ void SettingsBase::imageLoadingSettingsTimerFired()
     if (!m_page)
         return;
 
-    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (!frame->document())
+    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
             continue;
-        frame->document()->cachedResourceLoader().setImagesEnabled(m_page->settings().areImagesEnabled());
-        frame->document()->cachedResourceLoader().setAutoLoadImages(m_page->settings().loadsImagesAutomatically());
+        if (!localFrame->document())
+            continue;
+        localFrame->document()->cachedResourceLoader().setImagesEnabled(m_page->settings().areImagesEnabled());
+        localFrame->document()->cachedResourceLoader().setAutoLoadImages(m_page->settings().loadsImagesAutomatically());
     }
 }
 
@@ -409,8 +418,11 @@ void SettingsBase::layerBasedSVGEngineEnabledChanged()
     if (!m_page)
         return;
 
-    for (auto* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        auto* document = frame->document();
+    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        auto* document = localFrame->document();
         if (!document)
             continue;
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -504,12 +504,15 @@ bool canScrollInDirection(const Frame* frame, FocusDirection direction)
 static LayoutRect rectToAbsoluteCoordinates(Frame* initialFrame, const LayoutRect& initialRect)
 {
     LayoutRect rect = initialRect;
-    for (Frame* frame = initialFrame; frame; frame = frame->tree().parent()) {
-        if (Element* element = frame->ownerElement()) {
+    for (AbstractFrame* frame = initialFrame; frame; frame = frame->tree().parent()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (Element* element = localFrame->ownerElement()) {
             do {
                 rect.move(LayoutUnit(element->offsetLeft()), LayoutUnit(element->offsetTop()));
             } while ((element = element->offsetParent()));
-            rect.moveBy((-frame->view()->scrollPosition()));
+            rect.moveBy((-localFrame->view()->scrollPosition()));
         }
     }
     return rect;

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -531,7 +531,7 @@ bool ContentSecurityPolicy::allowFrameAncestors(const Frame& frame, const URL& u
 {
     if (overrideContentSecurityPolicy)
         return true;
-    Frame& topFrame = frame.tree().top();
+    auto& topFrame = frame.tree().top();
     if (&frame == &topFrame)
         return true;
     String sourceURL;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -103,8 +103,11 @@ static inline bool checkFrameAncestors(ContentSecurityPolicySourceListDirective*
     if (!directive)
         return true;
     bool didReceiveRedirectResponse = false;
-    for (Frame* current = frame.tree().parent(); current; current = current->tree().parent()) {
-        URL origin = urlFromOrigin(current->document()->securityOrigin());
+    for (auto* current = frame.tree().parent(); current; current = current->tree().parent()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(current);
+        if (!localFrame)
+            continue;
+        URL origin = urlFromOrigin(localFrame->document()->securityOrigin());
         if (!origin.isValid() || !directive->allows(origin, didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::No))
             return false;
     }

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -175,8 +175,11 @@ ContentChangeObserver::ContentChangeObserver(Document& document)
 
 static void willNotProceedWithClick(Frame& mainFrame)
 {
-    for (auto* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
-        if (auto* document = frame->document())
+    for (AbstractFrame* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (auto* document = localFrame->document())
             document->contentChangeObserver().willNotProceedWithClick();
     }
 }

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -709,8 +709,12 @@ VisibleSelection Frame::rangedSelectionInitialExtent() const
 void Frame::recursiveSetUpdateAppearanceEnabled(bool enabled)
 {
     selection().setUpdateAppearanceEnabled(enabled);
-    for (Frame* child = tree().firstChild(); child; child = child->tree().nextSibling())
-        child->recursiveSetUpdateAppearanceEnabled(enabled);
+    for (auto* child = tree().firstChild(); child; child = child->tree().nextSibling()) {
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        localChild->recursiveSetUpdateAppearanceEnabled(enabled);
+    }
 }
 
 // FIXME: Break this function up into pieces with descriptive function names so that it's easier to follow.
@@ -834,8 +838,12 @@ void Frame::resetAllGeolocationPermission()
     if (document()->domWindow())
         document()->domWindow()->resetAllGeolocationPermission();
 
-    for (Frame* child = tree().firstChild(); child; child = child->tree().nextSibling())
-        child->resetAllGeolocationPermission();
+    for (auto* child = tree().firstChild(); child; child = child->tree().nextSibling()) {
+        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        if (!localChild)
+            continue;
+        localChild->resetAllGeolocationPermission();
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/mac/PageMac.mm
+++ b/Source/WebCore/page/mac/PageMac.mm
@@ -92,10 +92,13 @@ void Page::addSchedulePair(Ref<SchedulePair>&& pair)
         m_scheduledRunLoopPairs = makeUnique<SchedulePairHashSet>();
     m_scheduledRunLoopPairs->add(pair.ptr());
 
-    for (Frame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
-        if (DocumentLoader* documentLoader = frame->loader().documentLoader())
+    for (AbstractFrame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (auto* documentLoader = localFrame->loader().documentLoader())
             documentLoader->schedule(pair);
-        if (DocumentLoader* documentLoader = frame->loader().provisionalDocumentLoader())
+        if (auto* documentLoader = localFrame->loader().provisionalDocumentLoader())
             documentLoader->schedule(pair);
     }
 
@@ -110,10 +113,13 @@ void Page::removeSchedulePair(Ref<SchedulePair>&& pair)
 
     m_scheduledRunLoopPairs->remove(pair.ptr());
 
-    for (Frame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
-        if (DocumentLoader* documentLoader = frame->loader().documentLoader())
+    for (AbstractFrame* frame = &m_mainFrame.get(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (auto* documentLoader = localFrame->loader().documentLoader())
             documentLoader->unschedule(pair);
-        if (DocumentLoader* documentLoader = frame->loader().provisionalDocumentLoader())
+        if (auto* documentLoader = localFrame->loader().provisionalDocumentLoader())
             documentLoader->unschedule(pair);
     }
 }

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -337,8 +337,12 @@ void ServicesOverlayController::removeAllPotentialHighlightsOfType(DataDetectorH
 void ServicesOverlayController::buildPhoneNumberHighlights()
 {
     Vector<SimpleRange> phoneNumberRanges;
-    for (Frame* frame = &mainFrame(); frame; frame = frame->tree().traverseNext())
-        phoneNumberRanges.appendVector(frame->editor().detectedTelephoneNumberRanges());
+    for (AbstractFrame* frame = &mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        phoneNumberRanges.appendVector(localFrame->editor().detectedTelephoneNumberRanges());
+    }
 
     if (phoneNumberRanges.isEmpty()) {
         removeAllPotentialHighlightsOfType(DataDetectorHighlight::Type::TelephoneNumber);

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -399,8 +399,11 @@ FrameView* AsyncScrollingCoordinator::frameViewForScrollingNode(ScrollingNodeID 
     
     // Walk the frame tree to find the matching FrameView. This is not ideal, but avoids back pointers to FrameViews
     // from ScrollingTreeStateNodes.
-    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (auto* view = frame->view()) {
+    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        if (auto* view = localFrame->view()) {
             if (view->scrollingNodeID() == parentNode->scrollingNodeID())
                 return view;
         }

--- a/Source/WebCore/plugins/PluginInfoProvider.cpp
+++ b/Source/WebCore/plugins/PluginInfoProvider.cpp
@@ -56,8 +56,11 @@ void PluginInfoProvider::refresh(bool reloadPages)
         if (!reloadPages)
             continue;
 
-        for (auto* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
-            if (frame->loader().subframeLoader().containsPlugins())
+        for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+            if (!localFrame)
+                continue;
+            if (localFrame->loader().subframeLoader().containsPlugins())
                 framesNeedingReload.append(page.mainFrame());
         }
     }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -192,7 +192,7 @@ Frame* HitTestResult::targetFrame() const
     if (!frame)
         return nullptr;
 
-    return frame->tree().find(m_innerURLElement->target(), *frame);
+    return dynamicDowncast<LocalFrame>(frame->tree().find(m_innerURLElement->target(), *frame));
 }
 
 bool HitTestResult::isSelected() const

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -924,8 +924,11 @@ static void updateLayoutIgnoringPendingStylesheetsIncludingSubframes(Document& d
 {
     document.updateLayoutIgnorePendingStylesheets();
     auto* frame = document.frame();
-    for (auto* subframe = frame; subframe; subframe = subframe->tree().traverseNext(frame)) {
-        if (auto* document = subframe->document())
+    for (AbstractFrame* subframe = frame; subframe; subframe = subframe->tree().traverseNext(frame)) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(subframe);
+        if (!localFrame)
+            continue;
+        if (auto* document = localFrame->document())
             document->updateLayoutIgnorePendingStylesheets();
     }
 }

--- a/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClientData.cpp
@@ -76,8 +76,10 @@ ServiceWorkerClientData ServiceWorkerClientData::from(ScriptExecutionContext& co
 
         Vector<String> ancestorOrigins;
         if (auto* frame = document->frame()) {
-            for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent())
-                ancestorOrigins.append(ancestor->document()->securityOrigin().toString());
+            for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+                if (auto* ancestorFrame = dynamicDowncast<LocalFrame>(ancestor))
+                    ancestorOrigins.append(ancestorFrame->document()->securityOrigin().toString());
+            }
         }
 
         return {

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -479,7 +479,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithOrdinal(WebCore::PageIdenti
         return;
     }
 
-    WebCore::Frame* coreChildFrame = coreFrame->tree().scopedChild(ordinal);
+    auto* coreChildFrame = coreFrame->tree().scopedChild(ordinal);
     if (!coreChildFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;
@@ -567,7 +567,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithName(WebCore::PageIdentifie
         return;
     }
 
-    WebCore::Frame* coreChildFrame = coreFrame->tree().scopedChild(AtomString { name });
+    auto* coreChildFrame = coreFrame->tree().scopedChild(AtomString { name });
     if (!coreChildFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -341,10 +341,14 @@ InjectedBundle::DocumentIDToURLMap InjectedBundle::liveDocumentURLs(bool exclude
 
     if (excludeDocumentsInPageGroupPages) {
         Page::forEachPage([&](Page& page) {
-            for (auto* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
-                if (!frame->document())
+            for (AbstractFrame* frame = &page.mainFrame(); frame; frame = frame->tree().traverseNext()) {
+                auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+                if (!localFrame)
                     continue;
-                result.remove(frame->document()->identifier().object());
+                auto* document = localFrame->document();
+                if (!document)
+                    continue;
+                result.remove(document->identifier().object());
             }
         });
     }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -486,8 +486,12 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
 
     if (resourceLoader.options().mode == FetchOptions::Mode::Navigate) {
         Vector<RefPtr<SecurityOrigin>> frameAncestorOrigins;
-        for (auto* frame = resourceLoader.frame()->tree().parent(); frame; frame = frame->tree().parent())
-            frameAncestorOrigins.append(&frame->document()->securityOrigin());
+        for (auto* frame = resourceLoader.frame()->tree().parent(); frame; frame = frame->tree().parent()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+            if (!localFrame)
+                continue;
+            frameAncestorOrigins.append(&localFrame->document()->securityOrigin());
+        }
         loadParameters.frameAncestorOrigins = WTFMove(frameAncestorOrigins);
     }
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -134,8 +134,12 @@ void WebUserContentController::addContentWorlds(const Vector<std::pair<ContentWo
                     return;
 
                 auto& mainFrame = page.mainFrame();
-                for (auto* frame = &mainFrame; frame; frame = frame->tree().traverseNext())
-                    frame->loader().client().dispatchGlobalObjectAvailable(contentWorld->coreWorld());
+                for (AbstractFrame* frame = &mainFrame; frame; frame = frame->tree().traverseNext()) {
+                    auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+                    if (!localFrame)
+                        continue;
+                    localFrame->loader().client().dispatchGlobalObjectAvailable(contentWorld->coreWorld());
+                }
             });
         }
     }
@@ -433,8 +437,12 @@ void WebUserContentController::addUserScriptInternal(InjectedBundleScriptWorld& 
                 return;
             }
 
-            for (auto* frame = &mainFrame; frame; frame = frame->tree().traverseNext(&mainFrame))
-                frame->injectUserScriptImmediately(world.coreWorld(), userScript);
+            for (AbstractFrame* frame = &mainFrame; frame; frame = frame->tree().traverseNext(&mainFrame)) {
+                auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+                if (!localFrame)
+                    continue;
+                localFrame->injectUserScriptImmediately(world.coreWorld(), userScript);
+            }
         });
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -77,11 +77,16 @@ void WebContextMenuClient::searchWithSpotlight()
 
     Frame& mainFrame = m_page->corePage()->mainFrame();
 
-    Frame* selectionFrame = &mainFrame;
-    for (; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
-        if (selectionFrame->selection().isRange())
-            break;
-    }
+    LocalFrame* selectionFrame = [&] () -> LocalFrame* {
+        for (AbstractFrame* selectionFrame = &mainFrame; selectionFrame; selectionFrame = selectionFrame->tree().traverseNext()) {
+            auto* localFrame = dynamicDowncast<LocalFrame>(selectionFrame);
+            if (!localFrame)
+                continue;
+            if (localFrame->selection().isRange())
+                return localFrame;
+        }
+        return nullptr;
+    }();
     if (!selectionFrame)
         selectionFrame = &mainFrame;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -360,14 +360,17 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
 
     RefPtr mainFrameView = m_webPage->corePage()->mainFrame().view();
 
-    for (auto* frame = &m_webPage->corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        RefPtr document = frame->document();
+    for (AbstractFrame* frame = &m_webPage->corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        RefPtr document = localFrame->document();
         if (!document)
             continue;
 
         for (auto rect : document->markers().renderedRectsForMarkers(WebCore::DocumentMarker::TextMatch)) {
-            if (!frame->isMainFrame())
-                rect = mainFrameView->windowToContents(frame->view()->contentsToWindow(enclosingIntRect(rect)));
+            if (!localFrame->isMainFrame())
+                rect = mainFrameView->windowToContents(localFrame->view()->contentsToWindow(enclosingIntRect(rect)));
 
             if (rect.isEmpty() || !rect.intersects(clipRect))
                 continue;
@@ -385,7 +388,7 @@ WebCore::Document* WebFoundTextRangeController::documentForFoundTextRange(const 
     if (range.frameIdentifier.isEmpty())
         return mainFrame.document();
 
-    if (auto* frame = mainFrame.tree().find(AtomString { range.frameIdentifier }, mainFrame))
+    if (auto* frame = dynamicDowncast<LocalFrame>(mainFrame.tree().find(AtomString { range.frameIdentifier }, mainFrame)))
         return frame->document();
 
     return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -49,6 +49,7 @@ class Array;
 }
 
 namespace WebCore {
+class AbstractFrame;
 class CertificateInfo;
 class Frame;
 class HTMLFrameOwnerElement;
@@ -81,7 +82,7 @@ public:
 
     WebPage* page() const;
 
-    static WebFrame* fromCoreFrame(const WebCore::Frame&);
+    static WebFrame* fromCoreFrame(const WebCore::AbstractFrame&);
     WebCore::Frame* coreFrame() const;
 
     FrameInfoData info() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -28,6 +28,7 @@
 
 #include "WebFrame.h"
 #include "WebPage.h"
+#include <WebCore/Frame.h>
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/PageOverlay.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -142,8 +142,12 @@ void FindController::resetMatchIndex()
 
 static void setSelectionChangeUpdatesEnabledInAllFrames(WebPage& page, bool enabled)
 {
-    for (Frame* coreFrame = page.mainFrame(); coreFrame; coreFrame = coreFrame->tree().traverseNext())
-        coreFrame->editor().setIgnoreSelectionChanges(enabled);
+    for (AbstractFrame* coreFrame = page.mainFrame(); coreFrame; coreFrame = coreFrame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(coreFrame);
+        if (!localFrame)
+            continue;
+        localFrame->editor().setIgnoreSelectionChanges(enabled);
+    }
 }
 
 void FindController::willFindString()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3911,8 +3911,11 @@ void WebPage::resetIdempotentTextAutosizingIfNeeded(double previousInitialScale)
 void WebPage::resetTextAutosizing()
 {
 #if ENABLE(TEXT_AUTOSIZING)
-    for (Frame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        Document* document = frame->document();
+    for (AbstractFrame* frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+        if (!localFrame)
+            continue;
+        auto* document = localFrame->document();
         if (!document || !document->renderView())
             continue;
         document->renderView()->resetTextAutosizing();

--- a/Source/WebKitLegacy/win/WebView.cpp
+++ b/Source/WebKitLegacy/win/WebView.cpp
@@ -3627,8 +3627,8 @@ static Frame *incrementFrame(Frame *curr, bool forward, bool wrapFlag)
 {
     CanWrap canWrap = wrapFlag ? CanWrap::Yes : CanWrap::No;
     return forward
-        ? curr->tree().traverseNext(canWrap)
-        : curr->tree().traversePrevious(canWrap);
+        ? dynamicDowncast<LocalFrame>(curr->tree().traverseNext(canWrap))
+        : dynamicDowncast<LocalFrame>(curr->tree().traversePrevious(canWrap));
 }
 
 HRESULT WebView::searchFor(_In_ BSTR str, BOOL forward, BOOL caseFlag, BOOL wrapFlag, _Out_ BOOL* found)


### PR DESCRIPTION
#### 97a2057f8e50bd8eee92ce275564ab891ebe238a
<pre>
Prepare to start instantiating RemoteFrame for site-isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=246670">https://bugs.webkit.org/show_bug.cgi?id=246670</a>

Reviewed by Chris Dumez.

* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::jsDOMWindowGetOwnPropertySlotRestrictedAccess):
(WebCore::JSDOMWindow::getOwnPropertySlotByIndex):
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
(WebCore::jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter):
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
(WebCore::DeviceOrientationAndMotionAccessController::shouldAllowAccess):
* Source/WebCore/dom/Document.cpp:
(WebCore::canAccessAncestor):
(WebCore::Document::isFullyActive const):
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
(WebCore::Document::setDesignMode):
(WebCore::Document::parentDocument const):
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
(WebCore::Document::isSecureContext const):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::exitFullscreen):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::focusedFrameOwnerElement):
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::UserGestureToken::UserGestureToken):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::selectFrameElementInParentIfFullySelected):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheFrame):
(WebCore::destroyRenderTree):
(WebCore::firePageHideEventRecursively):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrame::CachedFrame):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::firePageShowAndPopStateEvents):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::parseAttribute):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::isProhibitedSelfReference const):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::showPicker):
* Source/WebCore/inspector/PageDebugger.cpp:
(WebCore::PageDebugger::setJavaScriptPaused):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::findFrameWithSecurityOrigin):
(WebCore::InspectorPageAgent::getCookies):
(WebCore::InspectorPageAgent::setCookie):
(WebCore::InspectorPageAgent::deleteCookie):
(WebCore::InspectorPageAgent::searchInResources):
(WebCore::InspectorPageAgent::buildObjectForFrame):
(WebCore::InspectorPageAgent::buildObjectForFrameTree):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
(WebCore::DocumentWriter::decoder):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::preventsParentFromBeingComplete const):
(WebCore::FrameLoader::allChildrenAreComplete const):
(WebCore::FrameLoader::allAncestorsAreComplete const):
(WebCore::FrameLoader::outgoingReferrer const):
(WebCore::FrameLoader::updateFirstPartyForCookies):
(WebCore::FrameLoader::setFirstPartyForCookies):
(WebCore::FrameLoader::completed):
(WebCore::FrameLoader::started):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::stopAllLoaders):
(WebCore::FrameLoader::stopForBackForwardCache):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::closeOldDataSources):
(WebCore::FrameLoader::subframeIsLoading const):
(WebCore::FrameLoader::subresourceCachePolicy const):
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::checkLoadComplete):
(WebCore::FrameLoader::numPendingOrLoadingRequests const):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::findFrameForNavigation):
(WebCore::FrameLoader::effectiveReferrerPolicy const):
(WebCore::FrameLoader::effectiveSandboxFlags const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::FrameLoader::HistoryController::saveDocumentAndScrollState):
(WebCore::FrameLoader::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::FrameLoader::HistoryController::recursiveUpdateForCommit):
(WebCore::FrameLoader::HistoryController::recursiveUpdateForSameDocumentNavigation):
(WebCore::FrameLoader::HistoryController::clearPreviousItem):
(WebCore::FrameLoader::HistoryController::createItemTree):
(WebCore::FrameLoader::HistoryController::recursiveSetProvisionalItem):
(WebCore::FrameLoader::HistoryController::recursiveGoToItem):
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::MixedContentChecker::checkForMixedContentInFrameTree):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::mustLockBackForwardList):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::shouldAllowResourceToAskForCredentials const):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::checkInsecureContent const):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::consumeTransientActivation):
(WebCore::DOMWindow::notifyActivated):
(WebCore::DOMWindow::open):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::MouseWheelRegionOverlay::updateRegion):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::scrollRecursively):
(WebCore::EventHandler::logicalScrollRecursively):
(WebCore::EventHandler::keyboardScrollRecursively):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
(WebCore::FocusController::setIsVisibleAndActiveInternal):
* Source/WebCore/page/Frame.cpp:
(WebCore::parentPageZoomFactor):
(WebCore::parentTextZoomFactor):
(WebCore::Frame::Frame):
(WebCore::Frame::setPrinting):
(WebCore::Frame::shouldUsePrintingLayout const):
(WebCore::Frame::willDetachPage):
(WebCore::Frame::setPageAndTextZoomFactors):
(WebCore::Frame::deviceOrPageScaleFactorChanged):
(WebCore::Frame::dropChildren):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::~FrameTree):
(WebCore::FrameTree::parent const):
(WebCore::FrameTree::appendChild):
(WebCore::FrameTree::removeChild):
(WebCore::inScope):
(WebCore::FrameTree::scopedChild const):
(WebCore::FrameTree::scopedChildCount const):
(WebCore::FrameTree::child const):
(WebCore::isFrameFamiliarWith):
(WebCore::FrameTree::find const):
(WebCore::FrameTree::isDescendantOf const):
(WebCore::FrameTree::traverseNext const):
(WebCore::FrameTree::firstRenderedChild const):
(WebCore::FrameTree::nextRenderedSibling const):
(WebCore::FrameTree::traverseNextRendered const):
(WebCore::FrameTree::traversePrevious const):
(WebCore::FrameTree::traverseNextInPostOrder const):
(WebCore::FrameTree::deepFirstChild const):
(WebCore::FrameTree::deepLastChild const):
(WebCore::FrameTree::top const):
(printFrames):
(showFrameTree):
* Source/WebCore/page/FrameTree.h:
(WebCore::FrameTree::nextSibling const):
(WebCore::FrameTree::previousSibling const):
(WebCore::FrameTree::firstChild const):
(WebCore::FrameTree::lastChild const):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::flushCompositingStateIncludingSubframes):
(WebCore::FrameView::updateCanBlitOnScrollRecursively):
(WebCore::FrameView::applyRecursivelyWithVisibleRect):
(WebCore::FrameView::updateBackgroundRecursively):
(WebCore::FrameView::safeToPropagateScrollToParent const):
(WebCore::FrameView::notifyAllFramesThatContentAreaWillPaint const):
(WebCore::FrameView::parentFrameView const):
(WebCore::FrameView::paintContentsForSnapshot):
(WebCore::FrameView::updateLayoutAndStyleIfNeededRecursive):
(WebCore::FrameView::setTracksRepaints):
(WebCore::FrameView::notifyWidgetsInAllFrames):
* Source/WebCore/page/Location.cpp:
(WebCore::Location::ancestorOrigins const):
* Source/WebCore/page/Page.cpp:
(WebCore::networkStateChanged):
(WebCore::Page::takeAnyMediaCanStartListener):
(WebCore::incrementFrame):
(WebCore::Page::findString):
(WebCore::Page::findTextMatches):
(WebCore::Page::rangeOfString):
(WebCore::Page::findMatchesForText):
(WebCore::replaceRanges):
(WebCore::Page::setDefersLoading):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::setIsInWindowInternal):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::setDebugger):
(WebCore::Page::setMemoryCacheClientCallsEnabled):
(WebCore::Page::stopKeyboardScrollAnimation):
(WebCore::Page::suspendActiveDOMObjectsAndAnimations):
(WebCore::Page::resumeActiveDOMObjectsAndAnimations):
(WebCore::Page::forEachDocumentFromMainFrame):
(WebCore::Page::forEachFrame):
(WebCore::dispatchPrintEvent):
(WebCore::Page::forceRepaintAllFrames):
* Source/WebCore/page/PageGroupLoadDeferrer.cpp:
(WebCore::PageGroupLoadDeferrer::PageGroupLoadDeferrer):
(WebCore::PageGroupLoadDeferrer::~PageGroupLoadDeferrer):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeFrame):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::setMinimumDOMTimerInterval):
(WebCore::SettingsBase::setNeedsRelayoutAllFrames):
(WebCore::SettingsBase::imageLoadingSettingsTimerFired):
(WebCore::SettingsBase::layerBasedSVGEngineEnabledChanged):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::rectToAbsoluteCoordinates):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowFrameAncestors const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkFrameAncestors):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::willNotProceedWithClick):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::Frame::recursiveSetUpdateAppearanceEnabled):
(WebCore::Frame::resetAllGeolocationPermission):
* Source/WebCore/page/mac/PageMac.mm:
(WebCore::Page::addSchedulePair):
(WebCore::Page::removeSchedulePair):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::absoluteEventTrackingRegionsForFrame const):
(WebCore::ScrollingCoordinator::updateSynchronousScrollingReasonsForAllFrames):
* Source/WebCore/plugins/PluginInfoProvider.cpp:
(WebCore::PluginInfoProvider::refresh):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::targetFrame const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollCoordinatedLayersAfterFlushIncludingSubframes):
(WebCore::RenderLayerCompositor::updateCompositingForLayerTreeAsTextDump):
(WebCore::RenderLayerCompositor::invalidateEventRegionForAllFrames):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::updateLayoutIgnoringPendingStylesheetsIncludingSubframes):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::suspendAnimations const):
(WebCore::Internals::resumeAnimations const):
(WebCore::Internals::numberOfScrollableAreas):
* Source/WebCore/workers/service/ServiceWorkerClientData.cpp:
(WebCore::ServiceWorkerClientData::from):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithOrdinal):
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithName):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::liveDocumentURLs):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserContentController::addContentWorlds):
(WebKit::WebUserContentController::addUserScriptInternal):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::searchWithSpotlight):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::frameWithSelection):
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
(WebKit::WebFoundTextRangeController::documentForFoundTextRange const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::fromCoreFrame):
(WebKit::WebFrame::contentsAsString const):
(WebKit::WebFrame::childFrames):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::frameTreeNodeData):
(WebKit::WebPage::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPage::getContentsAsString):
(WebKit::frameWithSelection):
(WebKit::WebPage::removeDataDetectedLinks):
(WebKit::WebPage::detectDataInAllFrames):
(WebKit::WebPage::unmarkAllMisspellings):
(WebKit::WebPage::unmarkAllBadGrammar):
(WebKit::pageContainsAnyHorizontalScrollbars):
(WebKit::WebPage::setAppHighlightsVisibility):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _updateBackgroundAndUpdatesWhileOffscreen]):
(-[WebFrame _unmarkAllBadGrammar]):
(-[WebFrame _unmarkAllMisspellings]):
(-[WebFrame _atMostOneFrameHasSelection]):
(-[WebFrame _findFrameWithSelection]):
(-[WebFrame _drawRect:contentsOnly:]):
(-[WebFrame resetTextAutosizingBeforeLayout]):
(-[WebFrame findFrameNamed:]):
(-[WebFrame parentFrame]):
(-[WebFrame childFrames]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView updateLayoutIgnorePendingStyleSheets]):
(-[WebView _attachScriptDebuggerToAllFrames]):
(-[WebView _detachScriptDebuggerFromAllFrames]):
(-[WebView _isUsingAcceleratedCompositing]):
(-[WebView _isSoftwareRenderable]):
(-[WebView setHostWindow:]):
(incrementFrame):
* Source/WebKitLegacy/win/WebFrame.cpp:
(WebFrame::findFrameNamed):
(WebFrame::parentFrame):
(WebFrame::unmarkAllMisspellings):
(WebFrame::unmarkAllBadGrammar):
* Source/WebKitLegacy/win/WebView.cpp:
(incrementFrame):

Canonical link: <a href="https://commits.webkit.org/255711@main">https://commits.webkit.org/255711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e95e758bf80df5493c3be80ec3a22e5eeb304e72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103049 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2578 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30875 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99153 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99037 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79826 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28756 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71818 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37258 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3952 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38959 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37812 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->