### PR TITLE
[JSC][armv7] Use register numbers, not names, in disassembly

### DIFF
--- a/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
@@ -47,6 +47,8 @@ bool tryToDisassemble(const CodePtr<DisassemblyPtrTag>& codePtr, size_t size, vo
 #elif CPU(ARM_THUMB2)
     if (cs_open(CS_ARCH_ARM, CS_MODE_THUMB, &handle) != CS_ERR_OK)
         return false;
+    if (cs_option(handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_NOREGNAME) != CS_ERR_OK)
+        return false;
 #elif CPU(ARM64)
     if (cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &handle) != CS_ERR_OK)
         return false;


### PR DESCRIPTION
#### 51613ad86d5893667dd02bcdc0430f542f766fb9
<pre>
[JSC][armv7] Use register numbers, not names, in disassembly
<a href="https://bugs.webkit.org/show_bug.cgi?id=246708">https://bugs.webkit.org/show_bug.cgi?id=246708</a>

Reviewed by Yusuke Suzuki.

As title. Capstone by default will use the conventional names for some registers
under the usual ARM abi: e.g. r12 is the &quot;InterProcedural link&quot; register, `ip`,
and r11 is `fp` for ARM code...

Neither of these makes any sense inside of the JIT, which uses r12 as a GPR and
r7 as the frame pointer (like other thumb code does.) To alleviate confusion, I
suggest we ask capstone to just use register numbers for these. Note that `pc`
and `sp` are always named in the ISA, they don&apos;t have numbers at all, so they&apos;ll
still disassemble as `pc` and `sp`.

* Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp:
(JSC::tryToDisassemble):

Canonical link: <a href="https://commits.webkit.org/256113@main">https://commits.webkit.org/256113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e3a87598eef9b45b3d5f73852e5367e876bd81

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103033 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163360 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2561 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30859 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99139 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1794 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79810 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28745 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71808 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84670 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37242 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17332 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79739 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35068 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18579 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27546 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4216 "Failed to push to pull request branch") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41108 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82373 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37799 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18607 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->