### PR TITLE
[webkitdirs] Support building from a symlink base path

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -421,6 +421,7 @@ sub determineBaseProductDir
         $baseProductDir =~ s|^~/|$ENV{HOME}/|;
         die "Can't handle Xcode product directory with a ~ in it.\n" if $baseProductDir =~ /~/;
         die "Can't handle Xcode product directory with a variable in it.\n" if $baseProductDir =~ /\$/;
+        $baseProductDir = realpath($baseProductDir);
         @baseProductDirOption = ("SYMROOT=$baseProductDir", "OBJROOT=$baseProductDir");
         push(@baseProductDirOption, "SHARED_PRECOMPS_DIR=${baseProductDir}/PrecompiledHeaders") if $setSharedPrecompsDir;
         push(@baseProductDirOption, "INDEX_ENABLE_DATA_STORE=YES", "INDEX_DATA_STORE_DIR=${indexDataStoreDir}") if $indexDataStoreDir;


### PR DESCRIPTION
#### b7ab7c6573c35e1eeb8c13220dbf5988cff8e751
<pre>
[webkitdirs] Support building from a symlink base path
<a href="https://bugs.webkit.org/show_bug.cgi?id=246720">https://bugs.webkit.org/show_bug.cgi?id=246720</a>

Reviewed by Simon Fraser.

When SYMROOT/OBJROOT are symlinked paths, Xcode&apos;s build system doesn&apos;t
handle it very well and may emit &quot;x is located outside of the allowed
root paths.&quot; errors.

Work around this in Make and build-webkit invocations by realpath-ing
the build products directory we give to xcodebuild.

* Tools/Scripts/webkitdirs.pm:
(determineBaseProductDir):

Canonical link: <a href="https://commits.webkit.org/255710@main">https://commits.webkit.org/255710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ecdbfa1b03830304dbe8fecea3b99bb2a5f2c9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103063 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2593 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30887 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85757 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99051 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79839 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83734 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37270 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79771 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18600 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3949 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38973 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82405 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37821 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18615 "Passed tests") | 
<!--EWS-Status-Bubble-End-->