### PR TITLE
Move BuilderState::createFilterOperations() to a separate file

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2674,8 +2674,10 @@ storage/StorageQuotaManager.cpp
 style/AttributeChangeInvalidation.cpp
 style/ChildChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp
+style/ColorFromPrimitiveValue.cpp
 style/ContainerQueryEvaluator.cpp
 style/ElementRuleCollector.cpp
+style/FilterOperationsBuilder.cpp
 style/HasSelectorFilter.cpp
 style/IdChangeInvalidation.cpp
 style/InlineTextBoxStyle.cpp

--- a/Source/WebCore/css/CSSFilterImageValue.cpp
+++ b/Source/WebCore/css/CSSFilterImageValue.cpp
@@ -142,8 +142,10 @@ void CSSFilterImageValue::filterImageChanged(const IntRect&)
 
 void CSSFilterImageValue::createFilterOperations(Style::BuilderState& builderState)
 {
-    m_filterOperations.clear();
-    builderState.createFilterOperations(m_filterValue, m_filterOperations);
+    if (auto filterOperations = builderState.createFilterOperations(m_filterValue))
+        m_filterOperations = WTFMove(*filterOperations);
+    else
+        m_filterOperations.clear();
 }
 
 void CSSFilterImageValue::FilterSubimageObserverProxy::imageChanged(CachedImage*, const IntRect* rect)

--- a/Source/WebCore/style/ColorFromPrimitiveValue.cpp
+++ b/Source/WebCore/style/ColorFromPrimitiveValue.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ColorFromPrimitiveValue.h"
+
+#include "CSSPrimitiveValue.h"
+#include "Document.h"
+#include "RenderStyle.h"
+#include "RenderTheme.h"
+#include "StyleBuilderState.h"
+#include "StyleColor.h"
+
+namespace WebCore {
+
+namespace Style {
+
+StyleColor colorFromPrimitiveValue(const Document& document, RenderStyle& style, const CSSPrimitiveValue& value, ForVisitedLink forVisitedLink)
+{
+    if (value.isRGBColor())
+        return value.color();
+
+    auto identifier = value.valueID();
+    switch (identifier) {
+    case CSSValueInternalDocumentTextColor:
+        return { document.textColor() };
+    case CSSValueWebkitLink:
+        return { forVisitedLink == ForVisitedLink::Yes ? document.visitedLinkColor() : document.linkColor() };
+    case CSSValueWebkitActivelink:
+        return { document.activeLinkColor() };
+    case CSSValueWebkitFocusRingColor:
+        return { RenderTheme::singleton().focusRingColor(document.styleColorOptions(&style)) };
+    case CSSValueCurrentcolor:
+        return StyleColor::currentColor();
+    default:
+        return { StyleColor::colorFromKeyword(identifier, document.styleColorOptions(&style)) };
+    }
+}
+
+Color colorFromPrimitiveValueWithResolvedCurrentColor(const Document& document, RenderStyle& style, const CSSPrimitiveValue& value)
+{
+    // FIXME: 'currentcolor' should be resolved at use time to make it inherit correctly. https://bugs.webkit.org/show_bug.cgi?id=210005
+    if (StyleColor::isCurrentColor(value)) {
+        // Color is an inherited property so depending on it effectively makes the property inherited.
+        style.setHasExplicitlyInheritedProperties();
+        style.setDisallowsFastPathInheritance();
+        return style.color();
+    }
+
+    return colorFromPrimitiveValue(document, style, value, ForVisitedLink::No).absoluteColor();
+}
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/ColorFromPrimitiveValue.h
+++ b/Source/WebCore/style/ColorFromPrimitiveValue.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "StyleColor.h"
+
+namespace WebCore {
+
+class CSSPrimitiveValue;
+class Document;
+class RenderStyle;
+
+namespace Style {
+
+enum class ForVisitedLink : bool;
+
+StyleColor colorFromPrimitiveValue(const Document&, RenderStyle&, const CSSPrimitiveValue&, Style::ForVisitedLink);
+Color colorFromPrimitiveValueWithResolvedCurrentColor(const Document&, RenderStyle&, const CSSPrimitiveValue&);
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/FilterOperationsBuilder.cpp
+++ b/Source/WebCore/style/FilterOperationsBuilder.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FilterOperationsBuilder.h"
+
+#include "CSSFunctionValue.h"
+#include "CSSShadowValue.h"
+#include "CSSToLengthConversionData.h"
+#include "ColorFromPrimitiveValue.h"
+#include "Document.h"
+#include "TransformFunctions.h"
+
+namespace WebCore {
+
+namespace Style {
+
+static FilterOperation::OperationType filterOperationForType(CSSValueID type)
+{
+    switch (type) {
+    case CSSValueUrl:
+        return FilterOperation::REFERENCE;
+    case CSSValueGrayscale:
+        return FilterOperation::GRAYSCALE;
+    case CSSValueSepia:
+        return FilterOperation::SEPIA;
+    case CSSValueSaturate:
+        return FilterOperation::SATURATE;
+    case CSSValueHueRotate:
+        return FilterOperation::HUE_ROTATE;
+    case CSSValueInvert:
+        return FilterOperation::INVERT;
+    case CSSValueAppleInvertLightness:
+        return FilterOperation::APPLE_INVERT_LIGHTNESS;
+    case CSSValueOpacity:
+        return FilterOperation::OPACITY;
+    case CSSValueBrightness:
+        return FilterOperation::BRIGHTNESS;
+    case CSSValueContrast:
+        return FilterOperation::CONTRAST;
+    case CSSValueBlur:
+        return FilterOperation::BLUR;
+    case CSSValueDropShadow:
+        return FilterOperation::DROP_SHADOW;
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return FilterOperation::NONE;
+}
+
+std::optional<FilterOperations> createFilterOperations(const Document& document, RenderStyle& style, const CSSToLengthConversionData& cssToLengthConversionData, const CSSValue& inValue)
+{
+    FilterOperations operations;
+
+    if (is<CSSPrimitiveValue>(inValue)) {
+        auto& primitiveValue = downcast<CSSPrimitiveValue>(inValue);
+        if (primitiveValue.valueID() == CSSValueNone)
+            return operations;
+    }
+
+    if (!is<CSSValueList>(inValue))
+        return std::nullopt;
+
+    for (auto& currentValue : downcast<CSSValueList>(inValue)) {
+        if (is<CSSPrimitiveValue>(currentValue)) {
+            auto& primitiveValue = downcast<CSSPrimitiveValue>(currentValue.get());
+            if (!primitiveValue.isURI())
+                continue;
+
+            auto filterURL = primitiveValue.stringValue();
+            auto fragment = document.completeURL(filterURL).fragmentIdentifier().toAtomString();
+            operations.operations().append(ReferenceFilterOperation::create(filterURL, WTFMove(fragment)));
+            continue;
+        }
+
+        if (!is<CSSFunctionValue>(currentValue))
+            continue;
+
+        auto& filterValue = downcast<CSSFunctionValue>(currentValue.get());
+        FilterOperation::OperationType operationType = filterOperationForType(filterValue.name());
+
+        // Check that all parameters are primitive values, with the
+        // exception of drop shadow which has a CSSShadowValue parameter.
+        const CSSPrimitiveValue* firstValue = nullptr;
+        if (operationType != FilterOperation::DROP_SHADOW) {
+            bool haveNonPrimitiveValue = false;
+            for (unsigned j = 0; j < filterValue.length(); ++j) {
+                if (!is<CSSPrimitiveValue>(*filterValue.itemWithoutBoundsCheck(j))) {
+                    haveNonPrimitiveValue = true;
+                    break;
+                }
+            }
+            if (haveNonPrimitiveValue)
+                continue;
+            if (filterValue.length())
+                firstValue = downcast<CSSPrimitiveValue>(filterValue.itemWithoutBoundsCheck(0));
+        }
+
+        switch (operationType) {
+        case FilterOperation::GRAYSCALE:
+        case FilterOperation::SEPIA:
+        case FilterOperation::SATURATE: {
+            double amount = 1;
+            if (filterValue.length() == 1) {
+                amount = firstValue->doubleValue();
+                if (firstValue->isPercentage())
+                    amount /= 100;
+            }
+
+            operations.operations().append(BasicColorMatrixFilterOperation::create(amount, operationType));
+            break;
+        }
+        case FilterOperation::HUE_ROTATE: {
+            double angle = 0;
+            if (filterValue.length() == 1)
+                angle = firstValue->computeDegrees();
+
+            operations.operations().append(BasicColorMatrixFilterOperation::create(angle, operationType));
+            break;
+        }
+        case FilterOperation::INVERT:
+        case FilterOperation::BRIGHTNESS:
+        case FilterOperation::CONTRAST:
+        case FilterOperation::OPACITY: {
+            double amount = 1;
+            if (filterValue.length() == 1) {
+                amount = firstValue->doubleValue();
+                if (firstValue->isPercentage())
+                    amount /= 100;
+            }
+
+            operations.operations().append(BasicComponentTransferFilterOperation::create(amount, operationType));
+            break;
+        }
+        case FilterOperation::APPLE_INVERT_LIGHTNESS: {
+            operations.operations().append(InvertLightnessFilterOperation::create());
+            break;
+        }
+        case FilterOperation::BLUR: {
+            Length stdDeviation = Length(0, LengthType::Fixed);
+            if (filterValue.length() >= 1)
+                stdDeviation = convertToFloatLength(firstValue, cssToLengthConversionData);
+            if (stdDeviation.isUndefined())
+                return std::nullopt;
+
+            operations.operations().append(BlurFilterOperation::create(stdDeviation));
+            break;
+        }
+        case FilterOperation::DROP_SHADOW: {
+            if (filterValue.length() != 1)
+                return std::nullopt;
+
+            const auto* cssValue = filterValue.itemWithoutBoundsCheck(0);
+            if (!is<CSSShadowValue>(cssValue))
+                continue;
+
+            const auto& item = downcast<CSSShadowValue>(*cssValue);
+            int x = item.x->computeLength<int>(cssToLengthConversionData);
+            int y = item.y->computeLength<int>(cssToLengthConversionData);
+            IntPoint location(x, y);
+            int blur = item.blur ? item.blur->computeLength<int>(cssToLengthConversionData) : 0;
+            auto color = item.color ? colorFromPrimitiveValueWithResolvedCurrentColor(document, style, *item.color) : style.color();
+
+            operations.operations().append(DropShadowFilterOperation::create(location, blur, color.isValid() ? color : Color::transparentBlack));
+            break;
+        }
+        default:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    }
+
+    return operations;
+}
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/FilterOperationsBuilder.h
+++ b/Source/WebCore/style/FilterOperationsBuilder.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class CSSToLengthConversionData;
+class CSSValue;
+class Document;
+class RenderStyle;
+
+namespace Style {
+
+std::optional<FilterOperations> createFilterOperations(const Document&, RenderStyle&, const CSSToLengthConversionData&, const CSSValue&);
+
+} // namespace Style
+
+} // namespace WebCore

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1292,10 +1292,7 @@ inline std::optional<Length> BuilderConverter::convertMarqueeIncrement(BuilderSt
 
 inline std::optional<FilterOperations> BuilderConverter::convertFilterOperations(BuilderState& builderState, const CSSValue& value)
 {
-    FilterOperations operations;
-    if (builderState.createFilterOperations(value, operations))
-        return operations;
-    return std::nullopt;
+    return builderState.createFilterOperations(value);
 }
 
 inline FontFeatureSettings BuilderConverter::convertFontFeatureSettings(BuilderState&, const CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -94,7 +94,7 @@ public:
 
     Ref<CSSValue> resolveImageStyles(CSSValue&);
     RefPtr<StyleImage> createStyleImage(CSSValue&);
-    bool createFilterOperations(const CSSValue&, FilterOperations& outOperations);
+    std::optional<FilterOperations> createFilterOperations(const CSSValue&);
 
     static bool isColorFromPrimitiveValueDerivedFromElement(const CSSPrimitiveValue&);
     StyleColor colorFromPrimitiveValue(const CSSPrimitiveValue&, ForVisitedLink = ForVisitedLink::No) const;


### PR DESCRIPTION
#### ea05e83e61422ff0c4a68c659f9a99aa14064121
<pre>
Move BuilderState::createFilterOperations() to a separate file
<a href="https://bugs.webkit.org/show_bug.cgi?id=246675">https://bugs.webkit.org/show_bug.cgi?id=246675</a>

Reviewed by Antti Koivisto.

Make this function a stand-alone function and make used by the CSS style builder.
The plan is to use this function the 2D canvas for the filter API.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSFilterImageValue.cpp:
(WebCore::CSSFilterImageValue::createFilterOperations):
* Source/WebCore/style/ColorFromPrimitiveValue.cpp: Added.
(WebCore::colorFromPrimitiveValue):
(WebCore::colorFromPrimitiveValueWithResolvedCurrentColor):
* Source/WebCore/style/ColorFromPrimitiveValue.h: Added.
* Source/WebCore/style/FilterOperationsBuilder.cpp: Added.
(WebCore::filterOperationForType):
(WebCore::createFilterOperations):
* Source/WebCore/style/FilterOperationsBuilder.h: Added.
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFilterOperations):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createFilterOperations):
(WebCore::Style::BuilderState::colorFromPrimitiveValue const):
(WebCore::Style::BuilderState::colorFromPrimitiveValueWithResolvedCurrentColor const):
(WebCore::Style::filterOperationForType): Deleted.
* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/255706@main">https://commits.webkit.org/255706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb7622f7f03e427ab7e96d7fd39172a880629bf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103038 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2566 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30864 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85731 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99025 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79815 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28754 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83467 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37247 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18583 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37803 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->