### PR TITLE
[JSC] Intl.NumberFormat ignores maximumFractionDigits with compact notation (both currency and decimal)

### DIFF
--- a/JSTests/stress/intl-numberformat-fd-handling-v2.js
+++ b/JSTests/stress/intl-numberformat-fd-handling-v2.js
@@ -1,0 +1,13 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var fmt = new Intl.NumberFormat('en-US', {style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 2, compactDisplay: 'long'});
+
+shouldBe(JSON.stringify(fmt.resolvedOptions()), `{"locale":"en-US","numberingSystem":"latn","style":"currency","currency":"USD","currencyDisplay":"symbol","currencySign":"standard","minimumIntegerDigits":1,"minimumFractionDigits":2,"maximumFractionDigits":2,"useGrouping":"min2","notation":"compact","compactDisplay":"long","signDisplay":"auto","roundingMode":"halfExpand","roundingIncrement":1,"trailingZeroDisplay":"auto","roundingPriority":"auto"}`);
+shouldBe(fmt.format(97896), `$97.90K`);
+
+var fmt = new Intl.NumberFormat('en-US', {style: 'decimal', notation: 'compact', maximumFractionDigits: 2, compactDisplay: 'long'})
+shouldBe(JSON.stringify(fmt.resolvedOptions()), `{"locale":"en-US","numberingSystem":"latn","style":"decimal","minimumIntegerDigits":1,"minimumFractionDigits":0,"maximumFractionDigits":2,"useGrouping":"min2","notation":"compact","compactDisplay":"long","signDisplay":"auto","roundingMode":"halfExpand","roundingIncrement":1,"trailingZeroDisplay":"auto","roundingPriority":"auto"}`);
+shouldBe(fmt.format(97896), `97.9 thousand`);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -67,8 +67,15 @@ void setNumberFormatDigitOptions(JSGlobalObject* globalObject, IntlType* intlIns
 
     bool hasSd = !minimumSignificantDigitsValue.isUndefined() || !maximumSignificantDigitsValue.isUndefined();
     bool hasFd = !minimumFractionDigitsValue.isUndefined() || !maximumFractionDigitsValue.isUndefined();
-    bool needSd = hasSd || roundingPriority != IntlRoundingPriority::Auto;
-    bool needFd = (!hasSd && notation != IntlNotation::Compact) || roundingPriority != IntlRoundingPriority::Auto;
+
+    bool needSd = true;
+    bool needFd = true;
+
+    if (roundingPriority == IntlRoundingPriority::Auto) {
+        needSd = hasSd;
+        if (hasSd || (!hasFd && notation == IntlNotation::Compact))
+            needFd = false;
+    }
 
     if (needSd) {
         if (hasSd) {


### PR DESCRIPTION
#### 9c113c3fb2ab451254444ee83739c69a1bca8948
<pre>
[JSC] Intl.NumberFormat ignores maximumFractionDigits with compact notation (both currency and decimal)
<a href="https://bugs.webkit.org/show_bug.cgi?id=246646">https://bugs.webkit.org/show_bug.cgi?id=246646</a>
rdar://101298045

Reviewed by Justin Michaud.

This patch aligns our hasFd / hasSd / needFd / needSd computation to the latest Intl.NumberFormat v3[1].
In particular, we strictly align our implementation to [2] function, and this change fixes compact notation&apos;s fd handling.

[1]: <a href="https://github.com/tc39/proposal-intl-numberformat-v3">https://github.com/tc39/proposal-intl-numberformat-v3</a>
[2]: <a href="https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/diff.html#sec-setnfdigitoptions">https://tc39.es/proposal-intl-numberformat-v3/out/numberformat/diff.html#sec-setnfdigitoptions</a>

* JSTests/stress/intl-numberformat-fd-handling-v2.js: Added.
(shouldBe):
(shouldBe.fmt.resolvedOptions):
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::setNumberFormatDigitOptions):

Canonical link: <a href="https://commits.webkit.org/255691@main">https://commits.webkit.org/255691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4e5a7faa4b96301c8cad9f777beb02b5ce2bd97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23974 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2530 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30835 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85703 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/98996 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79786 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83683 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84638 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37219 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79705 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18560 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27540 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38917 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82339 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1840 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37780 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18602 "Passed tests") | 
<!--EWS-Status-Bubble-End-->