### PR TITLE
Add an `isThirdParty` argument when calling into `enableNetworkConnectionIntegrity`

### DIFF
--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -29,6 +29,7 @@
 #include "HTTPHeaderNames.h"
 #include "Logging.h"
 #include "PublicSuffix.h"
+#include "RegistrableDomain.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include "SecurityOrigin.h"
@@ -800,6 +801,11 @@ String ResourceRequestBase::partitionName(const String& domain)
 #endif
     return emptyString();
 #endif
+}
+
+bool ResourceRequestBase::isThirdParty() const
+{
+    return !areRegistrableDomainsEqual(url(), firstPartyForCookies());
 }
 
 }

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -81,6 +81,8 @@ public:
     WEBCORE_EXPORT const URL& firstPartyForCookies() const;
     WEBCORE_EXPORT void setFirstPartyForCookies(const URL&);
 
+    WEBCORE_EXPORT bool isThirdParty() const;
+
     // Same-Site cookies; see <https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-2.1>
     // and <https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-5.2>.
     // FIXME: For some reason the main resource request may be updated more than once. We start off as Unspecified

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -177,15 +177,10 @@ NetworkSession* NetworkDataTask::networkSession()
     return m_session.get();
 }
 
-bool NetworkDataTask::isThirdPartyRequest(const WebCore::ResourceRequest& request) const
-{
-    return !WebCore::areRegistrableDomainsEqual(request.url(), request.firstPartyForCookies());
-}
-
 void NetworkDataTask::restrictRequestReferrerToOriginIfNeeded(WebCore::ResourceRequest& request)
 {
 #if ENABLE(TRACKING_PREVENTION)
-    if ((m_session->sessionID().isEphemeral() || m_session->isResourceLoadStatisticsEnabled()) && m_session->shouldDowngradeReferrer() && isThirdPartyRequest(request))
+    if ((m_session->sessionID().isEphemeral() || m_session->isResourceLoadStatisticsEnabled()) && m_session->shouldDowngradeReferrer() && request.isThirdParty())
         request.setExistingHTTPReferrerToOriginString();
 #endif
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -160,7 +160,6 @@ protected:
     };
     void scheduleFailure(FailureType);
 
-    bool isThirdPartyRequest(const WebCore::ResourceRequest&) const;
     void restrictRequestReferrerToOriginIfNeeded(WebCore::ResourceRequest&);
 
     WeakPtr<NetworkSession> m_session;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -131,6 +131,6 @@ private:
 WebCore::Credential serverTrustCredential(const WebCore::AuthenticationChallenge&);
 void setPCMDataCarriedOnRequest(WebCore::PrivateClickMeasurement::PcmDataCarried, NSMutableURLRequest *);
 
-void enableNetworkConnectionIntegrity(NSMutableURLRequest *);
+void enableNetworkConnectionIntegrity(NSMutableURLRequest *, bool isThirdParty);
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -59,7 +59,7 @@
 #import <WebKitAdditions/NetworkDataTaskCocoaAdditions.h>
 #else
 namespace WebKit {
-void enableNetworkConnectionIntegrity(NSMutableURLRequest *) { }
+void enableNetworkConnectionIntegrity(NSMutableURLRequest *, bool /* isThirdParty */) { }
 }
 #endif
 
@@ -191,7 +191,7 @@ void NetworkDataTaskCocoa::applyCookiePolicyForThirdPartyCNAMECloaking(const Web
     if (isTopLevelNavigation() || !shouldApplyCookiePolicyForThirdPartyCNAMECloaking())
         return;
 
-    if (isThirdPartyRequest(request)) {
+    if (request.isThirdParty()) {
         m_task.get()._cookieTransformCallback = nil;
         return;
     }
@@ -370,7 +370,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
 #endif
 
     if (parameters.networkConnectionIntegrityEnabled)
-        enableNetworkConnectionIntegrity(mutableRequest.get());
+        enableNetworkConnectionIntegrity(mutableRequest.get(), request.isThirdParty());
 
 #if ENABLE(APP_PRIVACY_REPORT)
     mutableRequest.get().attribution = request.isAppInitiated() ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1715,7 +1715,7 @@ std::unique_ptr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageP
     }
 
     if (networkConnectionIntegrityEnabled)
-        enableNetworkConnectionIntegrity(ensureMutableRequest());
+        enableNetworkConnectionIntegrity(ensureMutableRequest(), request.isThirdParty());
 
     auto& sessionSet = sessionSetForPage(webPageProxyID);
     RetainPtr task = [sessionSet.sessionWithCredentialStorage.session webSocketTaskWithRequest:nsRequest.get()];


### PR DESCRIPTION
#### 11e75f8501ba2d377ca928f0bef4a02872ce0abc
<pre>
Add an `isThirdParty` argument when calling into `enableNetworkConnectionIntegrity`
<a href="https://bugs.webkit.org/show_bug.cgi?id=246722">https://bugs.webkit.org/show_bug.cgi?id=246722</a>
rdar://101316400

Reviewed by Youenn Fablet.

Refactor some code that calls into `enableNetworkConnectionIntegrity`, such that we also pass in
whether or not the resource request is third party. See below for more details.

* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::isThirdParty const):

Move `NetworkDataTask::isThirdPartyRequest(const ResourceRequest&amp;)` down into `ResourceRequestBase`
as a const method, so that we don&apos;t need to reach into `NetworkDataTask` in order to perform this
check.

* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::restrictRequestReferrerToOriginIfNeeded):
(WebKit::NetworkDataTask::isThirdPartyRequest const): Deleted.

Moved to `ResourceRequestBase` (see above).

* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::enableNetworkConnectionIntegrity):

Add a boolean argument to represent whether or not the request is third party.

(WebKit::NetworkDataTaskCocoa::applyCookiePolicyForThirdPartyCNAMECloaking):

Adopt the `isThirdParty()` method.

(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::createWebSocketTask):

Pass in whether or not the given request is third party.

Canonical link: <a href="https://commits.webkit.org/255734@main">https://commits.webkit.org/255734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1ea8284e43ccd2169c4036c57da509b45e9ff21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103076 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163395 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2607 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30900 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99175 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1833 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79853 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71833 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37283 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3967 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/38986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41141 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37831 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->