### PR TITLE
Bind CanvasFilters.filter to a string in CanvasRenderingContext2DBase::State

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-basics-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-filter-basics-expected.txt
@@ -1,0 +1,36 @@
+This tests canavs filter setter
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+context.filter should be initialized with 'none'
+PASS context.filter is "none"
+PASS context.filter is "invert( 75% ) sepia(1) url(#svgDropShadow)"
+PASS context.filter is "invert( 75% ) sepia(1)"
+PASS context.filter is "invert( 75% )"
+PASS context.filter is "invert(75%)"
+
+Empty string , null and undefined should leave context.filter unchanged
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+
+Unparsable strings should leave context.filter unchanged
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+PASS context.filter is "invert(75%)"
+
+context.filter = 'none'; should disable filters for the context
+PASS context.filter is "none"
+
+context.filter is part of the context state
+PASS context.filter is "invert(75%)"
+PASS context.filter is "sepia(1)"
+PASS context.filter is "invert(75%)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-filter-basics.html
+++ b/LayoutTests/fast/canvas/canvas-filter-basics.html
@@ -1,0 +1,66 @@
+<html>
+<head>
+    <script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+    <canvas id="canvas"></canvas>
+    <script>
+        description("This tests canavs filter setter");
+
+        const canvas = document.getElementById('canvas');
+        const context = canvas.getContext('2d');
+
+        debug("");
+        debug("context.filter should be initialized with 'none'");
+        shouldBeEqualToString("context.filter", "none");
+
+        context.filter = "invert( 75% ) sepia(1) url(#svgDropShadow)";
+        shouldBeEqualToString("context.filter", "invert( 75% ) sepia(1) url(#svgDropShadow)");
+        context.filter = "invert( 75% ) sepia(1)";
+        shouldBeEqualToString("context.filter", "invert( 75% ) sepia(1)");
+        context.filter = "invert( 75% )";
+        shouldBeEqualToString("context.filter", "invert( 75% )");
+        context.filter = "invert(75%)";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+
+        debug("");
+        debug("Empty string , null and undefined should leave context.filter unchanged");
+        context.filter = "";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = null;
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = undefined;
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        let foo;
+        context.filter = foo;
+        shouldBeEqualToString("context.filter", "invert(75%)");
+
+        debug("");
+        debug("Unparsable strings should leave context.filter unchanged");
+        context.filter = "inherit";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = "inherit(#svgDropShadow)";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = 'initial';
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.filter = 'unset';
+        shouldBeEqualToString("context.filter", "invert(75%)");
+
+        debug("");
+        debug("context.filter = 'none'; should disable filters for the context");
+        context.filter = "none";
+        shouldBeEqualToString("context.filter", "none");
+
+        debug("");
+        debug("context.filter is part of the context state");
+        context.filter = "invert(75%)";
+        shouldBeEqualToString("context.filter", "invert(75%)");
+        context.save();
+        context.filter = "sepia(1)";
+        shouldBeEqualToString("context.filter", "sepia(1)");
+        context.restore();
+        shouldBeEqualToString("context.filter", "invert(75%)");
+    </script>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject
-Test CanvasFilter() object
-Actual output:
-
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.discrete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.discrete-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.discrete
-Test pixels on CanvasFilter() componentTransfer with discrete type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with discrete type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.gamma-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.gamma-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.gamma
-Test pixels on CanvasFilter() componentTransfer with gamma type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with gamma type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.identity
-Test pixels on CanvasFilter() componentTransfer with identity type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with identity type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.linear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.linear-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.linear
-Test pixels on CanvasFilter() componentTransfer with linear type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with linear type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.table-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.table-expected.txt
@@ -1,6 +1,0 @@
-2d.filter.canvasFilterObject.componentTransfer.table
-Test pixels on CanvasFilter() componentTransfer with table type
-Actual output:
-
-FAIL Test pixels on CanvasFilter() componentTransfer with table type Can't find variable: CanvasFilter
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.tentative-expected.txt
@@ -2,5 +2,5 @@
 Test CanvasFilter() object
 Actual output:
 
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
+FAIL Test CanvasFilter() object Can't find variable: CanvasFilter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.value-expected.txt
@@ -2,5 +2,5 @@
 test if ctx.filter works correctly
 Actual output:
 
-FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'none' expected true got false
+PASS test if ctx.filter works correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative-expected.txt
@@ -3,5 +3,5 @@
 Test CanvasFilter() object
 
 
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
+FAIL Test CanvasFilter() object assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test CanvasFilter() object assert_true: ctx.filter == 'none' expected true got false
+FAIL Test CanvasFilter() object assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value-expected.txt
@@ -3,5 +3,5 @@
 test if ctx.filter works correctly
 
 
-FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'none' expected true got false
+FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'none' expected true got false
+FAIL test if ctx.filter works correctly assert_true: ctx.filter == 'blur(5px)' expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -472,7 +472,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -569,7 +569,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
@@ -788,7 +788,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -374,7 +374,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -373,7 +373,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3965,7 +3965,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -4062,7 +4062,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
@@ -4281,7 +4281,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3965,7 +3965,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -4062,7 +4062,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type

--- a/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2-expected.txt
+++ b/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2-expected.txt
@@ -3,5 +3,5 @@
 Stroke line widths are scaled by the current transformation matrix
 
 
-FAIL Stroke line widths are scaled by the current transformation matrix assert_equals: Red channel of the pixel at (0, 0) expected 0 but got 255
+PASS Stroke line widths are scaled by the current transformation matrix
 

--- a/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker-expected.txt
+++ b/LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Stroke line widths are scaled by the current transformation matrix assert_equals: Red channel of the pixel at (0, 0) expected 0 but got 255
+PASS Stroke line widths are scaled by the current transformation matrix
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt
@@ -3965,7 +3965,7 @@ PASS CanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS CanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS CanvasRenderingContext2D interface: attribute shadowBlur
 PASS CanvasRenderingContext2D interface: attribute shadowColor
-FAIL CanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS CanvasRenderingContext2D interface: attribute filter
 PASS CanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
@@ -4062,7 +4062,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowOffsetY" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowBlur" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "shadowColor" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type assert_inherits: property "filter" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "filter" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)" with the proper type
@@ -4281,7 +4281,7 @@ PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetX
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowOffsetY
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowBlur
 PASS OffscreenCanvasRenderingContext2D interface: attribute shadowColor
-FAIL OffscreenCanvasRenderingContext2D interface: attribute filter assert_true: The prototype object must have a property "filter" expected true got false
+PASS OffscreenCanvasRenderingContext2D interface: attribute filter
 PASS OffscreenCanvasRenderingContext2D interface: operation clearRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation fillRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation strokeRect(unrestricted double, unrestricted double, unrestricted double, unrestricted double)

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1467,7 +1467,7 @@ CanvasColorSpaceEnabled:
 
 CanvasFiltersEnabled:
   type: bool
-  status: unstable
+  status: testable
   category: dom
   webcoreOnChange: setNeedsRelayoutAllFrames
   humanReadableName: "Canvas Filters"

--- a/Source/WebCore/html/canvas/CanvasFilters.idl
+++ b/Source/WebCore/html/canvas/CanvasFilters.idl
@@ -25,7 +25,5 @@
 
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters
 interface mixin CanvasFilters {
-    // filters
-    // FIXME: Implement filter.
-    // attribute DOMString filter; // (default "none")
+    [ImplementedAs=filterString] attribute DOMString filter; // (default "none")
 };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
@@ -61,6 +61,8 @@ private:
 
     void setFontWithoutUpdatingStyle(const String&);
 
+    std::optional<FilterOperations> createFilterOperations(const String&) const final;
+
     void drawTextInternal(const String& text, double x, double y, bool fill, std::optional<double> maxWidth = std::nullopt);
 
     void drawFocusIfNeededInternal(const Path&, Element&);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -233,6 +233,9 @@ public:
     CanvasTextBaseline textBaseline() const { return state().canvasTextBaseline(); }
     void setTextBaseline(CanvasTextBaseline);
 
+    String filterString() const { return state().filterString; }
+    void setFilterString(const String&);
+
     using Direction = CanvasDirection;
     void setDirection(Direction);
 
@@ -293,6 +296,9 @@ public:
         String unparsedFont;
         FontProxy font;
 
+        String filterString;
+        FilterOperations filterOperations;
+
         CanvasLineCap canvasLineCap() const;
         CanvasLineJoin canvasLineJoin() const;
         CanvasTextAlign canvasTextAlign() const;
@@ -312,6 +318,8 @@ protected:
     State& modifiableState() { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
 
     GraphicsContext* drawingContext() const;
+
+    virtual std::optional<FilterOperations> createFilterOperations(const String&) const { return std::nullopt; }
 
     static String normalizeSpaces(const String&);
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -46,6 +46,7 @@ public:
     void commit();
 
     void setFont(const String&);
+    std::optional<FilterOperations> createFilterOperations(const String&) const final;
     CanvasDirection direction() const;
     void fillText(const String& text, double x, double y, std::optional<double> maxWidth = std::nullopt);
     void strokeText(const String& text, double x, double y, std::optional<double> maxWidth = std::nullopt);

--- a/Source/WebCore/style/FilterOperationsBuilder.h
+++ b/Source/WebCore/style/FilterOperationsBuilder.h
@@ -35,9 +35,20 @@ class CSSValue;
 class Document;
 class RenderStyle;
 
+enum CSSParserMode : uint8_t;
+
 namespace Style {
 
-std::optional<FilterOperations> createFilterOperations(const Document&, RenderStyle&, const CSSToLengthConversionData&, const CSSValue&);
+struct FilterParserContext {
+    std::function<Color(const CSSPrimitiveValue*)> resolvedColor;
+    std::function<AtomString(const String&)> resolvedUrl;
+};
+
+const FilterParserContext& defaultFilterParserContext();
+FilterParserContext documentFilterParserContext(const Document&, RenderStyle&);
+
+std::optional<FilterOperations> createFilterOperations(const CSSToLengthConversionData&, const CSSValue&, const FilterParserContext& = defaultFilterParserContext());
+std::optional<FilterOperations> createFilterOperations(const String&, CSSParserMode, const FilterParserContext& = defaultFilterParserContext());
 
 } // namespace Style
 

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -136,7 +136,7 @@ RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value)
 
 std::optional<FilterOperations> BuilderState::createFilterOperations(const CSSValue& inValue)
 {
-    return WebCore::Style::createFilterOperations(document(), m_style, m_cssToLengthConversionData, inValue);
+    return WebCore::Style::createFilterOperations(m_cssToLengthConversionData, inValue, documentFilterParserContext(document(), m_style));
 }
 
 bool BuilderState::isColorFromPrimitiveValueDerivedFromElement(const CSSPrimitiveValue& value)


### PR DESCRIPTION
#### 2159194ab15bb6ed75611ed48b3c34b7f8926d06
<pre>
Bind CanvasFilters.filter to a string in CanvasRenderingContext2DBase::State
<a href="https://bugs.webkit.org/show_bug.cgi?id=246732">https://bugs.webkit.org/show_bug.cgi?id=246732</a>
rdar://101323769

Reviewed by NOBODY (OOPS!).

Bind the IDL string to a string in CanvasRenderingContext2DBase::State. The actual
filter will be drawn to the canvas in a future patch.

Parsing the filter string has to happen when the API is called because unparsed
values should not change the property.

createFilterOperations() will be used for parsing the CSS filter, the &lt;canvas&gt;
filter and the OffscreenCanvas filter. Becasue OffscreenCanvas can render on a
worker thread, Document can&apos;t be safely used while parsing its filter.

FilterParserContext is passed to the createFilterOperations() to control resolving
the URL of the referenced SVG filter and resolving the drop-shadow color. For CSS
filter and &lt;canvas&gt; filter only, createFilterOperations() will use the Document
and the RenderStyle through FilterParserContext.

Specs link: <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters">https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters</a>

* LayoutTests/fast/canvas/canvas-filter-basics-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-filter-basics.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.discrete-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.gamma-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.identity-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.linear-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.componentTransfer.table-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.canvasFilterObject.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/filters/2d.filter.value-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.canvasFilterObject.tentative.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/filters/2d.filter.value.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2-expected.txt:
* LayoutTests/platform/mac-bigsur-wk1/imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/dom/idlharness.https-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/canvas/CanvasFilters.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilterOperations const):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::State::State):
(WebCore::CanvasRenderingContext2DBase::setFilterString):
(WebCore::CanvasRenderingContext2DBase::fillInternal):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::filterString const):
(WebCore::CanvasRenderingContext2DBase::createFilterOperations const):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::createFilterOperations const):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h:
* Source/WebCore/style/FilterOperationsBuilder.cpp:
(WebCore::Style::defaultFilterParserContext):
(WebCore::Style::documentFilterParserContext):
(WebCore::Style::createFilterOperations):
* Source/WebCore/style/FilterOperationsBuilder.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createFilterOperations):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2159194ab15bb6ed75611ed48b3c34b7f8926d06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11633 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13935 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13678 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17677 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9871 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10720 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13874 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11018 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9145 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11701 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10445 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3155 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14549 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12031 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10949 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2925 "Passed tests") | 
<!--EWS-Status-Bubble-End-->