### PR TITLE
[WPE] Set cog's PKG_CONFIG_PATH via cmake

### DIFF
--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -52,6 +52,7 @@ if (DEVELOPER_MODE AND ENABLE_COG)
         CONFIGURE_COMMAND
             meson setup <BINARY_DIR> <SOURCE_DIR>
             --buildtype ${COG_MESON_BUILDTYPE}
+            --pkg-config-path ${CMAKE_BINARY_DIR}
             -Dsoup2=${COG_MESON_SOUP2}
             -Dplatforms=drm,headless,gtk4,x11,wayland
         BUILD_COMMAND

--- a/Tools/flatpak/flatpakutils.py
+++ b/Tools/flatpak/flatpakutils.py
@@ -996,14 +996,6 @@ class WebkitFlatpak:
                 "NUMBER_OF_PROCESSORS": n_cores,
             })
 
-        # Set PKG_CONFIG_PATH in sandbox so uninstalled WebKit.pc files can be used.
-        pkg_config_path = os.environ.get("PKG_CONFIG_PATH")
-        if pkg_config_path:
-            pkg_config_path = "%s:%s" % (self.build_path, pkg_config_path)
-        else:
-            pkg_config_path = self.build_path
-        sandbox_environment["PKG_CONFIG_PATH"] = pkg_config_path
-
         if not building_local_deps and args[0] != "sccache":
             # Merge local dependencies build env vars in sandbox environment, without overriding
             # previously set PATH values.


### PR DESCRIPTION
#### aa8e922ba6cf3eb3bcb876fe2063aabde50c49e2
<pre>
[WPE] Set cog&apos;s PKG_CONFIG_PATH via cmake
<a href="https://bugs.webkit.org/show_bug.cgi?id=246680">https://bugs.webkit.org/show_bug.cgi?id=246680</a>

Reviewed by Philippe Normand.

* Tools/PlatformWPE.cmake:
* Tools/flatpak/flatpakutils.py:
(WebkitFlatpak.run_in_sandbox):

Canonical link: <a href="https://commits.webkit.org/255671@main">https://commits.webkit.org/255671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fe15755ac4d75efd8aab600f2ae6f4615a9bdfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102959 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2475 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30781 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85651 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99072 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98940 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79732 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28686 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71748 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37170 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18518 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3931 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40794 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37733 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->