### PR TITLE
[ews-app] Add python 3 support

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/github.py
+++ b/Tools/CISupport/ews-app/ews/common/github.py
@@ -370,7 +370,7 @@ class GitHubEWS(GitHub):
         return '; '.join([step.state_string for step in build.step_set.all().order_by('uid') if self._should_display_step(step)])
 
     def _should_display_step(self, step):
-        return not filter(lambda step_to_hide: re.search(step_to_hide, step.state_string), StatusBubble.STEPS_TO_HIDE)
+        return not [step_to_hide for step_to_hide in StatusBubble.STEPS_TO_HIDE if re.search(step_to_hide, step.state_string)]
 
     def _does_build_contains_any_failed_step(self, build):
         for step in build.step_set.all():

--- a/Tools/CISupport/ews-app/ews/fetcher.py
+++ b/Tools/CISupport/ews-app/ews/fetcher.py
@@ -140,4 +140,4 @@ class BugzillaPatchFetcher():
 
     @classmethod
     def filter_valid_patches(cls, patch_ids):
-        return list(filter(lambda p: Change.is_valid_change_id(p), patch_ids))
+        return [p for p in patch_ids if Change.is_valid_change_id(p)]

--- a/Tools/CISupport/ews-app/ews/views/statusbubble.py
+++ b/Tools/CISupport/ews-app/ews/views/statusbubble.py
@@ -217,7 +217,7 @@ class StatusBubble(View):
         return message
 
     def _should_display_step(self, step):
-        return not filter(lambda step_to_hide: re.search(step_to_hide, step.state_string), StatusBubble.STEPS_TO_HIDE)
+        return not [step_to_hide for step_to_hide in StatusBubble.STEPS_TO_HIDE if re.search(step_to_hide, step.state_string)]
 
     def _does_build_contains_any_failed_step(self, build):
         for step in build.step_set.all():


### PR DESCRIPTION
#### 2b778871c42d1772cfe9a97af335b3361d446439
<pre>
[ews-app] Add python 3 support
<a href="https://bugs.webkit.org/show_bug.cgi?id=246725">https://bugs.webkit.org/show_bug.cgi?id=246725</a>

Reviewed by Alexey Proskuryakov.

* Tools/CISupport/ews-app/ews/common/github.py:
(GitHubEWS._should_display_step):
* Tools/CISupport/ews-app/ews/fetcher.py:
(BugzillaPatchFetcher.filter_valid_patches):
* Tools/CISupport/ews-app/ews/views/statusbubble.py:
(StatusBubble._should_display_step):

Canonical link: <a href="https://commits.webkit.org/255728@main">https://commits.webkit.org/255728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4516252ac9ee10c5eb7d57d43b791dde108fb33b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103072 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163392 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2603 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30896 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99172 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1829 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79849 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28770 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71832 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37279 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18606 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41136 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1853 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37827 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->