### PR TITLE
[GStreamer][EME] Prevent race conditions when flushing

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -51,6 +51,12 @@ private:
     WebKitMediaCommonEncryptionDecrypt* m_decryptor;
 };
 
+enum DecryptionState {
+    Idle,
+    Decrypting,
+    FlushPending
+};
+
 #define WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(obj) (G_TYPE_INSTANCE_GET_PRIVATE((obj), WEBKIT_TYPE_MEDIA_CENC_DECRYPT, WebKitMediaCommonEncryptionDecryptPrivate))
 struct _WebKitMediaCommonEncryptionDecryptPrivate {
     RefPtr<CDMProxy> cdmProxy;
@@ -61,6 +67,7 @@ struct _WebKitMediaCommonEncryptionDecryptPrivate {
 
     bool isFlushing { false };
     std::unique_ptr<CDMProxyDecryptionClientImplementation> cdmProxyDecryptionClientImplementation;
+    enum DecryptionState decryptionState { DecryptionState::Idle };
 };
 
 static constexpr Seconds MaxSecondsToWaitForCDMProxy = 5_s;
@@ -247,8 +254,10 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
         GST_DEBUG_OBJECT(self, "CDM now available with address %p", priv->cdmProxy.get());
     }
 
-    auto removeProtectionMetaOnReturn = makeScopeExit([buffer, protectionMeta] {
+    // We are still going to be locked when running this, so no need to lock here.
+    auto scopeExit = makeScopeExit([buffer, protectionMeta, priv] {
         gst_buffer_remove_meta(buffer, reinterpret_cast<GstMeta*>(protectionMeta));
+        priv->decryptionState = DecryptionState::Idle;
     });
 
     bool isCbcs = !g_strcmp0(gst_structure_get_string(protectionMeta->info, "cipher-mode"), "cbcs");
@@ -321,6 +330,10 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
     GstBuffer* ivBuffer = gst_value_get_buffer(value);
     WebKitMediaCommonEncryptionDecryptClass* klass = WEBKIT_MEDIA_CENC_DECRYPT_GET_CLASS(self);
 
+    ASSERT(priv->decryptionState == DecryptionState::Idle);
+    // Value is set back to Idle in the scopeExit.
+    priv->decryptionState = DecryptionState::Decrypting;
+
     GST_TRACE_OBJECT(self, "decrypting");
 
     bool didDecryptionSucceed;
@@ -333,11 +346,12 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
     }
 
     // Accessing priv members again.
+    if (priv->isFlushing || priv->decryptionState == DecryptionState::FlushPending) {
+        GST_DEBUG_OBJECT(self, "flushing, bailing out");
+        return GST_FLOW_FLUSHING;
+    }
+
     if (!didDecryptionSucceed) {
-        if (priv->isFlushing) {
-            GST_DEBUG_OBJECT(self, "Decryption aborted because of flush");
-            return GST_FLOW_FLUSHING;
-        }
         GST_ELEMENT_ERROR(self, STREAM, DECRYPT, ("Decryption failed"), (nullptr));
         return GST_FLOW_NOT_SUPPORTED;
     }
@@ -432,6 +446,9 @@ static gboolean sinkEventHandler(GstBaseTransform* trans, GstEvent* event)
             Locker locker { priv->lock };
             bool isCdmProxyAttached = priv->cdmProxy;
             priv->isFlushing = true;
+            ASSERT(priv->decryptionState == DecryptionState::Idle || priv->decryptionState == DecryptionState::Decrypting);
+            if (priv->decryptionState == DecryptionState::Decrypting)
+                priv->decryptionState = DecryptionState::FlushPending;
             if (isCdmProxyAttached) {
                 locker.unlockEarly();
                 priv->cdmProxy->abortWaitingForKey();


### PR DESCRIPTION
#### 14bba72947fdcef536f4fa5fa7a0a27f7b68ab07
<pre>
[GStreamer][EME] Prevent race conditions when flushing
<a href="https://bugs.webkit.org/show_bug.cgi?id=246682">https://bugs.webkit.org/show_bug.cgi?id=246682</a>

Reviewed by Philippe Normand.

In some cases, decryption can be slower than flush processing and we might be setting and unsetting the flushing flag
without the decryption thread noticing. We add a small state machine to ensure that if we get a flush while decrypting,
we are going to ditch that buffer even if the result was correctly decrypted.

* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformInPlace):
(sinkEventHandler):

Canonical link: <a href="https://commits.webkit.org/255673@main">https://commits.webkit.org/255673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb0f594c59e35c559037e409b71c101721f00c8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102964 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2481 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30787 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99076 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98946 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79737 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28695 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71757 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37175 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34995 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3932 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38869 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37740 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->