### PR TITLE
Pixel cracks in text-masked background images in replayed CG display lists

### DIFF
--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -441,13 +441,6 @@ AffineTransform BifurcatedGraphicsContext::getCTM(IncludeDeviceScale includeDevi
     return m_primaryContext.getCTM(includeDeviceScale);
 }
 
-FloatRect BifurcatedGraphicsContext::roundToDevicePixels(const FloatRect& rect, RoundingMode roundingMode)
-{
-    auto roundedRect = m_primaryContext.roundToDevicePixels(rect, roundingMode);
-    VERIFY_STATE_SYNCHRONIZATION();
-    return roundedRect;
-}
-
 void BifurcatedGraphicsContext::drawFocusRing(const Vector<FloatRect>& rects, float width, float offset, const Color& color)
 {
     m_primaryContext.drawFocusRing(rects, width, offset, color);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -118,8 +118,6 @@ public:
 
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final;
 
-    FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) final;
-
     void drawFocusRing(const Vector<FloatRect>&, float, float, const Color&) final;
     void drawFocusRing(const Path&, float, float, const Color&) final;
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -192,7 +192,6 @@ public:
         RoundAllSides,
         RoundOriginAndDimensions
     };
-    virtual FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) = 0;
     WEBCORE_EXPORT static void adjustLineToPixelBoundaries(FloatPoint& p1, FloatPoint& p2, float strokeWidth, StrokeStyle);
 
     // Shapes

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -87,7 +87,6 @@ private:
     void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { }
     void strokeRect(const FloatRect&, float) final { }
     void clipPath(const Path&, WindRule = WindRule::EvenOdd) final { }
-    FloatRect roundToDevicePixels(const FloatRect& rect, RoundingMode = RoundAllSides) final { return rect; }
     void drawLinesForText(const FloatPoint&, float, const DashArray&, bool, bool = false, StrokeStyle = SolidStroke) final { }
     void setLineCap(LineCap) final { }
     void setLineDash(const DashArray&, float) final { }

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.cpp
@@ -510,44 +510,6 @@ IntRect getClipBounds(GraphicsContextCairo& platformContext)
     return enclosingIntRect(FloatRect(x1, y1, x2 - x1, y2 - y1));
 }
 
-FloatRect roundToDevicePixels(GraphicsContextCairo& platformContext, const FloatRect& rect)
-{
-    FloatRect result;
-    double x = rect.x();
-    double y = rect.y();
-
-    cairo_t* cr = platformContext.cr();
-    cairo_user_to_device(cr, &x, &y);
-    x = round(x);
-    y = round(y);
-    cairo_device_to_user(cr, &x, &y);
-    result.setX(narrowPrecisionToFloat(x));
-    result.setY(narrowPrecisionToFloat(y));
-
-    // We must ensure width and height are at least 1 (or -1) when
-    // we're given float values in the range between 0 and 1 (or -1 and 0).
-    double width = rect.width();
-    double height = rect.height();
-    cairo_user_to_device_distance(cr, &width, &height);
-    if (width > -1 && width < 0)
-        width = -1;
-    else if (width > 0 && width < 1)
-        width = 1;
-    else
-        width = round(width);
-    if (height > -1 && height < 0)
-        height = -1;
-    else if (height > 0 && height < 1)
-        height = 1;
-    else
-        height = round(height);
-    cairo_device_to_user_distance(cr, &width, &height);
-    result.setWidth(narrowPrecisionToFloat(width));
-    result.setHeight(narrowPrecisionToFloat(height));
-
-    return result;
-}
-
 bool isAcceleratedContext(GraphicsContextCairo& platformContext)
 {
     return cairo_surface_get_type(cairo_get_target(platformContext.cr())) == CAIRO_SURFACE_TYPE_GL;

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.h
@@ -63,7 +63,6 @@ void setCTM(GraphicsContextCairo&, const AffineTransform&);
 AffineTransform getCTM(GraphicsContextCairo&);
 
 IntRect getClipBounds(GraphicsContextCairo&);
-FloatRect roundToDevicePixels(GraphicsContextCairo&, const FloatRect&);
 
 bool isAcceleratedContext(GraphicsContextCairo&);
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -272,12 +272,6 @@ void GraphicsContextCairo::drawDotsForDocumentMarker(const FloatRect& rect, Docu
     Cairo::drawDotsForDocumentMarker(*this, rect, style);
 }
 
-FloatRect GraphicsContextCairo::roundToDevicePixels(const FloatRect& rect, RoundingMode roundingMode)
-{
-    UNUSED_PARAM(roundingMode);
-    return Cairo::State::roundToDevicePixels(*this, rect);
-}
-
 void GraphicsContextCairo::translate(float x, float y)
 {
     Cairo::translate(*this, x, y);

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -108,8 +108,6 @@ public:
     
     RenderingMode renderingMode() const final;
 
-    FloatRect roundToDevicePixels(const FloatRect&, GraphicsContext::RoundingMode) final;
-
     cairo_t* cr() const;
     Vector<float>& layers();
     void pushImageMask(cairo_surface_t*, const FloatRect&);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1292,7 +1292,7 @@ AffineTransform GraphicsContextCG::getCTM(IncludeDeviceScale includeScale) const
     return CGContextGetCTM(platformContext());
 }
 
-FloatRect GraphicsContextCG::roundToDevicePixels(const FloatRect& rect, RoundingMode roundingMode)
+FloatRect GraphicsContextCG::roundToDevicePixels(const FloatRect& rect, RoundingMode roundingMode) const
 {
     // It is not enough just to round to pixels in device space. The rotation part of the
     // affine transform matrix to device space can mess with this conversion if we have a

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -107,8 +107,6 @@ public:
 
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const override;
 
-    FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) final;
-
     void drawFocusRing(const Vector<FloatRect>&, float, float, const Color&) final;
     void drawFocusRing(const Path&, float, float, const Color&) final;
 #if PLATFORM(MAC)
@@ -134,6 +132,8 @@ public:
 #if OS(WINDOWS)
     GraphicsContextPlatformPrivate* deprecatedPrivateContext() const final;
 #endif
+
+    virtual FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) const;
 
 protected:
     virtual void setCGShadow(RenderingMode, const FloatSize& offset, float blur, const Color&, bool shadowsIgnoreTransforms);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -600,12 +600,6 @@ void Recorder::applyDeviceScaleFactor(float deviceScaleFactor)
     recordApplyDeviceScaleFactor(deviceScaleFactor);
 }
 
-FloatRect Recorder::roundToDevicePixels(const FloatRect& rect, GraphicsContext::RoundingMode)
-{
-    WTFLogAlways("GraphicsContext::roundToDevicePixels() is not yet compatible with DisplayList::Recorder.");
-    return rect;
-}
-
 const Recorder::ContextState& Recorder::currentState() const
 {
     ASSERT(m_stateStack.size());

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -275,8 +275,6 @@ private:
 
     WEBCORE_EXPORT void applyDeviceScaleFactor(float) final;
 
-    WEBCORE_EXPORT FloatRect roundToDevicePixels(const FloatRect&, GraphicsContext::RoundingMode) final;
-
     void appendStateChangeItemIfNecessary();
     void appendStateChangeItem(const GraphicsContextState&);
 

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
@@ -1169,11 +1169,6 @@ void CairoOperationRecorder::applyDeviceScaleFactor(float)
 {
 }
 
-FloatRect CairoOperationRecorder::roundToDevicePixels(const FloatRect& rect, GraphicsContext::RoundingMode)
-{
-    return rect;
-}
-
 void CairoOperationRecorder::append(std::unique_ptr<PaintingOperation>&& command)
 {
     m_commandList.append(WTFMove(command));

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
@@ -105,8 +105,6 @@ private:
 
     void applyDeviceScaleFactor(float) override;
 
-    WebCore::FloatRect roundToDevicePixels(const WebCore::FloatRect&, WebCore::GraphicsContext::RoundingMode) override;
-
     void append(std::unique_ptr<PaintingOperation>&&);
     PaintingOperations& m_commandList;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -77,6 +77,11 @@ public:
         return m_immutableBaseTransform * GraphicsContextCG::getCTM(includeDeviceScale);
     }
 
+    WebCore::FloatRect roundToDevicePixels(const WebCore::FloatRect& rect, RoundingMode = RoundAllSides) const final
+    {
+        return rect;
+    }
+
     bool canUseShadowBlur() const final { return false; }
 
 protected:


### PR DESCRIPTION
#### 21fdc41d3fa21f181667abb71aa052cbc5bb99b8
<pre>
Pixel cracks in text-masked background images in replayed CG display lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=246738">https://bugs.webkit.org/show_bug.cgi?id=246738</a>
rdar://100183888

Reviewed by Wenson Hsieh.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::roundToDevicePixels): Deleted.
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::State::roundToDevicePixels): Deleted.
* Source/WebCore/platform/graphics/cairo/CairoOperations.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::roundToDevicePixels): Deleted.
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::roundToDevicePixels const):
(WebCore::GraphicsContextCG::roundToDevicePixels): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::roundToDevicePixels): Deleted.
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp:
(Nicosia::CairoOperationRecorder::roundToDevicePixels): Deleted.
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h:
`roundToDevicePixels` is only called from CG code, so we don&apos;t need it on
GraphicsContext, it can live on GraphicsContextCG.

* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
Make `roundToDevicePixels` a no-op for CG display lists; it doesn&apos;t make sense
to round to &quot;device&quot; pixels when the display list can be replayed at arbitrary scales,
and also sometimes causes pixel cracks in `background-clip: text` elements
(and likely other cases).

Canonical link: <a href="https://commits.webkit.org/255750@main">https://commits.webkit.org/255750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/385cc68ed536ada2bcc3447a3775e4babe7bfa03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103105 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163435 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2641 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30931 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99206 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1858 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79885 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28905 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71861 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37314 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18637 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3980 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41163 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37863 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->