### PR TITLE
[WTF] MediaTime: assert not double in timeValue() and timeScale()

### DIFF
--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -106,8 +106,8 @@ public:
     static const MediaTime& negativeInfiniteTime();
     static const MediaTime& indefiniteTime();
 
-    const int64_t& timeValue() const { return m_timeValue; }
-    const uint32_t& timeScale() const { return m_timeScale; }
+    int64_t timeValue() const { ASSERT(!hasDoubleValue()); return m_timeValue; }
+    uint32_t timeScale() const { ASSERT(!hasDoubleValue()); return m_timeScale; }
 
     void dump(PrintStream& out) const;
     String toString() const;


### PR DESCRIPTION
#### 2733129cea54de287bf68be56be657efcd76b98c
<pre>
[WTF] MediaTime: assert not double in timeValue() and timeScale()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246406">https://bugs.webkit.org/show_bug.cgi?id=246406</a>

Reviewed by NOBODY (OOPS!).

A MediaTime can either represent a time as a fraction or as a floating
point number.

Both representations are stored in a union, with a tag in m_timeFlags to
know which one must be used.

timeValue() and timeScale() are the methods used to get the numerator
and denominator of the time when a MediaTime is fractional. However, as
the code stood before this patch, there is no check (even in Debug mode)
to assert this is the case. An accidental use of timeValue() in this
situation would return an int64_t with the bit contents of an IEEE 754
double, which could cause a hard to debug bug. Similarly, timeScale() is
undefined in this case.

This code adds an assert to both methods to guard against accidental
usages on MediaTime instances containing floating point values.

Additionally: these functions used to return references. Doing so
exposes implementation details of MediaTime and would enable dangerous
and confusing uses (e.g. calling timeValue() first, saving it in a
reference variable, updating the MediaTime and checking the variable
afterwards). All existing uses are as an immediate, so they can be
safely refactored to return by value, which is safer.

* Source/WTF/wtf/MediaTime.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2733129cea54de287bf68be56be657efcd76b98c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93440 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103111 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163440 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2647 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30937 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99211 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1863 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79891 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28917 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71874 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/84743 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37320 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17394 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79825 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18644 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27574 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39023 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41169 "Found 30 new test failures: compositing/geometry/clipped-video-controller.html, compositing/geometry/video-fixed-scrolling.html, compositing/geometry/video-opacity-overlay.html, compositing/layers-inside-overflow-scroll.html, compositing/overflow/scroll-ancestor-update.html, compositing/self-painting-layers.html, compositing/shared-backing/clipping-and-shared-backing.html, compositing/video/video-border-radius-clipping.html, compositing/video/video-poster.html, compositing/video/video-with-invalid-source.html ... (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82459 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37871 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18637 "Passed tests") | 
<!--EWS-Status-Bubble-End-->