### PR TITLE
Make WebCodecs isConfigSupported more accurate by relying on codec creation code path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: OffscreenCanvas"
+PASS Encoding and decoding cycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,5 +1,7 @@
 CONSOLE MESSAGE: TypeError: Type error
 CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Type error
 
 FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoEncoder is not configured"
+PASS Encoding and decoding cycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "InvalidStateError: VideoEncoder is not configured"
+PASS Reconfiguring encoder
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_unreached: Not supported Reached unreachable code
 
-FAIL Reconfiguring encoder promise_test: Unhandled rejection with value: object "InvalidStateError: VideoEncoder is not configured"
+PASS Reconfiguring encoder
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -83,6 +83,27 @@ static bool isValidDecoderConfig(const WebCodecsVideoDecoderConfig& config)
     return true;
 }
 
+static VideoDecoder::Config createVideoDecoderConfig(const WebCodecsVideoDecoderConfig& config)
+{
+    Span<const uint8_t> description;
+    if (config.description) {
+        auto* data = std::visit([](auto& buffer) -> const uint8_t* {
+            return buffer ? static_cast<const uint8_t*>(buffer->data()) : nullptr;
+        }, *config.description);
+        auto length = std::visit([](auto& buffer) -> size_t {
+            return buffer ? buffer->byteLength() : 0;
+        }, *config.description);
+        if (length)
+            description = { data, length };
+    }
+
+    return {
+        description,
+        config.codedWidth.value_or(0),
+        config.codedHeight.value_or(0)
+    };
+}
+
 ExceptionOr<void> WebCodecsVideoDecoder::configure(WebCodecsVideoDecoderConfig&& config)
 {
     if (!isValidDecoderConfig(config))
@@ -108,18 +129,8 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(WebCodecsVideoDecoderConfig&&
                 });
             };
         }
-        Span<const uint8_t> description;
-        if (config.description) {
-            BufferSource buffer { WTFMove(*config.description) };
-            if (buffer.length())
-                description = { buffer.data(), buffer.length() };
-        }
-        VideoDecoder::Config videoDecoderConfig {
-            description,
-            config.codedWidth.value_or(0),
-            config.codedHeight.value_or(0)
-        };
-        VideoDecoder::create(config.codec, videoDecoderConfig, [this, weakedThis = WeakPtr { *this }](auto&& result) {
+
+        VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [this, weakedThis = WeakPtr { *this }](auto&& result) {
             if (!weakedThis)
                 return;
 
@@ -209,14 +220,30 @@ ExceptionOr<void> WebCodecsVideoDecoder::close()
     return closeDecoder(Exception { AbortError, "Close called"_s });
 }
 
-void WebCodecsVideoDecoder::isConfigSupported(WebCodecsVideoDecoderConfig&& config, Ref<DeferredPromise>&& promise)
+void WebCodecsVideoDecoder::isConfigSupported(ScriptExecutionContext& context, WebCodecsVideoDecoderConfig&& config, Ref<DeferredPromise>&& promise)
 {
     if (!isValidDecoderConfig(config)) {
         promise->reject(Exception { TypeError, "Config is not valid"_s });
         return;
     }
-    // FIXME: Implement accurate checks.
-    promise->resolve<IDLDictionary<WebCodecsVideoDecoderSupport>>(WebCodecsVideoDecoderSupport { true, WTFMove(config) });
+
+    auto* promisePtr = promise.ptr();
+    context.addDeferredPromise(WTFMove(promise));
+
+    auto videoDecoderConfig = createVideoDecoderConfig(config);
+    Vector<uint8_t> description { videoDecoderConfig.description };
+    VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [identifier = context.identifier(), config = config.isolatedCopyWithoutDescription(), description = WTFMove(description), promisePtr](auto&& result) mutable {
+        ScriptExecutionContext::postTaskTo(identifier, [success = result.has_value(), config = WTFMove(config).isolatedCopyWithoutDescription(), description = WTFMove(description), promisePtr](auto& context) mutable {
+            if (auto promise = context.takeDeferredPromise(promisePtr)) {
+                if (description.size())
+                    config.description = RefPtr { JSC::ArrayBuffer::create(description.data(), description.size()) };
+                promise->template resolve<IDLDictionary<WebCodecsVideoDecoderSupport>>(WebCodecsVideoDecoderSupport { success, WTFMove(config) });
+            }
+        });
+    }, [](auto&&) {
+    }, [] (auto&& task) {
+        task();
+    });
 }
 
 ExceptionOr<void> WebCodecsVideoDecoder::closeDecoder(Exception&& exception)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -67,7 +67,7 @@ public:
     ExceptionOr<void> reset();
     ExceptionOr<void> close();
 
-    static void isConfigSupported(WebCodecsVideoDecoderConfig&&, Ref<DeferredPromise>&&);
+    static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoDecoderConfig&&, Ref<DeferredPromise>&&);
 
     using RefCounted::ref;
     using RefCounted::deref;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl
@@ -43,7 +43,7 @@
     undefined reset();
     undefined close();
 
-    static Promise<WebCodecsVideoDecoderSupport> isConfigSupported(WebCodecsVideoDecoderConfig config);
+    [CallWith=CurrentScriptExecutionContext] static Promise<WebCodecsVideoDecoderSupport> isConfigSupported(WebCodecsVideoDecoderConfig config);
 };
 
 [

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoderConfig.h
@@ -44,6 +44,9 @@ struct WebCodecsVideoDecoderConfig {
     std::optional<VideoColorSpaceInit> colorSpace;
     HardwareAcceleration hardwareAcceleration { HardwareAcceleration::NoPreference };
     std::optional<bool> optimizeForLatency;
+
+    WebCodecsVideoDecoderConfig isolatedCopyWithoutDescription() && { return { WTFMove(codec).isolatedCopy(), { }, codedWidth, codedHeight, displayAspectWidth, displayAspectHeight, colorSpace, hardwareAcceleration, optimizeForLatency }; }
+    WebCodecsVideoDecoderConfig isolatedCopyWithoutDescription() const & { return { codec.isolatedCopy(), { }, codedWidth, codedHeight, displayAspectWidth, displayAspectHeight, colorSpace, hardwareAcceleration, optimizeForLatency }; }
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -68,7 +68,7 @@ public:
     ExceptionOr<void> reset();
     ExceptionOr<void> close();
 
-    static void isConfigSupported(WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&&);
+    static void isConfigSupported(ScriptExecutionContext&, WebCodecsVideoEncoderConfig&&, Ref<DeferredPromise>&&);
 
     using RefCounted::ref;
     using RefCounted::deref;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl
@@ -43,7 +43,7 @@
     undefined reset();
     undefined close();
 
-    static Promise<WebCodecsVideoEncoderSupport> isConfigSupported(WebCodecsVideoEncoderConfig config);
+    [CallWith=CurrentScriptExecutionContext] static Promise<WebCodecsVideoEncoderSupport> isConfigSupported(WebCodecsVideoEncoderConfig config);
 };
 
 [

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h
@@ -50,6 +50,9 @@ struct WebCodecsVideoEncoderConfig {
     BitrateMode bitrateMode { BitrateMode::Variable };
     LatencyMode latencyMode { LatencyMode::Quality };
     std::optional<AvcEncoderConfig> avc;
+
+    WebCodecsVideoEncoderConfig isolatedCopy() && { return { WTFMove(codec).isolatedCopy(), width, height, displayWidth, displayHeight, bitrate, framerate, hardwareAcceleration, alpha, WTFMove(scalabilityMode).isolatedCopy(), bitrateMode, latencyMode, avc }; }
+    WebCodecsVideoEncoderConfig isolatedCopy() const & { return { codec.isolatedCopy(), width, height, displayWidth, displayHeight, bitrate, framerate, hardwareAcceleration, alpha, scalabilityMode.isolatedCopy(), bitrateMode, latencyMode, avc }; }
 };
 
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -40,6 +40,7 @@
 #include "FontLoadRequest.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMPromiseDeferred.h"
 #include "JSDOMWindow.h"
 #include "JSWorkerGlobalScope.h"
 #include "JSWorkletGlobalScope.h"
@@ -344,6 +345,7 @@ void ScriptExecutionContext::stopActiveDOMObjects()
         activeDOMObject.stop();
         return ShouldContinue::Yes;
     });
+    m_deferredPromises.clear();
 }
 
 void ScriptExecutionContext::suspendActiveDOMObjectIfNeeded(ActiveDOMObject& activeDOMObject)
@@ -783,6 +785,16 @@ ScriptExecutionContext::NotificationCallbackIdentifier ScriptExecutionContext::a
 CompletionHandler<void()> ScriptExecutionContext::takeNotificationCallback(NotificationCallbackIdentifier identifier)
 {
     return m_notificationCallbacks.take(identifier);
+}
+
+void ScriptExecutionContext::addDeferredPromise(Ref<DeferredPromise>&& promise)
+{
+    m_deferredPromises.add(WTFMove(promise));
+}
+
+RefPtr<DeferredPromise> ScriptExecutionContext::takeDeferredPromise(DeferredPromise* promise)
+{
+    return m_deferredPromises.take(promise);
 }
 
 WebCoreOpaqueRoot root(ScriptExecutionContext* context)

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -65,6 +65,7 @@ class CachedScript;
 class CSSFontSelector;
 class CSSValuePool;
 class DatabaseContext;
+class DeferredPromise;
 class EventQueue;
 class EventLoopTaskGroup;
 class EventTarget;
@@ -321,6 +322,9 @@ public:
     WEBCORE_EXPORT NotificationCallbackIdentifier addNotificationCallback(CompletionHandler<void()>&&);
     WEBCORE_EXPORT CompletionHandler<void()> takeNotificationCallback(NotificationCallbackIdentifier);
 
+    void addDeferredPromise(Ref<DeferredPromise>&&);
+    RefPtr<DeferredPromise> takeDeferredPromise(DeferredPromise*);
+
 protected:
     class AddConsoleMessageTask : public Task {
     public:
@@ -406,6 +410,7 @@ private:
     StorageBlockingPolicy m_storageBlockingPolicy { StorageBlockingPolicy::AllowAll };
 
     HashMap<NotificationCallbackIdentifier, CompletionHandler<void()>> m_notificationCallbacks;
+    HashSet<Ref<DeferredPromise>> m_deferredPromises;
 };
 
 WebCoreOpaqueRoot root(ScriptExecutionContext*);

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -61,7 +61,7 @@ public:
     using PostTaskCallback = Function<void(Function<void()>&&)>;
     using OutputCallback = Function<void(Expected<DecodedFrame, String>&&)>;
     using CreateResult = Expected<UniqueRef<VideoDecoder>, String>;
-    using CreateCallback = CompletionHandler<void(CreateResult&&)>;
+    using CreateCallback = Function<void(CreateResult&&)>;
 
     using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, OutputCallback&&, PostTaskCallback&&);
     WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -70,7 +70,7 @@ public:
     using PostTaskCallback = Function<void(Function<void()>&&)>;
     using DescriptionCallback = Function<void(ActiveConfiguration&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;
-    using CreateCallback = CompletionHandler<void(CreateResult&&)>;
+    using CreateCallback = Function<void(CreateResult&&)>;
 
     using CreatorFunction = void(*)(const String&, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&, PostTaskCallback&&);
     WEBCORE_EXPORT static void setCreatorCallback(CreatorFunction&&);


### PR DESCRIPTION
#### 2c09844aebd21276ecc9c4f7fd6f922ff099811b
<pre>
Make WebCodecs isConfigSupported more accurate by relying on codec creation code path
<a href="https://bugs.webkit.org/show_bug.cgi?id=246677">https://bugs.webkit.org/show_bug.cgi?id=246677</a>
rdar://problem/101278486

Reviewed by Eric Carlson.

Use VideoDecoder::create and VideoEncoder::create to validate whether a configuration is supported or not.
Since this might hop to other threads, we store the promises in ScriptExecutionContext to prevent from refing/unrefing them in other threads.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_vp9_p2-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::createVideoDecoderConfig):
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoderConfig.h:
(WebCore::WebCodecsVideoDecoderConfig::isolatedCopy):
(WebCore::WebCodecsVideoDecoderConfig::isolatedCopy const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::createVideoEncoderConfig):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::isConfigSupported):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoderConfig.h:
(WebCore::WebCodecsVideoEncoderConfig::isolatedCopy):
(WebCore::WebCodecsVideoEncoderConfig::isolatedCopy const):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::stopActiveDOMObjects):
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::addDeferredPromise):
(WebCore::ScriptExecutionContext::takeDeferredPromise):
* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/VideoEncoder.h:

Canonical link: <a href="https://commits.webkit.org/255775@main">https://commits.webkit.org/255775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f43f504dfd6e01bc2b053ed1e8bfff556285513d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103122 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163448 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2659 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30949 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99219 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99113 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79903 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28922 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83538 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37331 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35160 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3993 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41175 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/40970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37879 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->