### PR TITLE
[git-webkit] Identify all unpicked pickable commits

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -58,7 +58,7 @@ setup(
         'webkitscmpy.test',
     ],
     scripts=['git-webkit'],
-    install_requires=['fasteners', 'inspect2', 'jinja2', 'monotonic', 'webkitcorepy', 'webkitbugspy', 'xmltodict'],
+    install_requires=['fasteners', 'inspect2', 'jinja2', 'monotonic', 'webkitcorepy', 'webkitbugspy', 'xmltodict', 'rapidfuzz'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -58,6 +58,9 @@ AutoInstall.register(Package('webkitbugspy', Version(0, 8, 0)), local=True)
 if sys.version_info < (3, 0):
     AutoInstall.register(Package('inspect2', Version(0, 1, 2)))
 
+if sys.version_info > (3, 6):
+    AutoInstall.register(Package('rapidfuzz', Version(2, 11, 1)))
+
 from webkitscmpy.contributor import Contributor
 from webkitscmpy.commit import Commit
 from webkitscmpy.pull_request import PullRequest

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
@@ -20,21 +20,62 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import itertools
 import json
 import sys
-from re import search
+import re
 
 from .command import Command
 from .find import Info
 from .trace import Trace, Relationship, CommitsStory
 from datetime import datetime
-from webkitcorepy import arguments
+from webkitcorepy import arguments, run, string_utils
 from webkitscmpy import Commit, local
+
+
+def fuzzy_filter(string, ratio=None):
+    return re.compile(string)
+
+
+if sys.version_info > (3, 6):
+    try:
+        from rapidfuzz import fuzz
+
+        def fuzzy_filter(string, ratio=90):
+            return lambda content: fuzz.partial_ratio(string, content) >= ratio
+    except ModuleNotFoundError:
+        pass
 
 
 class Pickable(Command):
     name = 'pickable'
     help = 'List commits in a range which can be cherry-picked'
+
+    DEFAULT_PATTERNS = [
+        'Versioning',
+        'Gardening',
+        'Build-Fix',
+        'Apply-Patch',
+    ]
+    PATTERNS = {
+        'Cherry-pick': [re.compile(r'^[Cc]herry[- ][Pp]ick')],
+        'Versioning': [
+            re.compile(r'^[Vv]ersioning\.?$'),
+            re.compile(r'^Revert "?[Vv]ersioning\.?"?$'),
+        ],
+        'Gardening': [
+            fuzzy_filter(r'GARDENING', ratio=85),
+            fuzzy_filter(r'gardening', ratio=85),
+            fuzzy_filter(r'REBASELINE'),
+            fuzzy_filter(r'rebaseline'),
+        ],
+        'Build-Fix': [
+            re.compile(r'^Apply build[ -]fix'),
+            re.compile(r'^Unreviewed build[ -]fix'),
+        ],
+        'Apply-Patch': [re.compile(r'^Apply patch')],
+        'None': [],
+    }
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -50,34 +91,78 @@ class Pickable(Command):
             dest='json',
             default=False,
         )
+        parser.add_argument(
+            '--into', '-i',
+            help='Branch to pick changes into',
+            type=str,
+            dest='into',
+            default=None,
+        )
+        parser.add_argument(
+            '--exclude', '-e',
+            help='Exclude certain patterns. By default, assumes the string argument is a regex. The program '
+                'will use certain prepared regexes for some string arguments (some of which are enabled by default), '
+                'those arguments are: {}'.format(string_utils.join([
+                    "'{}' ({})".format(pattern, 'enabled' if pattern in cls.DEFAULT_PATTERNS else 'disabled')
+                    for pattern in cls.PATTERNS.keys()
+                ])),
+            action='append',
+            dest='excluded',
+            default=None,
+        )
+        parser.add_argument(
+            '--scope', '-s',
+            help='Scope pickable query to a specific path in the project',
+            action='append',
+            dest='scopes',
+            default=None,
+        )
+        parser.add_argument(
+            '--filter', '-f',
+            help='Print only commits whose message matches a provided filter',
+            action='append',
+            dest='filters',
+            default=[],
+        )
+        parser.add_argument(
+            '--by', '-b',
+            help='Print only commits made by a specific individual (or individuals)',
+            action='append',
+            dest='by',
+            default=[],
+        )
 
     @classmethod
-    def pickable(cls, commits, repository, commits_story=None):
+    def pickable(cls, commits, repository, commits_story=None, excluded=None):
         filtered_in = set()
         all_commits = dict()
 
         commits_story = commits_story or CommitsStory()
 
+        if excluded is None:
+            excluded = cls.DEFAULT_PATTERNS
+        excluded = list(itertools.chain(
+            *[cls.PATTERNS[arg] if arg in cls.PATTERNS else [re.compile(arg)] for arg in excluded]
+        ))
+
         for commit in commits:
             commits_story.add(commit)
             title = commit.message.splitlines()[0]
             all_commits[str(commit)] = commit
-            if search('Cherry-pick', title) or search('Versioning', title):
+            if any([ex(title) if callable(ex) else ex.search(title) for ex in excluded]):
                 continue
             filtered_in.add(str(commit))
 
-        # FIXME: We can eliminate more classes of commits by reasoning about commit relationship
-        #    For example, a revert of a non-pickable commit is not itself pickable
         for ref in list(filtered_in):
             commit = all_commits[ref]
             relationships = Trace.relationships(commit, repository, commits_story=commits_story)
             if not relationships:
                 continue
             for rel in relationships:
-                if rel.type in Relationship.PAIRED and str(rel.commit) not in filtered_in:
+                if rel.type in Relationship.IDENTITY:
                     filtered_in.remove(ref)
                     break
-                elif rel.type in Relationship.UNDO and str(rel.commit) not in filtered_in:
+                if rel.type in Relationship.PAIRED + Relationship.UNDO and str(rel.commit) not in filtered_in:
                     filtered_in.remove(ref)
                     break
 
@@ -85,13 +170,23 @@ class Pickable(Command):
 
     @classmethod
     def main(cls, args, repository, **kwargs):
-        if not repository:
-            sys.stderr.write('No repository provided\n')
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only run '{}' on a native Git repository\n".format(cls.name))
             return 1
 
         reference = args.argument[0]
-        if reference != repository.default_branch and reference in repository.branches:
-            reference = '0@{}..{}'.format(reference, reference)
+        if not args.into:
+            args.into = repository.default_branch
+        if reference == args.into:
+            sys.stderr.write("Cannot merge '{}' into itself\n".format(args.into))
+            if args.into == repository.default_branch:
+                sys.stderr.write("Specify branch to merge into with the --into flag\n")
+            return 1
+
+        branch_point = None
+        if reference in repository.branches:
+            branch_point = repository.merge_base(args.into, reference)
+            reference = '{}..{}'.format(branch_point.hash if branch_point else args.into, reference)
 
         try:
             if '..' in reference:
@@ -102,9 +197,19 @@ class Pickable(Command):
                 if len(references) > 2:
                     sys.stderr.write('Can only include two references in a range\n')
                     return 1
-                commits = [commit for commit in repository.commits(begin=dict(argument=references[0]), end=dict(argument=references[1]))]
+                if not branch_point:
+                    branch_point = repository.merge_base(args.into, references[1])
+                commits = [commit for commit in repository.commits(
+                    begin=dict(argument=references[0]),
+                    end=dict(argument=references[1]),
+                    scopes=args.scopes,
+                )]
 
             else:
+                if args.scopes:
+                    sys.stderr.write('Scope argument invalid when only one commit specified\n')
+                    return 1
+                branch_point = repository.merge_base(args.into, reference)
                 commits = [repository.find(reference, include_log=True)]
 
         except (local.Scm.Exception, TypeError, ValueError) as exception:
@@ -113,8 +218,25 @@ class Pickable(Command):
             sys.stderr.write(str(exception) + '\n')
             return 1
 
-        commits = cls.pickable(commits, repository)
+        story = None
+        if branch_point:
+            story = CommitsStory()
+            for commit in repository.commits(begin=dict(argument=branch_point.hash), end=dict(argument=args.into)):
+                story.add(commit)
+
+        commits = cls.pickable(commits, repository, commits_story=story, excluded=args.excluded)
         if not commits:
             sys.stderr.write("No commits in specified range are 'pickable'\n")
             return 1
+
+        filters = []
+        if args.by:
+            for person in args.by:
+                filters.append(lambda commit: commit.author == person or person in commit.author.emails or person == commit.author.github)
+        if args.filters:
+            for filter in args.filters:
+                filters.append(lambda commit: re.search(filter, commit.message))
+        if filters:
+            commits = [commit for commit in commits if any([f(commit) for f in filters])]
+
         return Info.print_(args, commits, verbose_default=1)


### PR DESCRIPTION
#### 13e85ed5ecaed35f43d4db23a0d81220f7042022
<pre>
[git-webkit] Identify all unpicked pickable commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=246542">https://bugs.webkit.org/show_bug.cgi?id=246542</a>
rdar://97399813

Reviewed by Dewei Zhu and Elliott Williams.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version, add rapidfuzz dependency.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py:
(fuzzy_filter): Use rapidfuzz if it&apos;s available, otherwise use regexes.
(Pickable): Specify default patern categories.
(Pickable.parser): Add --into, --exclude, --scope, --filter and --by arguments.
(Pickable.pickable): Accept commits story, use global exclude list and named filters.
(Pickable.main): Construct a commits story to pass to pickable, use --filter argyuments
to filter commits based on commit message, use --by to filter commits based on author and
pass --scope into commit list to scope pickable query to a specific directory path.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py:
(TestPickable.test_none):
(TestPickable.test_main_no_into):
(TestPickable.test_main):
(TestPickable.test_scope):
(TestPickable.test_main_git_svn):
(TestPickable.test_branch_none):
(TestPickable.test_branch_include_versioning):

Canonical link: <a href="https://commits.webkit.org/255979@main">https://commits.webkit.org/255979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1efa89c8b6f265c0eea965d553a16b10ac9bdd43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94236 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/3424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/98233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3453 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99892 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/80644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/97827 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38021 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/93239 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35906 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39785 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/80644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1947 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41729 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/25285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->