### PR TITLE
Add missing implementation for CSSMathClamp::toSumValue()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/numeric-objects/to.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/numeric-objects/to.tentative-expected.txt
@@ -11,7 +11,7 @@ PASS Converting a CSSMathMin to a single unit finds the min value
 PASS Converting a CSSMathMin to a single unit with different units throws a TypeError
 PASS Converting a CSSMathMax to a single unit finds the max value
 PASS Converting a CSSMathMax to a single unit with different units throws a TypeError
-FAIL Converting a CSSMathClamp to a single unit returns the clamped value Type error
+PASS Converting a CSSMathClamp to a single unit returns the clamped value
 PASS Converting a CSSMathClamp to a single unit with different units throws a TypeError
 PASS Converting a CSSMathNegate to a single unit negates its value
 PASS Converting a CSSMathInvert to a single unit inverts its value and units

--- a/Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp
@@ -76,8 +76,22 @@ void CSSMathClamp::serialize(StringBuilder& builder, OptionSet<SerializationArgu
 
 auto CSSMathClamp::toSumValue() const -> std::optional<SumValue>
 {
-    // FIXME: Implement.
-    return std::nullopt;
+    auto validateSumValue = [](const std::optional<SumValue>& sumValue, const UnitMap* expectedUnits) {
+        return sumValue && sumValue->size() == 1 && (!expectedUnits || *expectedUnits == sumValue->first().units);
+    };
+
+    auto lower = m_lower->toSumValue();
+    if (!validateSumValue(lower, nullptr))
+        return std::nullopt;
+    auto value = m_value->toSumValue();
+    if (!validateSumValue(value, &lower->first().units))
+        return std::nullopt;
+    auto upper = m_upper->toSumValue();
+    if (!validateSumValue(upper, &lower->first().units))
+        return std::nullopt;
+
+    value->first().value = std::max(lower->first().value, std::min(value->first().value, upper->first().value));
+    return value;
 }
 
 bool CSSMathClamp::equals(const CSSNumericValue& other) const


### PR DESCRIPTION
#### f8ada9305175b96be669f6ca4d7e5b3d9e174b3e
<pre>
Add missing implementation for CSSMathClamp::toSumValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246703">https://bugs.webkit.org/show_bug.cgi?id=246703</a>

Reviewed by Geoffrey Garen.

Add missing implementation for CSSMathClamp::toSumValue(). Sadly I couldn&apos;t
find the corresponding specification text for this so I filed:
- <a href="https://github.com/w3c/css-houdini-drafts/issues/1078">https://github.com/w3c/css-houdini-drafts/issues/1078</a>

The specification is at [1] but currently fails to mention CSSMathClamp.
However, I implemented the same behavior as Blink for interoperability.

[1] <a href="https://drafts.css-houdini.org/css-typed-om/#create-a-sum-value">https://drafts.css-houdini.org/css-typed-om/#create-a-sum-value</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/numeric-objects/to.tentative-expected.txt:
* Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp:
(WebCore::CSSMathClamp::toSumValue const):

Canonical link: <a href="https://commits.webkit.org/255746@main">https://commits.webkit.org/255746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b391084a5f595adb5e9539431c4debd528bc28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/23993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103026 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163354 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2554 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30852 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99131 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1784 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79803 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28738 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71800 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37235 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17325 "Found 1 new test failure: webanimations/accelerated-web-animation-with-single-interval-and-easing-y-axis-above-1.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3977 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41101 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37792 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->