### PR TITLE
watchOS 9 Open Source Bringup

### DIFF
--- a/Tools/CISupport/build-webkit-org/wkbuild.py
+++ b/Tools/CISupport/build-webkit-org/wkbuild.py
@@ -51,8 +51,8 @@ def _should_file_trigger_build(target_platform, file):
         "ios-simulator-16",
         "tvos-16",
         "tvos-simulator-16",
-        "watchos-8",
-        "watchos-simulator-8",
+        "watchos-9",
+        "watchos-simulator-9",
     ))
 
     directories = [

--- a/Tools/CISupport/build-webkit-org/wkbuild_unittest.py
+++ b/Tools/CISupport/build-webkit-org/wkbuild_unittest.py
@@ -29,8 +29,8 @@ class ShouldBuildTest(unittest.TestCase):
         (["ChangeLog", "Source/WebCore/ChangeLog", "Source/WebKit/ChangeLog-2011-02-11"], []),
         (["Websites/bugs.webkit.org/foo", "Source/WebCore/bar"], ["*"]),
         (["Websites/bugs.webkit.org/foo"], []),
-        (["Source/JavaScriptCore/JavaScriptCore.xcodeproj/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
-        (["Source/JavaScriptCore/Configurations/Base.xcconfig"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
+        (["Source/JavaScriptCore/JavaScriptCore.xcodeproj/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
+        (["Source/JavaScriptCore/Configurations/Base.xcconfig"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
         (["Source/JavaScriptCore/JavaScriptCore.vcproj/foo", "Source/WebKit/win/WebKit2.vcproj", "Source/WebKitLegacy/win/WebKit.sln", "Tools/WebKitTestRunner/Configurations/WebKitTestRunnerCommon.vsprops"], ["win"]),
         (["LayoutTests/platform/mac/foo", "Source/WebCore/bar"], ["*"]),
         (["LayoutTests/foo"], ["*"]),
@@ -52,19 +52,19 @@ class ShouldBuildTest(unittest.TestCase):
         (["LayoutTests/platform/win-xp/foo"], ["win"]),
         (["LayoutTests/platform/win-wk1/foo"], ["win"]),
         (["LayoutTests/platform/win/foo"], ["win"]),
-        (["LayoutTests/platform/spi/cocoa/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
-        (["LayoutTests/platform/spi/cf/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
+        (["LayoutTests/platform/spi/cocoa/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
+        (["LayoutTests/platform/spi/cf/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
         (["Source/WebKitLegacy/mac/WebKit.mac.exp"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
-        (["Source/WebKitLegacy/ios/WebKit.iOS.exp"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
-        (["Source/Dummy/foo.exp"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
-        (["Source/WebCore/ios/foo"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
+        (["Source/WebKitLegacy/ios/WebKit.iOS.exp"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
+        (["Source/Dummy/foo.exp"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
+        (["Source/WebCore/ios/foo"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
         (["Source/WebCore/mac/foo"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
         (["Source/WebCore/win/foo"], ["win"]),
-        (["Source/WebCore/bridge/objc/objc_class.mm"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
+        (["Source/WebCore/bridge/objc/objc_class.mm"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
         (["Source/WebCore/platform/wx/wxcode/win/foo"], []),
-        (["Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
+        (["Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
         (["Source/WebCore/rendering/RenderThemeMac.mm", "Source/WebCore/rendering/RenderThemeMac.h"], ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave"]),
-        (["Source/WebCore/rendering/RenderThemeIOS.mm", "Source/WebCore/rendering/RenderThemeIOS.h"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]),
+        (["Source/WebCore/rendering/RenderThemeIOS.mm", "Source/WebCore/rendering/RenderThemeIOS.h"], ["ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]),
         (["Tools/CISupport/build-webkit-org/public_html/LeaksViewer/LeaksViewer.js"], []),
     ]
 
@@ -72,7 +72,7 @@ class ShouldBuildTest(unittest.TestCase):
         for files, platforms in self._should_build_tests:
             # FIXME: We should test more platforms here once
             # wkbuild._should_file_trigger_build is implemented for them.
-            for platform in ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-8", "watchos-simulator-8"]:
+            for platform in ["mac-yosemite", "mac-elcapitan", "mac-sierra", "mac-highsierra", "mac-mojave", "win", "ios-16", "ios-simulator-16", "tvos-16", "tvos-simulator-16", "watchos-9", "watchos-simulator-9"]:
                 should_build = platform in platforms or "*" in platforms
                 self.assertEqual(wkbuild.should_build(platform, files), should_build, "%s should%s have built but did%s (files: %s)" % (platform, "" if should_build else "n't", "n't" if should_build else "", str(files)))
 


### PR DESCRIPTION
#### 005b5a6fc5654fbc4cbb164d501289d503d069c0
<pre>
watchOS 9 Open Source Bringup
<a href="https://bugs.webkit.org/show_bug.cgi?id=246700">https://bugs.webkit.org/show_bug.cgi?id=246700</a>
rdar://99766626

Reviewed by Jonathan Bedard.

* Tools/CISupport/build-webkit-org/wkbuild.py:
(_should_file_trigger_build):
* Tools/CISupport/build-webkit-org/wkbuild_unittest.py:
(ShouldBuildTest):
(ShouldBuildTest.test_should_build):

Canonical link: <a href="https://commits.webkit.org/255699@main">https://commits.webkit.org/255699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed1e460cce8d51e50da734ea38021c0d11895a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24002 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2563 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/30861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99022 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79812 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/92386 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35070 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38944 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1845 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40879 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/37801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->