### PR TITLE
[JSC] Optimize runtime iterations for arguments and string

### DIFF
--- a/JSTests/microbenchmarks/cloned-arguments-varargs.js
+++ b/JSTests/microbenchmarks/cloned-arguments-varargs.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(a, b, c, d, e) {
+    return a + b + c + d + e;
+}
+
+function ok()
+{
+    "use strict";
+    globalThis.escape = arguments;
+    return test.apply(undefined, arguments);
+}
+noInline(ok);
+
+for (var i = 0; i < 1e4; ++i)
+    shouldBe(ok(1, 2, 3, 4, 5), 15);

--- a/JSTests/microbenchmarks/spread-string.js
+++ b/JSTests/microbenchmarks/spread-string.js
@@ -1,0 +1,14 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(string) {
+    return [...string]
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(JSON.stringify(test('Hello')), `["H","e","l","l","o"]`);
+    shouldBe(JSON.stringify(test('𠮷野家')), `["𠮷","野","家"]`);
+}

--- a/JSTests/stress/array-storage-fast-slice-hole.js
+++ b/JSTests/stress/array-storage-fast-slice-hole.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array1 = [0, 1, 2, 3,,, 4, 5];
+$vm.ensureArrayStorage(array1);
+
+function test(array) {
+    var sliced = array.slice();
+    shouldBe(JSON.stringify(sliced), `[0,1,2,3,null,null,4,5]`);
+    shouldBe(4 in array, false);
+    shouldBe(4 in sliced, false);
+}
+
+for (var i = 0; i < 1e4; ++i)
+    test(array1);

--- a/JSTests/stress/array-storage-slice.js
+++ b/JSTests/stress/array-storage-slice.js
@@ -1,0 +1,21 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var array1 = [0, 1, 2, 3, 4, 5];
+$vm.ensureArrayStorage(array1);
+
+var array2 = [0, 1, 2, 3, 4, 5];
+array2.length = 42;
+$vm.ensureArrayStorage(array2);
+
+function test(array) {
+    return array.slice();
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(JSON.stringify(test(array1)), `[0,1,2,3,4,5]`);
+    shouldBe(JSON.stringify(test(array2)), `[0,1,2,3,4,5,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]`);
+}

--- a/JSTests/stress/cloned-arguments-varargs.js
+++ b/JSTests/stress/cloned-arguments-varargs.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(a, b, c, d, e) {
+    return a + b + c + d + e;
+}
+
+function ok()
+{
+    "use strict";
+    globalThis.escape = arguments;
+    return test.apply(undefined, arguments);
+}
+noInline(ok);
+
+for (var i = 0; i < 1e4; ++i)
+    shouldBe(ok(1, 2, 3, 4, 5), 15);

--- a/JSTests/stress/spread-arguments-slow.js
+++ b/JSTests/stress/spread-arguments-slow.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// DirectArguments
+function test1(a, b, c) {
+    arguments.length = 1;
+    return [...arguments]
+}
+noInline(test1);
+
+// ScopedArguments
+function test2(a, b, c) {
+    function hello() { return b + c; }
+    globalThis.hello = hello;
+    arguments.length = 1;
+    return [...arguments];
+}
+noInline(test2);
+
+// ClonedArguments
+function test3(a, b, c) {
+    "use strict";
+    arguments.length = 1;
+    return [...arguments]
+}
+noInline(test3);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(JSON.stringify(test1('a', 1, 2)), `["a"]`);
+    shouldBe(JSON.stringify(test2('a', 1, 2)), `["a"]`);
+    shouldBe(JSON.stringify(test3('a', 1, 2)), `["a"]`);
+}

--- a/JSTests/stress/spread-arguments.js
+++ b/JSTests/stress/spread-arguments.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// DirectArguments
+function test1(a, b, c) {
+    return [...arguments]
+}
+noInline(test1);
+
+// ScopedArguments
+function test2(a, b, c) {
+    function hello() { return b + c; }
+    globalThis.hello = hello;
+    return [...arguments];
+}
+noInline(test2);
+
+// ClonedArguments
+function test3(a, b, c) {
+    "use strict";
+    return [...arguments]
+}
+noInline(test3);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(JSON.stringify(test1('a', 1, 2)), `["a",1,2]`);
+    shouldBe(JSON.stringify(test2('a', 1, 2)), `["a",1,2]`);
+    shouldBe(JSON.stringify(test3('a', 1, 2)), `["a",1,2]`);
+}

--- a/JSTests/stress/spread-string.js
+++ b/JSTests/stress/spread-string.js
@@ -1,0 +1,14 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(string) {
+    return [...string]
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(JSON.stringify(test('Hello')), `["H","e","l","l","o"]`);
+    shouldBe(JSON.stringify(test('𠮷野家')), `["𠮷","野","家"]`);
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -933,6 +933,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
 
     runtime/AbstractModuleRecord.h
     runtime/ArgList.h
+    runtime/ArgumentsMode.h
     runtime/ArityCheckMode.h
     runtime/ArrayConstructor.h
     runtime/ArrayBuffer.h
@@ -968,6 +969,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/CatchScope.h
     runtime/CellSize.h
     runtime/ClassInfo.h
+    runtime/ClonedArguments.h
     runtime/CodeSpecializationKind.h
     runtime/CommonIdentifiers.h
     runtime/CompilationResult.h
@@ -992,6 +994,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/DeferredWorkTimer.h
     runtime/DefinePropertyAttributes.h
     runtime/DeletePropertySlot.h
+    runtime/DirectArguments.h
     runtime/DirectArgumentsOffset.h
     runtime/DirectEvalExecutable.h
     runtime/DisallowScope.h
@@ -1023,6 +1026,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/FunctionRareData.h
     runtime/FuzzerAgent.h
     runtime/Gate.h
+    runtime/GenericArguments.h
     runtime/GenericOffset.h
     runtime/GenericTypedArrayView.h
     runtime/GenericTypedArrayViewInlines.h
@@ -1088,11 +1092,12 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSImmutableButterfly.h
     runtime/JSInternalFieldObjectImpl.h
     runtime/JSInternalPromise.h
-    runtime/JSMicrotask.h
+    runtime/JSLexicalEnvironment.h
     runtime/JSLock.h
     runtime/JSMap.h
     runtime/JSMapInlines.h
     runtime/JSMapIterator.h
+    runtime/JSMicrotask.h
     runtime/JSModuleLoader.h
     runtime/JSModuleRecord.h
     runtime/JSNativeStdFunction.h
@@ -1174,6 +1179,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/RuntimeType.h
     runtime/SamplingProfiler.h
     runtime/ScopeOffset.h
+    runtime/ScopedArguments.h
     runtime/ScopedArgumentsTable.h
     runtime/Scribble.h
     runtime/ScriptExecutable.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1707,7 +1707,7 @@
 		BC18C4130E16F5CD00B34460 /* JavaScript.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAA8B4A0D32C39A0041BCFF /* JavaScript.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC18C4140E16F5CD00B34460 /* JavaScriptCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAA8B4B0D32C39A0041BCFF /* JavaScriptCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC18C4150E16F5CD00B34460 /* JavaScriptCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = F5C290E60284F98E018635CA /* JavaScriptCorePrefix.h */; };
-		BC18C4160E16F5CD00B34460 /* JSLexicalEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA818E0D99FD2000B0A4FB /* JSLexicalEnvironment.h */; settings = {ATTRIBUTES = (); }; };
+		BC18C4160E16F5CD00B34460 /* JSLexicalEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA818E0D99FD2000B0A4FB /* JSLexicalEnvironment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC18C4170E16F5CD00B34460 /* JSArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 938772E5038BFE19008635CE /* JSArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC18C4180E16F5CD00B34460 /* JSBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 142711380A460BBB0080EEEA /* JSBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BC18C4190E16F5CD00B34460 /* JSCallbackConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1440F8AC0A508D200005F061 /* JSCallbackConstructor.h */; };

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -32,7 +32,7 @@
 #include "ClonedArguments.h"
 #include "CodeBlock.h"
 #include "CodeBlockInlines.h"
-#include "CommonSlowPaths.h"
+#include "CommonSlowPathsInlines.h"
 #include "DFGDriver.h"
 #include "DFGJITCode.h"
 #include "DFGToFTLDeferredCompilationCallback.h"
@@ -3469,11 +3469,10 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject* globa
 
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    if (isJSArray(iterable)) {
-        JSArray* array = jsCast<JSArray*>(iterable);
-        if (array->isIteratorProtocolFastAndNonObservable())
-            RELEASE_AND_RETURN(throwScope, JSImmutableButterfly::createFromArray(globalObject, vm, array));
-    }
+    auto* result = CommonSlowPaths::trySpreadFast(globalObject, iterable);
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
+    if (result)
+        return result;
 
     // FIXME: we can probably make this path faster by having our caller JS code call directly into
     // the iteration protocol builtin: https://bugs.webkit.org/show_bug.cgi?id=164520

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -206,6 +206,9 @@ unsigned sizeOfVarargs(JSGlobalObject* globalObject, JSValue arguments, uint32_t
     case ScopedArgumentsType:
         length = jsCast<ScopedArguments*>(cell)->length(globalObject);
         break;
+    case ClonedArgumentsType:
+        length = jsCast<ClonedArguments*>(cell)->length(globalObject);
+        break;
     case JSImmutableButterflyType:
         length = jsCast<JSImmutableButterfly*>(cell)->length();
         break;
@@ -279,10 +282,14 @@ void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValu
         scope.release();
         jsCast<ScopedArguments*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
         return;
+    case ClonedArgumentsType:
+        scope.release();
+        jsCast<ClonedArguments*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
+        return;
     case JSImmutableButterflyType:
         scope.release();
         jsCast<JSImmutableButterfly*>(cell)->copyToArguments(globalObject, firstElementDest, offset, length);
-        return; 
+        return;
     default: {
         ASSERT(arguments.isObject());
         JSObject* object = jsCast<JSObject*>(cell);
@@ -300,7 +307,8 @@ void loadVarargs(JSGlobalObject* globalObject, JSValue* firstElementDest, JSValu
             firstElementDest[i] = value;
         }
         return;
-    } }
+    }
+    }
 }
 
 void setupVarargsFrame(JSGlobalObject* globalObject, CallFrame* callFrame, CallFrame* newCallFrame, JSValue arguments, uint32_t offset, uint32_t length)

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -645,7 +645,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToLocaleString, (JSGlobalObject* globalOb
         return JSValue::encode(earlyReturnValue);
 
     // 2. Let len be ? ToLength(? Get(array, "length")).
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObject));
+    uint64_t length = toLength(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
 
     // 3. Let separator be the String value for the list-separator String appropriate for
@@ -766,7 +766,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
         return JSValue::encode(earlyReturnValue);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    double length = toLength(globalObject, thisObject);
+    uint64_t length = toLength(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     // 3. If separator is undefined, let separator be the single-element String ",".
@@ -775,12 +775,10 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
         const LChar comma = ',';
 
         if (UNLIKELY(length > std::numeric_limits<unsigned>::max() || !canUseFastJoin(thisObject))) {
-            uint64_t length64 = static_cast<uint64_t>(length);
-            ASSERT(static_cast<double>(length64) == length);
             JSString* jsSeparator = jsSingleCharacterString(vm, comma);
             RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-            RELEASE_AND_RETURN(scope, JSValue::encode(slowJoin(globalObject, thisObject, jsSeparator, length64)));
+            RELEASE_AND_RETURN(scope, JSValue::encode(slowJoin(globalObject, thisObject, jsSeparator, length)));
         }
 
         unsigned unsignedLength = static_cast<unsigned>(length);
@@ -793,12 +791,8 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
     JSString* jsSeparator = separatorValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    if (UNLIKELY(length > std::numeric_limits<unsigned>::max() || !canUseFastJoin(thisObject))) {
-        uint64_t length64 = static_cast<uint64_t>(length);
-        ASSERT(static_cast<double>(length64) == length);
-
-        RELEASE_AND_RETURN(scope, JSValue::encode(slowJoin(globalObject, thisObject, jsSeparator, length64)));
-    }
+    if (UNLIKELY(length > std::numeric_limits<unsigned>::max() || !canUseFastJoin(thisObject)))
+        RELEASE_AND_RETURN(scope, JSValue::encode(slowJoin(globalObject, thisObject, jsSeparator, length)));
 
     auto viewWithString = jsSeparator->viewWithUnderlyingString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -849,7 +843,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncPop, (JSGlobalObject* globalObject, CallF
     EXCEPTION_ASSERT(!!scope.exception() == !thisObj);
     if (UNLIKELY(!thisObj))
         return encodedJSValue();
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObj));
+    uint64_t length = toLength(globalObject, thisObj);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     if (length == 0) {
@@ -891,7 +885,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncPush, (JSGlobalObject* globalObject, Call
     EXCEPTION_ASSERT(!!scope.exception() == !thisObj);
     if (UNLIKELY(!thisObj))
         return encodedJSValue();
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObj));
+    uint64_t length = toLength(globalObject, thisObj);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     unsigned argCount = callFrame->argumentCount();
 
@@ -919,7 +913,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncReverse, (JSGlobalObject* globalObject, C
     if (UNLIKELY(!thisObject))
         return encodedJSValue();
 
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObject));
+    uint64_t length = toLength(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     thisObject->ensureWritable(vm);
@@ -1020,7 +1014,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncShift, (JSGlobalObject* globalObject, Cal
     EXCEPTION_ASSERT(!!scope.exception() == !thisObj);
     if (UNLIKELY(!thisObj))
         return encodedJSValue();
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObj));
+    uint64_t length = toLength(globalObject, thisObj);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     if (length == 0) {
@@ -1109,7 +1103,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncSplice, (JSGlobalObject* globalObject, Ca
     EXCEPTION_ASSERT(!!scope.exception() == !thisObj);
     if (UNLIKELY(!thisObj))
         return encodedJSValue();
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObj));
+    uint64_t length = toLength(globalObject, thisObj);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     if (!callFrame->argumentCount()) {
@@ -1213,7 +1207,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncUnShift, (JSGlobalObject* globalObject, C
     EXCEPTION_ASSERT(!!scope.exception() == !thisObj);
     if (UNLIKELY(!thisObj))
         return encodedJSValue();
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObj));
+    uint64_t length = toLength(globalObject, thisObj);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     unsigned nrArgs = callFrame->argumentCount();
@@ -1348,7 +1342,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncIndexOf, (JSGlobalObject* globalObject, C
     EXCEPTION_ASSERT(!!scope.exception() == !thisObject);
     if (UNLIKELY(!thisObject))
         return { };
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObject));
+    uint64_t length = toLength(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
     if (!length)
         return JSValue::encode(jsNumber(-1));
@@ -1388,7 +1382,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncLastIndexOf, (JSGlobalObject* globalObjec
     EXCEPTION_ASSERT(!!scope.exception() == !thisObject);
     if (UNLIKELY(!thisObject))
         return { };
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, thisObject));
+    uint64_t length = toLength(globalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, { });
     if (!length)
         return JSValue::encode(jsNumber(-1));

--- a/Source/JavaScriptCore/runtime/ClonedArguments.h
+++ b/Source/JavaScriptCore/runtime/ClonedArguments.h
@@ -37,6 +37,9 @@ namespace JSC {
 // properties of the object are populated. The only reason why we need a special class is to make
 // the object claim to be "Arguments" from a toString standpoint, and to avoid materializing the
 // caller/callee/@@iterator properties unless someone asks for them.
+
+static constexpr PropertyOffset clonedArgumentsLengthPropertyOffset = firstOutOfLineOffset;
+
 class ClonedArguments final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
@@ -48,6 +51,27 @@ public:
         static_assert(!CellType::needsDestruction);
         return &vm.clonedArgumentsSpace();
     }
+
+    uint64_t length(JSGlobalObject* globalObject) const
+    {
+        VM& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        JSValue lengthValue;
+        if (LIKELY(!structure()->didTransition())) {
+            lengthValue = getDirect(clonedArgumentsLengthPropertyOffset);
+            if (LIKELY(lengthValue.isInt32()))
+                return std::max(lengthValue.asInt32(), 0);
+        } else {
+            lengthValue = get(globalObject, vm.propertyNames->length);
+            RETURN_IF_EXCEPTION(scope, 0);
+        }
+        RELEASE_AND_RETURN(scope, lengthValue.toLength(globalObject));
+    }
+
+    void copyToArguments(JSGlobalObject*, JSValue* firstElementDest, unsigned offset, unsigned length);
+
+    JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
     
 private:
     ClonedArguments(VM&, Structure*, Butterfly*);
@@ -81,7 +105,5 @@ private:
     
     WriteBarrier<JSFunction> m_callee; // Set to nullptr when we materialize all of our special properties.
 };
-
-static constexpr PropertyOffset clonedArgumentsLengthPropertyOffset = firstOutOfLineOffset;
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/DirectArguments.cpp
+++ b/Source/JavaScriptCore/runtime/DirectArguments.cpp
@@ -174,5 +174,21 @@ unsigned DirectArguments::mappedArgumentsSize()
     return WTF::roundUpToMultipleOf<8>(m_length ? m_length : 1);
 }
 
+bool DirectArguments::isIteratorProtocolFastAndNonObservable()
+{
+    Structure* structure = this->structure();
+    JSGlobalObject* globalObject = structure->globalObject();
+    if (!globalObject->isArgumentsPrototypeIteratorProtocolFastAndNonObservable())
+        return false;
+
+    if (UNLIKELY(m_mappedArguments))
+        return false;
+
+    if (structure->didTransition())
+        return false;
+
+    return true;
+}
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/DirectArguments.h
+++ b/Source/JavaScriptCore/runtime/DirectArguments.h
@@ -74,11 +74,11 @@ public:
     
     uint32_t length(JSGlobalObject* globalObject) const
     {
+        VM& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
         if (UNLIKELY(m_mappedArguments)) {
-            VM& vm = getVM(globalObject);
-            auto scope = DECLARE_THROW_SCOPE(vm);
             JSValue value = get(globalObject, vm.propertyNames->length);
-            RETURN_IF_EXCEPTION(scope, 0);
+            RETURN_IF_EXCEPTION(scope, { });
             RELEASE_AND_RETURN(scope, value.toUInt32(globalObject));
         }
         return m_length;
@@ -145,6 +145,8 @@ public:
     }
 
     void copyToArguments(JSGlobalObject*, JSValue* firstElementDest, unsigned offset, unsigned length);
+
+    JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
 
     DECLARE_INFO;
     

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -736,7 +736,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
     JSValue lengthProperty = localesObject->get(globalObject, vm.propertyNames->length);
     RETURN_IF_EXCEPTION(scope, Vector<String>());
 
-    uint64_t length = static_cast<uint64_t>(lengthProperty.toLength(globalObject));
+    uint64_t length = lengthProperty.toLength(globalObject);
     RETURN_IF_EXCEPTION(scope, Vector<String>());
 
     HashSet<String> seenSet;

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -44,16 +44,14 @@ double JSValue::toIntegerPreserveNaN(JSGlobalObject* globalObject) const
     return trunc(toNumber(globalObject));
 }
 
-double JSValue::toLength(JSGlobalObject* globalObject) const
+uint64_t JSValue::toLength(JSGlobalObject* globalObject) const
 {
     // ECMA 7.1.15
     // http://www.ecma-international.org/ecma-262/6.0/#sec-tolength
     double d = toIntegerOrInfinity(globalObject);
     if (d <= 0)
-        return 0.0;
-    if (std::isinf(d))
-        return maxSafeInteger();
-    return std::min(d, maxSafeInteger());
+        return 0;
+    return static_cast<uint64_t>(std::min(d, maxSafeInteger()));
 }
 
 double JSValue::toNumberSlowCase(JSGlobalObject* globalObject) const

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -306,7 +306,7 @@ public:
     uint32_t toUInt32(JSGlobalObject*) const;
     uint32_t toIndex(JSGlobalObject*, const char* errorName) const;
     size_t toTypedArrayIndex(JSGlobalObject*, const char* errorName) const;
-    double toLength(JSGlobalObject*) const;
+    uint64_t toLength(JSGlobalObject*) const;
 
     JS_EXPORT_PRIVATE JSValue toBigInt(JSGlobalObject*) const;
     int64_t toBigInt64(JSGlobalObject*) const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -712,7 +712,7 @@ public:
     bool isStringPrototypeIteratorProtocolFastAndNonObservable();
     bool isMapPrototypeSetFastAndNonObservable();
     bool isSetPrototypeAddFastAndNonObservable();
-
+    bool isArgumentsPrototypeIteratorProtocolFastAndNonObservable();
 
 #if ENABLE(DFG_JIT)
     using ReferencedGlobalPropertyWatchpointSets = HashMap<RefPtr<UniquedStringImpl>, Ref<WatchpointSet>, IdentifierRepHash>;
@@ -1219,6 +1219,7 @@ public:
     static bool objectPrototypeIsSaneConcurrently(Structure* objectPrototypeStructure);
     bool arrayPrototypeChainIsSaneConcurrently(Structure* arrayPrototypeStructure, Structure* objectPrototypeStructure);
     bool stringPrototypeChainIsSaneConcurrently(Structure* stringPrototypeStructure, Structure* objectPrototypeStructure);
+    bool objectPrototypeChainIsSane();
     bool arrayPrototypeChainIsSane();
     bool stringPrototypeChainIsSane();
 

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
@@ -27,6 +27,10 @@
 #include "JSImmutableButterfly.h"
 
 #include "ButterflyInlines.h"
+#include "ClonedArguments.h"
+#include "DirectArguments.h"
+#include "ScopedArguments.h"
+#include <wtf/IterationStatus.h>
 
 namespace JSC {
 
@@ -59,5 +63,176 @@ void JSImmutableButterfly::copyToArguments(JSGlobalObject*, JSValue* firstElemen
 }
 
 static_assert(JSImmutableButterfly::offsetOfData() == sizeof(JSImmutableButterfly), "m_header needs to be adjacent to Data");
+
+JSImmutableButterfly* JSImmutableButterfly::createFromClonedArguments(JSGlobalObject* globalObject, ClonedArguments* arguments)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = arguments->length(globalObject); // This must be side-effect free, and it is ensured by ClonedArguments::isIteratorProtocolFastAndNonObservable.
+    unsigned vectorLength = arguments->getVectorLength();
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].get(), length);
+    if (UNLIKELY(!result)) {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    if (!length)
+        return result;
+
+    IndexingType indexingType = arguments->indexingType() & IndexingShapeMask;
+    if (indexingType == ContiguousShape) {
+        // Since |length| is not tightly coupled with butterfly, it is possible that |length| is larger than vectorLength.
+        for (unsigned i = 0; i < std::min(length, vectorLength); i++) {
+            JSValue value = arguments->butterfly()->contiguous().at(arguments, i).get();
+            value = !!value ? value : jsUndefined();
+            result->setIndex(vm, i, value);
+        }
+        if (vectorLength < length) {
+            for (unsigned i = vectorLength; i < length; i++)
+                result->setIndex(vm, i, jsUndefined());
+        }
+        return result;
+    }
+
+    for (unsigned i = 0; i < length; i++) {
+        JSValue value = arguments->getDirectIndex(globalObject, i);
+        if (!value) {
+            // When we see a hole, we assume that it's safe to assume the get would have returned undefined.
+            // We may still call into this function when !globalObject->isArgumentsIteratorProtocolFastAndNonObservable(),
+            // however, if we do that, we ensure we're calling in with an array with all self properties between
+            // [0, length).
+            value = jsUndefined();
+        }
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        result->setIndex(vm, i, value);
+    }
+
+    return result;
+}
+
+template<typename Arguments>
+static ALWAYS_INLINE JSImmutableButterfly* createFromNonClonedArguments(JSGlobalObject* globalObject, Arguments* arguments)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = arguments->internalLength();
+
+    JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].get(), length);
+    if (UNLIKELY(!result)) {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    if (!length)
+        return result;
+
+    for (unsigned i = 0; i < length; ++i) {
+        JSValue value = arguments->getIndexQuickly(i);
+        if (!value) {
+            // When we see a hole, we assume that it's safe to assume the get would have returned undefined.
+            // We may still call into this function when !globalObject->isArgumentsIteratorProtocolFastAndNonObservable(),
+            // however, if we do that, we ensure we're calling in with an array with all self properties between
+            // [0, length).
+            value = jsUndefined();
+        }
+        result->setIndex(vm, i, value);
+    }
+
+    return result;
+}
+
+JSImmutableButterfly* JSImmutableButterfly::createFromDirectArguments(JSGlobalObject* globalObject, DirectArguments* arguments)
+{
+    return createFromNonClonedArguments(globalObject, arguments);
+}
+
+JSImmutableButterfly* JSImmutableButterfly::createFromScopedArguments(JSGlobalObject* globalObject, ScopedArguments* arguments)
+{
+    return createFromNonClonedArguments(globalObject, arguments);
+}
+
+JSImmutableButterfly* JSImmutableButterfly::createFromString(JSGlobalObject* globalObject, JSString* string)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto holder = string->viewWithUnderlyingString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    unsigned length = holder.view.length();
+    if (holder.view.is8Bit()) {
+        JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].get(), length);
+        if (UNLIKELY(!result)) {
+            throwOutOfMemoryError(globalObject, scope);
+            return nullptr;
+        }
+
+        const auto* characters = holder.view.characters8();
+        for (unsigned i = 0; i < length; ++i) {
+            auto* value = jsSingleCharacterString(vm, characters[i]);
+            result->setIndex(vm, i, value);
+        }
+        return result;
+    }
+
+    auto forEachCodePointViaStringIteratorProtocol = [](const UChar* characters, unsigned length, auto func) {
+        for (unsigned i = 0; i < length; ++i) {
+            UChar character = characters[i];
+            if (character < 0xD800 || character > 0xDBFF || (i + 1) == length) {
+                if (func(i, 1) == IterationStatus::Done)
+                    return;
+                continue;
+            }
+            UChar second = characters[i + 1];
+            if (second < 0xDC00 || second > 0xDFFF) {
+                if (func(i, 1) == IterationStatus::Done)
+                    return;
+                continue;
+            }
+
+            // Construct surrogate.
+            if (func(i, 2) == IterationStatus::Done)
+                return;
+            ++i;
+        }
+    };
+
+    const auto* characters = holder.view.characters16();
+    unsigned codePointLength = 0;
+    forEachCodePointViaStringIteratorProtocol(characters, length, [&](unsigned, unsigned) {
+        codePointLength += 1;
+        return IterationStatus::Continue;
+    });
+
+    JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].get(), codePointLength);
+    if (UNLIKELY(!result)) {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    unsigned resultIndex = 0;
+    forEachCodePointViaStringIteratorProtocol(characters, length, [&](unsigned index, unsigned size) {
+        JSString* value = nullptr;
+        if (size == 1)
+            value = jsSingleCharacterString(vm, characters[index]);
+        else {
+            ASSERT(size == 2);
+            UChar string[2] = {
+                characters[index],
+                characters[index + 1],
+            };
+            value = jsNontrivialString(vm, String(string, 2));
+        }
+
+        result->setIndex(vm, resultIndex++, value);
+        return IterationStatus::Continue;
+    });
+
+    return result;
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -34,6 +34,10 @@
 
 namespace JSC {
 
+class ClonedArguments;
+class DirectArguments;
+class ScopedArguments;
+
 class JSImmutableButterfly : public JSCell {
     using Base = JSCell;
 
@@ -127,6 +131,11 @@ public:
         }
         return result;
     }
+
+    static JSImmutableButterfly* createFromClonedArguments(JSGlobalObject*, ClonedArguments*);
+    static JSImmutableButterfly* createFromDirectArguments(JSGlobalObject*, DirectArguments*);
+    static JSImmutableButterfly* createFromScopedArguments(JSGlobalObject*, ScopedArguments*);
+    static JSImmutableButterfly* createFromString(JSGlobalObject*, JSString*);
 
     unsigned publicLength() const { return m_header.publicLength(); }
     unsigned vectorLength() const { return m_header.vectorLength(); }

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -507,7 +507,7 @@ bool Stringifier::Holder::appendNextProperty(Stringifier& stringifier, StringBui
     // First time through, initialize.
     if (!m_index) {
         if (m_isArray) {
-            uint64_t length = static_cast<uint64_t>(toLength(globalObject, m_object));
+            uint64_t length = toLength(globalObject, m_object);
             RETURN_IF_EXCEPTION(scope, false);
             if (UNLIKELY(length > std::numeric_limits<uint32_t>::max())) {
                 throwOutOfMemoryError(globalObject, scope);
@@ -1170,7 +1170,7 @@ NEVER_INLINE JSValue Walker::walk(JSValue unfiltered)
 
                 JSObject* array = asObject(inValue);
                 markedStack.appendWithCrashOnOverflow(array);
-                uint64_t length = static_cast<uint64_t>(toLength(m_globalObject, array));
+                uint64_t length = toLength(m_globalObject, array);
                 RETURN_IF_EXCEPTION(scope, { });
                 if (UNLIKELY(length > std::numeric_limits<uint32_t>::max())) {
                     throwOutOfMemoryError(m_globalObject, scope);

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -50,7 +50,7 @@ void forEachInArrayLike(JSGlobalObject* globalObject, JSObject* arrayLikeObject,
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    uint64_t length = static_cast<uint64_t>(toLength(globalObject, arrayLikeObject));
+    uint64_t length = toLength(globalObject, arrayLikeObject);
     RETURN_IF_EXCEPTION(scope, void());
     for (uint64_t index = 0; index < length; index++) {
         JSValue value = arrayLikeObject->getIndex(globalObject, index);

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -59,6 +59,7 @@ JSString* jsString(VM&, Ref<AtomStringImpl>&&);
 JSString* jsString(VM&, Ref<StringImpl>&&);
 
 JSString* jsSingleCharacterString(VM&, UChar);
+JSString* jsSingleCharacterString(VM&, LChar);
 JSString* jsSubstring(VM&, const String&, unsigned offset, unsigned length);
 
 // Non-trivial strings are two or more characters long.
@@ -269,6 +270,7 @@ private:
     friend JSString* jsString(JSGlobalObject*, JSString*, JSString*, JSString*);
     friend JSString* jsString(JSGlobalObject*, const String&, const String&, const String&);
     friend JSString* jsSingleCharacterString(VM&, UChar);
+    friend JSString* jsSingleCharacterString(VM&, LChar);
     friend JSString* jsNontrivialString(VM&, const String&);
     friend JSString* jsNontrivialString(VM&, String&&);
     friend JSString* jsSubstring(VM&, const String&, unsigned, unsigned);
@@ -761,6 +763,14 @@ ALWAYS_INLINE JSString* jsSingleCharacterString(VM& vm, UChar c)
     if (c <= maxSingleCharacterString)
         return vm.smallStrings.singleCharacterString(c);
     return JSString::create(vm, StringImpl::create(&c, 1));
+}
+
+ALWAYS_INLINE JSString* jsSingleCharacterString(VM& vm, LChar c)
+{
+    if constexpr (validateDFGDoesGC)
+        vm.verifyCanGC();
+    ASSERT(maxSingleCharacterString >= 0xff);
+    return vm.smallStrings.singleCharacterString(c);
 }
 
 inline JSString* jsNontrivialString(VM& vm, const String& s)

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -48,6 +48,12 @@ constexpr double minSafeInteger()
     return -9007199254740991.0;
 }
 
+constexpr uint64_t maxSafeIntegerAsUInt64()
+{
+    // 2 ^ 53 - 1
+    return 9007199254740991ULL;
+}
+
 inline bool isInteger(double value)
 {
     return std::isfinite(value) && std::trunc(value) == value;

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -144,6 +144,8 @@ public:
 
     void copyToArguments(JSGlobalObject*, JSValue* firstElementDest, unsigned offset, unsigned length);
 
+    JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
+
     DECLARE_INFO;
     
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
@@ -161,6 +163,7 @@ private:
     }
     
     bool m_overrodeThings { false }; // True if length, callee, and caller are fully materialized in the object.
+    bool m_hasUnmappedArgument { false };
     unsigned m_totalLength; // The length of declared plus overflow arguments.
     WriteBarrier<JSFunction> m_callee;
     WriteBarrier<ScopedArgumentsTable> m_table;

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -73,7 +73,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
     unsigned length = callFrame->argumentCount();
     if (LIKELY(length == 1)) {
         scope.release();
-        unsigned code = callFrame->uncheckedArgument(0).toUInt32(globalObject);
+        UChar code = callFrame->uncheckedArgument(0).toUInt32(globalObject);
         // Not checking for an exception here is ok because jsSingleCharacterString will just fetch an unused string if there's an exception.
         return JSValue::encode(jsSingleCharacterString(vm, code));
     }
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
 
 JSString* stringFromCharCode(JSGlobalObject* globalObject, int32_t arg)
 {
-    return jsSingleCharacterString(globalObject->vm(), arg);
+    return jsSingleCharacterString(globalObject->vm(), static_cast<UChar>(arg));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringFromCodePoint, (JSGlobalObject* globalObject, CallFrame* callFrame))


### PR DESCRIPTION
#### b5cc1fa8fff5886b7bf430b824101214da06fe9d
<pre>
[JSC] Optimize runtime iterations for arguments and string
<a href="https://bugs.webkit.org/show_bug.cgi?id=246714">https://bugs.webkit.org/show_bug.cgi?id=246714</a>
rdar://101317088

Reviewed by Alexey Shvayka.

This patch enhances the existing C++ runtime functions to efficiently iterate arguments and strings.
This change improves rollup with babel source code roughtly 8 - 10%.

Before:
    DYLD_FRAMEWORK_PATH=$VM $VM/jsc -m rollup.js  3.00s user 0.13s system 161% cpu 1.936 total
After:
    DYLD_FRAMEWORK_PATH=$VM $VM/jsc -m rollup.js  2.76s user 0.14s system 162% cpu 1.789 total

And some microbenchmarks get faster.

    array-slice-call-cloned-arguments           37.4436+-0.0669     ^     25.3087+-0.1296        ^ definitely 1.4795x faster
    cloned-arguments-varargs                     0.9464+-0.0349     ^      0.8217+-0.0278        ^ definitely 1.1518x faster
    spread-string                                5.5482+-0.0348     ^      3.1329+-0.0258        ^ definitely 1.7709x faster

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::sizeOfVarargs):
(JSC::loadVarargs):
* Source/JavaScriptCore/runtime/ClonedArguments.cpp:
(JSC::ClonedArguments::copyToArguments):
(JSC::ClonedArguments::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/ClonedArguments.h:
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:
(JSC::JSC_DEFINE_COMMON_SLOW_PATH):
* Source/JavaScriptCore/runtime/DirectArguments.cpp:
(JSC::DirectArguments::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastSlice):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::toLength):
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
(JSC::JSValue::toLength const):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::objectPrototypeChainIsSane):
(JSC::JSGlobalObject::isArgumentsPrototypeIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp:
(JSC::JSImmutableButterfly::createFromClonedArguments):
(JSC::createFromNonClonedArguments):
(JSC::JSImmutableButterfly::createFromDirectArguments):
(JSC::JSImmutableButterfly::createFromScopedArguments):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::maxSafeIntegerAsUInt64):
* Source/JavaScriptCore/runtime/ScopedArguments.cpp:
(JSC::ScopedArguments::unmapArgument):
(JSC::ScopedArguments::isIteratorProtocolFastAndNonObservable):
* Source/JavaScriptCore/runtime/ScopedArguments.h:

Canonical link: <a href="https://commits.webkit.org/255790@main">https://commits.webkit.org/255790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/287f2e353a38529941276b302888a586e7566437

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103250 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2804 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31075 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85949 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99260 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80041 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84879 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37458 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79981 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35297 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/27615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39173 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82617 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1878 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41110 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/38000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/18679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->