### PR TITLE
[webkitscmpy] Add merge-base function

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.6.25',
+    version='5.6.26',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 6, 25)
+version = Version(5, 6, 26)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -1125,3 +1125,16 @@ class Git(Scm):
             if argument in self.branches_for(remote=remote):
                 return remote
         return None
+
+    def merge_base(self, ref_a, ref_b, include_log=True, include_identifier=True):
+        a = self.find(ref_a, include_log=False, include_identifier=False)
+        b = self.find(ref_b, include_log=False, include_identifier=False)
+        if not a or not b:
+            return None
+        result = run(
+            [self.executable(), 'merge-base', a.hash, b.hash],
+            capture_output=True, encoding='utf-8', cwd=self.path,
+        )
+        if result.returncode:
+            return None
+        return self.commit(hash=result.stdout.rstrip(), include_log=include_log, include_identifier=include_identifier)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -608,6 +608,10 @@ nothing to commit, working tree clean
                     returncode=0,
                 ) if args[4] in self.remotes else mocks.ProcessCompletion(returncode=128, stderr="fatal: branch '{}' does not exist".format(args[4])),
             ), mocks.Subprocess.Route(
+                self.executable, 'merge-base', re.compile(r'.+'), re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.merge_base(args[2], args[3]),
+            ), mocks.Subprocess.Route(
                 self.executable,
                 cwd=self.path,
                 completion=mocks.ProcessCompletion(
@@ -1246,4 +1250,24 @@ nothing to commit, working tree clean
         return mocks.ProcessCompletion(
             returncode=0,
             stdout='Updated Git hooks.\nGit LFS initialized.\n',
+        )
+
+    def merge_base(self, *refs):
+        objs = [self.find(ref) for ref in refs]
+        for i in [0, 1]:
+            if not refs[i] or not objs[i]:
+                return mocks.ProcessCompletion(
+                    returncode=128,
+                    stderr='fatal: Not a valid object name {}\n'.format(refs[i]),
+                )
+        if objs[0].branch != objs[1].branch:
+            for i in [0, 1]:
+                if objs[i].branch == self.default_branch:
+                    continue
+                objs[i] = self.commits[self.default_branch][objs[i].branch_point - 1]
+
+        base = objs[0] if objs[0].identifier < objs[1].identifier else objs[1]
+        return mocks.ProcessCompletion(
+            returncode=0,
+            stdout='{}\n'.format(base.hash),
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -562,6 +562,17 @@ CommitDate: {time_c}
                 ['Source/main.cpp', 'Source/main.h'],
             )
 
+    def test_merge_base(self):
+        with mocks.local.Git(self.path), OutputCapture():
+            self.assertEqual(
+                str(local.Git(self.path).merge_base('main', 'branch-b')),
+                '2@main',
+            )
+            self.assertEqual(
+                str(local.Git(self.path).merge_base('branch-a', 'branch-b')),
+                '2@main',
+            )
+
 
 class TestGitHub(testing.TestCase):
     remote = 'https://github.example.com/WebKit/WebKit'


### PR DESCRIPTION
#### 402b4118973bea6542a61a69153a9501ca5d5b26
<pre>
[webkitscmpy] Add merge-base function
<a href="https://bugs.webkit.org/show_bug.cgi?id=246689">https://bugs.webkit.org/show_bug.cgi?id=246689</a>
rdar://101292972

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.merge_base): Determine the merge-base of the provided git refs.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): Add `git merge-base` mock.
(Git.merge_base): Mock the `git merge-base` command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(TestGit.test_merge_base):

Canonical link: <a href="https://commits.webkit.org/255689@main">https://commits.webkit.org/255689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/026a858fa9acc3c4ee6aaaf45218701ac804c0d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/93341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/2536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/97339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/2545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/30843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/99004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/2545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/79794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/96919 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/2545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/92368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/35052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/38926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/79794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1836 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/40861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/23984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->