### PR TITLE
Displayed text link uses matched group 1 while generate link uses matched group 2 due to another regex handing trac.webkit.org link.

### DIFF
--- a/Websites/bugs.webkit.org/extensions/Commits/Extension.pm
+++ b/Websites/bugs.webkit.org/extensions/Commits/Extension.pm
@@ -36,8 +36,8 @@ sub bug_format_comment {
     # Should match "r12345" and "trac.webkit.org/r12345" but not "https://trac.webkit.org/r12345"
     push(@$regexes, { match => qr/(?<!\/|\#)\b((r[[:digit:]]{5,}))\b/, replace => \&_replace_reference });
     push(@$regexes, { match => qr/(?<!\/)(trac.webkit.org\/(r[[:digit:]]{5,}))\b/, replace => \&_replace_reference });
-    push(@$regexes, { match => qr/\b(?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+@\S+)\b/, replace => \&_replace_reference });
-    push(@$regexes, { match => qr/\b(?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+\.?\d+@\S+)\b/, replace => \&_replace_reference });
+    push(@$regexes, { match => qr/\b((?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+@\S+))\b/, replace => \&_replace_reference });
+    push(@$regexes, { match => qr/\b((?<!https:\/\/)(?<!\/|\x{2026}|\.)(\d+\.?\d+@\S+))\b/, replace => \&_replace_reference });
 }
 
 sub _replace_reference {


### PR DESCRIPTION
#### 3f0b2fe64691154a33e6aa83027d5d9a4ef4e7bd
<pre>
Displayed text link uses matched group 1 while generate link uses matched group 2 due to another regex handing trac.webkit.org link.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246692">https://bugs.webkit.org/show_bug.cgi?id=246692</a>
rdar://problem/101297471

Reviewed by Jonathan Bedard.

* Websites/bugs.webkit.org/extensions/Commits/Extension.pm:
(bug_format_comment):

sub _replace_reference {
    my $args = shift;
    my $text = $args-&gt;{matches}-&gt;[0];
    my $reference = $args-&gt;{matches}-&gt;[1];
    return qq{&lt;a href=&quot;<a href="https://commits.webkit.org/$reference&quot">https://commits.webkit.org/$reference&quot</a>;&gt;$text&lt;/a&gt;};
};
My last patch left out a parentesis pair causing group 2 to be NULL.

Canonical link: <a href="https://commits.webkit.org/255732@main">https://commits.webkit.org/255732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39469f6e761a4cc109580260677da57f20538c3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103037 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2565 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30863 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99143 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1797 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79814 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28746 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83466 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71809 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37246 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35072 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18582 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38946 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41112 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1854 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37802 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->