### PR TITLE
Fix broken Windows build after r255677

### DIFF
--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -719,27 +719,28 @@ RefPtr<StyleRuleFontFeatureValues> CSSParserImpl::consumeFontFeatureValuesRule(C
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
 
     // Convert block rules to value (remove duplicates...etc)
-    FontFeatureValuesValue fontFeaturesValuesvalue;
-    auto currentTagsForType = [&fontFeaturesValuesvalue](FontFeatureValuesType type) -> Tags& {
+    FontFeatureValuesValue fontFeatureValuesValue;
+    auto upsertTag = [&fontFeatureValuesValue](FontFeatureValuesType type, Tag tag) {
         switch (type) {
         case FontFeatureValuesType::Styleset:
-            return fontFeaturesValuesvalue.styleset;
+            fontFeatureValuesValue.styleset.set(tag.first, tag.second);
+            break;
         case FontFeatureValuesType::Stylistic:
-            return fontFeaturesValuesvalue.stylistic;
+            fontFeatureValuesValue.stylistic.set(tag.first, tag.second);
+            break;
         case FontFeatureValuesType::CharacterVariant:
-            return fontFeaturesValuesvalue.characterVariant;
+            fontFeatureValuesValue.characterVariant.set(tag.first, tag.second);
+            break;
         case FontFeatureValuesType::Swash:
-            return fontFeaturesValuesvalue.swash;
+            fontFeatureValuesValue.swash.set(tag.first, tag.second);
+            break;
         case FontFeatureValuesType::Ornaments:
-            return fontFeaturesValuesvalue.ornaments;
+            fontFeatureValuesValue.ornaments.set(tag.first, tag.second);
+            break;
         case FontFeatureValuesType::Annotation:
-            return fontFeaturesValuesvalue.annotation;
+            fontFeatureValuesValue.annotation.set(tag.first, tag.second);
+            break;
         }
-    };
-
-    auto upsertTag = [&currentTagsForType](FontFeatureValuesType type, Tag tag) {
-        auto& tags = currentTagsForType(type);
-        tags.set(tag.first, tag.second);
     };
     
     for (auto block : rules) {
@@ -752,7 +753,7 @@ RefPtr<StyleRuleFontFeatureValues> CSSParserImpl::consumeFontFeatureValuesRule(C
             upsertTag(fontFeatureValuesBlockRule.fontFeatureValuesType(), tag);
     }
 
-    return StyleRuleFontFeatureValues::create(fontFamilies, fontFeaturesValuesvalue);
+    return StyleRuleFontFeatureValues::create(fontFamilies, fontFeatureValuesValue);
 }
 
 RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(CSSParserTokenRange prelude, CSSParserTokenRange block)


### PR DESCRIPTION
#### 5a42f279267dfbb9f081967e130f3b74bf92aeea
<pre>
Fix broken Windows build after r255677
<a href="https://bugs.webkit.org/show_bug.cgi?id=246715">https://bugs.webkit.org/show_bug.cgi?id=246715</a>
rdar://problem/101311092

Reviewed by Aakash Jain.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):

Canonical link: <a href="https://commits.webkit.org/255707@main">https://commits.webkit.org/255707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e873a669c9897b72c8f80d19f329e620f9091337

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103052 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2582 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30878 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85746 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79829 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28757 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83726 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37261 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18594 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38963 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1851 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37814 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->