### PR TITLE
Add some missing CSS-Typed-OM functions on the CSS namespace

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
@@ -494,24 +494,24 @@ PASS CSS namespace: operation vi(double)
 PASS CSS namespace: operation vb(double)
 PASS CSS namespace: operation vmin(double)
 PASS CSS namespace: operation vmax(double)
-FAIL CSS namespace: operation svw(double) assert_own_property: namespace object missing operation "svw" expected property "svw" missing
-FAIL CSS namespace: operation svh(double) assert_own_property: namespace object missing operation "svh" expected property "svh" missing
-FAIL CSS namespace: operation svi(double) assert_own_property: namespace object missing operation "svi" expected property "svi" missing
-FAIL CSS namespace: operation svb(double) assert_own_property: namespace object missing operation "svb" expected property "svb" missing
-FAIL CSS namespace: operation svmin(double) assert_own_property: namespace object missing operation "svmin" expected property "svmin" missing
-FAIL CSS namespace: operation svmax(double) assert_own_property: namespace object missing operation "svmax" expected property "svmax" missing
-FAIL CSS namespace: operation lvw(double) assert_own_property: namespace object missing operation "lvw" expected property "lvw" missing
-FAIL CSS namespace: operation lvh(double) assert_own_property: namespace object missing operation "lvh" expected property "lvh" missing
-FAIL CSS namespace: operation lvi(double) assert_own_property: namespace object missing operation "lvi" expected property "lvi" missing
-FAIL CSS namespace: operation lvb(double) assert_own_property: namespace object missing operation "lvb" expected property "lvb" missing
-FAIL CSS namespace: operation lvmin(double) assert_own_property: namespace object missing operation "lvmin" expected property "lvmin" missing
-FAIL CSS namespace: operation lvmax(double) assert_own_property: namespace object missing operation "lvmax" expected property "lvmax" missing
-FAIL CSS namespace: operation dvw(double) assert_own_property: namespace object missing operation "dvw" expected property "dvw" missing
-FAIL CSS namespace: operation dvh(double) assert_own_property: namespace object missing operation "dvh" expected property "dvh" missing
-FAIL CSS namespace: operation dvi(double) assert_own_property: namespace object missing operation "dvi" expected property "dvi" missing
-FAIL CSS namespace: operation dvb(double) assert_own_property: namespace object missing operation "dvb" expected property "dvb" missing
-FAIL CSS namespace: operation dvmin(double) assert_own_property: namespace object missing operation "dvmin" expected property "dvmin" missing
-FAIL CSS namespace: operation dvmax(double) assert_own_property: namespace object missing operation "dvmax" expected property "dvmax" missing
+PASS CSS namespace: operation svw(double)
+PASS CSS namespace: operation svh(double)
+PASS CSS namespace: operation svi(double)
+PASS CSS namespace: operation svb(double)
+PASS CSS namespace: operation svmin(double)
+PASS CSS namespace: operation svmax(double)
+PASS CSS namespace: operation lvw(double)
+PASS CSS namespace: operation lvh(double)
+PASS CSS namespace: operation lvi(double)
+PASS CSS namespace: operation lvb(double)
+PASS CSS namespace: operation lvmin(double)
+PASS CSS namespace: operation lvmax(double)
+PASS CSS namespace: operation dvw(double)
+PASS CSS namespace: operation dvh(double)
+PASS CSS namespace: operation dvi(double)
+PASS CSS namespace: operation dvb(double)
+PASS CSS namespace: operation dvmin(double)
+PASS CSS namespace: operation dvmax(double)
 PASS CSS namespace: operation cqw(double)
 PASS CSS namespace: operation cqh(double)
 PASS CSS namespace: operation cqi(double)

--- a/Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl
+++ b/Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl
@@ -47,6 +47,30 @@
     CSSUnitValue vb(double value);
     CSSUnitValue vmin(double value);
     CSSUnitValue vmax(double value);
+    CSSUnitValue svw(double value);
+    CSSUnitValue svh(double value);
+    CSSUnitValue svi(double value);
+    CSSUnitValue svb(double value);
+    CSSUnitValue svmin(double value);
+    CSSUnitValue svmax(double value);
+    CSSUnitValue lvw(double value);
+    CSSUnitValue lvh(double value);
+    CSSUnitValue lvi(double value);
+    CSSUnitValue lvb(double value);
+    CSSUnitValue lvmin(double value);
+    CSSUnitValue lvmax(double value);
+    CSSUnitValue dvw(double value);
+    CSSUnitValue dvh(double value);
+    CSSUnitValue dvi(double value);
+    CSSUnitValue dvb(double value);
+    CSSUnitValue dvmin(double value);
+    CSSUnitValue dvmax(double value);
+    CSSUnitValue cqw(double value);
+    CSSUnitValue cqh(double value);
+    CSSUnitValue cqi(double value);
+    CSSUnitValue cqb(double value);
+    CSSUnitValue cqmin(double value);
+    CSSUnitValue cqmax(double value);
     CSSUnitValue cm(double value);
     CSSUnitValue mm(double value);
     CSSUnitValue Q(double value);
@@ -54,12 +78,6 @@
     CSSUnitValue pt(double value);
     CSSUnitValue pc(double value);
     CSSUnitValue px(double value);
-    CSSUnitValue cqw(double value);
-    CSSUnitValue cqh(double value);
-    CSSUnitValue cqi(double value);
-    CSSUnitValue cqb(double value);
-    CSSUnitValue cqmin(double value);
-    CSSUnitValue cqmax(double value);
 
     // <angle>
     CSSUnitValue deg(double value);

--- a/Source/WebCore/css/typedom/CSSNumericFactory.h
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.h
@@ -75,6 +75,24 @@ public:
     static Ref<CSSUnitValue> cqb(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CQB); }
     static Ref<CSSUnitValue> cqmin(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CQMIN); }
     static Ref<CSSUnitValue> cqmax(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_CQMAX); }
+    static Ref<CSSUnitValue> svw(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_SVW); }
+    static Ref<CSSUnitValue> svh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_SVH); }
+    static Ref<CSSUnitValue> svi(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_SVI); }
+    static Ref<CSSUnitValue> svb(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_SVB); }
+    static Ref<CSSUnitValue> svmin(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_SVMIN); }
+    static Ref<CSSUnitValue> svmax(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_SVMAX); }
+    static Ref<CSSUnitValue> lvw(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LVW); }
+    static Ref<CSSUnitValue> lvh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LVH); }
+    static Ref<CSSUnitValue> lvi(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LVI); }
+    static Ref<CSSUnitValue> lvb(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LVB); }
+    static Ref<CSSUnitValue> lvmin(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LVMIN); }
+    static Ref<CSSUnitValue> lvmax(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_LVMAX); }
+    static Ref<CSSUnitValue> dvw(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_DVW); }
+    static Ref<CSSUnitValue> dvh(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_DVH); }
+    static Ref<CSSUnitValue> dvi(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_DVI); }
+    static Ref<CSSUnitValue> dvb(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_DVB); }
+    static Ref<CSSUnitValue> dvmin(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_DVMIN); }
+    static Ref<CSSUnitValue> dvmax(double value) { return CSSUnitValue::create(value, CSSUnitType::CSS_DVMAX); }
 
 
     // <angle>


### PR DESCRIPTION
#### f729af82c4515cf5594d34f0c6aa2ecb19f51e98
<pre>
Add some missing CSS-Typed-OM functions on the CSS namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=246696">https://bugs.webkit.org/show_bug.cgi?id=246696</a>

Reviewed by Geoffrey Garen and Sam Weinig.

Add some missing CSS-Typed-OM functions on the CSS namespace (like CSS.lvmin()):
- <a href="https://drafts.css-houdini.org/css-typed-om/#dom-css-lvw">https://drafts.css-houdini.org/css-typed-om/#dom-css-lvw</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt:
* Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl:
* Source/WebCore/css/typedom/CSSNumericFactory.h:

Canonical link: <a href="https://commits.webkit.org/255695@main">https://commits.webkit.org/255695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ce4b3d974fbb9604d179bba16a465c54d2c7a39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103001 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2515 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30822 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99106 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98981 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79772 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28720 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83674 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71782 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37208 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18556 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3938 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38903 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37776 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->