### PR TITLE
[Nicosia] AsyncScrolling: lock/unlock layers for hit testing is not implemented

### DIFF
--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -339,6 +339,15 @@ void ThreadedScrollingTree::setActiveScrollSnapIndices(ScrollingNodeID nodeID, s
     });
 }
 
+void ThreadedScrollingTree::lockLayersForHitTesting()
+{
+    m_layerHitTestMutex.lock();
+}
+
+void ThreadedScrollingTree::unlockLayersForHitTesting()
+{
+    m_layerHitTestMutex.unlock();
+}
 
 bool ThreadedScrollingTree::scrollingThreadIsActive()
 {

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -90,6 +90,7 @@ protected:
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<SynchronousScrollingReason>) override;
 
     RefPtr<AsyncScrollingCoordinator> m_scrollingCoordinator;
+    mutable Lock m_layerHitTestMutex;
 
 private:
     bool isThreadedScrollingTree() const override { return true; }
@@ -116,6 +117,9 @@ private:
     Seconds maxAllowableRenderingUpdateDurationForSynchronization();
     
     bool scrollingThreadIsActive();
+
+    void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
+    void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
 
     enum class SynchronizationState : uint8_t {
         Idle,

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h
@@ -54,13 +54,7 @@ private:
     void registerForPlatformRenderingUpdateCallback();
     void applyLayerPositionsInternal() final WTF_REQUIRES_LOCK(m_treeLock);
 
-    void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
-    void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
-
     void didCompleteRenderingUpdate() final;
-
-    // This lock protects the CALayer/PlatformCALayer tree.
-    mutable Lock m_layerHitTestMutex;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -232,16 +232,6 @@ OptionSet<EventListenerRegionType> ScrollingTreeMac::eventListenerRegionTypesFor
 }
 #endif
 
-void ScrollingTreeMac::lockLayersForHitTesting()
-{
-    m_layerHitTestMutex.lock();
-}
-
-void ScrollingTreeMac::unlockLayersForHitTesting()
-{
-    m_layerHitTestMutex.unlock();
-}
-
 void ScrollingTreeMac::didCompleteRenderingUpdate()
 {
     bool hasActiveCATransaction = [CATransaction currentState];

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
@@ -116,7 +116,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeNicosia::scrollingNodeForPoint(FloatPoint
     if (!rootScrollingNode)
         return nullptr;
 
-    LayerTreeHitTestLocker layerLocker(m_scrollingCoordinator.get());
+    Locker layerLocker { m_layerHitTestMutex };
 
     auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeNicosia*>(rootScrollingNode)->rootContentsLayer();
     Vector<RefPtr<CompositionLayer>> layersAtPoint;


### PR DESCRIPTION
#### 248bd5dfd8705b4d7ae1a7ce41f9ea1ac075ed4c
<pre>
[Nicosia] AsyncScrolling: lock/unlock layers for hit testing is not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=246687">https://bugs.webkit.org/show_bug.cgi?id=246687</a>

Reviewed by Žan Doberšek and Simon Fraser.

It&apos;s only implemented for mac platform, we can just move it to ThreadedScrollingTree.

* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::lockLayersForHitTesting):
(WebCore::ThreadedScrollingTree::unlockLayersForHitTesting):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(ScrollingTreeMac::lockLayersForHitTesting): Deleted.
(ScrollingTreeMac::unlockLayersForHitTesting): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp:
(WebCore::ScrollingTreeNicosia::scrollingNodeForPoint):

Canonical link: <a href="https://commits.webkit.org/255722@main">https://commits.webkit.org/255722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd7ba3e64b7722c9ac7dd8a13a6271aa0d1b068

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/102984 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163269 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2500 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30807 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99093 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1743 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79757 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28706 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37194 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41070 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37758 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->