### PR TITLE
Scrolling by pressing space bar has regressed in trunk, is choppy (not 120Hz)

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
+++ b/LayoutTests/css3/scroll-snap/scroll-padding-overflow-paging.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/repaint/fixed-move-after-keyboard-scroll.html
+++ b/LayoutTests/fast/repaint/fixed-move-after-keyboard-scroll.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">

--- a/LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html
+++ b/LayoutTests/fast/scrolling/keyboard-scrolling-distance-downArrow.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 
 <html>
 

--- a/LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scrolling-overflow-scroll.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 
 <html>
 

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-frame-to-overflow.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <script src="../../../resources/ui-helper.js"></script>

--- a/LayoutTests/fast/scrolling/unfocusing-page-while-keyboard-scrolling.html
+++ b/LayoutTests/fast/scrolling/unfocusing-page-while-keyboard-scrolling.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ EventHandlerDrivenSmoothKeyboardScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
 <html>
 <head>
     <script src="../../resources/ui-helper.js"></script>

--- a/LayoutTests/platform/mac/fast/repaint/fixed-move-after-keyboard-scroll-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/fixed-move-after-keyboard-scroll-expected.txt
@@ -1,8 +1,8 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x584
+layer at (0,0) size 800x542
+  RenderBlock {HTML} at (0,0) size 800x542
+    RenderBody {BODY} at (8,8) size 784x526
       RenderText {#text} at (0,0) size 488x18
         text run at (0,0) width 488: "If running this test manually put focus inside the iframe and hit 'page down'."
       RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1989,6 +1989,7 @@ platform/ScreenOrientationManager.cpp
 platform/ScreenOrientationProvider.cpp
 platform/ScrollAlignment.cpp
 platform/ScrollAnimation.cpp
+platform/ScrollAnimationKeyboard.cpp
 platform/ScrollAnimationKinetic.cpp
 platform/ScrollAnimationMomentum.cpp
 platform/ScrollAnimationSmooth.cpp

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -3014,6 +3014,22 @@ bool FrameView::isRubberBandInProgress() const
     return false;
 }
 
+bool FrameView::requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData)
+{
+    if (auto scrollingCoordinator = this->scrollingCoordinator())
+        return scrollingCoordinator->requestStartKeyboardScrollAnimation(*this, scrollData);
+
+    return false;
+}
+
+bool FrameView::requestStopKeyboardScrollAnimation(bool immediate)
+{
+    if (auto scrollingCoordinator = this->scrollingCoordinator())
+        return scrollingCoordinator->requestStopKeyboardScrollAnimation(*this, immediate);
+
+    return false;
+}
+
 bool FrameView::requestScrollPositionUpdate(const ScrollPosition& position, ScrollType scrollType, ScrollClamping clamping)
 {
     LOG_WITH_STREAM(Scrolling, stream << "FrameView::requestScrollPositionUpdate " << position);

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -273,6 +273,9 @@ public:
     void updateCompositingLayersAfterScrolling() final;
     static WEBCORE_EXPORT bool scrollRectToVisible(const LayoutRect& absoluteRect, const RenderObject&, bool insideFixed, const ScrollRectToVisibleOptions&);
 
+    bool requestStartKeyboardScrollAnimation(const KeyboardScroll&) final;
+    bool requestStopKeyboardScrollAnimation(bool immediate) final;
+
     bool requestScrollPositionUpdate(const ScrollPosition&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped) final;
     bool requestAnimatedScrollToPosition(const ScrollPosition&, ScrollClamping = ScrollClamping::Clamped) final;
     void stopAsyncAnimatedScroll() final;

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -254,6 +254,42 @@ void AsyncScrollingCoordinator::frameViewRootLayerDidChange(FrameView& frameView
     node->setHorizontalScrollbarLayer(frameView.layerForHorizontalScrollbar());
 }
 
+bool AsyncScrollingCoordinator::requestStartKeyboardScrollAnimation(ScrollableArea& scrollableArea, const KeyboardScroll& scrollData)
+{
+    ASSERT(isMainThread());
+    ASSERT(m_page);
+    auto scrollingNodeID = scrollableArea.scrollingNodeID();
+    if (!scrollingNodeID)
+        return false;
+
+    auto* stateNode = downcast<ScrollingStateScrollingNode>(m_scrollingStateTree->stateNodeForID(scrollingNodeID));
+    if (!stateNode)
+        return false;
+
+    stateNode->setKeyboardScrollData({ KeyboardScrollAction::StartAnimation, scrollData });
+    // FIXME: This should schedule a rendering update
+    commitTreeStateIfNeeded();
+    return true;
+}
+
+bool AsyncScrollingCoordinator::requestStopKeyboardScrollAnimation(ScrollableArea& scrollableArea, bool immediate)
+{
+    ASSERT(isMainThread());
+    ASSERT(m_page);
+    auto scrollingNodeID = scrollableArea.scrollingNodeID();
+    if (!scrollingNodeID)
+        return false;
+
+    auto* stateNode = downcast<ScrollingStateScrollingNode>(m_scrollingStateTree->stateNodeForID(scrollingNodeID));
+    if (!stateNode)
+        return false;
+
+    stateNode->setKeyboardScrollData({ immediate ? KeyboardScrollAction::StopImmediately : KeyboardScrollAction::StopWithAnimation, std::nullopt });
+    // FIXME: This should schedule a rendering update
+    commitTreeStateIfNeeded();
+    return true;
+}
+
 bool AsyncScrollingCoordinator::requestScrollPositionUpdate(ScrollableArea& scrollableArea, const ScrollPosition& scrollPosition, ScrollType scrollType, ScrollClamping clamping)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -102,6 +102,9 @@ private:
     WEBCORE_EXPORT void frameViewEventTrackingRegionsChanged(FrameView&) override;
     WEBCORE_EXPORT void frameViewWillBeDetached(FrameView&) override;
 
+    WEBCORE_EXPORT bool requestStartKeyboardScrollAnimation(ScrollableArea&, const KeyboardScroll&) final;
+    WEBCORE_EXPORT bool requestStopKeyboardScrollAnimation(ScrollableArea&, bool) final;
+
     WEBCORE_EXPORT bool requestScrollPositionUpdate(ScrollableArea&, const ScrollPosition&, ScrollType, ScrollClamping) final;
     WEBCORE_EXPORT bool requestAnimatedScrollToPosition(ScrollableArea&, const ScrollPosition&, ScrollClamping) final;
     WEBCORE_EXPORT void stopAnimatedScroll(ScrollableArea&) final;

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -48,6 +48,7 @@ class Document;
 class Frame;
 class FrameView;
 class GraphicsLayer;
+struct KeyboardScroll;
 class Page;
 class Region;
 class RenderObject;
@@ -118,6 +119,9 @@ public:
 
     // These virtual functions are currently unique to the threaded scrolling architecture. 
     virtual void commitTreeStateIfNeeded() { }
+
+    virtual bool requestStartKeyboardScrollAnimation(ScrollableArea&, const KeyboardScroll&) { return false; }
+    virtual bool requestStopKeyboardScrollAnimation(ScrollableArea&, bool) { return false; }
 
     virtual bool requestScrollPositionUpdate(ScrollableArea&, const ScrollPosition&, ScrollType = ScrollType::Programmatic, ScrollClamping = ScrollClamping::Clamped) { return false; }
     virtual bool requestAnimatedScrollToPosition(ScrollableArea&, const ScrollPosition&, ScrollClamping) { return false; }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "FloatPoint.h"
+#include "KeyboardScroll.h"
 #include "ScrollTypes.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
@@ -130,6 +131,17 @@ struct RequestedScrollData {
             && clamping == other.clamping
             && animated == other.animated;
     }
+};
+
+enum class KeyboardScrollAction : uint8_t {
+    StartAnimation,
+    StopWithAnimation,
+    StopImmediately
+};
+
+struct RequestedKeyboardScrollData {
+    KeyboardScrollAction action;
+    std::optional<KeyboardScroll> keyboardScroll;
 };
 
 enum class ScrollUpdateType : uint8_t {

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -268,6 +268,7 @@ public:
         ViewportConstraints                         = 1LLU << 42,
         // ScrollingStateOverflowScrollProxyNode
         OverflowScrollingNode                       = 1LLU << 43,
+        KeyboardScrollData                          = 1LLU << 44,
     };
     
     bool hasChangedProperties() const { return !m_changedProperties.isEmpty(); }

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -53,6 +53,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
 #endif
     , m_scrollableAreaParameters(stateNode.scrollableAreaParameters())
     , m_requestedScrollData(stateNode.requestedScrollData())
+    , m_keyboardScrollData(stateNode.keyboardScrollData())
 #if ENABLE(SCROLLING_THREAD)
     , m_synchronousScrollingReasons(stateNode.synchronousScrollingReasons())
 #endif
@@ -198,6 +199,13 @@ void ScrollingStateScrollingNode::setSynchronousScrollingReasons(OptionSet<Synch
     setPropertyChanged(Property::ReasonsForSynchronousScrolling);
 }
 #endif
+
+
+void ScrollingStateScrollingNode::setKeyboardScrollData(RequestedKeyboardScrollData&& scrollData)
+{
+    m_keyboardScrollData = WTFMove(scrollData);
+    setPropertyChanged(Property::KeyboardScrollData);
+}
 
 void ScrollingStateScrollingNode::setRequestedScrollData(const RequestedScrollData& scrollData)
 {

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -75,6 +75,9 @@ public:
     bool hasSynchronousScrollingReasons() const { return !m_synchronousScrollingReasons.isEmpty(); }
 #endif
 
+    const RequestedKeyboardScrollData& keyboardScrollData() const { return m_keyboardScrollData; }
+    WEBCORE_EXPORT void setKeyboardScrollData(RequestedKeyboardScrollData&&);
+
     const RequestedScrollData& requestedScrollData() const { return m_requestedScrollData; }
     WEBCORE_EXPORT void setRequestedScrollData(const RequestedScrollData&);
 
@@ -132,6 +135,7 @@ private:
 
     ScrollableAreaParameters m_scrollableAreaParameters;
     RequestedScrollData m_requestedScrollData;
+    RequestedKeyboardScrollData m_keyboardScrollData;
 #if ENABLE(SCROLLING_THREAD)
     OptionSet<SynchronousScrollingReason> m_synchronousScrollingReasons;
 #endif

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -106,6 +106,9 @@ void ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNo
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition))
         handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
 
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::KeyboardScrollData))
+        handleKeyboardScrollRequest(scrollingStateNode.keyboardScrollData());
+
     // This synthetic bit is added back in ScrollingTree::propagateSynchronousScrollingReasons().
 #if ENABLE(SCROLLING_THREAD)
     m_synchronousScrollingReasons.remove(SynchronousScrollingReason::DescendantScrollersHaveSynchronousScrolling);
@@ -259,6 +262,12 @@ void ScrollingTreeScrollingNode::serviceScrollAnimation(MonotonicTime currentTim
 void ScrollingTreeScrollingNode::setScrollAnimationInProgress(bool animationInProgress)
 {
     scrollingTree().setScrollAnimationInProgressForNode(scrollingNodeID(), animationInProgress);
+}
+
+void ScrollingTreeScrollingNode::handleKeyboardScrollRequest(const RequestedKeyboardScrollData& scrollData)
+{
+    if (m_delegate)
+        m_delegate->handleKeyboardScrollRequest(scrollData);
 }
 
 void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScrollData& requestedScrollData)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -59,6 +59,8 @@ class WEBCORE_EXPORT ScrollingTreeScrollingNode : public ScrollingTreeNode {
 public:
     virtual ~ScrollingTreeScrollingNode();
 
+    void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&);
+
     void commitStateBeforeChildren(const ScrollingStateNode&) override;
     void commitStateAfterChildren(const ScrollingStateNode&) override;
     void didCompleteCommitForNode() final;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -47,6 +47,8 @@ public:
 
     virtual void updateFromStateNode(const ScrollingStateScrollingNode&) { }
 
+    virtual void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&) { }
+
     virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
 
 protected:

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -51,6 +51,8 @@ public:
 
     bool handleWheelEvent(const PlatformWheelEvent&);
 
+    void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&) override;
+
     void willDoProgrammaticScroll(const FloatPoint&);
     void currentScrollPositionChanged();
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -146,6 +146,23 @@ bool ScrollingTreeScrollingNodeDelegateMac::isRubberBandInProgress() const
     return m_scrollController.isRubberBandInProgress();
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::handleKeyboardScrollRequest(const RequestedKeyboardScrollData& scrollData)
+{
+    switch (scrollData.action) {
+    case KeyboardScrollAction::StartAnimation:
+        m_scrollController.startKeyboardScroll(*scrollData.keyboardScroll);
+        return;
+
+    case KeyboardScrollAction::StopWithAnimation:
+        m_scrollController.finishKeyboardScroll(false);
+        return;
+
+    case KeyboardScrollAction::StopImmediately:
+        m_scrollController.finishKeyboardScroll(true);
+        return;
+    }
+}
+
 bool ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching(const PlatformWheelEvent& wheelEvent) const
 {
     switch (horizontalScrollElasticity()) {

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -29,22 +29,21 @@
 #include "EventNames.h"
 #include "FrameView.h"
 #include "PlatformKeyboardEvent.h"
+#include "ScrollAnimator.h"
 #include "ScrollTypes.h"
-#include "ScrollableArea.h"
 #include <wtf/SortedArrayMap.h>
 
 namespace WebCore {
 
-KeyboardScrollingAnimator::KeyboardScrollingAnimator(ScrollAnimator& scrollAnimator, ScrollingEffectsController& scrollController)
-    : m_scrollAnimator(scrollAnimator)
-    , m_scrollController(scrollController)
+KeyboardScrollingAnimator::KeyboardScrollingAnimator(ScrollableArea& scrollableArea)
+    : m_scrollableArea(scrollableArea)
 {
 }
 
 RectEdges<bool> KeyboardScrollingAnimator::scrollableDirectionsFromPosition(FloatPoint position) const
 {
-    auto minimumScrollPosition = m_scrollAnimator.scrollableArea().minimumScrollPosition();
-    auto maximumScrollPosition = m_scrollAnimator.scrollableArea().maximumScrollPosition();
+    auto minimumScrollPosition = m_scrollableArea.minimumScrollPosition();
+    auto maximumScrollPosition = m_scrollableArea.maximumScrollPosition();
 
     RectEdges<bool> edges;
 
@@ -70,20 +69,6 @@ static BoxSide boxSideForDirection(ScrollDirection direction)
     }
     ASSERT_NOT_REACHED();
     return BoxSide::Top;
-}
-
-static FloatSize perpendicularAbsoluteUnitVector(ScrollDirection direction)
-{
-    switch (direction) {
-    case ScrollDirection::ScrollUp:
-    case ScrollDirection::ScrollDown:
-        return { 1, 0 };
-    case ScrollDirection::ScrollLeft:
-    case ScrollDirection::ScrollRight:
-        return { 0, 1 };
-    }
-    ASSERT_NOT_REACHED();
-    return { };
 }
 
 const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(const KeyboardEvent& event)
@@ -174,66 +159,9 @@ const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const K
     return granularity;
 }
 
-void KeyboardScrollingAnimator::updateKeyboardScrollPosition(MonotonicTime currentTime)
-{
-    auto force = FloatSize { };
-    auto axesToApplySpring = FloatSize { 1, 1 };
-    KeyboardScrollParameters params = KeyboardScrollParameters::parameters();
-
-    if (m_currentKeyboardScroll) {
-        auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollAnimator.currentPosition());
-        auto direction = m_currentKeyboardScroll->direction;
-
-        if (scrollableDirections.at(boxSideForDirection(direction))) {
-            // Apply the scrolling force. Only apply the spring in the perpendicular axis,
-            // otherwise it drags against the direction of motion.
-            axesToApplySpring = perpendicularAbsoluteUnitVector(direction);
-            force = m_currentKeyboardScroll->force;
-        } else {
-            // The scroll view cannot scroll in this direction, and is rubber-banding.
-            // Apply a constant and significant force; otherwise, the force for a
-            // single-line increment is not strong enough to rubber-band perceptibly.
-            force = unitVectorForScrollDirection(direction).scaled(params.rubberBandForce);
-        }
-
-        if (fabs(m_velocity.width()) >= fabs(m_currentKeyboardScroll->maximumVelocity.width()))
-            force.setWidth(0);
-
-        if (fabs(m_velocity.height()) >= fabs(m_currentKeyboardScroll->maximumVelocity.height()))
-            force.setHeight(0);
-    }
-
-    ScrollPosition idealPosition = m_scrollAnimator.scrollableArea().constrainedScrollPosition(IntPoint(m_currentKeyboardScroll ? m_scrollAnimator.currentPosition() : m_idealPosition));
-    FloatSize displacement = m_scrollAnimator.currentPosition() - idealPosition;
-
-    auto springForce = -displacement.scaled(params.springStiffness) - m_velocity.scaled(params.springDamping);
-    force += springForce * axesToApplySpring;
-
-    float frameDuration = (currentTime - m_timeAtLastFrame).value();
-    m_timeAtLastFrame = currentTime;
-
-    FloatSize acceleration = force.scaled(1. / params.springMass);
-    m_velocity += acceleration.scaled(frameDuration);
-    FloatPoint newPosition = m_scrollAnimator.currentPosition() + m_velocity.scaled(frameDuration);
-
-    m_scrollAnimator.scrollToPositionWithoutAnimation(newPosition);
-
-    // Stop the spring if it reaches the ideal position.
-    FloatSize newDisplacement = newPosition - idealPosition;
-    if (axesToApplySpring.width() && displacement.width() * newDisplacement.width() < 0)
-        m_velocity.setWidth(0);
-    if (axesToApplySpring.height() && displacement.height() * newDisplacement.height() < 0)
-        m_velocity.setHeight(0);
-
-    if (!m_scrollTriggeringKeyIsPressed && m_velocity.diagonalLengthSquared() < 1) {
-        m_scrollController.didStopKeyboardScrolling();
-        m_velocity = { };
-    }
-}
-
 float KeyboardScrollingAnimator::scrollDistance(ScrollDirection direction, ScrollGranularity granularity) const
 {
-    auto scrollbar = m_scrollAnimator.scrollableArea().scrollbarForDirection(direction);
+    auto scrollbar = m_scrollableArea.scrollbarForDirection(direction);
     if (!scrollbar)
         return false;
 
@@ -255,7 +183,7 @@ float KeyboardScrollingAnimator::scrollDistance(ScrollDirection direction, Scrol
 
     auto axis = axisFromDirection(direction);
     if (granularity == ScrollGranularity::Page && axis == ScrollEventAxis::Vertical)
-        step = m_scrollAnimator.scrollableArea().adjustVerticalPageScrollStepForFixedContent(step);
+        step = m_scrollableArea.adjustVerticalPageScrollStepForFixedContent(step);
 
     return step;
 }
@@ -284,9 +212,7 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
     if (!scroll)
         return false;
 
-    m_currentKeyboardScroll = scroll;
-
-    auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollAnimator.currentPosition());
+    auto scrollableDirections = scrollableDirectionsFromPosition(m_scrollableArea.scrollAnimator().currentPosition());
     if (!scrollableDirections.at(boxSideForDirection(direction))) {
         stopScrollingImmediately();
         return false;
@@ -296,63 +222,17 @@ bool KeyboardScrollingAnimator::beginKeyboardScrollGesture(ScrollDirection direc
         return true;
 
     if (granularity == ScrollGranularity::Document) {
-        m_velocity = { };
-        stopKeyboardScrollAnimation();
-        auto newPosition = IntPoint(m_scrollAnimator.currentPosition() + m_currentKeyboardScroll->offset);
-        m_scrollAnimator.scrollToPositionWithAnimation(newPosition);
+        m_scrollableArea.endKeyboardScroll(false);
+        auto newPosition = IntPoint(m_scrollableArea.scrollAnimator().currentPosition() + scroll->offset);
+        m_scrollableArea.scrollAnimator().scrollToPositionWithAnimation(newPosition);
         return true;
     }
 
-    m_timeAtLastFrame = MonotonicTime::now();
     m_scrollTriggeringKeyIsPressed = true;
 
-    m_idealPositionForMinimumTravel = m_scrollAnimator.currentPosition() + m_currentKeyboardScroll->offset;
-    m_scrollController.willBeginKeyboardScrolling();
+    m_scrollableArea.beginKeyboardScroll(*scroll);
 
     return true;
-}
-
-static ScrollPosition farthestPointInDirection(FloatPoint a, FloatPoint b, ScrollDirection direction)
-{
-    switch (direction) {
-    case ScrollDirection::ScrollUp:
-        return ScrollPosition(a.x(), std::min(a.y(), b.y()));
-    case ScrollDirection::ScrollDown:
-        return ScrollPosition(a.x(), std::max(a.y(), b.y()));
-    case ScrollDirection::ScrollLeft:
-        return ScrollPosition(std::min(a.x(), b.x()), a.y());
-    case ScrollDirection::ScrollRight:
-        return ScrollPosition(std::max(a.x(), b.x()), a.y());
-    }
-
-    ASSERT_NOT_REACHED();
-    return { };
-}
-
-void KeyboardScrollingAnimator::stopKeyboardScrollAnimation()
-{
-    if (!m_currentKeyboardScroll)
-        return;
-
-    auto params = KeyboardScrollParameters::parameters();
-
-    // Determine the settling position of the spring, conserving the system's current energy.
-    // Kinetic = elastic potential
-    // 1/2 * m * v^2 = 1/2 * k * x^2
-    // x = sqrt(v^2 * m / k)
-    auto displacementMagnitudeSquared = (m_velocity * m_velocity).scaled(params.springMass / params.springStiffness);
-    FloatSize displacement = {
-        std::copysign(sqrt(displacementMagnitudeSquared.width()), m_velocity.width()),
-        std::copysign(sqrt(displacementMagnitudeSquared.height()), m_velocity.height())
-    };
-
-    // If the spring would settle before the minimum travel distance
-    // for an instantaneous tap, move the settling position of the spring
-    // out to that point.
-    ScrollPosition farthestPoint = farthestPointInDirection(m_scrollAnimator.currentPosition() + displacement, m_idealPositionForMinimumTravel, m_currentKeyboardScroll->direction);
-    m_idealPosition = m_scrollAnimator.scrollableArea().constrainedScrollPosition(farthestPoint);
-
-    m_currentKeyboardScroll = std::nullopt;
 }
 
 void KeyboardScrollingAnimator::handleKeyUpEvent()
@@ -360,15 +240,15 @@ void KeyboardScrollingAnimator::handleKeyUpEvent()
     if (!m_scrollTriggeringKeyIsPressed)
         return;
 
-    stopKeyboardScrollAnimation();
     m_scrollTriggeringKeyIsPressed = false;
+
+    m_scrollableArea.endKeyboardScroll(false);
 }
 
 void KeyboardScrollingAnimator::stopScrollingImmediately()
 {
     m_scrollTriggeringKeyIsPressed = false;
-    m_scrollController.didStopKeyboardScrolling();
-    m_velocity = { };
+    m_scrollableArea.endKeyboardScroll(true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -28,7 +28,7 @@
 #include "KeyboardEvent.h"
 #include "KeyboardScroll.h" // FIXME: This is a layering violation.
 #include "RectEdges.h"
-#include "ScrollAnimator.h"
+#include "ScrollableArea.h"
 
 namespace WebCore {
 
@@ -52,27 +52,19 @@ class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimato
     WTF_MAKE_NONCOPYABLE(KeyboardScrollingAnimator);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    KeyboardScrollingAnimator(ScrollAnimator&, ScrollingEffectsController&);
+    KeyboardScrollingAnimator(ScrollableArea&);
 
     bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity);
     void handleKeyUpEvent();
-    void updateKeyboardScrollPosition(MonotonicTime);
     WEBCORE_EXPORT void stopScrollingImmediately();
 
 private:
-    void stopKeyboardScrollAnimation();
     RectEdges<bool> scrollableDirectionsFromPosition(FloatPoint) const;
     std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection, ScrollGranularity) const;
     float scrollDistance(ScrollDirection, ScrollGranularity) const;
 
-    ScrollAnimator& m_scrollAnimator;
-    ScrollingEffectsController& m_scrollController;
-    std::optional<WebCore::KeyboardScroll> m_currentKeyboardScroll;
+    ScrollableArea& m_scrollableArea;
     bool m_scrollTriggeringKeyIsPressed { false };
-    FloatSize m_velocity;
-    MonotonicTime m_timeAtLastFrame;
-    FloatPoint m_idealPositionForMinimumTravel;
-    FloatPoint m_idealPosition;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollAnimation.cpp
+++ b/Source/WebCore/platform/ScrollAnimation.cpp
@@ -37,6 +37,7 @@ TextStream& operator<<(TextStream& ts, ScrollAnimation::Type animationType)
     case ScrollAnimation::Type::Kinetic: ts << "kinetic"; break;
     case ScrollAnimation::Type::Momentum: ts << "momentum"; break;
     case ScrollAnimation::Type::RubberBand: ts << "rubber-band"; break;
+    case ScrollAnimation::Type::Keyboard: ts << "keyboard"; break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/ScrollAnimation.h
+++ b/Source/WebCore/platform/ScrollAnimation.h
@@ -57,6 +57,7 @@ public:
         Kinetic,
         Momentum,
         RubberBand,
+        Keyboard,
     };
 
     ScrollAnimation(Type animationType, ScrollAnimationClient& client)

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollAnimationKeyboard.h"
+
+#include "FloatPoint.h"
+#include "GeometryUtilities.h"
+#include "ScrollExtents.h"
+#include "ScrollableArea.h"
+#include "TimingFunction.h"
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+static FloatSize perpendicularAbsoluteUnitVector(ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+    case ScrollDirection::ScrollDown:
+        return { 1, 0 };
+    case ScrollDirection::ScrollLeft:
+    case ScrollDirection::ScrollRight:
+        return { 0, 1 };
+    }
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+static BoxSide boxSideForDirection(ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+        return BoxSide::Top;
+    case ScrollDirection::ScrollDown:
+        return BoxSide::Bottom;
+    case ScrollDirection::ScrollLeft:
+        return BoxSide::Left;
+    case ScrollDirection::ScrollRight:
+        return BoxSide::Right;
+    }
+    ASSERT_NOT_REACHED();
+    return BoxSide::Top;
+}
+
+static FloatPoint farthestPointInDirection(FloatPoint a, FloatPoint b, ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+        return { a.x(), std::min(a.y(), b.y()) };
+    case ScrollDirection::ScrollDown:
+        return { a.x(), std::max(a.y(), b.y()) };
+    case ScrollDirection::ScrollLeft:
+        return { std::min(a.x(), b.x()), a.y() };
+    case ScrollDirection::ScrollRight:
+        return { std::max(a.x(), b.x()), a.y() };
+    }
+
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+RectEdges<bool> ScrollAnimationKeyboard::scrollableDirectionsFromPosition(FloatPoint position)
+{
+    auto extents = m_client.scrollExtentsForAnimation(*this);
+
+    auto minimumScrollPosition = extents.minimumScrollOffset();
+    auto maximumScrollPosition = extents.maximumScrollOffset();
+
+    RectEdges<bool> edges;
+
+    edges.setTop(position.y() > minimumScrollPosition.y());
+    edges.setBottom(position.y() < maximumScrollPosition.y());
+    edges.setLeft(position.x() > minimumScrollPosition.x());
+    edges.setRight(position.x() < maximumScrollPosition.x());
+
+    return edges;
+}
+
+ScrollAnimationKeyboard::ScrollAnimationKeyboard(ScrollAnimationClient& client)
+    : ScrollAnimation(Type::Keyboard, client)
+{
+}
+
+ScrollAnimationKeyboard::~ScrollAnimationKeyboard() = default;
+
+bool ScrollAnimationKeyboard::retargetActiveAnimation(const FloatPoint&)
+{
+    if (!isActive())
+        return false;
+
+    return true;
+}
+
+void ScrollAnimationKeyboard::serviceAnimation(MonotonicTime currentTime)
+{
+    animateScroll(currentTime);
+}
+
+bool ScrollAnimationKeyboard::startKeyboardScroll(const KeyboardScroll& scrollData)
+{
+    m_timeAtLastFrame = MonotonicTime::now();
+    m_currentKeyboardScroll = scrollData;
+    m_scrollTriggeringKeyIsPressed = true;
+    m_currentOffset = m_client.scrollOffset(*this);
+    m_idealPositionForMinimumTravel = {
+        (m_currentOffset + m_currentKeyboardScroll->offset).x(),
+        (m_currentOffset + m_currentKeyboardScroll->offset).y() };
+
+    if (!isActive())
+        didStart(MonotonicTime::now());
+
+    return true;
+}
+
+void ScrollAnimationKeyboard::stopKeyboardScrollAnimation()
+{
+    if (!m_currentKeyboardScroll)
+        return;
+
+    auto params = KeyboardScrollParameters::parameters();
+
+    // Determine the settling position of the spring, conserving the system's current energy.
+    // Kinetic = elastic potential
+    // 1/2 * m * v^2 = 1/2 * k * x^2
+    // x = sqrt(v^2 * m / k)
+    auto displacementMagnitudeSquared = (m_velocity * m_velocity).scaled(params.springMass / params.springStiffness);
+    FloatPoint displacement = {
+        std::copysign(sqrt(displacementMagnitudeSquared.width()), m_velocity.width()),
+        std::copysign(sqrt(displacementMagnitudeSquared.height()), m_velocity.height())
+    };
+
+    // If the spring would settle before the minimum travel distance
+    // for an instantaneous tap, move the settling position of the spring
+    // out to that point.
+    FloatPoint farthestPoint = farthestPointInDirection(m_currentOffset + displacement, { m_idealPositionForMinimumTravel.width(), m_idealPositionForMinimumTravel.height() }, m_currentKeyboardScroll->direction);
+
+    auto extents = m_client.scrollExtentsForAnimation(*this);
+
+    m_idealPosition = farthestPoint.constrainedBetween(extents.minimumScrollOffset(), extents.maximumScrollOffset());
+
+    m_currentKeyboardScroll = std::nullopt;
+}
+
+void ScrollAnimationKeyboard::finishKeyboardScroll(bool immediate)
+{
+    if (!m_scrollTriggeringKeyIsPressed && !immediate)
+        return;
+
+    if (!immediate)
+        stopKeyboardScrollAnimation();
+    
+    m_scrollTriggeringKeyIsPressed = false;
+
+    if (immediate) {
+        didEnd();
+        m_velocity = { };
+    }
+}
+
+bool ScrollAnimationKeyboard::animateScroll(MonotonicTime currentTime)
+{
+    auto force = FloatSize { };
+    auto axesToApplySpring = FloatSize { 1, 1 };
+    KeyboardScrollParameters params = KeyboardScrollParameters::parameters();
+
+    if (m_currentKeyboardScroll) {
+        auto scrollableDirections = scrollableDirectionsFromPosition(m_currentOffset);
+        auto direction = m_currentKeyboardScroll->direction;
+
+        if (scrollableDirections.at(boxSideForDirection(direction))) {
+            // Apply the scrolling force. Only apply the spring in the perpendicular axis,
+            // otherwise it drags against the direction of motion.
+            axesToApplySpring = perpendicularAbsoluteUnitVector(direction);
+            force = m_currentKeyboardScroll->force;
+        } else {
+            // The scroll view cannot scroll in this direction, and is rubber-banding.
+            // Apply a constant and significant force; otherwise, the force for a
+            // single-line increment is not strong enough to rubber-band perceptibly.
+            force = unitVectorForScrollDirection(direction).scaled(params.rubberBandForce);
+        }
+
+        if (fabs(m_velocity.width()) >= fabs(m_currentKeyboardScroll->maximumVelocity.width()))
+            force.setWidth(0);
+
+        if (fabs(m_velocity.height()) >= fabs(m_currentKeyboardScroll->maximumVelocity.height()))
+            force.setHeight(0);
+    }
+
+    auto extents = m_client.scrollExtentsForAnimation(*this);
+
+    FloatPoint idealPosition = (IntPoint(m_currentKeyboardScroll ? m_currentOffset : m_idealPosition).constrainedBetween(IntPoint(extents.minimumScrollOffset()), IntPoint(extents.maximumScrollOffset())));
+    FloatSize displacement = m_currentOffset - idealPosition;
+
+    auto springForce = -displacement.scaled(params.springStiffness) - m_velocity.scaled(params.springDamping);
+    force += springForce * axesToApplySpring;
+
+    float frameDuration = (currentTime - m_timeAtLastFrame).value();
+    m_timeAtLastFrame = currentTime;
+
+    FloatSize acceleration = force.scaled(1. / params.springMass);
+    m_velocity += acceleration.scaled(frameDuration);
+    m_currentOffset = m_currentOffset + m_velocity.scaled(frameDuration);
+
+    m_client.scrollAnimationDidUpdate(*this, m_currentOffset);
+
+    // Stop the spring if it reaches the ideal position.
+    FloatSize newDisplacement = m_currentOffset - idealPosition;
+
+    if (axesToApplySpring.width() && displacement.width() * newDisplacement.width() < 0)
+        m_velocity.setWidth(0);
+    if (axesToApplySpring.height() && displacement.height() * newDisplacement.height() < 0)
+        m_velocity.setHeight(0);
+
+    if (!m_scrollTriggeringKeyIsPressed && m_velocity.diagonalLengthSquared() < 1) {
+        didEnd();
+        m_velocity = { };
+    }
+
+    return true;
+}
+
+String ScrollAnimationKeyboard::debugDescription() const
+{
+    TextStream textStream;
+    textStream << "ScrollAnimationKeyboard " << this << " active " << isActive() << " current offset " << currentOffset() << " current velocity " << m_velocity;
+    return textStream.release();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.h
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "KeyboardScroll.h"
+#include "RectEdges.h"
+#include "ScrollAnimation.h"
+
+namespace WebCore {
+
+class FloatPoint;
+class TimingFunction;
+
+class ScrollAnimationKeyboard final: public ScrollAnimation {
+public:
+    ScrollAnimationKeyboard(ScrollAnimationClient&);
+    virtual ~ScrollAnimationKeyboard();
+
+    bool startKeyboardScroll(const KeyboardScroll&);
+
+    void finishKeyboardScroll(bool immediate);
+
+    void stopKeyboardScrollAnimation();
+
+private:
+    void serviceAnimation(MonotonicTime) final;
+    bool retargetActiveAnimation(const FloatPoint&) final;
+
+    String debugDescription() const final;
+
+    bool animateScroll(MonotonicTime);
+
+    RectEdges<bool> scrollableDirectionsFromPosition(FloatPoint position);
+
+    std::optional<KeyboardScroll> m_currentKeyboardScroll;
+    FloatSize m_velocity;
+    MonotonicTime m_timeAtLastFrame;
+    FloatPoint m_idealPosition;
+    FloatSize m_idealPositionForMinimumTravel;
+    bool m_scrollTriggeringKeyIsPressed;
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_SCROLL_ANIMATION(WebCore::ScrollAnimationKeyboard, type() == WebCore::ScrollAnimation::Type::Keyboard)

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<ScrollAnimator> ScrollAnimator::create(ScrollableArea& scrollabl
 ScrollAnimator::ScrollAnimator(ScrollableArea& scrollableArea)
     : m_scrollableArea(scrollableArea)
     , m_scrollController(*this)
-    , m_keyboardScrollingAnimator(makeUnique<KeyboardScrollingAnimator>(*this, m_scrollController))
+    , m_keyboardScrollingAnimator(makeUnique<KeyboardScrollingAnimator>(scrollableArea))
 {
 }
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -132,6 +132,22 @@ bool ScrollableArea::scroll(ScrollDirection direction, ScrollGranularity granula
     return scrollAnimator().singleAxisScroll(axis, scrollDelta, ScrollAnimator::ScrollBehavior::RespectScrollSnap);
 }
 
+void ScrollableArea::beginKeyboardScroll(const KeyboardScroll& scrollData)
+{
+    bool startedAnimation = requestStartKeyboardScrollAnimation(scrollData);
+
+    if (startedAnimation)
+        setScrollAnimationStatus(ScrollAnimationStatus::Animating);
+}
+
+void ScrollableArea::endKeyboardScroll(bool immediate)
+{
+    bool finishedAnimation = requestStopKeyboardScrollAnimation(immediate);
+
+    if (finishedAnimation)
+        setScrollAnimationStatus(ScrollAnimationStatus::NotAnimating);
+}
+
 void ScrollableArea::scrollToPositionWithoutAnimation(const FloatPoint& position, ScrollClamping clamping)
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithoutAnimation " << position);

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "KeyboardScroll.h"
 #include "RectEdges.h"
 #include "ScrollAlignment.h"
 #include "ScrollSnapOffsetsInfo.h"
@@ -68,6 +69,9 @@ public:
     virtual bool isRenderLayer() const { return false; }
     virtual bool isListBox() const { return false; }
 
+    WEBCORE_EXPORT void beginKeyboardScroll(const KeyboardScroll& scrollData);
+    WEBCORE_EXPORT void endKeyboardScroll(bool);
+
     WEBCORE_EXPORT bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1);
     WEBCORE_EXPORT void scrollToPositionWithAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     WEBCORE_EXPORT void scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
@@ -85,6 +89,9 @@ public:
     virtual bool requestScrollPositionUpdate(const ScrollPosition&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped) { return false; }
     virtual bool requestAnimatedScrollToPosition(const ScrollPosition&, ScrollClamping = ScrollClamping::Clamped) { return false; }
     virtual void stopAsyncAnimatedScroll() { }
+
+    virtual bool requestStartKeyboardScrollAnimation(const KeyboardScroll&) { return false; }
+    virtual bool requestStopKeyboardScrollAnimation(bool) { return false; }
 
     WEBCORE_EXPORT virtual bool handleWheelEventForScrolling(const PlatformWheelEvent&, std::optional<WheelScrollGestureState>);
 

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -28,6 +28,7 @@
 #include "FloatPoint.h"
 #include "FloatSize.h"
 
+#include "KeyboardScroll.h"
 #include "RectEdges.h"
 #include "ScrollAnimation.h"
 #include "ScrollSnapAnimatorState.h"
@@ -77,7 +78,6 @@ public:
     virtual void startAnimationCallback(ScrollingEffectsController&) = 0;
     virtual void stopAnimationCallback(ScrollingEffectsController&) = 0;
 
-    virtual void updateKeyboardScrollPosition(MonotonicTime) { }
     virtual KeyboardScrollingAnimator *keyboardScrollingAnimator() const { return nullptr; }
 
     virtual bool allowsHorizontalScrolling() const = 0;
@@ -146,6 +146,10 @@ public:
 
     void willBeginKeyboardScrolling();
     void didStopKeyboardScrolling();
+
+    bool startKeyboardScroll(const KeyboardScroll&);
+
+    void finishKeyboardScroll(bool immediate);
     
     // Should be called periodically by the client. Started by startAnimationCallback(), stopped by stopAnimationCallback().
     void animationCallback(MonotonicTime);
@@ -186,7 +190,6 @@ public:
 
 private:
     void updateRubberBandAnimatingState();
-    void updateKeyboardScrollingAnimatingState(MonotonicTime);
 
     void setIsAnimatingRubberBand(bool);
     void setIsAnimatingScrollSnap(bool);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -257,6 +257,22 @@ bool RenderLayerScrollableArea::requestScrollPositionUpdate(const ScrollPosition
     return false;
 }
 
+bool RenderLayerScrollableArea::requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData)
+{
+    if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
+        return scrollingCoordinator->requestStartKeyboardScrollAnimation(*this, scrollData);
+
+    return false;
+}
+
+bool RenderLayerScrollableArea::requestStopKeyboardScrollAnimation(bool immediate)
+{
+    if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
+        return scrollingCoordinator->requestStopKeyboardScrollAnimation(*this, immediate);
+
+    return false;
+}
+
 bool RenderLayerScrollableArea::requestAnimatedScrollToPosition(const ScrollPosition& destinationPosition, ScrollClamping clamping)
 {
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -206,6 +206,9 @@ public:
     IntSize contentsSize() const final;
     IntSize reachableTotalContentsSize() const final;
 
+    bool requestStartKeyboardScrollAnimation(const KeyboardScroll&) final;
+    bool requestStopKeyboardScrollAnimation(bool immediate) final;
+
     bool requestScrollPositionUpdate(const ScrollPosition&, ScrollType = ScrollType::User, ScrollClamping = ScrollClamping::Clamped) final;
     bool requestAnimatedScrollToPosition(const ScrollPosition&, ScrollClamping = ScrollClamping::Clamped) final;
     void stopAsyncAnimatedScroll() final;

--- a/Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/SpacebarScrolling.cpp
@@ -68,11 +68,10 @@ TEST(WebKit, SpacebarScrolling)
 {
     WKRetainPtr<WKContextRef> context = adoptWK(Util::createContextWithInjectedBundle());
 
-    // Turn off threaded scrolling; synchronously waiting for the main thread scroll position to
-    // update using WKPageForceRepaint would be better, but for some reason the test still fails occasionally.
-    WKRetainPtr<WKPageGroupRef> pageGroup = adoptWK(WKPageGroupCreateWithIdentifier(Util::toWK("NoThreadedScrollingPageGroup").get()));
+    WKRetainPtr<WKPageGroupRef> pageGroup = adoptWK(WKPageGroupCreateWithIdentifier(Util::toWK("AsyncScrollingPageGroup").get()));
     WKPreferencesRef preferences = WKPageGroupGetPreferences(pageGroup.get());
-    WKPreferencesSetThreadedScrollingEnabled(preferences, false);
+    WKPreferencesSetThreadedScrollingEnabled(preferences, true);
+    WKPreferencesSetInternalDebugFeatureForKey(preferences, true, Util::toWK("AsyncFrameScrollingEnabled").get());
 
     PlatformWebView webView(context.get(), pageGroup.get());
 


### PR DESCRIPTION
#### cb5925ef6a3e94f82e753b50298c2a25f7160da0
<pre>
Scrolling by pressing space bar has regressed in trunk, is choppy (not 120Hz)
<a href="https://bugs.webkit.org/show_bug.cgi?id=246878">https://bugs.webkit.org/show_bug.cgi?id=246878</a>
rdar://101052130

Reviewed by Simon Fraser.

Moves keyboard smooth scrolling onto the scrolling thread instead of the main thread.

A new `ScrollAnimation` is created to facilitate this, `ScrollAnimationKeyboard`. Most
of the changes are to allow the state to propogate through the various classes and
the scrolling tree.

Since keyboard scrolling is now on a different thread, some tests had to be modified to
enable the `AsyncOverflowScrollingEnabled` and `AsyncFrameScrollingEnabled` settings.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::requestStartKeyboardAnimation):
(WebCore::FrameView::requestFinishKeyboardAnimation):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestStartKeyboardAnimation):
(WebCore::AsyncScrollingCoordinator::requestFinishKeyboardAnimation):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::requestStartKeyboardAnimation):
(WebCore::ScrollingCoordinator::requestFinishKeyboardAnimation):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::setKeyboardScrollData):
(WebCore::ScrollingStateScrollingNode::setKeyboardScrollEndData):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::keyboardScrollData const):
(WebCore::ScrollingStateScrollingNode::keyboardScrollEndData const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateAfterChildren):
(WebCore::ScrollingTreeScrollingNode::handleKeyboardScrollRequest):
(WebCore::ScrollingTreeScrollingNode::handleKeyboardScrollEndRequest):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::handleKeyboardScrollRequest):
(WebCore::ScrollingTreeScrollingNodeDelegate::handleKeyboardScrollEndRequest):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleKeyboardScrollRequest):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleKeyboardScrollEndRequest):
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::KeyboardScrollingAnimator):
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
(WebCore::KeyboardScrollingAnimator::handleKeyUpEvent):
(WebCore::KeyboardScrollingAnimator::stopScrollingImmediately):
(WebCore::perpendicularAbsoluteUnitVector): Deleted.
(WebCore::KeyboardScrollingAnimator::updateKeyboardScrollPosition): Deleted.
(WebCore::farthestPointInDirection): Deleted.
(WebCore::KeyboardScrollingAnimator::stopKeyboardScrollAnimation): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.h:
* Source/WebCore/platform/ScrollAnimation.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollAnimation.h:
* Source/WebCore/platform/ScrollAnimationKeyboard.cpp: Added.
(WebCore::perpendicularAbsoluteUnitVector):
(WebCore::boxSideForDirection):
(WebCore::farthestPointInDirection):
(WebCore::ScrollAnimationKeyboard::scrollableDirectionsFromPosition):
(WebCore::ScrollAnimationKeyboard::ScrollAnimationKeyboard):
(WebCore::ScrollAnimationKeyboard::retargetActiveAnimation):
(WebCore::ScrollAnimationKeyboard::serviceAnimation):
(WebCore::ScrollAnimationKeyboard::startKeyboardScroll):
(WebCore::ScrollAnimationKeyboard::stopKeyboardScrollAnimation):
(WebCore::ScrollAnimationKeyboard::finishKeyboardScroll):
(WebCore::ScrollAnimationKeyboard::animateScroll):
(WebCore::ScrollAnimationKeyboard::debugDescription const):
* Source/WebCore/platform/ScrollAnimationKeyboard.h: Copied from Source/WebCore/platform/ScrollAnimation.cpp.
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::ScrollAnimator::ScrollAnimator):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::beginKeyboardScroll):
(WebCore::ScrollableArea::endKeyboardScroll):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::requestStartKeyboardAnimation):
(WebCore::ScrollableArea::requestFinishKeyboardAnimation):
* Source/WebCore/platform/ScrollingEffectsController.cpp:
(WebCore::ScrollingEffectsController::animationCallback):
(WebCore::ScrollingEffectsController::startKeyboardScroll):
(WebCore::ScrollingEffectsController::finishKeyboardScroll):
(WebCore::ScrollingEffectsController::updateKeyboardScrollingAnimatingState):
(WebCore::ScrollingEffectsController::scrollAnimationWillStart):
* Source/WebCore/platform/ScrollingEffectsController.h:
(WebCore::ScrollingEffectsControllerClient::updateKeyboardScrollPosition): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::requestStartKeyboardAnimation):
(WebCore::RenderLayerScrollableArea::requestFinishKeyboardAnimation):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/256266@main">https://commits.webkit.org/256266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc8ff7d1afa2f9d08a3c794b419907fd149b9983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104813 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165072 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4469 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33220 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100708 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3263 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81766 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30229 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/86996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73131 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38945 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36761 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4328 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40699 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39079 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->