### PR TITLE
Move EditorState to generated serialization

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -516,6 +516,7 @@ GENERATE_MESSAGE_SOURCES(WebKit_DERIVED_SOURCES "${WebKit_MESSAGES_IN_FILES}")
 set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/NetworkProcessCreationParameters.serialization.in
 
+    Shared/EditorState.serialization.in
     Shared/FocusedElementInformation.serialization.in
     Shared/FrameInfoData.serialization.in
     Shared/FrameTreeNodeData.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -132,6 +132,7 @@ $(PROJECT_DIR)/Shared/ApplePay/WebPaymentCoordinatorProxy.messages.in
 $(PROJECT_DIR)/Shared/Authentication/AuthenticationManager.messages.in
 $(PROJECT_DIR)/Shared/AuxiliaryProcess.messages.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+$(PROJECT_DIR)/Shared/EditorState.serialization.in
 $(PROJECT_DIR)/Shared/FocusedElementInformation.serialization.in
 $(PROJECT_DIR)/Shared/FrameInfoData.serialization.in
 $(PROJECT_DIR)/Shared/FrameTreeNodeData.serialization.in
@@ -146,15 +147,14 @@ $(PROJECT_DIR)/Shared/Notifications/NotificationManagerProxy.messages.in
 $(PROJECT_DIR)/Shared/Pasteboard.serialization.in
 $(PROJECT_DIR)/Shared/Plugins/NPObjectMessageReceiver.messages.in
 $(PROJECT_DIR)/Shared/ShareableBitmap.serialization.in
+$(PROJECT_DIR)/Shared/Shared/EditorState.serialization.in
 $(PROJECT_DIR)/Shared/TextFlags.serialization.in
 $(PROJECT_DIR)/Shared/WTFArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in
-$(PROJECT_DIR)/Shared/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebEvent.serialization.in
+$(PROJECT_DIR)/Shared/WebExtensionContextParameters.serialization.in
 $(PROJECT_DIR)/Shared/WebExtensionControllerParameters.serialization.in
-$(PROJECT_DIR)/Shared/WebPushDaemonConnectionConfiguration.serialization.in
-$(PROJECT_DIR)/Shared/WebPushMessage.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBindGroupEntry.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBlendComponent.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUBlendState.serialization.in
@@ -179,6 +179,8 @@ $(PROJECT_DIR)/Shared/WebGPU/WebGPUTextureBindingLayout.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUValidationError.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexAttribute.serialization.in
 $(PROJECT_DIR)/Shared/WebGPU/WebGPUVertexBufferLayout.serialization.in
+$(PROJECT_DIR)/Shared/WebPushDaemonConnectionConfiguration.serialization.in
+$(PROJECT_DIR)/Shared/WebPushMessage.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteData/WebsiteDataFetchOption.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -457,6 +457,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	NetworkProcess/NetworkProcessCreationParameters.serialization.in \
 	Shared/API/APIGeometry.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \
+	Shared/EditorState.serialization.in \
 	Shared/FocusedElementInformation.serialization.in \
 	Shared/FrameInfoData.serialization.in \
 	Shared/FrameTreeNodeData.serialization.in \

--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -32,245 +32,6 @@
 namespace WebKit {
 using namespace WebCore;
 
-void EditorState::encode(IPC::Encoder& encoder) const
-{
-    encoder << identifier;
-    encoder << shouldIgnoreSelectionChanges;
-    encoder << selectionIsNone;
-    encoder << selectionIsRange;
-    encoder << selectionIsRangeInsideImageOverlay;
-    encoder << selectionIsRangeInAutoFilledAndViewableField;
-    encoder << isContentEditable;
-    encoder << isContentRichlyEditable;
-    encoder << isInPasswordField;
-    encoder << isInPlugin;
-    encoder << hasComposition;
-    encoder << triggeredByAccessibilitySelectionChange;
-#if PLATFORM(MAC)
-    encoder << canEnableAutomaticSpellingCorrection;
-#endif
-    encoder << isMissingPostLayoutData;
-    if (!isMissingPostLayoutData)
-        m_postLayoutData.encode(encoder);
-}
-
-bool EditorState::decode(IPC::Decoder& decoder, EditorState& result)
-{
-    if (!decoder.decode(result.identifier))
-        return false;
-
-    if (!decoder.decode(result.shouldIgnoreSelectionChanges))
-        return false;
-
-    if (!decoder.decode(result.selectionIsNone))
-        return false;
-
-    if (!decoder.decode(result.selectionIsRange))
-        return false;
-
-    if (!decoder.decode(result.selectionIsRangeInsideImageOverlay))
-        return false;
-
-    if (!decoder.decode(result.selectionIsRangeInAutoFilledAndViewableField))
-        return false;
-
-    if (!decoder.decode(result.isContentEditable))
-        return false;
-
-    if (!decoder.decode(result.isContentRichlyEditable))
-        return false;
-
-    if (!decoder.decode(result.isInPasswordField))
-        return false;
-
-    if (!decoder.decode(result.isInPlugin))
-        return false;
-
-    if (!decoder.decode(result.hasComposition))
-        return false;
-
-    if (!decoder.decode(result.triggeredByAccessibilitySelectionChange))
-        return false;
-
-#if PLATFORM(MAC)
-    if (!decoder.decode(result.canEnableAutomaticSpellingCorrection))
-        return false;
-#endif
-
-    if (!decoder.decode(result.isMissingPostLayoutData))
-        return false;
-
-    if (!result.isMissingPostLayoutData) {
-        if (!PostLayoutData::decode(decoder, result.postLayoutData()))
-            return false;
-    }
-
-    return true;
-}
-
-void EditorState::PostLayoutData::encode(IPC::Encoder& encoder) const
-{
-    encoder << typingAttributes;
-#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
-    encoder << caretRectAtStart;
-#endif
-#if PLATFORM(COCOA)
-    encoder << selectedTextLength;
-    encoder << textAlignment;
-    encoder << textColor;
-    encoder << enclosingListType;
-    encoder << baseWritingDirection;
-#endif
-#if PLATFORM(IOS_FAMILY)
-    encoder << selectionClipRect;
-    encoder << caretRectAtEnd;
-    encoder << selectionGeometries;
-    encoder << markedTextRects;
-    encoder << markedText;
-    encoder << markedTextCaretRectAtStart;
-    encoder << markedTextCaretRectAtEnd;
-    encoder << wordAtSelection;
-    encoder << characterAfterSelection;
-    encoder << characterBeforeSelection;
-    encoder << twoCharacterBeforeSelection;
-#if USE(DICTATION_ALTERNATIVES)
-    encoder << dictationContextsForSelection;
-#endif
-    encoder << isReplaceAllowed;
-    encoder << hasContent;
-    encoder << isStableStateUpdate;
-    encoder << insideFixedPosition;
-    encoder << hasPlainText;
-    encoder << editableRootIsTransparentOrFullyClipped;
-    encoder << caretColor;
-    encoder << selectionStartIsAtParagraphBoundary;
-    encoder << selectionEndIsAtParagraphBoundary;
-    encoder << selectedEditableImage;
-#endif
-#if PLATFORM(MAC)
-    encoder << selectionBoundingRect;
-    encoder << candidateRequestStartPosition;
-    encoder << paragraphContextForCandidateRequest;
-    encoder << stringForCandidateRequest;
-#endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    encoder << surroundingContext;
-    encoder << surroundingContextCursorPosition;
-    encoder << surroundingContextSelectionPosition;
-#endif
-    encoder << fontAttributes;
-    encoder << canCut;
-    encoder << canCopy;
-    encoder << canPaste;
-}
-
-bool EditorState::PostLayoutData::decode(IPC::Decoder& decoder, PostLayoutData& result)
-{
-    if (!decoder.decode(result.typingAttributes))
-        return false;
-#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
-    if (!decoder.decode(result.caretRectAtStart))
-        return false;
-#endif
-#if PLATFORM(COCOA)
-    if (!decoder.decode(result.selectedTextLength))
-        return false;
-    if (!decoder.decode(result.textAlignment))
-        return false;
-    if (!decoder.decode(result.textColor))
-        return false;
-    if (!decoder.decode(result.enclosingListType))
-        return false;
-    if (!decoder.decode(result.baseWritingDirection))
-        return false;
-#endif
-#if PLATFORM(IOS_FAMILY)
-    if (!decoder.decode(result.selectionClipRect))
-        return false;
-    if (!decoder.decode(result.caretRectAtEnd))
-        return false;
-    if (!decoder.decode(result.selectionGeometries))
-        return false;
-    if (!decoder.decode(result.markedTextRects))
-        return false;
-    if (!decoder.decode(result.markedText))
-        return false;
-    if (!decoder.decode(result.markedTextCaretRectAtStart))
-        return false;
-    if (!decoder.decode(result.markedTextCaretRectAtEnd))
-        return false;
-    if (!decoder.decode(result.wordAtSelection))
-        return false;
-    if (!decoder.decode(result.characterAfterSelection))
-        return false;
-    if (!decoder.decode(result.characterBeforeSelection))
-        return false;
-    if (!decoder.decode(result.twoCharacterBeforeSelection))
-        return false;
-#if USE(DICTATION_ALTERNATIVES)
-    if (!decoder.decode(result.dictationContextsForSelection))
-        return false;
-#endif
-    if (!decoder.decode(result.isReplaceAllowed))
-        return false;
-    if (!decoder.decode(result.hasContent))
-        return false;
-    if (!decoder.decode(result.isStableStateUpdate))
-        return false;
-    if (!decoder.decode(result.insideFixedPosition))
-        return false;
-    if (!decoder.decode(result.hasPlainText))
-        return false;
-    if (!decoder.decode(result.editableRootIsTransparentOrFullyClipped))
-        return false;
-    if (!decoder.decode(result.caretColor))
-        return false;
-    if (!decoder.decode(result.selectionStartIsAtParagraphBoundary))
-        return false;
-    if (!decoder.decode(result.selectionEndIsAtParagraphBoundary))
-        return false;
-    if (!decoder.decode(result.selectedEditableImage))
-        return false;
-#endif
-#if PLATFORM(MAC)
-    if (!decoder.decode(result.selectionBoundingRect))
-        return false;
-
-    if (!decoder.decode(result.candidateRequestStartPosition))
-        return false;
-
-    if (!decoder.decode(result.paragraphContextForCandidateRequest))
-        return false;
-
-    if (!decoder.decode(result.stringForCandidateRequest))
-        return false;
-#endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    if (!decoder.decode(result.surroundingContext))
-        return false;
-    if (!decoder.decode(result.surroundingContextCursorPosition))
-        return false;
-    if (!decoder.decode(result.surroundingContextSelectionPosition))
-        return false;
-#endif
-
-    std::optional<std::optional<FontAttributes>> optionalFontAttributes;
-    decoder >> optionalFontAttributes;
-    if (!optionalFontAttributes)
-        return false;
-
-    result.fontAttributes = optionalFontAttributes.value();
-
-    if (!decoder.decode(result.canCut))
-        return false;
-    if (!decoder.decode(result.canCopy))
-        return false;
-    if (!decoder.decode(result.canPaste))
-        return false;
-
-    return true;
-}
-
 TextStream& operator<<(TextStream& ts, const EditorState& editorState)
 {
     if (editorState.shouldIgnoreSelectionChanges)
@@ -295,83 +56,83 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
     if (!editorState.canEnableAutomaticSpellingCorrection)
         ts.dumpProperty("canEnableAutomaticSpellingCorrection", editorState.canEnableAutomaticSpellingCorrection);
 #endif
-    if (editorState.isMissingPostLayoutData)
-        ts.dumpProperty("isMissingPostLayoutData", editorState.isMissingPostLayoutData);
+    if (editorState.isMissingPostLayoutData())
+        ts.dumpProperty("isMissingPostLayoutData()", editorState.isMissingPostLayoutData());
 
-    if (editorState.isMissingPostLayoutData)
+    if (editorState.isMissingPostLayoutData())
         return ts;
 
     TextStream::GroupScope scope(ts);
     ts << "postLayoutData";
-    if (editorState.postLayoutData().typingAttributes != AttributeNone)
-        ts.dumpProperty("typingAttributes", editorState.postLayoutData().typingAttributes);
+    if (editorState.postLayoutData->typingAttributes != AttributeNone)
+        ts.dumpProperty("typingAttributes", editorState.postLayoutData->typingAttributes);
 #if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
-    if (editorState.postLayoutData().caretRectAtStart != IntRect())
-        ts.dumpProperty("caretRectAtStart", editorState.postLayoutData().caretRectAtStart);
+    if (editorState.postLayoutData->caretRectAtStart != IntRect())
+        ts.dumpProperty("caretRectAtStart", editorState.postLayoutData->caretRectAtStart);
 #endif
 #if PLATFORM(COCOA)
-    if (editorState.postLayoutData().selectedTextLength)
-        ts.dumpProperty("selectedTextLength", editorState.postLayoutData().selectedTextLength);
-    if (editorState.postLayoutData().textAlignment != NoAlignment)
-        ts.dumpProperty("textAlignment", editorState.postLayoutData().textAlignment);
-    if (editorState.postLayoutData().textColor.isValid())
-        ts.dumpProperty("textColor", editorState.postLayoutData().textColor);
-    if (editorState.postLayoutData().enclosingListType != NoList)
-        ts.dumpProperty("enclosingListType", editorState.postLayoutData().enclosingListType);
-    if (editorState.postLayoutData().baseWritingDirection != WebCore::WritingDirection::Natural)
-        ts.dumpProperty("baseWritingDirection", static_cast<uint8_t>(editorState.postLayoutData().baseWritingDirection));
+    if (editorState.postLayoutData->selectedTextLength)
+        ts.dumpProperty("selectedTextLength", editorState.postLayoutData->selectedTextLength);
+    if (editorState.postLayoutData->textAlignment != NoAlignment)
+        ts.dumpProperty("textAlignment", editorState.postLayoutData->textAlignment);
+    if (editorState.postLayoutData->textColor.isValid())
+        ts.dumpProperty("textColor", editorState.postLayoutData->textColor);
+    if (editorState.postLayoutData->enclosingListType != NoList)
+        ts.dumpProperty("enclosingListType", editorState.postLayoutData->enclosingListType);
+    if (editorState.postLayoutData->baseWritingDirection != WebCore::WritingDirection::Natural)
+        ts.dumpProperty("baseWritingDirection", static_cast<uint8_t>(editorState.postLayoutData->baseWritingDirection));
 #endif // PLATFORM(COCOA)
 #if PLATFORM(IOS_FAMILY)
-    if (editorState.postLayoutData().selectionClipRect != IntRect())
-        ts.dumpProperty("selectionClipRect", editorState.postLayoutData().selectionClipRect);
-    if (editorState.postLayoutData().caretRectAtEnd != IntRect())
-        ts.dumpProperty("caretRectAtEnd", editorState.postLayoutData().caretRectAtEnd);
-    if (!editorState.postLayoutData().selectionGeometries.isEmpty())
-        ts.dumpProperty("selectionGeometries", editorState.postLayoutData().selectionGeometries);
-    if (!editorState.postLayoutData().markedTextRects.isEmpty())
-        ts.dumpProperty("markedTextRects", editorState.postLayoutData().markedTextRects);
-    if (editorState.postLayoutData().markedText.length())
-        ts.dumpProperty("markedText", editorState.postLayoutData().markedText);
-    if (editorState.postLayoutData().markedTextCaretRectAtStart != IntRect())
-        ts.dumpProperty("markedTextCaretRectAtStart", editorState.postLayoutData().markedTextCaretRectAtStart);
-    if (editorState.postLayoutData().markedTextCaretRectAtEnd != IntRect())
-        ts.dumpProperty("markedTextCaretRectAtEnd", editorState.postLayoutData().markedTextCaretRectAtEnd);
-    if (editorState.postLayoutData().wordAtSelection.length())
-        ts.dumpProperty("wordAtSelection", editorState.postLayoutData().wordAtSelection);
-    if (editorState.postLayoutData().characterAfterSelection)
-        ts.dumpProperty("characterAfterSelection", editorState.postLayoutData().characterAfterSelection);
-    if (editorState.postLayoutData().characterBeforeSelection)
-        ts.dumpProperty("characterBeforeSelection", editorState.postLayoutData().characterBeforeSelection);
-    if (editorState.postLayoutData().twoCharacterBeforeSelection)
-        ts.dumpProperty("twoCharacterBeforeSelection", editorState.postLayoutData().twoCharacterBeforeSelection);
+    if (editorState.postLayoutData->selectionClipRect != IntRect())
+        ts.dumpProperty("selectionClipRect", editorState.postLayoutData->selectionClipRect);
+    if (editorState.postLayoutData->caretRectAtEnd != IntRect())
+        ts.dumpProperty("caretRectAtEnd", editorState.postLayoutData->caretRectAtEnd);
+    if (!editorState.postLayoutData->selectionGeometries.isEmpty())
+        ts.dumpProperty("selectionGeometries", editorState.postLayoutData->selectionGeometries);
+    if (!editorState.postLayoutData->markedTextRects.isEmpty())
+        ts.dumpProperty("markedTextRects", editorState.postLayoutData->markedTextRects);
+    if (editorState.postLayoutData->markedText.length())
+        ts.dumpProperty("markedText", editorState.postLayoutData->markedText);
+    if (editorState.postLayoutData->markedTextCaretRectAtStart != IntRect())
+        ts.dumpProperty("markedTextCaretRectAtStart", editorState.postLayoutData->markedTextCaretRectAtStart);
+    if (editorState.postLayoutData->markedTextCaretRectAtEnd != IntRect())
+        ts.dumpProperty("markedTextCaretRectAtEnd", editorState.postLayoutData->markedTextCaretRectAtEnd);
+    if (editorState.postLayoutData->wordAtSelection.length())
+        ts.dumpProperty("wordAtSelection", editorState.postLayoutData->wordAtSelection);
+    if (editorState.postLayoutData->characterAfterSelection)
+        ts.dumpProperty("characterAfterSelection", editorState.postLayoutData->characterAfterSelection);
+    if (editorState.postLayoutData->characterBeforeSelection)
+        ts.dumpProperty("characterBeforeSelection", editorState.postLayoutData->characterBeforeSelection);
+    if (editorState.postLayoutData->twoCharacterBeforeSelection)
+        ts.dumpProperty("twoCharacterBeforeSelection", editorState.postLayoutData->twoCharacterBeforeSelection);
 
-    if (editorState.postLayoutData().isReplaceAllowed)
-        ts.dumpProperty("isReplaceAllowed", editorState.postLayoutData().isReplaceAllowed);
-    if (editorState.postLayoutData().hasContent)
-        ts.dumpProperty("hasContent", editorState.postLayoutData().hasContent);
-    ts.dumpProperty("isStableStateUpdate", editorState.postLayoutData().isStableStateUpdate);
-    if (editorState.postLayoutData().insideFixedPosition)
-        ts.dumpProperty("insideFixedPosition", editorState.postLayoutData().insideFixedPosition);
-    if (editorState.postLayoutData().caretColor.isValid())
-        ts.dumpProperty("caretColor", editorState.postLayoutData().caretColor);
+    if (editorState.postLayoutData->isReplaceAllowed)
+        ts.dumpProperty("isReplaceAllowed", editorState.postLayoutData->isReplaceAllowed);
+    if (editorState.postLayoutData->hasContent)
+        ts.dumpProperty("hasContent", editorState.postLayoutData->hasContent);
+    ts.dumpProperty("isStableStateUpdate", editorState.postLayoutData->isStableStateUpdate);
+    if (editorState.postLayoutData->insideFixedPosition)
+        ts.dumpProperty("insideFixedPosition", editorState.postLayoutData->insideFixedPosition);
+    if (editorState.postLayoutData->caretColor.isValid())
+        ts.dumpProperty("caretColor", editorState.postLayoutData->caretColor);
 #endif
 #if PLATFORM(MAC)
-    if (editorState.postLayoutData().selectionBoundingRect != IntRect())
-        ts.dumpProperty("selectionBoundingRect", editorState.postLayoutData().selectionBoundingRect);
-    if (editorState.postLayoutData().candidateRequestStartPosition)
-        ts.dumpProperty("candidateRequestStartPosition", editorState.postLayoutData().candidateRequestStartPosition);
-    if (editorState.postLayoutData().paragraphContextForCandidateRequest.length())
-        ts.dumpProperty("paragraphContextForCandidateRequest", editorState.postLayoutData().paragraphContextForCandidateRequest);
-    if (editorState.postLayoutData().stringForCandidateRequest.length())
-        ts.dumpProperty("stringForCandidateRequest", editorState.postLayoutData().stringForCandidateRequest);
+    if (editorState.postLayoutData->selectionBoundingRect != IntRect())
+        ts.dumpProperty("selectionBoundingRect", editorState.postLayoutData->selectionBoundingRect);
+    if (editorState.postLayoutData->candidateRequestStartPosition)
+        ts.dumpProperty("candidateRequestStartPosition", editorState.postLayoutData->candidateRequestStartPosition);
+    if (editorState.postLayoutData->paragraphContextForCandidateRequest.length())
+        ts.dumpProperty("paragraphContextForCandidateRequest", editorState.postLayoutData->paragraphContextForCandidateRequest);
+    if (editorState.postLayoutData->stringForCandidateRequest.length())
+        ts.dumpProperty("stringForCandidateRequest", editorState.postLayoutData->stringForCandidateRequest);
 #endif
 
-    if (editorState.postLayoutData().canCut)
-        ts.dumpProperty("canCut", editorState.postLayoutData().canCut);
-    if (editorState.postLayoutData().canCopy)
-        ts.dumpProperty("canCopy", editorState.postLayoutData().canCopy);
-    if (editorState.postLayoutData().canPaste)
-        ts.dumpProperty("canPaste", editorState.postLayoutData().canPaste);
+    if (editorState.postLayoutData->canCut)
+        ts.dumpProperty("canCut", editorState.postLayoutData->canCut);
+    if (editorState.postLayoutData->canCopy)
+        ts.dumpProperty("canCopy", editorState.postLayoutData->canCopy);
+    if (editorState.postLayoutData->canPaste)
+        ts.dumpProperty("canPaste", editorState.postLayoutData->canPaste);
 
     return ts;
 }

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -86,7 +86,6 @@ struct EditorState {
 #if PLATFORM(MAC)
     bool canEnableAutomaticSpellingCorrection { true };
 #endif
-    bool isMissingPostLayoutData { true };
 
     struct PostLayoutData {
         uint32_t typingAttributes { AttributeNone };
@@ -144,32 +143,12 @@ struct EditorState {
         bool canCut { false };
         bool canCopy { false };
         bool canPaste { false };
-
-        void encode(IPC::Encoder&) const;
-        static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, PostLayoutData&);
     };
 
-    const PostLayoutData& postLayoutData() const;
-    PostLayoutData& postLayoutData();
+    bool isMissingPostLayoutData() const { return !postLayoutData; }
 
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, EditorState&);
-
-private:
-    PostLayoutData m_postLayoutData;
+    std::optional<PostLayoutData> postLayoutData;
 };
-
-inline auto EditorState::postLayoutData() -> PostLayoutData&
-{
-    ASSERT_WITH_MESSAGE(!isMissingPostLayoutData, "Attempt to access post layout data before receiving it");
-    return m_postLayoutData;
-}
-
-inline auto EditorState::postLayoutData() const -> const PostLayoutData&
-{
-    ASSERT_WITH_MESSAGE(!isMissingPostLayoutData, "Attempt to access post layout data before receiving it");
-    return m_postLayoutData;
-}
 
 WTF::TextStream& operator<<(WTF::TextStream&, const EditorState&);
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -1,0 +1,99 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+struct WebKit::EditorState {
+    WebKit::EditorStateIdentifier identifier;
+    bool shouldIgnoreSelectionChanges;
+    bool selectionIsNone;
+    bool selectionIsRange;
+    bool selectionIsRangeInsideImageOverlay;
+    bool selectionIsRangeInAutoFilledAndViewableField;
+    bool isContentEditable;
+    bool isContentRichlyEditable;
+    bool isInPasswordField;
+    bool isInPlugin;
+    bool hasComposition;
+    bool triggeredByAccessibilitySelectionChange;
+#if PLATFORM(MAC)
+    bool canEnableAutomaticSpellingCorrection;
+#endif
+    std::optional<WebKit::EditorState::PostLayoutData> postLayoutData;
+};
+
+[Nested] struct WebKit::EditorState::PostLayoutData {
+    uint32_t typingAttributes;
+#if PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)
+    WebCore::IntRect caretRectAtStart;
+#endif
+#if PLATFORM(COCOA)
+    uint64_t selectedTextLength;
+    uint32_t textAlignment;
+    WebCore::Color textColor;
+    uint32_t enclosingListType;
+    WebCore::WritingDirection baseWritingDirection;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    WebCore::IntRect selectionClipRect;
+    WebCore::IntRect caretRectAtEnd;
+    Vector<WebCore::SelectionGeometry> selectionGeometries;
+    Vector<WebCore::SelectionGeometry> markedTextRects;
+    String markedText;
+    WebCore::IntRect markedTextCaretRectAtStart;
+    WebCore::IntRect markedTextCaretRectAtEnd;
+    String wordAtSelection;
+    UChar32 characterAfterSelection;
+    UChar32 characterBeforeSelection;
+    UChar32 twoCharacterBeforeSelection;
+#endif
+#if PLATFORM(IOS_FAMILY) && USE(DICTATION_ALTERNATIVES)
+    Vector<WebCore::DictationContext> dictationContextsForSelection;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    bool isReplaceAllowed;
+    bool hasContent;
+    bool isStableStateUpdate;
+    bool insideFixedPosition;
+    bool hasPlainText;
+    bool editableRootIsTransparentOrFullyClipped;
+    WebCore::Color caretColor;
+    bool atStartOfSentence;
+    bool selectionStartIsAtParagraphBoundary;
+    bool selectionEndIsAtParagraphBoundary;
+    std::optional<WebCore::ElementContext> selectedEditableImage;
+#endif
+#if PLATFORM(MAC)
+    WebCore::IntRect selectionBoundingRect;
+    uint64_t candidateRequestStartPosition;
+    String paragraphContextForCandidateRequest;
+    String stringForCandidateRequest;
+#endif
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    String surroundingContext;
+    uint64_t surroundingContextCursorPosition;
+    uint64_t surroundingContextSelectionPosition;
+#endif
+    std::optional<WebCore::FontAttributes> fontAttributes;
+    bool canCut;
+    bool canCopy;
+    bool canPaste;
+};

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1781,10 +1781,10 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 
 static NSDictionary *dictionaryRepresentationForEditorState(const WebKit::EditorState& state)
 {
-    if (state.isMissingPostLayoutData)
+    if (state.isMissingPostLayoutData())
         return @{ @"post-layout-data" : @NO };
 
-    auto& postLayoutData = state.postLayoutData();
+    auto& postLayoutData = *state.postLayoutData;
     return @{
         @"post-layout-data" : @YES,
         @"bold": postLayoutData.typingAttributes & WebKit::AttributeBold ? @YES : @NO,

--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
@@ -118,11 +118,11 @@ WebKitEditorState* webkitEditorStateCreate(WebPageProxy& page)
 
 void webkitEditorStateChanged(WebKitEditorState* editorState, const EditorState& newState)
 {
-    if (newState.isMissingPostLayoutData)
+    if (newState.isMissingPostLayoutData())
         return;
 
     unsigned typingAttributes = WEBKIT_EDITOR_TYPING_ATTRIBUTE_NONE;
-    const auto& postLayoutData = newState.postLayoutData();
+    const auto& postLayoutData = *newState.postLayoutData;
     if (postLayoutData.typingAttributes & AttributeBold)
         typingAttributes |= WEBKIT_EDITOR_TYPING_ATTRIBUTE_BOLD;
     if (postLayoutData.typingAttributes & AttributeItalics)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2551,10 +2551,10 @@ void webkitWebViewBaseSetInputMethodState(WebKitWebViewBase* webkitWebViewBase, 
 void webkitWebViewBaseUpdateTextInputState(WebKitWebViewBase* webkitWebViewBase)
 {
     const auto& editorState = webkitWebViewBase->priv->pageProxy->editorState();
-    if (!editorState.isMissingPostLayoutData) {
-        webkitWebViewBase->priv->inputMethodFilter.notifyCursorRect(editorState.postLayoutData().caretRectAtStart);
-        webkitWebViewBase->priv->inputMethodFilter.notifySurrounding(editorState.postLayoutData().surroundingContext, editorState.postLayoutData().surroundingContextCursorPosition,
-            editorState.postLayoutData().surroundingContextSelectionPosition);
+    if (!editorState.isMissingPostLayoutData()) {
+        webkitWebViewBase->priv->inputMethodFilter.notifyCursorRect(editorState.postLayoutData->caretRectAtStart);
+        webkitWebViewBase->priv->inputMethodFilter.notifySurrounding(editorState.postLayoutData->surroundingContext, editorState.postLayoutData->surroundingContextCursorPosition,
+            editorState.postLayoutData->surroundingContextSelectionPosition);
     }
 }
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -81,7 +81,9 @@
 
 - (NSRect)_candidateRect
 {
-    return _page->editorState().postLayoutData().selectionBoundingRect;
+    if (!_page->editorState().postLayoutData)
+        return NSZeroRect;
+    return _page->editorState().postLayoutData->selectionBoundingRect;
 }
 
 - (void)viewDidChangeEffectiveAppearance

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -377,10 +377,10 @@ void View::setInputMethodState(std::optional<InputMethodState>&& state)
 void View::selectionDidChange()
 {
     const auto& editorState = m_pageProxy->editorState();
-    if (!editorState.isMissingPostLayoutData) {
-        m_inputMethodFilter.notifyCursorRect(editorState.postLayoutData().caretRectAtStart);
-        m_inputMethodFilter.notifySurrounding(editorState.postLayoutData().surroundingContext, editorState.postLayoutData().surroundingContextCursorPosition,
-            editorState.postLayoutData().surroundingContextSelectionPosition);
+    if (!editorState.isMissingPostLayoutData()) {
+        m_inputMethodFilter.notifyCursorRect(editorState.postLayoutData->caretRectAtStart);
+        m_inputMethodFilter.notifySurrounding(editorState.postLayoutData->surroundingContext, editorState.postLayoutData->surroundingContextCursorPosition,
+            editorState.postLayoutData->surroundingContextSelectionPosition);
     }
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2553,10 +2553,10 @@ void WebPageProxy::updateFontAttributesAfterEditorStateChange()
 {
     m_cachedFontAttributesAtSelectionStart.reset();
 
-    if (m_editorState.isMissingPostLayoutData)
+    if (m_editorState.isMissingPostLayoutData())
         return;
 
-    if (auto fontAttributes = m_editorState.postLayoutData().fontAttributes) {
+    if (auto fontAttributes = m_editorState.postLayoutData->fontAttributes) {
         m_uiClient->didChangeFontAttributes(*fontAttributes);
         m_cachedFontAttributesAtSelectionStart = WTFMove(fontAttributes);
     }

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -768,7 +768,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     // Updating the selection requires a full editor state. If the editor state is missing post layout
     // data then it means there is a layout pending and we're going to be called again after the layout
     // so we delay the selection update.
-    if (!_page->editorState().isMissingPostLayoutData)
+    if (!_page->editorState().isMissingPostLayoutData())
         [self _updateChangedSelection];
 }
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1117,7 +1117,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const
 
 void WebPageProxy::dispatchDidUpdateEditorState()
 {
-    if (!m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement || m_editorState.isMissingPostLayoutData)
+    if (!m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement || m_editorState.isMissingPostLayoutData())
         return;
 
     pageClient().didUpdateEditorState();
@@ -1176,11 +1176,11 @@ WebCore::FloatRect WebPageProxy::selectionBoundingRectInRootViewCoordinates() co
     if (m_editorState.selectionIsNone)
         return { };
 
-    if (m_editorState.isMissingPostLayoutData)
+    if (m_editorState.isMissingPostLayoutData())
         return { };
 
     WebCore::FloatRect bounds;
-    auto& postLayoutData = m_editorState.postLayoutData();
+    auto& postLayoutData = *m_editorState.postLayoutData;
     if (m_editorState.selectionIsRange) {
         for (auto& geometry : postLayoutData.selectionGeometries)
             bounds.unite(geometry.rect());

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2701,7 +2701,7 @@ void WebViewImpl::selectionDidChange()
         m_softSpaceRange = NSMakeRange(NSNotFound, 0);
 #if HAVE(TOUCH_BAR)
     updateTouchBar();
-    if (!m_page->editorState().isMissingPostLayoutData)
+    if (!m_page->editorState().isMissingPostLayoutData())
         requestCandidatesForSelectionIfNeeded();
 #endif
 
@@ -3156,10 +3156,10 @@ void WebViewImpl::requestCandidatesForSelectionIfNeeded()
     if (!editorState.isContentEditable)
         return;
 
-    if (editorState.isMissingPostLayoutData)
+    if (editorState.isMissingPostLayoutData())
         return;
 
-    auto& postLayoutData = editorState.postLayoutData();
+    auto& postLayoutData = *editorState.postLayoutData;
     m_lastStringForCandidateRequest = postLayoutData.stringForCandidateRequest;
 
     NSRange selectedRange = NSMakeRange(postLayoutData.candidateRequestStartPosition, postLayoutData.selectedTextLength);
@@ -3188,10 +3188,10 @@ void WebViewImpl::handleRequestedCandidates(NSInteger sequenceNumber, NSArray<NS
 
     // FIXME: It's pretty lame that we have to depend on the most recent EditorState having post layout data,
     // and that we just bail if it is missing.
-    if (editorState.isMissingPostLayoutData)
+    if (editorState.isMissingPostLayoutData())
         return;
 
-    auto& postLayoutData = editorState.postLayoutData();
+    auto& postLayoutData = *editorState.postLayoutData;
     if (m_lastStringForCandidateRequest != postLayoutData.stringForCandidateRequest)
         return;
 
@@ -3237,10 +3237,10 @@ void WebViewImpl::handleAcceptedCandidate(NSTextCheckingResult *acceptedCandidat
 
     // FIXME: It's pretty lame that we have to depend on the most recent EditorState having post layout data,
     // and that we just bail if it is missing.
-    if (editorState.isMissingPostLayoutData)
+    if (editorState.isMissingPostLayoutData())
         return;
 
-    auto& postLayoutData = editorState.postLayoutData();
+    auto& postLayoutData = *editorState.postLayoutData;
     if (m_lastStringForCandidateRequest != postLayoutData.stringForCandidateRequest)
         return;
 
@@ -5639,13 +5639,13 @@ void WebViewImpl::updateTextTouchBar()
     // the text when changing selection throughout the document.
     if (isRichlyEditableForTouchBar()) {
         const EditorState& editorState = m_page->editorState();
-        if (!editorState.isMissingPostLayoutData) {
-            [m_textTouchBarItemController setTextIsBold:(bool)(m_page->editorState().postLayoutData().typingAttributes & AttributeBold)];
-            [m_textTouchBarItemController setTextIsItalic:(bool)(m_page->editorState().postLayoutData().typingAttributes & AttributeItalics)];
-            [m_textTouchBarItemController setTextIsUnderlined:(bool)(m_page->editorState().postLayoutData().typingAttributes & AttributeUnderline)];
-            [m_textTouchBarItemController setTextColor:cocoaColor(editorState.postLayoutData().textColor).get()];
-            [[m_textTouchBarItemController textListTouchBarViewController] setCurrentListType:(ListType)m_page->editorState().postLayoutData().enclosingListType];
-            [m_textTouchBarItemController setCurrentTextAlignment:nsTextAlignmentFromTextAlignment((TextAlignment)editorState.postLayoutData().textAlignment)];
+        if (!editorState.isMissingPostLayoutData()) {
+            [m_textTouchBarItemController setTextIsBold:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeBold)];
+            [m_textTouchBarItemController setTextIsItalic:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeItalics)];
+            [m_textTouchBarItemController setTextIsUnderlined:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeUnderline)];
+            [m_textTouchBarItemController setTextColor:cocoaColor(editorState.postLayoutData->textColor).get()];
+            [[m_textTouchBarItemController textListTouchBarViewController] setCurrentListType:(ListType)m_page->editorState().postLayoutData->enclosingListType];
+            [m_textTouchBarItemController setCurrentTextAlignment:nsTextAlignmentFromTextAlignment((TextAlignment)editorState.postLayoutData->textAlignment)];
         }
         BOOL isShowingCandidateListItem = [textTouchBar.defaultItemIdentifiers containsObject:NSTouchBarItemIdentifierCandidateList] && [NSSpellChecker isAutomaticTextReplacementEnabled];
         [m_textTouchBarItemController setUsesNarrowTextStyleItem:isShowingCombinedTextFormatItem && isShowingCandidateListItem];

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5453,6 +5453,7 @@
 		5C6C815D271928DF00D4FB42 /* com.apple.webkit.adattributiond.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.adattributiond.plist; sourceTree = "<group>"; };
 		5C6CE6D01F59BC460007C6CB /* PageClientImplCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PageClientImplCocoa.mm; sourceTree = "<group>"; };
 		5C6CE6D31F59EA350007C6CB /* PageClientImplCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageClientImplCocoa.h; sourceTree = "<group>"; };
+		5C6CED8E2900598000B5D522 /* EditorState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = EditorState.serialization.in; sourceTree = "<group>"; };
 		5C6E7D86232361E700C2159D /* WKWebsiteDataStoreConfigurationRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebsiteDataStoreConfigurationRef.h; sourceTree = "<group>"; };
 		5C6E7D87232361E700C2159D /* WKWebsiteDataStoreConfigurationRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKWebsiteDataStoreConfigurationRef.cpp; sourceTree = "<group>"; };
 		5C74300E21500492004BFA17 /* WKWebProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKWebProcess.h; sourceTree = "<group>"; };
@@ -8131,6 +8132,7 @@
 				E105FE5318D7B9DE008F57A8 /* EditingRange.h */,
 				8CFECE931490F140002AAA32 /* EditorState.cpp */,
 				1AA41AB412C02EC4002BE67B /* EditorState.h */,
+				5C6CED8E2900598000B5D522 /* EditorState.serialization.in */,
 				C59C4A5718B81174007BDCB6 /* FocusedElementInformation.h */,
 				86DA60C628EAE9C00044FE4D /* FocusedElementInformation.serialization.in */,
 				BCE81D8A1319F7EF00241910 /* FontInfo.cpp */,

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -436,7 +436,7 @@ void WebPage::getProcessDisplayName(CompletionHandler<void(String&&)>&& completi
 
 void WebPage::getPlatformEditorStateCommon(const Frame& frame, EditorState& result) const
 {
-    if (result.isMissingPostLayoutData)
+    if (result.isMissingPostLayoutData())
         return;
 
     const auto& selection = frame.selection().selection();
@@ -444,7 +444,7 @@ void WebPage::getPlatformEditorStateCommon(const Frame& frame, EditorState& resu
     if (!result.isContentEditable || selection.isNone())
         return;
 
-    auto& postLayoutData = result.postLayoutData();
+    auto& postLayoutData = *result.postLayoutData;
     if (auto editingStyle = EditingStyle::styleAtSelectionStart(selection)) {
         if (editingStyle->hasStyle(CSSPropertyFontWeight, "bold"_s))
             postLayoutData.typingAttributes |= AttributeBold;

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -101,10 +101,10 @@ void WebPage::sendMessageToWebExtension(UserMessage&& message)
 
 void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
 {
-    if (result.isMissingPostLayoutData || !frame.view() || frame.view()->needsLayout())
+    if (result.isMissingPostLayoutData() || !frame.view() || frame.view()->needsLayout())
         return;
 
-    auto& postLayoutData = result.postLayoutData();
+    auto& postLayoutData = *result.postLayoutData;
     postLayoutData.caretRectAtStart = frame.selection().absoluteCaretBounds();
 
     const VisibleSelection& selection = frame.selection().selection();

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -286,10 +286,10 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
 {
     getPlatformEditorStateCommon(frame, result);
 
-    if (result.isMissingPostLayoutData)
+    if (result.isMissingPostLayoutData())
         return;
     ASSERT(frame.view());
-    auto& postLayoutData = result.postLayoutData();
+    auto& postLayoutData = *result.postLayoutData;
     Ref view = *frame.view();
 
     if (frame.editor().hasComposition()) {

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -153,7 +153,7 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
 
     result.canEnableAutomaticSpellingCorrection = result.isContentEditable && frame.editor().canEnableAutomaticSpellingCorrection();
 
-    if (result.isMissingPostLayoutData)
+    if (result.isMissingPostLayoutData())
         return;
 
     auto& selection = frame.selection().selection();
@@ -161,7 +161,7 @@ void WebPage::getPlatformEditorState(Frame& frame, EditorState& result) const
     if (!selectedRange)
         return;
 
-    auto& postLayoutData = result.postLayoutData();
+    auto& postLayoutData = *result.postLayoutData;
     VisiblePosition selectionStart = selection.visibleStart();
     auto selectionStartBoundary = makeBoundaryPoint(selectionStart);
     auto selectionEnd = makeBoundaryPoint(selection.visibleEnd());


### PR DESCRIPTION
#### 897a438fd69c05f0226a4efbebb74ac64d3b324e
<pre>
Move EditorState to generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=246748">https://bugs.webkit.org/show_bug.cgi?id=246748</a>

Reviewed by Žan Doberšek.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/EditorState.cpp:
(WebKit::operator&lt;&lt;):
(WebKit::EditorState::encode const): Deleted.
(WebKit::EditorState::decode): Deleted.
(WebKit::EditorState::PostLayoutData::encode const): Deleted.
(WebKit::EditorState::PostLayoutData::decode): Deleted.
* Source/WebKit/Shared/EditorState.h:
(WebKit::EditorState::isMissingPostLayoutData const):
(WebKit::EditorState::postLayoutData): Deleted.
(WebKit::EditorState::postLayoutData const const): Deleted.
* Source/WebKit/Shared/EditorState.serialization.in: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(dictionaryRepresentationForEditorState):
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _candidateRect]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateFontAttributesAfterEditorStateChange):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _didCommitLayerTree:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(WebKit::WKSelectionDrawingInfo::WKSelectionDrawingInfo):
(-[WKContentView shouldHideSelectionWhenScrolling]):
(-[WKContentView rectToRevealWhenZoomingToFocusedElement]):
(-[WKContentView _selectionClipRect]):
(-[WKContentView canShowNonEmptySelectionView]):
(-[WKContentView webSelectionRects]):
(-[WKContentView _lookupForWebView:]):
(-[WKContentView _shareForWebView:]):
(-[WKContentView _translateForWebView:]):
(-[WKContentView _addShortcutForWebView:]):
(-[WKContentView selectedText]):
(-[WKContentView alternativesForSelectedText]):
(-[WKContentView isReplaceAllowed]):
(-[WKContentView _promptForReplaceForWebView:]):
(-[WKContentView _transliterateChineseForWebView:]):
(-[WKContentView textStylingAtPosition:inDirection:]):
(-[WKContentView _cascadeInteractionTintColor]):
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _showDictionary:]):
(-[WKContentView removeBackgroundMenu]):
(-[WKContentView doAfterComputingImageAnalysisResultsForBackgroundRemoval:]):
(-[WKContentView _characterInRelationToCaretSelection:]):
(-[WKContentView _selectionAtDocumentStart]):
(-[WKContentView textFirstRect]):
(-[WKContentView textLastRect]):
(-[WKContentView textInRange:]):
(-[WKContentView selectedTextRange]):
(-[WKContentView markedTextRange]):
(-[WKContentView hasText]):
(-[WKContentView hasContent]):
(-[WKContentView isPosition:atBoundary:inDirection:]):
(-[WKContentView _updateSelectionAssistantSuppressionState]):
(-[WKContentView _selectionChanged]):
(-[WKContentView _updateChangedSelection:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::dispatchDidUpdateEditorState):
(WebKit::WebPageProxy::selectionBoundingRectInRootViewCoordinates const):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::requestCandidatesForSelectionIfNeeded):
(WebKit::WebViewImpl::handleRequestedCandidates):
(WebKit::WebViewImpl::handleAcceptedCandidate):
(WebKit::WebViewImpl::updateTextTouchBar):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
(WebKit::WebPage::sendEditorStateUpdate):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getPlatformEditorState const):

Canonical link: <a href="https://commits.webkit.org/255806@main">https://commits.webkit.org/255806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4758181369c541810af983c35e8dfba039fd4e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2808 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103265 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2819 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31092 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99336 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2006 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80058 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29037 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83929 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71990 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37473 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17518 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35314 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18778 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41305 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1884 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38009 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->