### PR TITLE
Prepare DisplayLink to support UI-side compositing

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -511,6 +511,7 @@ UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
 UIProcess/mac/CorrectionPanel.mm
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/DisplayLink.cpp
+UIProcess/mac/DisplayLinkProcessProxyClient.cpp
 UIProcess/mac/HighPerformanceGPUManager.mm
 UIProcess/mac/LegacySessionStateCoding.cpp
 UIProcess/mac/PageClientImplMac.mm

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -902,6 +902,7 @@ bool WebProcessPool::isURLKnownHSTSHost(const String& urlString) const
 }
 
 #if HAVE(CVDISPLAYLINK)
+
 std::optional<unsigned> WebProcessPool::nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID displayID)
 {
     if (auto* displayLink = m_displayLinks.displayLinkForDisplay(displayID))
@@ -914,45 +915,45 @@ std::optional<unsigned> WebProcessPool::nominalFramesPerSecondForDisplay(WebCore
     return frameRate;
 }
 
-void WebProcessPool::startDisplayLink(IPC::Connection& connection, DisplayLinkObserverID observerID, PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
+void WebProcessPool::startDisplayLink(WebProcessProxy& processProxy, DisplayLinkObserverID observerID, PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
     if (auto* displayLink = m_displayLinks.displayLinkForDisplay(displayID)) {
-        displayLink->addObserver(connection.uniqueID(), observerID, preferredFramesPerSecond);
+        displayLink->addObserver(processProxy.displayLinkClient(), observerID, preferredFramesPerSecond);
         return;
     }
 
     auto displayLink = makeUnique<DisplayLink>(displayID);
-    displayLink->addObserver(connection.uniqueID(), observerID, preferredFramesPerSecond);
+    displayLink->addObserver(processProxy.displayLinkClient(), observerID, preferredFramesPerSecond);
     m_displayLinks.add(WTFMove(displayLink));
 }
 
-void WebProcessPool::stopDisplayLink(IPC::Connection& connection, DisplayLinkObserverID observerID, PlatformDisplayID displayID)
+void WebProcessPool::stopDisplayLink(WebProcessProxy& processProxy, DisplayLinkObserverID observerID, PlatformDisplayID displayID)
 {
     if (auto* displayLink = m_displayLinks.displayLinkForDisplay(displayID))
-        displayLink->removeObserver(connection.uniqueID(), observerID);
+        displayLink->removeObserver(processProxy.displayLinkClient(), observerID);
 }
 
-void WebProcessPool::stopDisplayLinks(IPC::Connection& connection)
+void WebProcessPool::stopDisplayLinks(WebProcessProxy& processProxy)
 {
     for (auto& displayLink : m_displayLinks.displayLinks())
-        displayLink->removeObservers(connection.uniqueID());
+        displayLink->removeClient(processProxy.displayLinkClient());
 }
 
-void WebProcessPool::setDisplayLinkPreferredFramesPerSecond(IPC::Connection& connection, DisplayLinkObserverID observerID, PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
+void WebProcessPool::setDisplayLinkPreferredFramesPerSecond(WebProcessProxy& processProxy, DisplayLinkObserverID observerID, PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] WebProcessPool::setDisplayLinkPreferredFramesPerSecond - display " << displayID << " observer " << observerID << " fps " << preferredFramesPerSecond);
 
     if (auto* displayLink = m_displayLinks.displayLinkForDisplay(displayID))
-        displayLink->setPreferredFramesPerSecond(connection.uniqueID(), observerID, preferredFramesPerSecond);
+        displayLink->setObserverPreferredFramesPerSecond(processProxy.displayLinkClient(), observerID, preferredFramesPerSecond);
 }
 
-void WebProcessPool::setDisplayLinkForDisplayWantsFullSpeedUpdates(IPC::Connection& connection, WebCore::PlatformDisplayID displayID, bool wantsFullSpeedUpdates)
+void WebProcessPool::setDisplayLinkForDisplayWantsFullSpeedUpdates(WebProcessProxy& processProxy, WebCore::PlatformDisplayID displayID, bool wantsFullSpeedUpdates)
 {
     if (auto* displayLink = m_displayLinks.displayLinkForDisplay(displayID)) {
         if (wantsFullSpeedUpdates)
-            displayLink->incrementFullSpeedRequestClientCount(connection.uniqueID());
+            displayLink->incrementFullSpeedRequestClientCount(processProxy.displayLinkClient());
         else
-            displayLink->decrementFullSpeedRequestClientCount(connection.uniqueID());
+            displayLink->decrementFullSpeedRequestClientCount(processProxy.displayLinkClient());
     }
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3065,7 +3065,7 @@ void WebPageProxy::updateDisplayLinkFrequency()
 
     bool wantsFullSpeedUpdates = m_hasActiveAnimatedScroll || m_wheelEventActivityHysteresis.state() == PAL::HysteresisState::Started;
     if (wantsFullSpeedUpdates != m_registeredForFullSpeedUpdates) {
-        process().processPool().setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_process->connection(), *m_displayID, wantsFullSpeedUpdates);
+        process().processPool().setDisplayLinkForDisplayWantsFullSpeedUpdates(process(), *m_displayID, wantsFullSpeedUpdates);
         m_registeredForFullSpeedUpdates = wantsFullSpeedUpdates;
     }
 }
@@ -4111,7 +4111,7 @@ void WebPageProxy::windowScreenDidChange(PlatformDisplayID displayID, std::optio
 {
 #if HAVE(CVDISPLAYLINK)
     if (hasRunningProcess() && m_displayID && m_registeredForFullSpeedUpdates)
-        process().processPool().setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_process->connection(), *m_displayID, false);
+        process().processPool().setDisplayLinkForDisplayWantsFullSpeedUpdates(process(), *m_displayID, false);
 
     m_registeredForFullSpeedUpdates = false;
 #endif

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -243,12 +243,12 @@ public:
 
 #if HAVE(CVDISPLAYLINK)
     std::optional<WebCore::FramesPerSecond> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
-    void startDisplayLink(IPC::Connection&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
-    void stopDisplayLink(IPC::Connection&, DisplayLinkObserverID, WebCore::PlatformDisplayID);
-    void setDisplayLinkPreferredFramesPerSecond(IPC::Connection&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
-    void stopDisplayLinks(IPC::Connection&);
 
-    void setDisplayLinkForDisplayWantsFullSpeedUpdates(IPC::Connection&, WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
+    void startDisplayLink(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
+    void stopDisplayLink(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID);
+    void setDisplayLinkPreferredFramesPerSecond(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
+    void stopDisplayLinks(WebProcessProxy&);
+    void setDisplayLinkForDisplayWantsFullSpeedUpdates(WebProcessProxy&, WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
 #endif
 
     void addSupportedPlugin(String&& matchingDomain, String&& name, HashSet<String>&& mimeTypes, HashSet<String> extensions);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -314,8 +314,7 @@ WebProcessProxy::~WebProcessProxy()
     WebPasteboardProxy::singleton().removeWebProcessProxy(*this);
 
 #if HAVE(CVDISPLAYLINK)
-    if (state() == State::Running)
-        processPool().stopDisplayLinks(*connection());
+    processPool().stopDisplayLinks(*this);
 #endif
 
     auto isResponsiveCallbacks = WTFMove(m_isResponsiveCallbacks);
@@ -507,6 +506,10 @@ void WebProcessProxy::connectionWillOpen(IPC::Connection& connection)
 #if ENABLE(SEC_ITEM_SHIM)
     SecItemShimProxy::singleton().initializeConnection(connection);
 #endif
+
+#if HAVE(CVDISPLAYLINK)
+    m_displayLinkClient.setConnection(&connection);
+#endif
 }
 
 void WebProcessProxy::processWillShutDown(IPC::Connection& connection)
@@ -515,7 +518,8 @@ void WebProcessProxy::processWillShutDown(IPC::Connection& connection)
     ASSERT_UNUSED(connection, this->connection() == &connection);
 
 #if HAVE(CVDISPLAYLINK)
-    processPool().stopDisplayLinks(connection);
+    m_displayLinkClient.setConnection(nullptr);
+    processPool().stopDisplayLinks(*this);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -28,7 +28,6 @@
 #include "APIUserInitiatedAction.h"
 #include "AuxiliaryProcessProxy.h"
 #include "BackgroundProcessResponsivenessTimer.h"
-#include "DisplayLinkObserverID.h"
 #include "MessageReceiverMap.h"
 #include "NetworkProcessProxy.h"
 #include "ProcessLauncher.h"
@@ -64,6 +63,11 @@
 
 #if HAVE(MEDIA_ACCESSIBILITY_FRAMEWORK)
 #include <WebCore/CaptionUserPreferences.h>
+#endif
+
+#if HAVE(CVDISPLAYLINK)
+#include "DisplayLinkObserverID.h"
+#include "DisplayLinkProcessProxyClient.h"
 #endif
 
 namespace API {
@@ -317,6 +321,8 @@ public:
 #endif
 
 #if HAVE(CVDISPLAYLINK)
+    DisplayLink::Client& displayLinkClient() { return m_displayLinkClient; }
+
     void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
     void stopDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID);
     void setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
@@ -617,6 +623,10 @@ private:
     std::unique_ptr<ProcessThrottler::BackgroundActivity> m_activityForHoldingLockedFiles;
     ForegroundWebProcessToken m_foregroundToken;
     BackgroundWebProcessToken m_backgroundToken;
+
+#if HAVE(CVDISPLAYLINK)
+    DisplayLinkProcessProxyClient m_displayLinkClient;
+#endif
 
 #if ENABLE(ROUTING_ARBITRATION)
     UniqueRef<AudioSessionRoutingArbitratorProxy> m_routingArbitrator;

--- a/Source/WebKit/UIProcess/mac/DisplayLink.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.h
@@ -27,49 +27,51 @@
 
 #if HAVE(CVDISPLAYLINK)
 
-#include "Connection.h"
 #include "DisplayLinkObserverID.h"
 #include <CoreVideo/CVDisplayLink.h>
 #include <WebCore/AnimationFrameRate.h>
 #include <WebCore/DisplayUpdate.h>
 #include <WebCore/PlatformScreen.h>
-#include <wtf/HashMap.h>
 #include <wtf/Lock.h>
-
-namespace IPC {
-class Connection;
-}
+#include <wtf/WeakHashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
 class DisplayLink {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    class Client : public CanMakeThreadSafeCheckedPtr {
+    friend class DisplayLink;
+    public:
+        virtual ~Client() = default;
+        
+    private:
+        virtual void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) = 0;
+    };
+
     explicit DisplayLink(WebCore::PlatformDisplayID);
     ~DisplayLink();
-    
-    void addObserver(IPC::Connection::UniqueID, DisplayLinkObserverID, WebCore::FramesPerSecond);
-    void removeObserver(IPC::Connection::UniqueID, DisplayLinkObserverID);
-    void removeObservers(IPC::Connection::UniqueID);
-
-    void incrementFullSpeedRequestClientCount(IPC::Connection::UniqueID);
-    void decrementFullSpeedRequestClientCount(IPC::Connection::UniqueID);
-
-    void setPreferredFramesPerSecond(IPC::Connection::UniqueID, DisplayLinkObserverID, WebCore::FramesPerSecond);
 
     WebCore::PlatformDisplayID displayID() const { return m_displayID; }
-    
     WebCore::FramesPerSecond nominalFramesPerSecond() const { return m_displayNominalFramesPerSecond; }
 
-    // When responsiveness is critical, we send the IPC to a background queue. Otherwise, we send it to the
-    // main thread to avoid unnecessary thread hopping and save power.
-    static void setShouldSendIPCOnBackgroundQueue(bool value) { shouldSendIPCOnBackgroundQueue = value; }
+    void addObserver(Client&, DisplayLinkObserverID, WebCore::FramesPerSecond);
+    void removeObserver(Client&, DisplayLinkObserverID);
+
+    void removeClient(Client&);
+
+    // FIXME: Maybe callers should just register a DisplayLinkObserverID with the appropriate fps.
+    void incrementFullSpeedRequestClientCount(Client&);
+    void decrementFullSpeedRequestClientCount(Client&);
+
+    void setObserverPreferredFramesPerSecond(Client&, DisplayLinkObserverID, WebCore::FramesPerSecond);
 
 private:
     static CVReturn displayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, const CVTimeStamp*, CVOptionFlags, CVOptionFlags*, void* data);
     void notifyObserversDisplayWasRefreshed();
 
-    void removeInfoForConnectionIfPossible(IPC::Connection::UniqueID) WTF_REQUIRES_LOCK(m_observersLock);
+    bool removeInfoForClientIfUnused(Client&) WTF_REQUIRES_LOCK(m_clientsLock);
 
     static WebCore::FramesPerSecond nominalFramesPerSecondFromDisplayLink(CVDisplayLinkRef);
 
@@ -77,20 +79,19 @@ private:
         DisplayLinkObserverID observerID;
         WebCore::FramesPerSecond preferredFramesPerSecond;
     };
-    
-    struct ConnectionClientInfo {
+
+    struct ClientInfo {
         unsigned fullSpeedUpdatesClientCount { 0 };
         Vector<ObserverInfo> observers;
     };
 
     CVDisplayLinkRef m_displayLink { nullptr };
-    Lock m_observersLock;
-    HashMap<IPC::Connection::UniqueID, ConnectionClientInfo> m_observers WTF_GUARDED_BY_LOCK(m_observersLock);
-    WebCore::PlatformDisplayID m_displayID;
+    Lock m_clientsLock;
+    HashMap<CheckedRef<Client>, ClientInfo> m_clients WTF_GUARDED_BY_LOCK(m_clientsLock);
+    const WebCore::PlatformDisplayID m_displayID;
     WebCore::FramesPerSecond m_displayNominalFramesPerSecond { WebCore::FullSpeedFramesPerSecond };
     WebCore::DisplayUpdate m_currentUpdate;
     unsigned m_fireCountWithoutObservers { 0 };
-    static bool shouldSendIPCOnBackgroundQueue;
 };
 
 class DisplayLinkCollection {

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "config.h"
+#include "DisplayLinkProcessProxyClient.h"
+
+#if HAVE(CVDISPLAYLINK)
+
+#include "EventDispatcherMessages.h"
+#include "WebProcessMessages.h"
+
+namespace WebKit {
+
+void DisplayLinkProcessProxyClient::setConnection(RefPtr<IPC::Connection>&& connection)
+{
+    Locker locker { m_connectionLock };
+    m_connection = WTFMove(connection);
+}
+
+// This is called off the main thread.
+void DisplayLinkProcessProxyClient::displayLinkFired(WebCore::PlatformDisplayID displayID, WebCore::DisplayUpdate displayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback)
+{
+    RefPtr<IPC::Connection> connection;
+    {
+        Locker locker { m_connectionLock };
+        connection = m_connection;
+    }
+
+    if (!connection)
+        return;
+
+    if (wantsFullSpeedUpdates)
+        connection->send(Messages::EventDispatcher::DisplayWasRefreshed(displayID, displayUpdate, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
+    else if (anyObserverWantsCallback)
+        connection->send(Messages::WebProcess::DisplayWasRefreshed(displayID, displayUpdate), 0, { }, Thread::QOS::UserInteractive);
+}
+
+}
+
+#endif // HAVE(CVDISPLAYLINK)

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DisplayLink.h"
+
+#if HAVE(CVDISPLAYLINK)
+
+#include "Connection.h"
+
+namespace WebKit {
+
+class WebProcessProxy;
+
+class DisplayLinkProcessProxyClient final : public DisplayLink::Client {
+public:
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    DisplayLinkProcessProxyClient() = default;
+    ~DisplayLinkProcessProxyClient() = default;
+    
+    void setConnection(RefPtr<IPC::Connection>&&);
+
+private:
+    void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
+
+    Lock m_connectionLock;
+    RefPtr<IPC::Connection> m_connection;
+};
+
+}
+
+#endif // HAVE(CVDISPLAYLINK)

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -62,20 +62,17 @@ bool WebProcessProxy::shouldAllowNonValidInjectedCode() const
 void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
-    ASSERT(connection());
-    processPool().startDisplayLink(*connection(), observerID, displayID, preferredFramesPerSecond);
+    processPool().startDisplayLink(*this, observerID, displayID, preferredFramesPerSecond);
 }
 
 void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID)
 {
-    ASSERT(connection());
-    processPool().stopDisplayLink(*connection(), observerID, displayID);
+    processPool().stopDisplayLink(*this, observerID, displayID);
 }
 
 void WebProcessProxy::setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
 {
-    ASSERT(connection());
-    processPool().setDisplayLinkPreferredFramesPerSecond(*connection(), observerID, displayID, preferredFramesPerSecond);
+    processPool().setDisplayLinkPreferredFramesPerSecond(*this, observerID, displayID, preferredFramesPerSecond);
 }
 
 void WebProcessProxy::platformSuspendProcess()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3062,6 +3062,8 @@
 		0F45A334239D89AF00294ABF /* WKWebViewTestingMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewTestingMac.mm; sourceTree = "<group>"; };
 		0F45A33B239D8CC400294ABF /* WKWebViewPrivateForTesting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebViewPrivateForTesting.h; sourceTree = "<group>"; };
 		0F45A33C239D8CC400294ABF /* WKWebViewTesting.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewTesting.mm; sourceTree = "<group>"; };
+		0F49294628FF0F4B00AF8509 /* DisplayLinkProcessProxyClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayLinkProcessProxyClient.h; sourceTree = "<group>"; };
+		0F49294728FF0F4B00AF8509 /* DisplayLinkProcessProxyClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DisplayLinkProcessProxyClient.cpp; sourceTree = "<group>"; };
 		0F4A438428F0968400D6161C /* RemoteLayerTreeDrawingAreaMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeDrawingAreaMac.mm; sourceTree = "<group>"; };
 		0F4A438528F0968400D6161C /* RemoteLayerTreeDrawingAreaMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerTreeDrawingAreaMac.h; sourceTree = "<group>"; };
 		0F5403002531006E00082BB9 /* WebWheelEventCoalescer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebWheelEventCoalescer.cpp; sourceTree = "<group>"; };
@@ -13042,6 +13044,8 @@
 				07EF07582745A8160066EA04 /* DisplayCaptureSessionManager.mm */,
 				C1817362205844A900DFDA65 /* DisplayLink.cpp */,
 				C18173602058424700DFDA65 /* DisplayLink.h */,
+				0F49294728FF0F4B00AF8509 /* DisplayLinkProcessProxyClient.cpp */,
+				0F49294628FF0F4B00AF8509 /* DisplayLinkProcessProxyClient.h */,
 				31ABA79C215AF9E000C90E31 /* HighPerformanceGPUManager.h */,
 				31ABA79D215AF9E000C90E31 /* HighPerformanceGPUManager.mm */,
 				1AFDE65B1954E8D500C48FFA /* LegacySessionStateCoding.cpp */,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
@@ -72,7 +72,7 @@ bool RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback()
     if (isScheduled())
         return true;
 
-    LOG_WITH_STREAM(DisplayLink, stream << "RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback - triggering update");
+    LOG_WITH_STREAM(DisplayLink, stream << "[Web] RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback - triggering update");
     static_cast<DrawingArea&>(*m_drawingArea.get()).triggerRenderingUpdate();
 
     setIsScheduled(true);


### PR DESCRIPTION
#### 0ca300a709eed3e70130a5e13cab0e5b5887b9b6
<pre>
Prepare DisplayLink to support UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=246694">https://bugs.webkit.org/show_bug.cgi?id=246694</a>
rdar://101296426

Reviewed by Chris Dumez.

The DisplayLink class has clients (currently denoted by IPC::Connection::UniqueID), and each client
has a collection of DisplayLinkObserverID, whose values are only unique in that context of that client.
In addition, each client has some extra state in the form of &quot;wants full speed updates&quot; which is used
for 120Hz scrolling animations and event handling.

With UI-side compositing, we&apos;ll need a client in the UI process. So replace IPC::Connection::UniqueID
with a Client class. For web process clients, DisplayLinkProcessProxyClient implements DisplayLink::Client,
and handles the IPC to the web process. WebProcessProxy owns an instance of DisplayLinkProcessProxyClient.
Getting WebProcessProxy&apos;s IPC connection isn&apos;t thread-safe, so we cache the IPC::Connection on
the main thread. DisplayLink::Client is accessed via a thread-safe CheckedPtr&lt;&gt; to catch lifetime
issues.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::startDisplayLink):
(WebKit::WebProcessPool::stopDisplayLink):
(WebKit::WebProcessPool::stopDisplayLinks):
(WebKit::WebProcessPool::setDisplayLinkPreferredFramesPerSecond):
(WebKit::WebProcessPool::setDisplayLinkForDisplayWantsFullSpeedUpdates):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateDisplayLinkFrequency):
(WebKit::WebPageProxy::windowScreenDidChange):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::connectionWillOpen):
(WebKit::WebProcessProxy::processWillShutDown):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::displayLinkClient):
* Source/WebKit/UIProcess/mac/DisplayLink.cpp:
(WebKit::DisplayLink::addObserver):
(WebKit::DisplayLink::removeObserver):
(WebKit::DisplayLink::removeClient):
(WebKit::DisplayLink::removeInfoForClientIfUnused):
(WebKit::DisplayLink::incrementFullSpeedRequestClientCount):
(WebKit::DisplayLink::decrementFullSpeedRequestClientCount):
(WebKit::DisplayLink::setObserverPreferredFramesPerSecond):
(WebKit::DisplayLink::notifyObserversDisplayWasRefreshed):
(WebKit::DisplayLink::removeObservers): Deleted.
(WebKit::DisplayLink::removeInfoForConnectionIfPossible): Deleted.
(WebKit::DisplayLink::setPreferredFramesPerSecond): Deleted.
* Source/WebKit/UIProcess/mac/DisplayLink.h:
(WebKit::DisplayLink::displayID const):
(WebKit::DisplayLink::setShouldSendIPCOnBackgroundQueue): Deleted.
* Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp: Added.
(WebKit::DisplayLinkProcessProxyClient::setConnection):
(WebKit::DisplayLinkProcessProxyClient::displayLinkFired):
* Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h: Added.
* Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm:
(WebKit::WebProcessProxy::startDisplayLink):
(WebKit::WebProcessProxy::stopDisplayLink):
(WebKit::WebProcessProxy::setDisplayLinkPreferredFramesPerSecond):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm:
(WebKit::RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback):

Canonical link: <a href="https://commits.webkit.org/255970@main">https://commits.webkit.org/255970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbebc23921182b608d447844b451fc0a8027fe56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3384 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3403 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31598 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99847 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/80606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37980 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35865 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4132 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/80606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41682 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->