### PR TITLE
[iOS] "text/uri-list" can't be read upon paste if the pasteboard set NSData for "public.url"

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
@@ -94,6 +94,16 @@ WK_SYSTEM_LDFLAGS_IOS_SINCE_15 = -framework System;
 WK_UIKITMACHELPER_LDFLAGS = $(WK_UIKITMACHELPER_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_UIKITMACHELPER_LDFLAGS_maccatalyst = -framework UIKitMacHelper;
 
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS = $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_$(WK_PLATFORM_NAME));
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_iphoneos = $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS$(WK_IOS_14));
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_iphonesimulator = $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS$(WK_IOS_14));
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_maccatalyst = $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS$(WK_IOS_14));
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_IOS_SINCE_14 = -framework UniformTypeIdentifiers;
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_watchos = -framework UniformTypeIdentifiers;
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_watchsimulator = -framework UniformTypeIdentifiers;
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_appletvos = -framework UniformTypeIdentifiers;
+WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS_appletvsimulator = -framework UniformTypeIdentifiers;
+
 WK_WEBCORE_LDFLAGS = $(WK_WEBCORE_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_WEBCORE_LDFLAGS_iphoneos = -framework WebCore
 WK_WEBCORE_LDFLAGS_iphonesimulator = -framework WebCore
@@ -102,7 +112,7 @@ WK_WEBCORE_LDFLAGS_watchsimulator = -framework WebCore
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network $(WK_HID_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
 OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
 
 // FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/dump-datatransfer-types.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/dump-datatransfer-types.html
@@ -95,6 +95,10 @@ function updateResultWithEvent(event) {
     event.preventDefault();
 }
 
+function clearOutput() {
+    output.value = "";
+}
+
 function setCustomData(event) {
     if (!writeCustomData)
         return true;


### PR DESCRIPTION
#### a035a72e61b9e468def2ac54f8ed8ff9be06bbb8
<pre>
[iOS] &quot;text/uri-list&quot; can&apos;t be read upon paste if the pasteboard set NSData for &quot;public.url&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=246699">https://bugs.webkit.org/show_bug.cgi?id=246699</a>
rdar://96854364

Reviewed by Tim Horton.

Currently, when copying from apps that write serialized URLs as `NSData` for the &quot;public.url&quot; type
and pasting into WebKit views, &quot;text/uri-list&quot; doesn&apos;t appear in `DataTransfer.types` upon paste,
and requesting &quot;text/uri-list&quot; using `getData()` just returns the empty string.

This is because `PlatformPasteboard::readURL()` uses `-valuesForPasteboardType:inItemSet:` to
collect URLs and expects the resulting value to be an `NSURL`; however, in this case, it ends up
being an `NSData`.

Since inserting data-backed URLs from the pasteboard works in native text views on iOS, we should
ensure that it also works for web views by falling back to `NSData`, if the value on the pasteboard
is not already an `NSURL`.

* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::PlatformPasteboard::readURL const):

Also modernize this code a bit by using `dynamic_objc_cast&lt;&gt;` when converting the read value.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:

Link against UniformTypeIdentifiers.framework so that we can use UTTypeURL on iOS.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/dump-datatransfer-types.html:
* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:

Additionally add an API test to exercise the change.

(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/255704@main">https://commits.webkit.org/255704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b75e187e0c3345a288421fda75a24388e226038

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103025 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2553 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30851 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99130 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99012 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79802 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28744 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71807 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37234 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18573 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41102 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37793 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->