### PR TITLE
[SOUP] Spammed by 0-byte downloads on imgur.com

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -535,7 +535,7 @@ static gboolean webkitWebViewDecidePolicy(WebKitWebView*, WebKitPolicyDecision* 
         return TRUE;
     }
 
-    if (webkit_response_policy_decision_is_mime_type_supported(WEBKIT_RESPONSE_POLICY_DECISION(decision)))
+    if (webkit_response_policy_decision_is_mime_type_supported(WEBKIT_RESPONSE_POLICY_DECISION(decision)) || webkit_uri_response_get_status_code(response) == SOUP_STATUS_NO_CONTENT)
         webkit_policy_decision_use(decision);
     else
         webkit_policy_decision_ignore(decision);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
@@ -431,6 +431,10 @@ static void testWebResourceMimeType(SingleResourceLoadTest* test, gconstpointer)
     test->loadURI(kServer->getURIForPath("/redirected-css.html").data());
     response = test->waitUntilResourceLoadFinishedAndReturnURIResponse();
     g_assert_cmpstr(webkit_uri_response_get_mime_type(response), ==, "text/css");
+
+    test->loadURI(kServer->getURIForPath("/iframe-no-content.html").data());
+    response = test->waitUntilResourceLoadFinishedAndReturnURIResponse();
+    g_assert_cmpstr(webkit_uri_response_get_mime_type(response), ==, "text/plain");
 }
 
 static void testWebResourceSuggestedFilename(SingleResourceLoadTest* test, gconstpointer)
@@ -900,6 +904,11 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
     } else if (g_str_equal(path, "/redirected-to-cancel.js")) {
         soup_server_message_set_status(message, SOUP_STATUS_MOVED_PERMANENTLY, nullptr);
         soup_message_headers_append(responseHeaders, "Location", "/cancel-this.js");
+    } else if (g_str_equal(path, "/iframe-no-content.html")) {
+        static const char* iframeNoContentHTML = "<html><body><iframe src='/no-content'/></body></html>";
+        soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, iframeNoContentHTML, strlen(iframeNoContentHTML));
+    } else if (g_str_equal(path, "/no-content")) {
+        soup_server_message_set_status(message, SOUP_STATUS_NO_CONTENT, nullptr);
     } else if (g_str_has_prefix(path, "/sync-request-on-max-conns-")) {
         char* contents;
         gsize contentsLength;


### PR DESCRIPTION
#### 16644424b9771fe72193676a0f9796baaf5880fc
<pre>
[SOUP] Spammed by 0-byte downloads on imgur.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=245625">https://bugs.webkit.org/show_bug.cgi?id=245625</a>

Reviewed by Michael Catanzaro.

Do not ignore subresources with no content.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewDecidePolicy):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp:
(testWebResourceMimeType):
(serverCallback):

Canonical link: <a href="https://commits.webkit.org/255721@main">https://commits.webkit.org/255721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3afba1358153414460a7e2008aeae2a4082a1cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102975 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163262 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2491 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30798 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99084 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1736 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79748 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28708 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37185 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17286 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18533 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3960 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41061 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37752 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->