### PR TITLE
WebCodecsVideoDecoderConfig description should be undefined instead of null if there is no description to provide

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: Error: assert_unreached: Decoder failure Reached unreachable code
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "AbortError: aborting flush as decoder is reset"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
@@ -1,6 +1,11 @@
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: DataError: Key frame is required
+CONSOLE MESSAGE: DataError: Key frame is required
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+Harness Error (FAIL), message = DataError: Key frame is required
+
+TIMEOUT Encoding and decoding cycle Test timed out
+
+Harness Error (FAIL), message = DataError: Key frame is required
+
+TIMEOUT Encoding and decoding cycle Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
@@ -1,21 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 
-Harness Error (FAIL), message = InvalidStateError: VideoDecoder is not configured
-
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Config is not valid
 CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -389,6 +389,9 @@ void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& desti
     // FIXME: It is not efficient to create a conformer everytime. We might want to make it more efficient, for instance by storing it in GraphicsContext.
     auto conformer = makeUnique<PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });
     auto image = NativeImage::create(conformer->createImageFromPixelBuffer(pixelBuffer()));
+    if (!image)
+        return;
+
     FloatRect imageRect { FloatPoint::zero(), image->size() };
     context.drawNativeImage(*image, presentationSize(), destination, imageRect);
 }


### PR DESCRIPTION
#### 146ca511cb11f32a0eda771a422443af135f48cc
<pre>
WebCodecsVideoDecoderConfig description should be undefined instead of null if there is no description to provide
<a href="https://bugs.webkit.org/show_bug.cgi?id=246685">https://bugs.webkit.org/show_bug.cgi?id=246685</a>
rdar://problem/101288923

Reviewed by Eric Carlson.

When the description size is 0, we should keep the comnfig description be a std::nullopt instead of a null array buffer.
Also fix the creation of the array buffer by providing a proper sampel size.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::createEncodedChunkMetadata):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::paintInContext): Drive-by fix.

Canonical link: <a href="https://commits.webkit.org/255726@main">https://commits.webkit.org/255726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677d4981d44be94b691ff3377b5c839ff1e4c371

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103107 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2643 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30933 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85805 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99098 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79887 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28906 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83522 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37316 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35145 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3964 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39019 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37864 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->