### PR TITLE
Conditionally block access to launchd in sandbox on iOS

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -960,7 +960,7 @@
     (preference-domain "com.apple.WebKit.WebContent.BlockIOKitInWebContentSandbox"))
 
 (with-filter (state-flag "BlockIOKitInWebContentSandbox")
-    (deny IOKIT_OPEN_SERVICE)
+    (deny iokit-open-service)
     (deny iokit-open (with telemetry-backtrace)
         (require-all
             (require-not (extension "com.apple.webkit.extension.iokit"))
@@ -1337,23 +1337,22 @@
             (allow mach-message-send
                 (mach-bootstrap-message-numbers)))))
 
+(allow-mach-bootstrap-with-filter)
+
 #if HAVE(SANDBOX_STATE_FLAGS)
-(if (require-ancestor-with-entitlement "com.apple.private.security.enable-state-flags")
+(with-filter
+    (require-all
+        (require-ancestor-with-entitlement "com.apple.private.security.enable-state-flags")
+        (state-flag "WebContentProcessLaunched")
+        (require-not (state-flag "EnableMachBootstrap")))
     (allow mach-bootstrap
+        (require-not (state-flag "EnableExperimentalSandbox"))
         (apply-message-filter
             (deny mach-message-send (with telemetry-backtrace))
             (allow mach-message-send (with telemetry-backtrace)
                 (mach-bootstrap-message-numbers-post-launch))))
-;; else
-    (allow-mach-bootstrap-with-filter))
-
-(with-filter
-    (require-any
-        (require-not (state-flag "WebContentProcessLaunched"))
-        (state-flag "EnableMachBootstrap"))
-    (allow-mach-bootstrap-with-filter))
-#else
-(allow-mach-bootstrap-with-filter)
+    (deny mach-bootstrap (with telemetry-backtrace)
+        (state-flag "EnableExperimentalSandbox")))
 #endif
 
 (define (syscall-mach-only-in-use-during-launch)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -401,7 +401,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     if (WebProcessProxy::shouldEnableRemoteInspector()) {
-        if (auto handle = SandboxExtension::createHandleForMachLookup("com.apple.webinspector"_s, std::nullopt))
+        if (auto handle = SandboxExtension::createHandleForMachLookup("com.apple.webinspector"_s, process.auditToken(), SandboxExtension::MachBootstrapOptions::EnableMachBootstrap))
             parameters.enableRemoteWebInspectorExtensionHandle = WTFMove(*handle);
     }
 #endif


### PR DESCRIPTION
#### d5160fa6b1b8ae5eb46357892784ce9de118acf1
<pre>
Conditionally block access to launchd in sandbox on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=246693">https://bugs.webkit.org/show_bug.cgi?id=246693</a>
rdar://101295943

Reviewed by Geoffrey Garen.

Conditionally block access to launchd in sandbox on iOS based on a new experimental sandbox setting.
This patch also makes sure we use the correct parameters when creating the Mach sandbox extension
to the Web Inspector service.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/255830@main">https://commits.webkit.org/255830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0843f89cee413c46d7aaca3d7f92740eb49249f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2930 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103379 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2945 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31186 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86074 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2098 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80176 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29121 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84023 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72073 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37579 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35428 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4028 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39306 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41240 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->