### PR TITLE
Add cropping support to WebCodecsVideoFrame copyTo

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt
@@ -13,6 +13,13 @@ PASS Test address overflow.
 PASS Test codedRect.
 PASS Test empty rect.
 PASS Test unaligned rect.
-FAIL Test left crop. assert_equals: buffer contents at index 0 expected 3 but got 1
+PASS Test left crop I420.
+PASS Test left crop NV12.
+PASS Test left crop RGBA.
+PASS Test left crop BGRA.
+PASS Test top crop I420.
+PASS Test top crop NV12.
+PASS Test top crop RGBA.
+PASS Test top crop BGRA.
 PASS Test invalid rect.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js
@@ -15,6 +15,70 @@ function makeRGBA_2x2() {
   return new VideoFrame(data, init);
 }
 
+function makeRGBA_4x2() {
+  const data = new Uint8Array([
+       1, 2, 3, 4,  5, 6, 7, 8,
+       9,10,11,12, 13,14,15,16,
+      21,22,23,24, 25,26,27,28,
+      29,30,31,32, 33,34,35,36,
+  ]);
+  const init = {
+      format: 'RGBA',
+      timestamp: 0,
+      codedWidth: 4,
+      codedHeight: 2,
+  };
+  return new VideoFrame(data, init);
+}
+
+function makeRGBA_2x4() {
+  const data = new Uint8Array([
+       1, 2, 3, 4,  5, 6, 7, 8,
+       9,10,11,12, 13,14,15,16,
+      21,22,23,24, 25,26,27,28,
+      29,30,31,32, 33,34,35,36,
+  ]);
+  const init = {
+      format: 'RGBA',
+      timestamp: 0,
+      codedWidth: 2,
+      codedHeight: 4,
+  };
+  return new VideoFrame(data, init);
+}
+
+function makeBGRA_4x2() {
+  const data = new Uint8Array([
+       1, 2, 3, 4,  5, 6, 7, 8,
+       9,10,11,12, 13,14,15,16,
+      21,22,23,24, 25,26,27,28,
+      29,30,31,32, 33,34,35,36,
+  ]);
+  const init = {
+      format: 'BGRA',
+      timestamp: 0,
+      codedWidth: 4,
+      codedHeight: 2,
+  };
+  return new VideoFrame(data, init);
+}
+
+function makeBGRA_2x4() {
+  const data = new Uint8Array([
+       1, 2, 3, 4,  5, 6, 7, 8,
+       9,10,11,12, 13,14,15,16,
+      21,22,23,24, 25,26,27,28,
+      29,30,31,32, 33,34,35,36,
+  ]);
+  const init = {
+      format: 'BGRA',
+      timestamp: 0,
+      codedWidth: 2,
+      codedHeight: 4,
+  };
+  return new VideoFrame(data, init);
+}
+
 const NV12_DATA = new Uint8Array([
       1, 2, 3, 4,   // y
       5, 6, 7, 8,
@@ -27,6 +91,26 @@ function makeNV12_4x2() {
       timestamp: 0,
       codedWidth: 4,
       codedHeight: 2,
+  };
+  return new VideoFrame(NV12_DATA, init);
+}
+
+function makeNV12_2x4() {
+  const init = {
+      format: 'NV12',
+      timestamp: 0,
+      codedWidth: 2,
+      codedHeight: 4,
+  };
+  return new VideoFrame(NV12_DATA, init);
+}
+
+function makeI420_2x4() {
+  const init = {
+      format: 'I420',
+      timestamp: 0,
+      codedWidth: 2,
+      codedHeight: 4,
   };
   return new VideoFrame(NV12_DATA, init);
 }
@@ -237,9 +321,154 @@ promise_test(async t => {
   assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
   const data = new Uint8Array(expectedData.length);
   const layout = await frame.copyTo(data, options);
+
   assert_layout_equals(layout, expectedLayout);
   assert_buffer_equals(data, expectedData);
-}, 'Test left crop.');
+}, 'Test left crop I420.');
+
+promise_test(async t => {
+  const frame = makeNV12_4x2();
+  const options = {
+      rect: {x: 2, y: 0, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 2},
+      {offset: 4, stride: 2},
+  ];
+  const expectedData = new Uint8Array([
+      3, 4,  // y
+      7, 8,
+      11,    // u
+      12     // v
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test left crop NV12.');
+
+promise_test(async t => {
+  const frame = makeRGBA_4x2();
+  const options = {
+      rect: {x: 2, y: 0, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 8},
+  ];
+  const expectedData = new Uint8Array([
+       9, 10, 11, 12,   13, 14, 15 ,16,
+      29, 30, 31, 32,   33, 34, 35, 36
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test left crop RGBA.');
+
+promise_test(async t => {
+  const frame = makeBGRA_4x2();
+  const options = {
+      rect: {x: 2, y: 0, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 8},
+  ];
+  const expectedData = new Uint8Array([
+       9, 10, 11, 12,   13, 14, 15 ,16,
+      29, 30, 31, 32,   33, 34, 35, 36
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test left crop BGRA.');
+
+promise_test(async t => {
+  const frame = makeI420_2x4();
+  const options = {
+      rect: {x: 0, y: 2, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 2},
+      {offset: 4, stride: 1},
+      {offset: 5, stride: 1},
+  ];
+  const expectedData = new Uint8Array([
+      5, 6,  // y
+      7, 8,
+      10,    // u
+      12     // v
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test top crop I420.');
+
+promise_test(async t => {
+  const frame = makeNV12_2x4();
+  const options = {
+      rect: {x: 0, y: 2, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 2},
+      {offset: 4, stride: 2},
+  ];
+  const expectedData = new Uint8Array([
+      5, 6,  // y
+      7, 8,
+      11,    // u
+      12     // v
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test top crop NV12.');
+
+promise_test(async t => {
+  const frame = makeRGBA_2x4();
+  const options = {
+      rect: {x: 0, y: 1, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 8},
+  ];
+  const expectedData = new Uint8Array([
+       9, 10, 11, 12,   13, 14, 15 ,16,
+      21, 22, 23, 24,   25, 26, 27, 28
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test top crop RGBA.');
+
+promise_test(async t => {
+  const frame = makeBGRA_2x4();
+  const options = {
+      rect: {x: 0, y: 1, width: 2, height: 2},
+  };
+  const expectedLayout = [
+      {offset: 0, stride: 8},
+  ];
+  const expectedData = new Uint8Array([
+       9, 10, 11, 12,   13, 14, 15 ,16,
+      21, 22, 23, 24,   25, 26, 27, 28
+  ]);
+  assert_equals(frame.allocationSize(options), expectedData.length, 'allocationSize()');
+  const data = new Uint8Array(expectedData.length);
+  const layout = await frame.copyTo(data, options);
+  assert_layout_equals(layout, expectedLayout);
+  assert_buffer_equals(data, expectedData);
+}, 'Test top crop BGRA.');
 
 promise_test(async t => {
   const frame = makeI420_4x2();

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt
@@ -13,6 +13,13 @@ PASS Test address overflow.
 PASS Test codedRect.
 PASS Test empty rect.
 PASS Test unaligned rect.
-FAIL Test left crop. assert_equals: buffer contents at index 0 expected 3 but got 1
+PASS Test left crop I420.
+PASS Test left crop NV12.
+PASS Test left crop RGBA.
+PASS Test left crop BGRA.
+PASS Test top crop I420.
+PASS Test top crop NV12.
+PASS Test top crop RGBA.
+PASS Test top crop BGRA.
 PASS Test invalid rect.
 


### PR DESCRIPTION
#### 903dab21ab4f09d231bd7064153c712243aaa900
<pre>
Add cropping support to WebCodecsVideoFrame copyTo
<a href="https://bugs.webkit.org/show_bug.cgi?id=246683">https://bugs.webkit.org/show_bug.cgi?id=246683</a>
rdar://problem/101282697

Reviewed by Eric Carlson.

Implement cropping in copyTo as per <a href="https://w3c.github.io/webcodecs/#dom-videoframe-copyto">https://w3c.github.io/webcodecs/#dom-videoframe-copyto</a> step 8.4.
Beef up testing for RGBA, BGRA and NV12 as well as I420.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.js:
(makeRGBA_4x2):
(makeRGBA_2x4):
(makeBGRA_4x2):
(makeBGRA_2x4):
(makeNV12_2x4):
(makeI420_2x4):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker-expected.txt:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::copyPlane):
(WebCore::copyRGBData):
(WebCore::copyNV12):
(WebCore::copyI420):
(WebCore::VideoFrame::copyTo):

Canonical link: <a href="https://commits.webkit.org/255716@main">https://commits.webkit.org/255716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/372868036b4f901b2bba3e9d75077e8924ed3bf8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102965 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163259 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2482 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30788 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99077 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1729 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79738 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28691 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71753 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37176 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17279 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/34996 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41055 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37741 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->