### PR TITLE
Update fuzzy annotations for tests running on macOS with accelerated drawing enabled

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-027.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-027.html
@@ -11,7 +11,7 @@
 
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' is '52px auto' and 'background-repeat' is 'repeat round', then the width of the corresponding background image is 52px and then repeated while the height is first rescaled from 100px to 52px to keep the original image aspect ratio and then to 60px due to 'round'.">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-193">
+    <meta name="fuzzy" content="maxDifference=0-96; totalPixels=0-4923">
     <style>
         div {
             background-color: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-028.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-028.html
@@ -10,6 +10,7 @@
 
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' is '50px' and 'background-repeat' is 'repeat', then the background image is shown with a width of 50px and its height is resolved by using the image's intrinsic ratio (in this test, the image's intrinsic ratio is 1:1) and (multiplied by) the size of the other dimension, and then it is repeated in both directions.">
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-5056">
     <style>
         div {
             background-color: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-029.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-029.html
@@ -11,6 +11,7 @@
 
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' is '52px auto' and 'background-repeat' is 'round repeat', then the width is first rescaled to from 100px to 52px and then rescaled to 60px due to 'round' and the height of the corresponding background image is rescaled from 100px to 60px (to keep the original image aspect ratio) and then repeated vertically.">
+    <meta name="fuzzy" content="maxDifference=0-91; totalPixels=0-5283">
     <style>
         div {
             background-color: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-030.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-030.html
@@ -10,6 +10,7 @@
     <meta name="flags" content="image">
 
     <meta name="assert" content="Check if 'background-size' is '25% 25%' and 'background-repeat' is 'repeat', then the background image is shown with a width and height of 25% (in this test, 50px by 50px), and then it is repeated in both directions.">
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-5056">
     <style>
         div {
             background-color: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-031.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-031.html
@@ -11,6 +11,7 @@
 
     <meta name="flags" content="image">
     <meta name="assert" content="Check if 'background-size' is '20% 30%' and 'background-repeat' is 'no-repeat round', then the height of the corresponding background image is 50px so that it fits a whole number of times (3 in this test) in the background positioning area, and the width of the background image is rescaled to 20% (50px in this test) of the background area.">
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-948">
     <style>
         #ref-overlapped-red {
             background-color: red;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-004.xht
@@ -3,6 +3,7 @@
     <title>border-bottom-left-radius using one percentage</title>
     <link rel="match" href="border-bottom-left-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-1" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-right-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-right-radius-004.xht
@@ -3,6 +3,7 @@
     <title>border-bottom-right-radius using one percentage</title>
     <link rel="match" href="border-bottom-right-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-1" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-round-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-round-2.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css3-background/#background-repeat">
     <link rel="match" href="border-image-repeat-round-2-ref.html">
     <meta name="assert" content="The test checks whether border-image-repeat: 'round' uses the correct rounding formula.">
+    <meta name="fuzzy" content="maxDifference=0-55; totalPixels=0-376">
     <style type="text/css">
       .outer {
         position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-004.xht
@@ -3,6 +3,7 @@
     <title>border-top-left-radius using one percentage</title>
     <link rel="match" href="border-top-left-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-1" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-right-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-right-radius-004.xht
@@ -3,6 +3,7 @@
     <title>border-top-right-radius using one percentage</title>
     <link rel="match" href="border-top-right-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-1" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/css-box-shadow-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/css-box-shadow-001.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-box-shadow">
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-border-radius">
     <link rel="match" href="reference/css-box-shadow-ref-001.html">
-    <meta name="fuzzy" content="maxDifference=0-56; totalPixels=0-138">
+    <meta name="fuzzy" content="maxDifference=0-56; totalPixels=0-237">
     <style type="text/css">
 		.greenSquare-shadow{
             position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-015.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-015.html
@@ -12,7 +12,7 @@
   -->
 
   <meta content="This test checks that the paint of the descendant (a red square image) and its geometry is clipped to the padding edge of the element's principal box, taking corner clipping into account." name="assert">
-  <meta name="fuzzy" content="maxDifference=0-99;totalPixels=0-374">
+  <meta name="fuzzy" content="maxDifference=0-99; totalPixels=0-388"/>
 
   <!--
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-016.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-016.html
@@ -12,7 +12,7 @@
   -->
 
   <meta content="This test checks that the paint of the descendant (a red square image) and its geometry is clipped to the padding edge of the element's principal box, taking corner clipping into account." name="assert">
-  <meta name="fuzzy" content="maxDifference=0-99;totalPixels=0-374">
+  <meta name="fuzzy" content="maxDifference=0-99;totalPixels=0-388">
 
   <!--
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/justify-content-001.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/justify-content-001.htm
@@ -7,7 +7,7 @@
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line." />
-        <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5810" />
+        <meta name="fuzzy" content="maxDifference=1; totalPixels=0-5841" />
         <style type="text/css">
             #flexbox
             {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/justify-content-005.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/justify-content-005.htm
@@ -7,7 +7,7 @@
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line, with half-size spaces on either end." />
-        <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5802" />
+        <meta name="fuzzy" content="maxDifference=1; totalPixels=0-5832" />
         <style type="text/css">
             #flexbox
             {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/tiled-radial-gradients.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/tiled-radial-gradients.html
@@ -6,7 +6,7 @@
         <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">
         <meta name="assert" content="Gradients are correctly repeated.">
         <link rel="match" href="tiled-radial-gradients-ref.html">
-        <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-4060">
+        <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-8009">
         <style>
             body {
                 margin: 0px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-c.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#propdef-mask-mode">
     <link rel="match" href="mask-mode-ref.html">
     <meta name="assert" content="Test checks that mask a PNG image referenced by mask-image is correct with different mask mode.">
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-11800">
     <style type="text/css">
       div {
         background-color: blue;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/multicol-rule-dashed-000.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/multicol-rule-dashed-000.xht
@@ -9,6 +9,7 @@
   <meta name="flags" content="ahem" />
   <meta name="assert" content="Tests that the dashed value of column-rule-style is correctly rendered when used in the shorthand column-rule property." />
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+  <meta name="fuzzy" content="maxDifference=0-85; totalPixels=0-20" />
   <style type="text/css"><![CDATA[
   div
   {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-rotate-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-rotate-001.html
@@ -5,7 +5,7 @@
 	    <link rel="author" title="Rick Hurst" href="http://mrkn.co/axegs">
 	    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
 	    <link rel="match" href="2d-rotate-ref.html">
-	    <meta name="fuzzy" content="maxDifference=87-159;totalPixels=643-1224">
+	    <meta name="fuzzy" content="maxDifference=87-159;totalPixels=643-1290">
 	    <meta name="flags" content="svg">
 	    <meta name="assert" content="asserting that you can rotate an element with CSS">
 	    <style type="text/css">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-skew-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-skew-002.html
@@ -6,7 +6,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <link rel="author" title="Adrien Pachkoff" href="mailto:adrien@pachkoff.com">
     <link rel="match" href="css-skew-002-ref.html">
-    <meta name="fuzzy" content="maxDifference=5-32;totalPixels=12-159">
+    <meta name="fuzzy" content="maxDifference=5-36;totalPixels=12-174">
     <style type="text/css">
         div {
             top:0px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html
@@ -6,6 +6,7 @@
 <link rel="author" title="Google" href="http://www.google.com/">
 <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#3d-transform-rendering">
 <meta name="assert" content="Elements are drawn in the correct z-order.">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=0-2889">
 <link rel="match" href="reference/green.html">
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/skew-test1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/skew-test1.html
@@ -8,7 +8,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#svg-transform">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <link rel="match" href="reference/skew-test1-ref.html">
-    <meta name="fuzzy" content="maxDifference=17-233;totalPixels=90-771">
+    <meta name="fuzzy" content="maxDifference=17-233;totalPixels=90-858">
     <meta name="flags" content="svg">
     <meta name="assert" content="The lime square in this test has a skew method applied : 30deg on x and 20deg on y. The red polygon should be totally hidden by the lime skewed square. Both start at 0,0">
   <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-rotate-degree-45.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-rotate-degree-45.html
@@ -6,7 +6,7 @@
     <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#transform-property">
     <link rel="help" href="https://drafts.csswg.org/css-transforms-1/#two-d-transform-functions">
     <link rel="match" href="reference/transforms-rotate-degree-45-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-16;totalPixels=0-564">
+    <meta name="fuzzy" content="maxDifference=0-19;totalPixels=0-564">
     <meta name="assert" content="If the rotate and scale with parameter not provided, greenSquare will not cover redSquare.">
     <style type="text/css">
         .greenSquare {

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html
@@ -3,7 +3,7 @@
 <link rel="match" href="masked-ref.html">
 <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
 <link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
-<meta name="fuzzy" content="maxDifference=0-36; totalPixels=0-65">
+<meta name="fuzzy" content="maxDifference=0-36; totalPixels=0-124">
 <svg style="display: block">
     <foreignObject x="0" y="0" width="32" height="32" mask="url(#circle)">
         <div style="width: 32px; height: 32px; background: green"></div>

--- a/LayoutTests/scrollingcoordinator/mac/rtl-programmatic-overflow-scroll.html
+++ b/LayoutTests/scrollingcoordinator/mac/rtl-programmatic-overflow-scroll.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-52835">
     <style>
         body {
             margin: 0;

--- a/LayoutTests/svg/animations/animated-string-href.svg
+++ b/LayoutTests/svg/animations/animated-string-href.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=3850-4000" />
+    <meta name="fuzzy" content="maxDifference=1; totalPixels=3800-4000" />
     <desc>Test that the 'href' attribute is animated correctly.</desc>
     <defs>
         <linearGradient id="red-fill">

--- a/LayoutTests/svg/clip-path/clip-path-line-use-before-defined.svg
+++ b/LayoutTests/svg/clip-path/clip-path-line-use-before-defined.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-531" />
+  <meta name="fuzzy" content="maxDifference=0-43; totalPixels=0-1188" />
   <defs>
     <style>
       line, path {

--- a/LayoutTests/svg/clip-path/clip-path-shape-rounded-inset-1.svg
+++ b/LayoutTests/svg/clip-path/clip-path-shape-rounded-inset-1.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-<meta name="fuzzy" content="maxDifference=0-46; totalPixels=0-105" />
+<meta name="fuzzy" content="maxDifference=0-46; totalPixels=0-256" />
 <rect width="200" height="200" fill="green" style="-webkit-clip-path: inset(10% round 10%)"/>
 </svg>

--- a/LayoutTests/svg/clip-path/clip-path-shape-rounded-inset-2.svg
+++ b/LayoutTests/svg/clip-path/clip-path-shape-rounded-inset-2.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-<meta name="fuzzy" content="maxDifference=0-46; totalPixels=0-105" />
+<meta name="fuzzy" content="maxDifference=0-46; totalPixels=0-256" />
 <rect width="200" height="200" fill="green" style="-webkit-clip-path: inset(20px round 20px)"/>
 </svg>

--- a/LayoutTests/svg/clip-path/svg-in-html.html
+++ b/LayoutTests/svg/clip-path/svg-in-html.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-88" />
+<meta name="fuzzy" content="maxDifference=1; totalPixels=0-164" />
 <style>
 body {
     border: 2em blue solid;

--- a/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=58; totalPixels=709" />
+<meta name="fuzzy" content="maxDifference=57-58; totalPixels=0-776" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/compositing/outermost-svg-with-border.html
+++ b/LayoutTests/svg/compositing/outermost-svg-with-border.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-<meta name="fuzzy" content="maxDifference=111; totalPixels=818" />
+<meta name="fuzzy" content="maxDifference=110-111; totalPixels=818" />
 <style>
     html, body {
         margin: 0;

--- a/LayoutTests/svg/custom/hidpi-masking-clipping.svg
+++ b/LayoutTests/svg/custom/hidpi-masking-clipping.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <meta name="fuzzy" content="maxDifference=0-39; totalPixels=0-825" />
+    <meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-7674" />
     <style>
         text {
             -webkit-font-smoothing: antialiased;

--- a/LayoutTests/svg/custom/local-url-reference-stroke.html
+++ b/LayoutTests/svg/custom/local-url-reference-stroke.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=7700-8000" />
+<meta name="fuzzy" content="maxDifference=1; totalPixels=7600-8000">
 <base href="http://www.example.com/">
 <svg>
     <linearGradient id="paint">

--- a/LayoutTests/svg/custom/pattern-content-inheritance-cycle.svg
+++ b/LayoutTests/svg/custom/pattern-content-inheritance-cycle.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-656"/>
     <defs>
         <!-- a => b => a -->
         <pattern id="a" x="0" y="0" width=".25" height=".25">

--- a/LayoutTests/svg/gradients/spreadMethodAlpha.svg
+++ b/LayoutTests/svg/gradients/spreadMethodAlpha.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=28400-29400" />
+    <meta name="fuzzy" content="maxDifference=1;totalPixels=28400-29700" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="0">
         <stop stop-color="rgba(0,0,255,0.5)" offset="0"/>
         <stop stop-color="rgba(0,0,255,0.5)" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodDiagonal.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDiagonal.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=24900-25600" />
+    <meta name="fuzzy" content="maxDifference=1;totalPixels=24900-25700" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="50%" y2="0">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/svg/gradients/spreadMethodDiagonal2.svg
+++ b/LayoutTests/svg/gradients/spreadMethodDiagonal2.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=24900-25600" />
+    <meta name="fuzzy" content="maxDifference=1;totalPixels=24900-25700" />
     <linearGradient id="base-grad" x1="0" y1="0" x2="0" y2="50%">
         <stop stop-color="green" offset="0"/>
         <stop stop-color="green" offset="0.5"/>

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-181783">
 <style>
 html {
     background: white;

--- a/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment.html
+++ b/LayoutTests/tiled-drawing/top-content-inset-fixed-attachment.html
@@ -1,4 +1,5 @@
 <html>
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-121349">
 <head>
 <style>
 


### PR DESCRIPTION
#### 757cc7c481205eb16fe4697f35820de6d4ec699c
<pre>
Update fuzzy annotations for tests running on macOS with accelerated drawing enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=246674">https://bugs.webkit.org/show_bug.cgi?id=246674</a>
&lt;rdar://problem/101275358&gt;

Unreviewed test gardening.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-027.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-028.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-029.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-030.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-size-031.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-right-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-round-2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-right-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/css-box-shadow-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-015.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/contain-paint-clip-016.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/justify-content-001.htm:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/justify-content-005.htm:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/tiled-radial-gradients.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/mask-image/mask-mode-c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-multicol/multicol-rule-dashed-000.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/2d-rotate-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-skew-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/skew-test1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-rotate-degree-45.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html:
* LayoutTests/scrollingcoordinator/mac/rtl-programmatic-overflow-scroll.html:
* LayoutTests/svg/animations/animated-string-href.svg:
* LayoutTests/svg/clip-path/clip-path-line-use-before-defined.svg:
* LayoutTests/svg/clip-path/clip-path-shape-rounded-inset-1.svg:
* LayoutTests/svg/clip-path/clip-path-shape-rounded-inset-2.svg:
* LayoutTests/svg/clip-path/svg-in-html.html:
* LayoutTests/svg/compositing/outermost-svg-with-border-overflow-visible.html:
* LayoutTests/svg/compositing/outermost-svg-with-border.html:
* LayoutTests/svg/custom/hidpi-masking-clipping.svg:
* LayoutTests/svg/custom/local-url-reference-stroke.html:
* LayoutTests/svg/custom/pattern-content-inheritance-cycle.svg:
* LayoutTests/svg/gradients/spreadMethodAlpha.svg:
* LayoutTests/svg/gradients/spreadMethodDiagonal.svg:
* LayoutTests/svg/gradients/spreadMethodDiagonal2.svg:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment-local.html:
* LayoutTests/tiled-drawing/top-content-inset-fixed-attachment.html:

Canonical link: <a href="https://commits.webkit.org/255753@main">https://commits.webkit.org/255753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b857f944795c0cdbeecc3fb6c7e11bfa7c9b9b28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103034 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163361 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2562 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30860 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99140 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1795 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79811 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28742 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71805 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37243 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17333 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35069 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18580 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41110 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1864 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37800 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->