### PR TITLE
[LBSE] Fix transform support for SVG <text> elements

### DIFF
--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations
@@ -37,6 +37,7 @@ svg/W3C-SVG-1.1/filters-specular-01-f.svg                                       
 svg/W3C-SVG-1.1/filters-tile-01-b.svg                                                  [ ImageOnlyFailure ]
 svg/W3C-SVG-1.1/filters-turb-02-f.svg                                                  [ ImageOnlyFailure ]
 svg/batik/filters/filterRegions.svg                                                    [ ImageOnlyFailure ]
+svg/batik/text/smallFonts.svg                                                          [ ImageOnlyFailure ]
 svg/batik/text/textEffect3.svg                                                         [ ImageOnlyFailure ]
 svg/batik/text/textFeatures.svg                                                        [ ImageOnlyFailure ]
 svg/custom/feComponentTransfer-Discrete.svg                                            [ Failure ]
@@ -324,7 +325,6 @@ svg/W3C-SVG-1.1/pservers-pattern-01-b.svg                       [ ImageOnlyFailu
 svg/batik/paints/patternPreserveAspectRatioA.svg                [ ImageOnlyFailure ]
 svg/batik/paints/patternRegionA.svg                             [ ImageOnlyFailure ]
 svg/batik/paints/patternRegions.svg                             [ ImageOnlyFailure ]
-svg/batik/text/smallFonts.svg                                   [ ImageOnlyFailure ]
 svg/custom/href-svg-namespace-static.svg                        [ ImageOnlyFailure ]
 svg/custom/js-late-pattern-and-object-creation.svg              [ Failure ]
 svg/custom/js-late-pattern-creation.svg                         [ Failure ]
@@ -509,28 +509,8 @@ svg/repaint/text-mask-update.svg                       [ ImageOnlyFailure ]
 svg/transforms/text-with-mask-with-svg-transform.svg   [ Failure ]
 svg/zoom/page/zoom-mask-with-percentages.svg           [ Failure ]
 
-# Text rendering ignores SVG 'transform' attribute (e.g. <text transform="rotate(... " is not transformed during rendering)
-svg/as-background-image/svg-as-background-5.html       [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1-SE/types-dom-01-b.svg                  [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1/animate-elem-24-t.svg                  [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1/fonts-kern-01-t.svg                    [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1/types-basicDOM-01-b.svg                [ ImageOnlyFailure ]
-svg/animations/animate-text-nested-transforms.html     [ Skip ]
-svg/carto.net/window.svg                               [ ImageOnlyFailure ]
-svg/custom/SVGPoint-matrixTransform.svg                [ ImageOnlyFailure ]
-svg/custom/pointer-events-text-css-transform.svg       [ Failure ]
-svg/custom/text-repaint-including-stroke.svg           [ Failure ]
-svg/custom/use-event-handler-on-referenced-element.svg [ Failure ]
-svg/custom/use-event-handler-on-use-element.svg        [ Failure ]
-svg/hixie/perf/003.xml                                 [ ImageOnlyFailure ]
-svg/text/append-text-node-to-tspan.html                [ ImageOnlyFailure ]
-svg/text/modify-text-node-in-tspan.html                [ ImageOnlyFailure ]
-svg/text/remove-text-node-from-tspan.html              [ ImageOnlyFailure ]
-svg/text/remove-tspan-from-text.html                   [ ImageOnlyFailure ]
-svg/text/scaled-font.svg                               [ Failure ]
-svg/text/scaling-font-with-geometric-precision.html    [ Failure ]
-
 # Hit testing / text selection issues
+svg/custom/pointer-events-text-css-transform.svg          [ Failure ]
 svg/custom/focus-event-handling.xhtml                     [ Failure ]
 svg/custom/mouse-move-on-svg-root-standalone.svg          [ Failure ]
 svg/custom/mouse-move-on-svg-root.xhtml                   [ Failure ]
@@ -561,14 +541,7 @@ svg/text/select-x-list-with-tspans-4.svg                  [ Failure ]
 svg/text/selection-doubleclick.svg                        [ ImageOnlyFailure ]
 
 # Text rendering placement issues (text renders at wrong location)
-svg/W3C-SVG-1.1/animate-elem-46-t.svg      [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1/extend-namespace-01-f.svg  [ ImageOnlyFailure ]
-svg/batik/text/textAnchor2.svg             [ ImageOnlyFailure ]
-svg/batik/text/textAnchor3.svg             [ ImageOnlyFailure ]
-svg/batik/text/textLayout2.svg             [ ImageOnlyFailure ]
 svg/carto.net/tabgroup.svg                 [ ImageOnlyFailure ]
-svg/text/text-hkern-on-vertical-text.svg   [ ImageOnlyFailure ]
-svg/text/text-vkern-on-horizontal-text.svg [ ImageOnlyFailure ]
 
 # Transforming inner svg elements has issues
 svg/transforms/svgsvgelement-transform.svg [ ImageOnlyFailure ]
@@ -581,15 +554,13 @@ svg/custom/focus-ring.svg         [ Failure ]
 svg/custom/rgba-color-outline.svg [ ImageOnlyFailure ]
 svg/text/text-outline-rgba.html   [ ImageOnlyFailure ]
 
-# Text rendering visually different ('screen font size scaling factor' probably differs between LBSE/legacy)
+# Text rendering visually different
 svg/foreignObject/text-tref-02-b.svg       [ ImageOnlyFailure ]
 svg/hittest/text-multiple-dx-values.svg    [ ImageOnlyFailure ]
 svg/hittest/text-with-multiple-tspans.svg  [ ImageOnlyFailure ]
 svg/hittest/text-with-text-path.svg        [ ImageOnlyFailure ]
-svg/text/font-size-below-point-five-2.svg  [ ImageOnlyFailure ]
-svg/text/monospace-text-size-in-img.html   [ ImageOnlyFailure ]
-svg/text/text-repaint-rects.xhtml          [ ImageOnlyFailure ]
 svg/text/text-rescale.html                 [ ImageOnlyFailure ]
+svg/text/scaled-font.svg                   [ ImageOnlyFailure ]
 
 # Text rendering has issues with CSS 'visibility'
 svg/batik/text/textProperties2.svg [ ImageOnlyFailure ]
@@ -606,6 +577,9 @@ svg/custom/object-no-size-attributes.xhtml                                    [ 
 svg/custom/object-sizing-no-width-height.xhtml                                [ Failure ]
 svg/custom/object-sizing.xhtml                                                [ Failure ]
 svg/wicd/sizing-flakiness.html                                                [ ImageOnlyFailure ]
+
+# Opacity clipping placement issue
+svg/as-background-image/svg-as-background-5.html [ ImageOnlyFailure ]
 
 # CSS 'mix-blend-mode' broken
 svg/css/mix-blend-mode-background-root.svg [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/types-basicDOM-01-b-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/types-basicDOM-01-b-expected.txt
@@ -10,11 +10,11 @@ layer at (-50,-50) size 452x353 backgroundClip at (0,0) size 480x360 clip at (0,
   RenderSVGTransformableContainer {g} at (0,0) size 451.11x352.77
 layer at (-50,-50) size 452x205 backgroundClip at (0,0) size 480x360 clip at (0,0) size 480x360
   RenderSVGTransformableContainer {g} at (0,0) size 451.11x204.61
-layer at (30,131.59) size 342x23
+layer at (30,131.27) size 342x24
   RenderSVGText {text} at (80,181) size 343x24 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 343x23
+    RenderSVGInlineText {#text} at (0,0) size 343x24
       chunk 1 text run 1 at (30.00,150.00) startOffset 0 endOffset 37 width 342.41: "Rotated Text for testing SVGLocatable"
-layer at (100,111.59) size 301x23
+layer at (100,111.73) size 301x23
   RenderSVGText {text} at (150,161) size 302x24 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 302x23
       chunk 1 text run 1 at (100.00,130.00) startOffset 0 endOffset 35 width 301.10: "Some other text with id 'otherText'"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/text/smallFonts-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/text/smallFonts-expected.txt
@@ -144,11 +144,11 @@ layer at (0.89,7.23) size 6x1
       RenderSVGInlineText {#text} at (0,0) size 3x1
         chunk 1 text run 1 at (0.90,7.90) startOffset 0 endOffset 21 width 2.54: "and placed on a path."
 layer at (0,-0.73) size 3x1 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGTransformableContainer {g} at (0,0) size 2.58x0.94
+  RenderSVGTransformableContainer {g} at (0,0) size 2.61x0.94
 layer at (0,-0.73) size 3x1 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
   RenderSVGText {text} at (0,0) size 3x1 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 3x1
-      chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 6 width 2.58: "Shadow"
+      chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 6 width 2.60: "Shadow"
 layer at (0,-0.73) size 3x1 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
   RenderSVGText {text} at (0,0) size 3x1 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 3x1

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/text/textFeatures-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/text/textFeatures-expected.txt
@@ -4,14 +4,14 @@ layer at (0,0) size 450x500
   RenderSVGRoot {svg} at (0,0) size 450x500
 layer at (0,0) size 450x500
   RenderSVGViewportContainer at (0,0) size 450x500
-layer at (0,-36) size 382x515 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGTransformableContainer {g} at (0,-36) size 381.19x514.75
+layer at (0,-36.34) size 382x516 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
+  RenderSVGTransformableContainer {g} at (0,-36.34) size 381.19x515.09
 layer at (149.13,36.41) size 152x17
   RenderSVGText {text} at (149,72) size 152x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 152x17
       chunk 1 (middle anchor) text run 1 at (149.14,50.00) startOffset 0 endOffset 21 width 151.73: "Text Element Features"
-layer at (0,-36) size 382x515 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGTransformableContainer {g} at (0,0) size 381.19x514.75
+layer at (0,-36.34) size 382x516 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
+  RenderSVGTransformableContainer {g} at (0,0) size 381.19x515.09
 layer at (45,72.50) size 318x35
   RenderSVGText {text} at (45,108) size 319x36 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,14) size 103x17
@@ -37,11 +37,11 @@ layer at (45,72.50) size 318x35
         chunk 1 text run 1 at (335.96,100.00) startOffset 0 endOffset 5 width 27.49: "style"
     RenderSVGInlineText {#text} at (0,0) size 0x0
 layer at (45,111.75) size 170x17
-  RenderSVGText {text} at (45,147) size 170x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,148) size 170x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 170x17
       chunk 1 text run 1 at (45.00,125.00) startOffset 0 endOffset 29 width 169.54: "within a single text element."
 layer at (45,161.75) size 329x17
-  RenderSVGText {text} at (45,197) size 329x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,198) size 329x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 147x17
       chunk 1 text run 1 at (45.00,175.00) startOffset 0 endOffset 25 width 146.21: "Styling features include "
     RenderSVGTSpan {tspan} at (0,0) size 47x17
@@ -58,10 +58,10 @@ layer at (45,161.75) size 329x17
       RenderSVGInlineText {#text} at (274,0) size 55x17
         chunk 1 text run 1 at (319.12,175.00) startOffset 0 endOffset 9 width 54.54: "typeface."
     RenderSVGInlineText {#text} at (0,0) size 0x0
-layer at (45,200) size 203x50
-  RenderSVGRect {rect} at (45,236) size 202.50x50 [fill={[type=SOLID] [color=#1E90FF]}] [x=45.00] [y=200.00] [width=202.50] [height=50.00]
+layer at (45,200) size 203x51
+  RenderSVGRect {rect} at (45,236.34) size 202.50x50 [fill={[type=SOLID] [color=#1E90FF]}] [x=45.00] [y=200.00] [width=202.50] [height=50.00]
 layer at (45,211.75) size 303x17
-  RenderSVGText {text} at (45,247) size 304x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,248) size 304x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 165x17
       chunk 1 text run 1 at (45.00,225.00) startOffset 0 endOffset 28 width 164.96: "Graphics attributes such as "
     RenderSVGTSpan {tspan} at (0,0) size 46x17
@@ -70,7 +70,7 @@ layer at (45,211.75) size 303x17
     RenderSVGInlineText {#text} at (209,0) size 95x17
       chunk 1 text run 1 at (254.11,225.00) startOffset 0 endOffset 16 width 94.12: " can be applied."
 layer at (45,261.75) size 320x17
-  RenderSVGText {text} at (45,297) size 321x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,298) size 321x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 179x17
       chunk 1 text run 1 at (45.00,275.00) startOffset 0 endOffset 30 width 178.01: "\"text decoration\" can include "
     RenderSVGTSpan {tspan} at (0,0) size 61x17
@@ -117,7 +117,7 @@ layer at (45,309.25) size 326x24
       chunk 1 text run 1 at (279.96,325.00) startOffset 0 endOffset 1 width 3.75: " "
       chunk 1 text run 1 at (283.71,325.00) startOffset 0 endOffset 14 width 87.45: "by percentage."
 layer at (45,361.75) size 336x17
-  RenderSVGText {text} at (45,397) size 337x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,398) size 337x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 52x17
       chunk 1 text run 1 at (45.00,375.00) startOffset 0 endOffset 8 width 51.24: "Various "
     RenderSVGTSpan {tspan} at (0,0) size 46x17
@@ -136,7 +136,7 @@ layer at (45,361.75) size 336x17
     RenderSVGInlineText {#text} at (297,0) size 39x17
       chunk 1 text run 1 at (342.45,375.00) startOffset 0 endOffset 6 width 38.72: "can be"
 layer at (45,386.75) size 329x17
-  RenderSVGText {text} at (45,422) size 330x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,423) size 330x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 211x17
       chunk 1 text run 1 at (45.00,400.00) startOffset 0 endOffset 36 width 210.77: "used, and the outline stroke can be "
     RenderSVGTSpan {tspan} at (0,0) size 50x17
@@ -150,21 +150,21 @@ layer at (45,386.75) size 329x17
         chunk 1 text run 1 at (324.92,400.00) startOffset 0 endOffset 8 width 49.56: "mitered."
     RenderSVGInlineText {#text} at (0,0) size 0x0
 layer at (45,436.75) size 155x17
-  RenderSVGText {text} at (45,472) size 155x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,473) size 155x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 155x17
       chunk 1 text run 1 at (45.00,450.00) startOffset 0 endOffset 25 width 154.94: "Text elements also can be"
 layer at (45,461.75) size 149x17
-  RenderSVGText {text} at (45,497) size 149x18 contains 1 chunk(s)
+  RenderSVGText {text} at (45,498) size 149x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 149x17
       chunk 1 text run 1 at (45.00,475.00) startOffset 0 endOffset 25 width 148.69: "filtered and transformed."
+layer at (0,-36.34) size 131x47 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
+  RenderSVGTransformableContainer {g} at (0,0) size 130.25x46.45
+layer at (0,-36.34) size 130x46 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
+  RenderSVGText {text} at (0,0) size 131x47 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 131x47
+      chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 6 width 130.24: "Shadow"
 layer at (0,-36) size 129x46 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGTransformableContainer {g} at (0,0) size 128.89x46
-layer at (0,-36) size 129x46 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGText {text} at (0,0) size 129x46 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 129x46
-      chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 6 width 128.89: "Shadow"
-layer at (0,-36) size 129x46 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500
-  RenderSVGText {text} at (0,0) size 129x46 contains 1 chunk(s)
+  RenderSVGText {text} at (0,0) size 129x47 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 129x46
       chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 6 width 128.89: "Shadow"
 layer at (-0.05,-0.36) size 540x565 backgroundClip at (0,0) size 450x500 clip at (0,0) size 450x500

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/SVGPoint-matrixTransform-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/SVGPoint-matrixTransform-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
-layer at (20,6) size 44x18
-  RenderSVGText {text} at (20,6) size 44x18 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 44x18
+layer at (20,5.50) size 44x18
+  RenderSVGText {text} at (20,5) size 44x19 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 44x19
       chunk 1 text run 1 at (20.00,20.00) startOffset 0 endOffset 6 width 43.55: "Passed"

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/append-text-node-to-tspan-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/append-text-node-to-tspan-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,1) size 32x38
+layer at (0,1.19) size 32x38
   RenderSVGText {text} at (0,1) size 32x38 contains 1 chunk(s)
     RenderSVGTSpan {tspan} at (0,0) size 29x14
       RenderSVGInlineText {#text} at (0,0) size 16x14

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/font-size-below-point-five-2-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/font-size-below-point-five-2-expected.txt
@@ -8,13 +8,14 @@ layer at (10,16) size 256x18
   RenderSVGText {text} at (10,16) size 256x18 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 256x18
       chunk 1 text run 1 at (10.00,30.00) startOffset 0 endOffset 38 width 255.50: "The two words should be the same size:"
-layer at (10,-2) size 6x18 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
-  RenderSVGText {text} at (10,-2) size 7x18 contains 1 chunk(s)
-    RenderSVGTSpan {tspan} at (0,0) size 3x2
-      RenderSVGInlineText {#text} at (0,13) size 3x1
-        chunk 1 text run 1 at (10.00,12.00) startOffset 0 endOffset 4 width 2.39: "TINY"
-    RenderSVGInlineText {#text} at (2,0) size 4x18
-      chunk 1 text run 1 at (12.39,12.00) startOffset 0 endOffset 1 width 4.00: " "
-    RenderSVGTSpan {tspan} at (0,0) size 0x0
-      RenderSVGInlineText {#text} at (-10,2) size 0x0
+layer at (10,-2.41) size 6x18 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGText {text} at (10,-3) size 7x19 contains 1 chunk(s)
+    RenderSVGTSpan {tspan} at (0,0) size 2x2
+      RenderSVGInlineText {#text} at (0,13) size 2x1
+        chunk 1 text run 1 at (10.00,12.00) startOffset 0 endOffset 4 width 1.27: "TINY"
+    RenderSVGInlineText {#text} at (1,0) size 4x19
+      chunk 1 text run 1 at (11.27,12.00) startOffset 0 endOffset 1 width 4.00: " "
+    RenderSVGTSpan {tspan} at (0,0) size 2x2
+      RenderSVGInlineText {#text} at (5,13) size 2x1
+        chunk 1 text run 1 at (15.27,12.00) startOffset 0 endOffset 4 width 1.11: "TINY"
     RenderSVGInlineText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/modify-text-node-in-tspan-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/modify-text-node-in-tspan-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,1) size 32x38
+layer at (0,1.19) size 32x38
   RenderSVGText {text} at (0,1) size 32x38 contains 1 chunk(s)
     RenderSVGTSpan {tspan} at (0,0) size 29x14
       RenderSVGInlineText {#text} at (0,0) size 29x14

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/remove-text-node-from-tspan-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/remove-text-node-from-tspan-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,13) size 32x26
+layer at (0,13.19) size 32x26
   RenderSVGText {text} at (0,13) size 32x26 contains 1 chunk(s)
     RenderSVGTSpan {tspan} at (0,0) size 0x0
     RenderSVGInlineText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/remove-tspan-from-text-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/remove-tspan-from-text-expected.txt
@@ -7,7 +7,7 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
-layer at (0,1) size 32x26
+layer at (0,1.19) size 32x26
   RenderSVGText {text} at (0,1) size 32x26 contains 1 chunk(s)
     RenderSVGTSpan {tspan} at (0,0) size 29x14
       RenderSVGInlineText {#text} at (0,0) size 29x14

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -166,7 +166,7 @@ public:
     LayoutPoint contentBoxLocation() const;
 
     // https://www.w3.org/TR/css-transforms-1/#reference-box
-    FloatRect referenceBoxRect(CSSBoxType) const final;
+    FloatRect referenceBoxRect(CSSBoxType) const override;
 
     // The content box in absolute coords. Ignores transforms.
     IntRect absoluteContentBox() const;

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -105,6 +105,18 @@ void RenderSVGBlock::styleDidChange(StyleDifference diff, const RenderStyle* old
     SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+FloatRect RenderSVGBlock::referenceBoxRect(CSSBoxType boxType) const
+{
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        // Skip RenderBox::referenceBoxRect() implementation (generic CSS, not SVG), if LBSE is enabled.
+        return RenderElement::referenceBoxRect(boxType);
+    }
+
+    return RenderBlockFlow::referenceBoxRect(boxType);
+}
+#endif
+
 void RenderSVGBlock::computeOverflow(LayoutUnit oldClientAfterEdge, bool recomputeFloats)
 {
     RenderBlockFlow::computeOverflow(oldClientAfterEdge, recomputeFloats);

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -49,6 +49,8 @@ private:
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     LayoutPoint currentSVGLayoutLocation() const final { return location(); }
     void setCurrentSVGLayoutLocation(const LayoutPoint& location) final { setLocation(location); }
+
+    FloatRect referenceBoxRect(CSSBoxType) const final;
 #endif
 
     LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext) const final;

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -488,6 +488,12 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 
     return false;
 }
+
+void RenderSVGText::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> options) const
+{
+    ASSERT(document().settings().layerBasedSVGEngineEnabled());
+    applySVGTransform(transform, textElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+}
 #endif
 
 VisiblePosition RenderSVGText::positionForPoint(const LayoutPoint& pointInContents, const RenderFragmentContainer* fragment)

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -78,6 +78,8 @@ private:
     void paint(PaintInfo&, const LayoutPoint&) override;
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
+
+    void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<RenderStyle::TransformOperationOption> = RenderStyle::allTransformOperations) const final;
 #endif
     VisiblePosition positionForPoint(const LayoutPoint&, const RenderFragmentContainer*) override;
 

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -209,6 +209,7 @@ void SVGGraphicsElement::didAttachRenderers()
 
 Path SVGGraphicsElement::toClipPath()
 {
+    // FIXME: [LBSE] Stop mutating the path here.
     Path path = pathFromGraphicsElement(this);
     // FIXME: How do we know the element has done a layout?
     path.transform(animatedLocalTransform());

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -50,7 +50,7 @@ public:
     AffineTransform animatedLocalTransform() const override;
     AffineTransform* supplementalTransform() override;
 
-    virtual bool hasTransformRelatedAttributes() const { return !animatedLocalTransform().isIdentity(); }
+    virtual bool hasTransformRelatedAttributes() const { return !transform().concatenate().isIdentity() || m_supplementalTransform; }
 
     Ref<SVGRect> getBBoxForBindings();
     FloatRect getBBox(StyleUpdateStrategy = AllowStyleUpdate) override;

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -317,6 +317,7 @@ Path SVGUseElement::toClipPath()
         return { };
     }
 
+    // FIXME: [LBSE] Stop mutating the path here.
     Path path = downcast<SVGGraphicsElement>(*targetClone).toClipPath();
     SVGLengthContext lengthContext(this);
     // FIXME: Find a way to do this without manual resolution of x/y here. It's potentially incorrect.


### PR DESCRIPTION
#### 0c33f22a764e207a6818f558211b2b0d833df4b3
<pre>
[LBSE] Fix transform support for SVG &lt;text&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=245508">https://bugs.webkit.org/show_bug.cgi?id=245508</a>

Reviewed by Rob Buis.

RenderSVGBlock::referenceBoxRect() was missing (affecting RenderSVGText), thus the
refeferenceBoxRect() for a RenderSVGText renderer was computed according to CSS rules,
see RenderBox::referenceBoxRect(), and not according to the SVG rules, implemented in
RenderLayerModelObject::referenceBoxRect() -- fix that.

This also uncovered a LBSE specific isssue with SMIL &lt;animateMotion&gt; - they were
post- instead of pre-multiplied, fix that as well, while I&apos;m at it.

Covered by numerous existing tests that now function properly in LBSE.

* LayoutTests/platform/mac-monterey-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/W3C-SVG-1.1/types-basicDOM-01-b-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/text/smallFonts-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/batik/text/textFeatures-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/custom/SVGPoint-matrixTransform-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/append-text-node-to-tspan-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/font-size-below-point-five-2-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/modify-text-node-in-tspan-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/remove-text-node-from-tspan-expected.txt:
* LayoutTests/platform/mac-monterey-wk2-lbse-text/svg/text/remove-tspan-from-text-expected.txt:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::applySVGTransform const):
(WebCore::RenderLayerModelObject::updateHasSVGTransformFlags):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::referenceBoxRect const):
* Source/WebCore/rendering/svg/RenderSVGBlock.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::applyTransform const):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::toClipPath):
* Source/WebCore/svg/SVGGraphicsElement.h:
(WebCore::SVGGraphicsElement::hasTransformRelatedAttributes const):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::toClipPath):

Canonical link: <a href="https://commits.webkit.org/255801@main">https://commits.webkit.org/255801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d38a0300c8d9386d56f2f40c0b21986e8b5f27c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103117 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163446 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2653 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30943 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99217 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1868 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79898 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28918 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71875 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37326 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17396 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4008 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41173 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37873 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->