### PR TITLE
Update fuzziness in compositing/ for accelerated drawing

### DIFF
--- a/LayoutTests/compositing/backgrounds/fixed-background-on-descendant.html
+++ b/LayoutTests/compositing/backgrounds/fixed-background-on-descendant.html
@@ -2,6 +2,7 @@
 
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-1203" />
     <style>
         body {
             height: 2000px;

--- a/LayoutTests/compositing/backgrounds/fixed-backgrounds.html
+++ b/LayoutTests/compositing/backgrounds/fixed-backgrounds.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-35" />
+    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-21611" />
     <style>
         body {
             height: 2000px;

--- a/LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html
+++ b/LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-190" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-400" />
     <style>
         .scroller {
             margin: 10px;

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-360" />
+    <meta name="fuzzy" content="maxDifference=0-70; totalPixels=0-401" />
     <style>
         .container {
             width: 400px;

--- a/LayoutTests/compositing/clipping/border-radius-with-composited-descendant.html
+++ b/LayoutTests/compositing/clipping/border-radius-with-composited-descendant.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-380" />
+    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-400" />
     <style>
         .clipping {
             margin: 10px;

--- a/LayoutTests/compositing/geometry/css-clip-oversize.html
+++ b/LayoutTests/compositing/geometry/css-clip-oversize.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-950" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1300" />
     <style>
         .parent {
             position: absolute;

--- a/LayoutTests/compositing/geometry/scroller-with-clipping-and-foreground-layers.html
+++ b/LayoutTests/compositing/geometry/scroller-with-clipping-and-foreground-layers.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-130" />
+    <meta name="fuzzy" content="maxDifference=0-61; totalPixels=0-68170" />
     <style>
         body {
             margin: 0;

--- a/LayoutTests/compositing/masks/compositing-clip-path-and-mask.html
+++ b/LayoutTests/compositing/masks/compositing-clip-path-and-mask.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=26000-26100" />
+    <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-26579" />
     <style>
         .box {
           width: 300px;

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-contain.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-contain.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=1700-2200" />
+  <meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-3162" />
   <style>
     .composited { -webkit-transform: rotate3d(0, 0, 1, 0); }
     .test {

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-cover.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-cover.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1049">
+  <meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-3000" />
   <style>
     .composited { -webkit-transform: rotate3d(0, 0, 1, 0); }
     .test {

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-position.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-position.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-3060">
+  <meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-14500" />
   <style>
     .composited { -webkit-transform: rotate3d(0, 0, 1, 0); }
     .test {

--- a/LayoutTests/compositing/patterns/direct-pattern-compositing-size.html
+++ b/LayoutTests/compositing/patterns/direct-pattern-compositing-size.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=1550-1900" />
+  <meta name="fuzzy" content="maxDifference=0-90; totalPixels=0-9030" />
   <style>
     .composited { -webkit-transform: rotate3d(0, 0, 1, 0); }
     .test {

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2133,6 +2133,9 @@ webkit.org/b/245014 imported/w3c/web-platform-tests/cookies/value/value-ctl.html
 
 webkit.org/b/245035 imported/w3c/web-platform-tests/fetch/metadata/script.https.sub.html [ Pass Failure ]
 
+# webkit.org/b/246973 This test renders incorrectly after enabling accelerated drawing
+compositing/geometry/css-clip-oversize.html [ Pass ImageOnlyFailure ]
+
 webkit.org/b/245102 imported/w3c/web-platform-tests/html/browsers/windows/auxiliary-browsing-contexts/opener-noreferrer.html [ Pass Failure ]
 
 # webkit.org/b/245801 These tests are flakily crashing with a WorkerOrWorkletThread error


### PR DESCRIPTION
#### 9e4349d1d6df5f38b62b5c612634db8c1430dc1b
<pre>
Update fuzziness in compositing/ for accelerated drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=246726">https://bugs.webkit.org/show_bug.cgi?id=246726</a>
rdar://101317781

Reviewed by Simon Fraser.

Update fuzziness in compositing/ for when accelerated drawing is enabled by default.

* LayoutTests/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt:
* LayoutTests/compositing/clipping/border-radius-async-overflow-non-stacking.html:
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant-nested.html:
* LayoutTests/compositing/clipping/border-radius-with-composited-descendant.html:
* LayoutTests/compositing/geometry/css-clip-oversize.html:
* LayoutTests/compositing/geometry/scroller-with-clipping-and-foreground-layers.html:
* LayoutTests/compositing/masks/compositing-clip-path-and-mask.html:
* LayoutTests/compositing/patterns/direct-pattern-compositing-contain.html:
* LayoutTests/compositing/patterns/direct-pattern-compositing-size.html:

Canonical link: <a href="https://commits.webkit.org/255975@main">https://commits.webkit.org/255975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c741b59035328e0e20f031a85b90392d09d4228f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94220 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/3412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/25017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/3439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/3439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/80632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/3439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/25017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/25017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35892 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/25017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39770 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/80632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1944 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41713 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/25017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->