### PR TITLE
[JSC] Simplify Finalization in DFG / FTL

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGFailedFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGFailedFinalizer.h
@@ -38,6 +38,7 @@ public:
     
     size_t codeSize() final;
     bool finalize() final;
+    bool isFailed() final { return true; }
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGFinalizer.h
@@ -42,6 +42,7 @@ public:
     
     virtual size_t codeSize() = 0;
     virtual bool finalize() = 0;
+    virtual bool isFailed() = 0;
 
 protected:
     Plan& m_plan;

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
@@ -40,6 +40,7 @@ public:
     
     size_t codeSize() final;
     bool finalize() final;
+    bool isFailed() final { return false; }
 
 private:
     

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -543,6 +543,11 @@ CompilationResult Plan::finalize()
     ASSERT(m_vm->heap.isDeferred());
 
     CompilationResult result = [&] {
+        if (m_finalizer->isFailed()) {
+            CODEBLOCK_LOG_EVENT(m_codeBlock, "dfgFinalize", ("failed"));
+            return CompilationFailed;
+        }
+
         if (!isStillValidOnMainThread() || !isStillValid()) {
             CODEBLOCK_LOG_EVENT(m_codeBlock, "dfgFinalize", ("invalidated"));
             return CompilationInvalidated;

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
@@ -54,6 +54,7 @@ public:
 
     size_t codeSize() final;
     bool finalize() final;
+    bool isFailed() final { return false; };
     
     std::unique_ptr<LinkBuffer> b3CodeLinkBuffer;
 


### PR DESCRIPTION
#### c4c58496ef4aeacde47688549148fd9e9fdf61b0
<pre>
[JSC] Simplify Finalization in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=246724">https://bugs.webkit.org/show_bug.cgi?id=246724</a>
rdar://101165751

Reviewed by Justin Michaud.

This patch simplifies DFG / FTL finalization by early returning failure case.

* Source/JavaScriptCore/dfg/DFGFailedFinalizer.h:
* Source/JavaScriptCore/dfg/DFGFinalizer.h:
* Source/JavaScriptCore/dfg/DFGJITFinalizer.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::finalize):
* Source/JavaScriptCore/ftl/FTLJITFinalizer.h:

Canonical link: <a href="https://commits.webkit.org/255714@main">https://commits.webkit.org/255714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34b01121d6cdab4e02e64d3cf4ef64e3cbaa2098

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103068 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2599 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30892 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85762 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99058 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79845 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71826 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84704 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37275 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79778 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35105 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18605 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27558 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82412 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1852 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37826 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18619 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->