### PR TITLE
Add WebCodecs VideoFrame support for createImageBitmap

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-alpha.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-alpha.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL OffscreenCanvas source preserves alpha assert_equals: expected 4278190335 but got 0
-FAIL ImageBitmap source preserves alpha assert_equals: expected 4278190335 but got 0
+PASS OffscreenCanvas source preserves alpha
+PASS ImageBitmap source preserves alpha
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
@@ -2,8 +2,8 @@
 
 FAIL <video> and VideoFrame constructed VideoFrame assert_unreached: Reached unreachable code
 FAIL CSSImageValue constructed VideoFrame assert_throws_dom: CSSImageValues are currently always tainted function "_ => { new VideoFrame(bgImage, {timestamp: 0}); }" did not throw
-FAIL Image element constructed VideoFrame assert_equals: top left corner expected "Yellow" but got "#0"
+PASS Image element constructed VideoFrame
 FAIL SVGImageElement constructed VideoFrame Type error
-FAIL Canvas element constructed VideoFrame assert_equals: top left corner expected "Yellow" but got "#0"
-FAIL Copy of canvas element constructed VideoFrame assert_equals: top left corner expected "Yellow" but got "#0"
+PASS Canvas element constructed VideoFrame
+PASS Copy of canvas element constructed VideoFrame
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL Test we can construct a VideoFrame. assert_equals: visibleRect.width expected 32 but got 0
+PASS Test we can construct a VideoFrame.
 FAIL Test closed VideoFrame. assert_equals: timestamp expected (object) null but got (number) 0
 PASS Test we can construct a VideoFrame with a negative timestamp.
 PASS Test that timestamp is required when constructing VideoFrame from ImageBitmap
 PASS Test that timestamp is required when constructing VideoFrame from OffscreenCanvas
 PASS Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame
-FAIL Test we can construct an odd-sized VideoFrame. assert_equals: visibleRect.width expected 1 but got 0
+PASS Test we can construct an odd-sized VideoFrame.
 PASS Test constructing w/ unusable image argument throws: HAVE_NOTHING <video>.
 PASS Test constructing w/ unusable image argument throws: emtpy Canvas.
 PASS Test constructing w/ unusable image argument throws: closed ImageBitmap.
@@ -17,7 +17,7 @@ PASS Test visibleRect metadata override where source display size = visible size
 PASS Test visibleRect metadata override where source display width = 2 * visible width (anamorphic)
 PASS Test visibleRect metadata override where source display size = 2 * visible size for both width and height
 PASS Test visibleRect + display size metadata override
-FAIL Test display size metadata override assert_equals: expected 32 but got 0
+PASS Test display size metadata override
 PASS Test invalid buffer constructed VideoFrames
 PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
 PASS Test ArrayBuffer constructed I420 VideoFrame
@@ -26,7 +26,7 @@ FAIL Test buffer constructed I420+Alpha VideoFrame VideoPixelFormat is not suppo
 PASS Test buffer constructed NV12 VideoFrame
 PASS Test buffer constructed RGB VideoFrames
 PASS Test VideoFrame constructed VideoFrame
-FAIL Test we can construct a VideoFrame from an offscreen canvas. assert_equals: expected 16 but got 0
+PASS Test we can construct a VideoFrame from an offscreen canvas.
 PASS Test I420 VideoFrame with odd visible size
 FAIL Test I420A VideoFrame and alpha={keep,discard} VideoPixelFormat is not supported
 PASS Test RGBA, BGRA VideoFrames with alpha={keep,discard}

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL ImageBitmap<->VideoFrame with canvas(48x36 srgb uint8). promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL ImageBitmap<->VideoFrame with canvas(480x360 srgb uint8). promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL ImageBitmap<->VideoFrame with canvas(48x36 display-p3 uint8). promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL ImageBitmap<->VideoFrame with canvas(480x360 display-p3 uint8). promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS ImageBitmap<->VideoFrame with canvas(48x36 srgb uint8).
+PASS ImageBitmap<->VideoFrame with canvas(480x360 srgb uint8).
+PASS ImageBitmap<->VideoFrame with canvas(48x36 display-p3 uint8).
+PASS ImageBitmap<->VideoFrame with canvas(480x360 display-p3 uint8).
 FAIL ImageBitmap<->VideoFrame with canvas(48x36 rec2020 uint8). Type error
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 rec2020 uint8). Type error
-FAIL createImageBitmap uses frame display size promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap uses frame display size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker-expected.txt
@@ -5,5 +5,5 @@ FAIL ImageBitmap<->VideoFrame with canvas(48x36 display-p3 uint8). Can't find va
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 display-p3 uint8). Can't find variable: OffscreenCanvas
 FAIL ImageBitmap<->VideoFrame with canvas(48x36 rec2020 uint8). Can't find variable: OffscreenCanvas
 FAIL ImageBitmap<->VideoFrame with canvas(480x360 rec2020 uint8). Can't find variable: OffscreenCanvas
-FAIL createImageBitmap uses frame display size promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS createImageBitmap uses frame display size
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt
@@ -1,10 +1,3 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: Type error
 
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
-TIMEOUT Create ImageBitmap for a VideoFrame from VP9 decoder. Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: Type error
-
-TIMEOUT Create ImageBitmap for a VideoFrame from VP9 decoder. Test timed out
+FAIL Create ImageBitmap for a VideoFrame from VP9 decoder. assert_approx_equals: expected 50 +/- 10 but got 0
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -69,7 +69,7 @@ public:
         std::optional<int64_t> timestamp;
         WebCodecsAlphaOption alpha { WebCodecsAlphaOption::Keep };
 
-        DOMRectInit visibleRect;
+        std::optional<DOMRectInit> visibleRect;
 
         std::optional<size_t> displayWidth;
         std::optional<size_t> displayHeight;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -263,13 +263,14 @@ ExceptionOr<CombinedPlaneLayout> parseVideoFrameCopyToOptions(const WebCodecsVid
 // https://w3c.github.io/webcodecs/#videoframe-initialize-visible-rect-and-display-size
 void initializeVisibleRectAndDisplaySize(WebCodecsVideoFrame& frame, const WebCodecsVideoFrame::Init& init, const DOMRectInit& defaultVisibleRect, size_t defaultDisplayWidth, size_t defaultDisplayHeight)
 {
-    frame.setVisibleRect(init.visibleRect);
+    auto visibleRect = init.visibleRect.value_or(defaultVisibleRect);
+    frame.setVisibleRect(visibleRect);
     if (init.displayWidth && init.displayHeight)
         frame.setDisplaySize(*init.displayWidth, *init.displayHeight);
     else {
         auto widthScale = defaultDisplayWidth / defaultVisibleRect.width;
         auto heightScale = defaultDisplayHeight / defaultVisibleRect.height;
-        frame.setDisplaySize(init.visibleRect.width * widthScale, init.visibleRect.height * heightScale);
+        frame.setDisplaySize(visibleRect.width * widthScale, visibleRect.height * heightScale);
     }
 }
 

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -41,6 +41,7 @@ namespace WebCore {
 
 class Blob;
 class CanvasBase;
+class CSSStyleImageValue;
 class HTMLCanvasElement;
 class HTMLImageElement;
 class HTMLVideoElement;
@@ -53,7 +54,10 @@ class OffscreenCanvas;
 #endif
 class PendingImageBitmap;
 class ScriptExecutionContext;
-class CSSStyleImageValue;
+#if ENABLE(WEB_CODECS)
+class WebCodecsVideoFrame;
+#endif
+
 struct ImageBitmapOptions;
 
 template<typename IDLType> class DOMPromiseDeferred;
@@ -73,6 +77,9 @@ public:
 #endif
 #if ENABLE(CSS_TYPED_OM)
         RefPtr<CSSStyleImageValue>,
+#endif
+#if ENABLE(WEB_CODECS)
+        RefPtr<WebCodecsVideoFrame>,
 #endif
         RefPtr<Blob>,
         RefPtr<ImageData>
@@ -126,6 +133,9 @@ private:
     static void createPromise(ScriptExecutionContext&, RefPtr<HTMLCanvasElement>&, ImageBitmapOptions&&, std::optional<IntRect>, Promise&&);
 #if ENABLE(OFFSCREEN_CANVAS)
     static void createPromise(ScriptExecutionContext&, RefPtr<OffscreenCanvas>&, ImageBitmapOptions&&, std::optional<IntRect>, Promise&&);
+#endif
+#if ENABLE(WEB_CODECS)
+    static void createPromise(ScriptExecutionContext&, RefPtr<WebCodecsVideoFrame>&, ImageBitmapOptions&&, std::optional<IntRect>, Promise&&);
 #endif
     static void createPromise(ScriptExecutionContext&, CanvasBase&, ImageBitmapOptions&&, std::optional<IntRect>, Promise&&);
     static void createPromise(ScriptExecutionContext&, RefPtr<Blob>&, ImageBitmapOptions&&, std::optional<IntRect>, Promise&&);

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.idl
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.idl
@@ -38,6 +38,9 @@ typedef (HTMLImageElement
 #if defined(ENABLE_CSS_TYPED_OM) && ENABLE_CSS_TYPED_OM
     or CSSStyleImageValue
 #endif
+#if defined(ENABLE_WEB_CODECS) && ENABLE_WEB_CODECS
+    or WebCodecsVideoFrame
+#endif
 ) CanvasImageSource;
 
 typedef (CanvasImageSource or Blob or ImageData) ImageBitmapSource;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -389,6 +389,9 @@ void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& desti
     // FIXME: It is not efficient to create a conformer everytime. We might want to make it more efficient, for instance by storing it in GraphicsContext.
     auto conformer = makeUnique<PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });
     auto image = NativeImage::create(conformer->createImageFromPixelBuffer(pixelBuffer()));
+    if (!image)
+        return;
+
     FloatRect imageRect { FloatPoint::zero(), image->size() };
     context.drawNativeImage(*image, presentationSize(), destination, imageRect);
 }


### PR DESCRIPTION
#### ec0b08a9250928a5b0712db55011517734bdecef
<pre>
Add WebCodecs VideoFrame support for createImageBitmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=246739">https://bugs.webkit.org/show_bug.cgi?id=246739</a>
rdar://problem/101331058

Reviewed by Eric Carlson.

Update WebIDL to support WebCodecsVideoFrame as input to createImageBitmap.
Reuse VideoFrame::paintInContext to create the ImageBitmap.
Fix WebCodecsVideoFrame to crrectly set visible rect and displayWidth/displayHeight.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-alpha.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::initializeVisibleRectAndDisplaySize):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createPromise):
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/page/WindowOrWorkerGlobalScope.idl:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::paintInContext):

Canonical link: <a href="https://commits.webkit.org/255776@main">https://commits.webkit.org/255776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1b8d6904d170a1076fbfd29b27e074b0c4b1a0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103110 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163439 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2646 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30936 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99210 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1865 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79890 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28910 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37319 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17390 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3994 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41166 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40958 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37866 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->