### PR TITLE
Add function to copy the state of a GraphicsContext to another GraphicsContext

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -571,11 +571,11 @@ bool BifurcatedGraphicsContext::supportsInternalLinks() const
 
 void BifurcatedGraphicsContext::didUpdateState(GraphicsContextState& state)
 {
-    // This calls updateState() instead of didUpdateState() so that changes
+    // This calls mergeLastChanges() instead of didUpdateState() so that changes
     // are also applied to each context's GraphicsContextState, so that code
     // internal to the child contexts that reads from the state gets the right values.
-    m_primaryContext.updateState(state);
-    m_secondaryContext.updateState(state);
+    m_primaryContext.mergeLastChanges(state);
+    m_secondaryContext.mergeLastChanges(state);
     state.didApplyChanges();
 
     VERIFY_STATE_SYNCHRONIZATION();

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -81,9 +81,15 @@ void GraphicsContext::restore()
         m_stack.clear();
 }
 
-void GraphicsContext::updateState(GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
+void GraphicsContext::mergeLastChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
 {
-    m_state.mergeChanges(state, lastDrawingState);
+    m_state.mergeLastChanges(state, lastDrawingState);
+    didUpdateState(m_state);
+}
+
+void GraphicsContext::mergeAllChanges(const GraphicsContextState& state)
+{
+    m_state.mergeAllChanges(state);
     didUpdateState(m_state);
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -159,7 +159,8 @@ public:
 #endif
 
     virtual const GraphicsContextState& state() const { return m_state; }
-    void updateState(GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    void mergeAllChanges(const GraphicsContextState&);
 
     // Called *after* any change to GraphicsContextState; generally used to propagate changes
     // to the platform context's state.

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -63,7 +63,7 @@ constexpr unsigned toIndex(GraphicsContextState::Change change)
     return WTF::ctzConstexpr(enumToUnderlyingType(change));
 }
 
-void GraphicsContextState::mergeChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
+void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
 {
     for (auto change : state.changes()) {
         auto mergeChange = [&](auto GraphicsContextState::*property) {
@@ -74,30 +74,95 @@ void GraphicsContextState::mergeChanges(const GraphicsContextState& state, const
         };
 
         switch (toIndex(change)) {
-        case toIndex(Change::FillBrush):                   mergeChange(&GraphicsContextState::m_fillBrush); break;
-        case toIndex(Change::FillRule):                    mergeChange(&GraphicsContextState::m_fillRule); break;
+        case toIndex(Change::FillBrush):
+            mergeChange(&GraphicsContextState::m_fillBrush);
+            break;
+        case toIndex(Change::FillRule):
+            mergeChange(&GraphicsContextState::m_fillRule);
+            break;
 
-        case toIndex(Change::StrokeBrush):                 mergeChange(&GraphicsContextState::m_strokeBrush); break;
-        case toIndex(Change::StrokeThickness):             mergeChange(&GraphicsContextState::m_strokeThickness); break;
-        case toIndex(Change::StrokeStyle):                 mergeChange(&GraphicsContextState::m_strokeStyle); break;
+        case toIndex(Change::StrokeBrush):
+            mergeChange(&GraphicsContextState::m_strokeBrush);
+            break;
+        case toIndex(Change::StrokeThickness):
+            mergeChange(&GraphicsContextState::m_strokeThickness);
+            break;
+        case toIndex(Change::StrokeStyle):
+            mergeChange(&GraphicsContextState::m_strokeStyle);
+            break;
 
-        case toIndex(Change::CompositeMode):               mergeChange(&GraphicsContextState::m_compositeMode); break;
-        case toIndex(Change::DropShadow):                  mergeChange(&GraphicsContextState::m_dropShadow); break;
+        case toIndex(Change::CompositeMode):
+            mergeChange(&GraphicsContextState::m_compositeMode);
+            break;
+        case toIndex(Change::DropShadow):
+            mergeChange(&GraphicsContextState::m_dropShadow);
+            break;
 
-        case toIndex(Change::Alpha):                       mergeChange(&GraphicsContextState::m_alpha); break;
-        case toIndex(Change::TextDrawingMode):             mergeChange(&GraphicsContextState::m_textDrawingMode); break;
-        case toIndex(Change::ImageInterpolationQuality):   mergeChange(&GraphicsContextState::m_imageInterpolationQuality); break;
+        case toIndex(Change::Alpha):
+            mergeChange(&GraphicsContextState::m_alpha);
+            break;
+        case toIndex(Change::TextDrawingMode):
+            mergeChange(&GraphicsContextState::m_textDrawingMode);
+            break;
+        case toIndex(Change::ImageInterpolationQuality):
+            mergeChange(&GraphicsContextState::m_imageInterpolationQuality);
+            break;
 
-        case toIndex(Change::ShouldAntialias):             mergeChange(&GraphicsContextState::m_shouldAntialias); break;
-        case toIndex(Change::ShouldSmoothFonts):           mergeChange(&GraphicsContextState::m_shouldSmoothFonts); break;
-        case toIndex(Change::ShouldSubpixelQuantizeFonts): mergeChange(&GraphicsContextState::m_shouldSubpixelQuantizeFonts); break;
-        case toIndex(Change::ShadowsIgnoreTransforms):     mergeChange(&GraphicsContextState::m_shadowsIgnoreTransforms); break;
-        case toIndex(Change::DrawLuminanceMask):           mergeChange(&GraphicsContextState::m_drawLuminanceMask); break;
+        case toIndex(Change::ShouldAntialias):
+            mergeChange(&GraphicsContextState::m_shouldAntialias);
+            break;
+        case toIndex(Change::ShouldSmoothFonts):
+            mergeChange(&GraphicsContextState::m_shouldSmoothFonts);
+            break;
+        case toIndex(Change::ShouldSubpixelQuantizeFonts):
+            mergeChange(&GraphicsContextState::m_shouldSubpixelQuantizeFonts);
+            break;
+        case toIndex(Change::ShadowsIgnoreTransforms):
+            mergeChange(&GraphicsContextState::m_shadowsIgnoreTransforms);
+            break;
+        case toIndex(Change::DrawLuminanceMask):
+            mergeChange(&GraphicsContextState::m_drawLuminanceMask);
+            break;
 #if HAVE(OS_DARK_MODE_SUPPORT)
-        case toIndex(Change::UseDarkAppearance):           mergeChange(&GraphicsContextState::m_useDarkAppearance); break;
+        case toIndex(Change::UseDarkAppearance):
+            mergeChange(&GraphicsContextState::m_useDarkAppearance);
+            break;
 #endif
         }
     }
+}
+
+void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
+{
+    auto mergeChange = [&](Change change, auto GraphicsContextState::*property) {
+        if (this->*property == state.*property)
+            return;
+        this->*property = state.*property;
+        m_changeFlags.add(change);
+    };
+
+    mergeChange(Change::FillBrush,                   &GraphicsContextState::m_fillBrush);
+    mergeChange(Change::FillRule,                    &GraphicsContextState::m_fillRule);
+
+    mergeChange(Change::StrokeBrush,                 &GraphicsContextState::m_strokeBrush);
+    mergeChange(Change::StrokeThickness,             &GraphicsContextState::m_strokeThickness);
+    mergeChange(Change::StrokeStyle,                 &GraphicsContextState::m_strokeStyle);
+
+    mergeChange(Change::CompositeMode,               &GraphicsContextState::m_compositeMode);
+    mergeChange(Change::DropShadow,                  &GraphicsContextState::m_dropShadow);
+
+    mergeChange(Change::Alpha,                       &GraphicsContextState::m_alpha);
+    mergeChange(Change::ImageInterpolationQuality,   &GraphicsContextState::m_textDrawingMode);
+    mergeChange(Change::TextDrawingMode,             &GraphicsContextState::m_imageInterpolationQuality);
+
+    mergeChange(Change::ShouldAntialias,             &GraphicsContextState::m_shouldAntialias);
+    mergeChange(Change::ShouldSmoothFonts,           &GraphicsContextState::m_shouldSmoothFonts);
+    mergeChange(Change::ShouldSubpixelQuantizeFonts, &GraphicsContextState::m_shouldSubpixelQuantizeFonts);
+    mergeChange(Change::ShadowsIgnoreTransforms,     &GraphicsContextState::m_shadowsIgnoreTransforms);
+    mergeChange(Change::DrawLuminanceMask,           &GraphicsContextState::m_drawLuminanceMask);
+#if HAVE(OS_DARK_MODE_SUPPORT)
+    mergeChange(Change::UseDarkAppearance,           &GraphicsContextState::m_useDarkAppearance);
+#endif
 }
 
 void GraphicsContextState::didBeginTransparencyLayer()

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -127,7 +127,8 @@ public:
 #endif
     
     bool containsOnlyInlineChanges() const;
-    void mergeChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    void mergeLastChanges(const GraphicsContextState&, const std::optional<GraphicsContextState>& lastDrawingState = std::nullopt);
+    void mergeAllChanges(const GraphicsContextState&);
 
     void didBeginTransparencyLayer();
     void didEndTransparencyLayer(float originalOpacity);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -102,7 +102,7 @@ SetState::SetState(const GraphicsContextState& state)
 
 void SetState::apply(GraphicsContext& context)
 {
-    context.updateState(m_state);
+    context.mergeLastChanges(m_state);
 }
 
 void SetLineCap::apply(GraphicsContext& context) const

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -112,7 +112,7 @@ const GraphicsContextState& Recorder::state() const
 
 void Recorder::didUpdateState(GraphicsContextState& state)
 {
-    currentState().state.mergeChanges(state, currentState().lastDrawingState);
+    currentState().state.mergeLastChanges(state, currentState().lastDrawingState);
     state.didApplyChanges();
 }
 


### PR DESCRIPTION
#### f3147a40773741a9debdbe180b6a02c196dc7e74
<pre>
Add function to copy the state of a GraphicsContext to another GraphicsContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=246681">https://bugs.webkit.org/show_bug.cgi?id=246681</a>

Reviewed by Tim Horton.

For the canvas filter API, we need to copy the current GraphicsContextState of a
canvas context to a newly created ImageBuffer. This should compare the two context
states and not rely on the flags which track which changes have not been committed
to the platform context.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::didUpdateState):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::mergeLastChanges):
(WebCore::GraphicsContext::mergeAllChanges):
(WebCore::GraphicsContext::updateState): Deleted.
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::GraphicsContextState::mergeChanges): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::SetState::apply):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::didUpdateState):

Canonical link: <a href="https://commits.webkit.org/255741@main">https://commits.webkit.org/255741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d566672d3704072b49324be2e05453e248840876

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103079 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163398 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2610 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30903 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99186 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1837 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79856 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28774 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71836 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37286 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41145 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37835 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->