### PR TITLE
Support v128 const load store and extract lane in bbq only with O0 register allocation

### DIFF
--- a/JSTests/wasm/stress/simd-const-spill.js
+++ b/JSTests/wasm/stress/simd-const-spill.js
@@ -1,0 +1,128 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86-64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $js_ident (import "imports" "ident") (param i32) (result i32))
+    (func (export "test") (param $sz i32) (result i32)
+        (local $a v128)
+        (local $b v128)
+        (local.set $a (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
+        (local.set $b (v128.const i8x16 9 0 2 0 0 0 0 0 0 0 5 0 0 0 0 1))
+        (i8x16.extract_lane_u 15 (local.get $a))
+        (i8x16.extract_lane_u 15 (local.get $b))
+        (i32.add)
+
+        (return)
+    )
+    (func $ident128 (param $i i32) (param $v v128) (param $i2 i32) (result v128)
+        (return (local.get $v))
+    )
+    (func $ident32 (param $i i32) (param $v v128) (param $i2 i32) (result i32)
+        (return (local.get $i2))
+    )
+    (func (export "test_spill") (param $i i32) (result i32)
+        (local $a v128)
+        (local.set $a (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
+        (i8x16.extract_lane_u 13
+            (call $ident128
+                (i32.const 1337)
+                (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+                (i32.const 4200000)))
+        (local.get $i)
+        (i8x16.extract_lane_u 14 (local.get $a))
+        (call $ident32
+            (i32.const 1337)
+            (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+            (i32.const 4200000))
+        (i32.add)
+        (i32.add)
+        (i32.add)
+
+        (return)
+    )
+    (func (export "test_spill_jscall") (param $i i32) (result i32)
+        (local $a v128)
+        (local.set $a (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
+        (i8x16.extract_lane_u 13
+            (call $ident128
+                (i32.const 1337)
+                (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+                (i32.const 4200000)))
+        (local.get $i)
+        (local.get $a)
+        (call $js_ident (i32.const 0))
+        (drop)
+        (i8x16.extract_lane_u 14)
+        (call $ident32
+            (i32.const 1337)
+            (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+            (i32.const 4200000))
+        (i32.add)
+        (i32.add)
+        (i32.add)
+
+        (return)
+    )
+    (func (export "test_if_i32") (param $i i32) (result i32)
+        (local $a v128)
+        (local.set $a (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
+        (local.get $i)
+        (if (result i32)
+            (then
+                (i8x16.extract_lane_u 13
+                    (call $ident128
+                        (i32.const 1337)
+                        (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+                        (i32.const 4200000))))
+            (else
+                (i8x16.extract_lane_u 14 (local.get $a))))
+        (call $ident32
+            (i32.const 1337)
+            (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+            (i32.const 4200000))
+        (i32.add)
+
+        (return)
+    )
+    (func (export "test_if_v128") (param $i i32) (result i32)
+        (local $a v128)
+        (local.set $a (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
+        (local.get $i)
+        (if (result v128)
+            (then
+                (call $ident128
+                    (i32.const 1337)
+                    (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+                    (i32.const 4200000)))
+            (else
+                (local.get $a)))
+        (i8x16.extract_lane_u 14)
+        (call $ident32
+            (i32.const 1337)
+            (v128.const i8x16 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160)
+            (i32.const 4200000))
+        (i32.add)
+
+        (return)
+    )
+)`
+
+async function test() {
+    const instance = await instantiate(wat, { imports: { ident: (x) => x } }, { simd: true })
+    const { test, test_spill, test_spill_jscall, test_if_i32, test_if_v128 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 16+1)
+        assert.eq(test_spill(5000), 140+5000+15+4200000)
+        assert.eq(test_spill_jscall(5000), 140+5000+15+4200000)
+        assert.eq(test_if_i32(0), 15+4200000)
+        assert.eq(test_if_i32(1), 140+4200000)
+        assert.eq(test_if_v128(0), 15+4200000)
+        assert.eq(test_if_v128(1), 150+4200000)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-const.js
+++ b/JSTests/wasm/stress/simd-const.js
@@ -1,0 +1,30 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86-64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param $sz i32) (result i32)
+        (i32.const 9)
+        (drop)
+        (return (i8x16.extract_lane_u 1 (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)))
+    )
+
+    (func (export "test2") (param $sz i32) (result i32)
+        (return (i8x16.extract_lane_u 12 (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test, test2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 2)
+        assert.eq(test2(48), 13);
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-load.js
+++ b/JSTests/wasm/stress/simd-load.js
@@ -1,0 +1,69 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86-64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (import "memory" "memory" (memory $mem 1))
+
+    (func (export "load_simple") (result i32)
+        (v128.load (i32.const 8))
+        (i8x16.extract_lane_u 5)
+        (return)
+    )
+
+    (func (export "load_simple2") (result i32)
+        (i64.store (i32.const 0) (i64.const 0xABCD))
+        (i64.store (i32.const 8) (i64.const 0xEFBD))
+
+        (v128.load (i32.const 0))
+        (i8x16.extract_lane_u 1)
+        
+        (return)
+    )
+
+    (func (export "store_simple") (result i64)
+        (v128.store (i32.const 0) (v128.const i64x2 0xABCD 0xEFBD))
+
+        (i64.load (i32.const 8))
+        
+        (return)
+    )
+)
+`
+
+async function test() {
+    let memory = new WebAssembly.Memory({ initial: 1, maximum: 1 })
+    let u8 = new Uint8Array(memory.buffer);
+    const instance = await instantiate(wat, { imports: { ident: (x) => x }, memory: { memory } }, { simd: true })
+    function dump() {
+        for (let i = 0; i < 16; ++i)
+            print(u8[i].toString(16))
+    }
+    const { 
+        load_simple, 
+        load_simple2, 
+        store_simple,
+    } = instance.exports
+
+    function deBruijin() {
+        const data = [
+            0x00, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 
+            0x88, 0x98, 0xA8, 0xB8, 0xC8, 0xD8, 0xE8, 0xF9, 
+            0x29, 0x39, 0x59, 0x69, 0x79, 0x9A, 0x9B, 0x9D, 
+            0x9E, 0x9F, 0xAA, 0xEB, 0x6B, 0xED, 0xEE, 0xFF
+        ]
+        for (let i = 0; i < data.length; ++i)
+            u8[i] = data[i]
+    }
+
+    for (let i = 0; i < 10000; ++i) {
+        deBruijin()
+        assert.eq(load_simple(), 0xD8)
+        assert.eq(load_simple2(), 0xAB)
+        assert.eq(store_simple(), 0xEFBDn)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-register-allocation.js
+++ b/JSTests/wasm/stress/simd-register-allocation.js
@@ -1,0 +1,55 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if $architecture != "arm64" && $architecture != "x86-64"
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $js_ident (import "imports" "ident") (param i32) (result i32))
+
+    (func $ident128 (param $f f32) (param $v v128) (result v128)
+        (return (local.get $v))
+    )
+
+    (func $ident32 (param $f f32) (param $v v128) (result f32)
+        (return (local.get $f))
+    )
+
+    (func (export "test_wasm_call_clobber_width") (result f32)
+        (local $a v128)
+        (local $b f32)
+        (local.set $a (v128.const f32x4 1 2 3 4))
+        (local.set $b (f32.const 1337.0))
+
+        (local.get $b)
+
+        (f32x4.extract_lane 3 
+            (call $ident128
+                (f32.const 42.42) 
+                (v128.const f32x4 5 6 7 8)))
+
+        (call $ident32
+            (f32.const 42.0)
+            (v128.const f32x4 5 6 7 8))
+
+        (f32x4.extract_lane 3 (local.get $a))
+
+        (f32.add)
+        (f32.add)
+        (f32.add)
+        
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, { imports: { ident: (x) => x } }, { simd: true })
+    const { test_wasm_call_clobber_width } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test_wasm_call_clobber_width(), 1337.0 + 8.0 + 42.0 + 4.0)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -11,6 +11,7 @@
         "i64":       { "type": "varint7", "value":   -2, "b3type": "B3::Int64",  "width": 64 },
         "f32":       { "type": "varint7", "value":   -3, "b3type": "B3::Float",  "width": 32 },
         "f64":       { "type": "varint7", "value":   -4, "b3type": "B3::Double", "width": 64 },
+        "v128":      { "type": "varint7", "value":   -5, "b3type": "B3::V128",   "width": 128 },
         "funcref":   { "type": "varint7", "value":  -16, "b3type": "B3::Int64",  "width": 64 },
         "externref": { "type": "varint7", "value":  -17, "b3type": "B3::Int64",  "width": 64 },
         "ref_null":  { "type": "varint7", "value":  -20, "b3type": "B3::Int64",  "width": 64 },
@@ -23,8 +24,8 @@
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
     },
-    "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref"],
-    "block_type": ["i32", "i64", "f32", "f64", "void", "externref", "funcref"],
+    "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref", "v128"],
+    "block_type": ["i32", "i64", "f32", "f64", "void", "externref", "funcref", "v128"],
     "ref_type": ["funcref", "externref", "ref", "ref_null"],
     "external_kind": {
         "Function":    { "type": "uint8", "value": 0 },

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -889,6 +889,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     jit/RegisterAtOffsetList.h
     jit/RegisterMap.h
     jit/RegisterSet.h
+    jit/SIMDInfo.h
     jit/ScratchRegisterAllocator.h
     jit/Snippet.h
     jit/SnippetParams.h
@@ -1274,6 +1275,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmNameSection.h
     wasm/WasmOSREntryData.h
     wasm/WasmPageCount.h
+    wasm/WasmSIMDOpcodes.h
     wasm/WasmSections.h
     wasm/WasmTypeDefinition.h
     wasm/WasmStreamingCompiler.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -874,10 +874,11 @@
 		4443AE3316E188D90076F110 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51F0EB6105C86C6B00E6DF1B /* Foundation.framework */; };
 		451539B912DC994500EF7AC4 /* Yarr.h in Headers */ = {isa = PBXBuildFile; fileRef = 451539B812DC994500EF7AC4 /* Yarr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		473DA4A4764C45FE871B0485 /* DefinePropertyAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 169948EDE68D4054B01EF797 /* DefinePropertyAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4B1F22F62900BFC700CB5E66 /* Width.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BBA4CD428FF5FE5003EBFC4 /* Width.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4B46940328984FA800512FDF /* MacroAssemblerARM64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEB137561BB11EEE00CD5100 /* MacroAssemblerARM64.cpp */; };
 		4B46940428984FEE00512FDF /* MacroAssemblerX86Common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A4AE0717973B26005612B1 /* MacroAssemblerX86Common.cpp */; };
 		4BAA07CEB81F49A296E02203 /* WasmTypeDefinitionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 30A5F403F11C4F599CD596D5 /* WasmTypeDefinitionInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		4BBA4CD528FF5FE5003EBFC4 /* Width.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BBA4CD428FF5FE5003EBFC4 /* Width.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4BC18E5628FDE6C800ECD68D /* SIMDInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BC18E5428FDE6C800ECD68D /* SIMDInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4BDF3004289324AC00AE1DE3 /* AssemblyComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BDF3002289324AC00AE1DE3 /* AssemblyComments.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4BE92D442898522400FA48E1 /* LowLevelInterpreter.asm in Sources */ = {isa = PBXBuildFile; fileRef = 86A054461556451B00445157 /* LowLevelInterpreter.asm */; };
 		4BE92D452898522400FA48E1 /* LowLevelInterpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680C714BBB16900BFE272 /* LowLevelInterpreter.cpp */; };
@@ -1162,6 +1163,7 @@
 		62D755D71B84FB4A001801FA /* CallFrameShuffler.h in Headers */ = {isa = PBXBuildFile; fileRef = 62D755D11B84FB39001801FA /* CallFrameShuffler.h */; };
 		62EC9BB71B7EB07C00303AD1 /* CallFrameShuffleData.h in Headers */ = {isa = PBXBuildFile; fileRef = 62EC9BB51B7EB07C00303AD1 /* CallFrameShuffleData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		62F2AA381B0BEDE300610C7A /* DFGLazyNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A9A29F1B0BED4800BD54CA /* DFGLazyNode.h */; };
+		641DF80E2890C7D500F9895F /* WasmSIMDOpcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 641DF80D2890C7D500F9895F /* WasmSIMDOpcodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6507D29E0E871E5E00D7D896 /* JSTypeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 6507D2970E871E4A00D7D896 /* JSTypeInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		651122FD14046A4C002B101D /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		651122FE14046A4C002B101D /* libedit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D5D8AD00E0D0EBE00F9C692 /* libedit.dylib */; };
@@ -3827,6 +3829,7 @@
 		451539B812DC994500EF7AC4 /* Yarr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Yarr.h; path = yarr/Yarr.h; sourceTree = "<group>"; };
 		45E12D8806A49B0F00E9DF84 /* jsc.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsc.cpp; sourceTree = "<group>"; tabWidth = 4; };
 		4BBA4CD428FF5FE5003EBFC4 /* Width.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Width.h; sourceTree = "<group>"; };
+		4BC18E5428FDE6C800ECD68D /* SIMDInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIMDInfo.h; sourceTree = "<group>"; };
 		4BDF15B128FF912800D36BA1 /* Width.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Width.cpp; sourceTree = "<group>"; };
 		4BDF3001289324AB00AE1DE3 /* AssemblyComments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AssemblyComments.cpp; sourceTree = "<group>"; };
 		4BDF3002289324AC00AE1DE3 /* AssemblyComments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AssemblyComments.h; sourceTree = "<group>"; };
@@ -4202,6 +4205,7 @@
 		62E3D5EF1B8D0B7300B868BB /* DataFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DataFormat.cpp; sourceTree = "<group>"; };
 		62EC9BB41B7EB07C00303AD1 /* CallFrameShuffleData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallFrameShuffleData.cpp; sourceTree = "<group>"; };
 		62EC9BB51B7EB07C00303AD1 /* CallFrameShuffleData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallFrameShuffleData.h; sourceTree = "<group>"; };
+		641DF80D2890C7D500F9895F /* WasmSIMDOpcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmSIMDOpcodes.h; sourceTree = "<group>"; };
 		6507D2970E871E4A00D7D896 /* JSTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTypeInfo.h; sourceTree = "<group>"; };
 		651122E5140469BA002B101D /* testRegExp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = testRegExp.cpp; sourceTree = "<group>"; };
 		6511230514046A4C002B101D /* testRegExp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testRegExp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6719,6 +6723,7 @@
 				0F24E54B17EE274900ABB217 /* ScratchRegisterAllocator.h */,
 				0FEE98421A89227500754E93 /* SetupVarargsFrame.cpp */,
 				0FEE98401A8865B600754E93 /* SetupVarargsFrame.h */,
+				4BC18E5428FDE6C800ECD68D /* SIMDInfo.h */,
 				6B731CC02647A8370014646F /* SlowPathCall.cpp */,
 				A709F2EF17A0AC0400512E98 /* SlowPathCall.h */,
 				E3F23A7B1ECF13E500978D99 /* Snippet.h */,
@@ -7526,6 +7531,7 @@
 				E3A0531721342B660022EC14 /* WasmSectionParser.cpp */,
 				E3A0531821342B670022EC14 /* WasmSectionParser.h */,
 				53F40E841D58F9770099A1B6 /* WasmSections.h */,
+				641DF80D2890C7D500F9895F /* WasmSIMDOpcodes.h */,
 				14AB0C92231747B7000250BC /* WasmSlowPaths.cpp */,
 				14AB0C93231747B7000250BC /* WasmSlowPaths.h */,
 				E33BBE0725BFA03C0053690F /* WasmStreamingCompiler.cpp */,
@@ -11175,6 +11181,7 @@
 				8602960426FB552D0078EB62 /* ShadowRealmObject.h in Headers */,
 				8602960526FB552D0078EB62 /* ShadowRealmPrototype.h in Headers */,
 				FE3022D31E3D73A500BAC493 /* SigillCrashAnalyzer.h in Headers */,
+				4BC18E5628FDE6C800ECD68D /* SIMDInfo.h in Headers */,
 				0F4D8C781FCA3CFA001D32AC /* SimpleMarkingConstraint.h in Headers */,
 				0F2B670517B6B5AB00A7AE3F /* SimpleTypedArrayController.h in Headers */,
 				14BA78F113AAB88F005B7C2C /* SlotVisitor.h in Headers */,
@@ -11383,6 +11390,7 @@
 				531374BD1D5CE67600AF7A0B /* WasmPlan.h in Headers */,
 				E3A0531C21342B680022EC14 /* WasmSectionParser.h in Headers */,
 				53F40E851D58F9770099A1B6 /* WasmSections.h in Headers */,
+				641DF80E2890C7D500F9895F /* WasmSIMDOpcodes.h in Headers */,
 				E33BBE0925BFA0410053690F /* WasmStreamingCompiler.h in Headers */,
 				E3A0531A21342B680022EC14 /* WasmStreamingParser.h in Headers */,
 				E3C73A9125BFA73B00EFE303 /* WasmStreamingPlan.h in Headers */,
@@ -11458,7 +11466,7 @@
 				14D01BE726DEEF3800CAE0D0 /* WebAssemblyTagPrototype.h in Headers */,
 				52F6C35E1E71EB080081F4CC /* WebAssemblyWrapperFunction.h in Headers */,
 				BC18C47A0E16F5CD00B34460 /* WebKitAvailability.h in Headers */,
-				4BBA4CD528FF5FE5003EBFC4 /* Width.h in Headers */,
+				4B1F22F62900BFC700CB5E66 /* Width.h in Headers */,
 				99DA00A61BD5993100F4575C /* wkbuiltins.py in Headers */,
 				A7DCB97312E5193F00911940 /* WriteBarrier.h in Headers */,
 				C2B6D75318A33793004A9301 /* WriteBarrierInlines.h in Headers */,

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -32,6 +32,7 @@
 #include "AssemblerCommon.h"
 #include "CPU.h"
 #include "JSCPtrTag.h"
+#include "SIMDInfo.h"
 #include <limits.h>
 #include <wtf/Assertions.h>
 #include <wtf/Vector.h>
@@ -42,11 +43,15 @@
 #endif
 
 #define CHECK_DATASIZE_OF(datasize) static_assert(datasize == 32 || datasize == 64)
-#define CHECK_MEMOPSIZE_OF(size) static_assert(size == 8 || size == 16 || size == 32 || size == 64 || size == 128);
-#define DATASIZE_OF(datasize) ((datasize == 64) ? Datasize_64 : Datasize_32)
+#define CHECK_DATASIZE_OF_SIMD(datasize) static_assert(datasize == 32 || datasize == 64 || datasize == 128)
+#define CHECK_MEMOPSIZE_OF(size) static_assert(size == 8 || size == 16 || size == 32 || size == 64);
+#define CHECK_MEMOPSIZE_OF_SIMD(size) static_assert(size == 8 || size == 16 || size == 32 || size == 64 || size == 128);
+#define DATASIZE_OF(datasize) ((datasize == 64) ? Datasize_64 : ((datasize == 128) ? Datasize_128 : Datasize_32))
 #define MEMOPSIZE_OF(datasize) ((datasize == 8 || datasize == 128) ? MemOpSize_8_or_128 : (datasize == 16) ? MemOpSize_16 : (datasize == 32) ? MemOpSize_32 : MemOpSize_64)
 #define CHECK_DATASIZE() CHECK_DATASIZE_OF(datasize)
+#define CHECK_DATASIZE_SIMD() CHECK_DATASIZE_OF_SIMD(datasize)
 #define CHECK_MEMOPSIZE() CHECK_MEMOPSIZE_OF(datasize)
+#define CHECK_MEMOPSIZE_SIMD() CHECK_MEMOPSIZE_OF_SIMD(datasize)
 #define CHECK_VECTOR_DATASIZE() ASSERT(datasize == 64 || datasize == 128)
 #define DATASIZE DATASIZE_OF(datasize)
 #define MEMOPSIZE MEMOPSIZE_OF(datasize)
@@ -179,7 +184,6 @@ typedef enum : int8_t {
 
 // ARM64 always has 32 FPU registers 128-bits each. See http://llvm.org/devmtg/2012-11/Northover-AArch64.pdf
 // and Section 5.1.2 in http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf.
-// However, we only use them for 64-bit doubles.
 typedef enum : int8_t {
 #define REGISTER_ID(id, name, r, cs) id,
     FOR_EACH_FP_REGISTER(REGISTER_ID)
@@ -511,18 +515,18 @@ protected:
         return pimm / (datasize / 8);
     }
 
-    enum Datasize {
-        Datasize_32,
-        Datasize_64,
-        Datasize_64_top,
-        Datasize_16
+    enum Datasize : uint8_t {
+        Datasize_32 = 0,
+        Datasize_64 = 1,
+        Datasize_128 = 2,
+        Datasize_16 = 3,
     };
 
-    enum MemOpSize {
-        MemOpSize_8_or_128,
-        MemOpSize_16,
-        MemOpSize_32,
-        MemOpSize_64,
+    enum MemOpSize : uint8_t {
+        MemOpSize_8_or_128 = 0,
+        MemOpSize_16 = 1,
+        MemOpSize_32 = 2,
+        MemOpSize_64 = 3,
     };
 
     enum BranchType {
@@ -744,7 +748,7 @@ public:
     template<int datasize, SetFlags setFlags = DontSetFlags>
     ALWAYS_INLINE void add(RegisterID rd, RegisterID rn, RegisterID rm, ExtendType extend, int amount)
     {
-        CHECK_DATASIZE();
+        CHECK_DATASIZE_SIMD();
         insn(addSubtractExtendedRegister(DATASIZE, AddOp_ADD, setFlags, rm, extend, amount, rn, rd));
     }
 
@@ -1468,6 +1472,617 @@ public:
     ALWAYS_INLINE void mneg(RegisterID rd, RegisterID rn, RegisterID rm)
     {
         msub<datasize>(rd, rn, rm, ARM64Registers::zr);
+    }
+
+    static constexpr bool simdQBit(SIMDLane lane)
+    {
+        return elementByteSize(lane) == 8;
+    }
+
+    // returns an imm5
+    static int encodeLaneAndIndex(SIMDLane lane, uint32_t laneIndex)
+    {
+        switch (elementByteSize(lane)) {
+        case 1:
+            ASSERT(laneIndex < 16);
+            return 0b00001 | (laneIndex << 1);
+        case 2:
+            ASSERT(laneIndex < 8);
+            return 0b00010 | (laneIndex << 2);
+        case 4:
+            ASSERT(laneIndex < 4);
+            return 0b00100 | (laneIndex << 3);
+        case 8:
+            ASSERT(laneIndex < 2);
+            return 0b01000 | (laneIndex << 4);
+        case 16:
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        return 0;
+    }
+
+    ALWAYS_INLINE void ins(FPRegisterID vd, RegisterID rn, SIMDLane lane, uint32_t laneIndex)
+    {
+        insn(simdGeneral(1, encodeLaneAndIndex(lane, laneIndex), 0b0011, rn, vd));
+    }
+
+    ALWAYS_INLINE void ins(FPRegisterID vd, FPRegisterID vn, SIMDLane lane, uint32_t laneIndex)
+    {
+        // This is insert vector element from another element. Our other element is always the low
+        // bits of "vn"
+        int inst = 0b01101110000000000000010000000000;
+        inst |= encodeLaneAndIndex(lane, laneIndex) << 16;
+        inst |= 0 << 11; // looking at "zero" index of vn
+        inst |= static_cast<int>(vn) << 5;
+        inst |= static_cast<int>(vd);
+        insn(inst);
+    }
+    
+    ALWAYS_INLINE void umov(RegisterID rd, FPRegisterID vn, SIMDLane lane, uint32_t laneIndex)
+    {
+        ASSERT(scalarTypeIsIntegral(lane));
+        insn(simdGeneral(simdQBit(lane), encodeLaneAndIndex(lane, laneIndex), 0b0111, vn, rd));
+    }
+
+    ALWAYS_INLINE void smov(RegisterID rd, FPRegisterID vn, SIMDLane lane, uint32_t laneIndex)
+    {
+        ASSERT(scalarTypeIsIntegral(lane));
+        insn(simdGeneral(simdQBit(lane), encodeLaneAndIndex(lane, laneIndex), 0b0101, vn, rd));
+    }
+
+    ALWAYS_INLINE void dupElement(FPRegisterID vd, FPRegisterID vn, SIMDLane lane, uint32_t laneIndex)
+    {
+        // Take element from vector and put it in vd
+        ASSERT(scalarTypeIsFloatingPoint(lane));
+        insn(0b01011110000000000000010000000000 | (encodeLaneAndIndex(lane, laneIndex) << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void dupGeneral(FPRegisterID vd, RegisterID rn, SIMDLane lane)
+    {
+        // Take element from gpr and put it in each lane in vd
+        ASSERT(scalarTypeIsIntegral(lane));
+        int imm5;
+        switch (elementByteSize(lane)) {
+        case 1:
+            imm5 = 0b00001;
+            break;
+        case 2:
+            imm5 = 0b00010;
+            break;
+        case 4:
+            imm5 = 0b00100;
+            break;
+        case 8:
+            imm5 = 0b01000;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        insn(0b01001110000000000000110000000000 | (imm5 << 16) | (rn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void fcmeq(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(simdFloatingPointVectorCompare(0, 0, 0, lane, vd, vn, vm));
+    }
+
+    ALWAYS_INLINE void fcmgt(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(simdFloatingPointVectorCompare(1, 1, 0, lane, vd, vn, vm));
+    }
+
+    ALWAYS_INLINE void fcmge(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(simdFloatingPointVectorCompare(1, 0, 0, lane, vd, vn, vm));
+    }
+
+    ALWAYS_INLINE void vectorNot(FPRegisterID vd, FPRegisterID vn)
+    {
+        insn(0b01101110001000000101100000000000 | (vn << 5) | vd);
+    }
+
+    static int sizeForIntegralSIMDOp(SIMDLane lane)
+    {
+        // It's sometimes convenient to pass in floating point lanes
+        // here for conversion ops, so we don't assert against that.
+        switch (elementByteSize(lane)) {
+        case 1:
+            return 0;
+        case 2:
+            return 1;
+        case 4:
+            return 2;
+        case 8:
+            return 3;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+
+    static bool sizeForFloatingPointSIMDOp(SIMDLane lane)
+    {
+        // It's sometimes convenient to pass in integral lanes
+        // here for conversion ops, so we don't assert against that.
+        RELEASE_ASSERT(elementByteSize(lane) == 4 || elementByteSize(lane) == 8);
+        return elementByteSize(lane) == 4 ? 0 : 1;
+    }
+
+    ALWAYS_INLINE void cmeq(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000001000110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void cmeqz(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01011110001000001001100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void cmhi(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000011010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void cmhs(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000011110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void cmgt(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000011010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void cmge(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000011110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorAdd(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000001000010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void urhadd(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000001010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void addpv(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000001011110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void addv(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01000000001100011011100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorSub(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000001000010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorMul(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        // OOPS: figure this out for i64x2
+        // oops: MUL
+        RELEASE_ASSERT(lane != SIMDLane::i64x2);
+        insn(0b01001110001000001001110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void smullv(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane inputLane, bool Q = 0, bool U = 0)
+    {
+        RELEASE_ASSERT(inputLane != SIMDLane::i64x2 && scalarTypeIsIntegral(inputLane));
+        insn(0b00001110001000001100000000000000 | (Q << 30) | (U << 29) | (sizeForIntegralSIMDOp(inputLane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void smull2v(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane inputLane) { smullv(vd, vn, vm, inputLane, 1, 0); }
+    ALWAYS_INLINE void umullv(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane inputLane) { smullv(vd, vn, vm, inputLane, 0, 1); }
+    ALWAYS_INLINE void umull2v(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane inputLane) { smullv(vd, vn, vm, inputLane, 1, 1); }
+
+    ALWAYS_INLINE void sqrdmlahv(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        // Signed Saturating Rounding Doubling Multiply Accumulate returning High Half (vector)
+        RELEASE_ASSERT(lane == SIMDLane::i16x8);
+        insn(0b01101110000000001000010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFadd(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000001101010000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFsub(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110101000001101010000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFmul(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000001101110000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFdiv(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000001111110000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void umax(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000110010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    template<unsigned destSize>
+    ALWAYS_INLINE void umaxv(FPRegisterID vd, FPRegisterID vn)
+    {
+        static_assert(destSize == 8 || destSize == 16 || destSize == 32);
+        const unsigned Q = 1;
+        const unsigned size = destSize == 8 ? 0 : destSize == 16 ? 1 : 2;
+        insn(0b00101110001100001010100000000000 | (Q << 30) | (size << 22)| (vn << 5) | vd);
+    }
+
+    template<unsigned destSize>
+    ALWAYS_INLINE void uminv(FPRegisterID vd, FPRegisterID vn)
+    {
+        static_assert(destSize == 8 || destSize == 16 || destSize == 32);
+        const unsigned Q = 1;
+        const unsigned size = destSize == 8 ? 0 : destSize == 16 ? 1 : 2;
+        insn(0b00101110001100011010100000000000 | (Q << 30) | (size << 22)| (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void smax(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000110010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void umin(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000110110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void smin(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000110110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFmax(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000001111010000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFmin(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110101000001111010000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void bsl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
+    {
+        insn(0b01101110011000000001110000000000 | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorEor(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
+    {
+        insn(0b01101110001000000001110000000000 | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorAbs(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110001000001011100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFabs(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110101000001111100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorNeg(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b00101110001000001011100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFneg(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01101110101000001111100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorCnt(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        ASSERT(lane == SIMDLane::i8x16);
+        insn(0b01001110001000000101100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFcvtps(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110101000011010100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFcvtms(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110001000011011100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFrintz(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110101000011001100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFcvtns(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110001000011010100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFsqrt(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01101110101000011111100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    static int immhForExtend(SIMDLane lane)
+    {
+        switch (elementByteSize(lane)) {
+        case 1:
+            return 0b0001;
+        case 2:
+            return 0b0010;
+        case 4:
+            return 0b0100;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+
+    ALWAYS_INLINE void uxtl(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b00101111000000001010010000000000 | (immhForExtend(lane) << 19) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void uxtl2(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01101111000000001010010000000000 | (immhForExtend(lane) << 19) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sxtl(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b00001111000000001010010000000000 | (immhForExtend(lane) << 19) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sxtl2(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001111000000001010010000000000 | (immhForExtend(lane) << 19) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void fcvtl(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        // Convert lower two f32s into two f64s, so sz bit == 1
+        // This represents the input lane, not the output. 
+        // The instruction encodes input element size as 16 << sz_bit
+        ASSERT_UNUSED(lane, lane == SIMDLane::f32x4);
+        insn(0b00001110011000010111100000000000 | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void fcvtn(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        ASSERT_UNUSED(lane, lane == SIMDLane::f64x2);
+        // Convert two f64s into the two lower f32s
+        insn(0b00001110011000010110100000000000 | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sqxtn(FPRegisterID vd, FPRegisterID vn, SIMDLane inputLane)
+    {
+        SIMDLane lane = narrowedLane(inputLane);
+        insn(0b00001110001000010100100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sqxtn2(FPRegisterID vd, FPRegisterID vn, SIMDLane inputLane)
+    {
+        SIMDLane lane = narrowedLane(inputLane);
+        insn(0b01001110001000010100100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sqxtun(FPRegisterID vd, FPRegisterID vn, SIMDLane inputLane)
+    {
+        SIMDLane lane = narrowedLane(inputLane);
+        insn(0b00101110001000010010100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sqxtun2(FPRegisterID vd, FPRegisterID vn, SIMDLane inputLane)
+    {
+        SIMDLane lane = narrowedLane(inputLane);
+        insn(0b01101110001000010010100000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void ushl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000100010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sshl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000100010000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sshr_vi(FPRegisterID vd, FPRegisterID vn, uint8_t shift, SIMDLane lane)
+    {
+        RELEASE_ASSERT(shift < elementByteSize(lane) * 8 && shift < 64);
+        unsigned immh = elementByteSize(lane) | ((shift & 0x1111000) >> 3);
+        unsigned immb = shift & 0b0111;
+        insn(lane == SIMDLane::v128 ? 0b01011111000000000000010000000000 : 0b010011110000000000000010000000000 | (immh << 19) | (immb << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sqadd(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000000110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void sqsub(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000000010110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void uqadd(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000000110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void uqsub(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01101110001000000010110000000000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFcvtzs(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110101000011011100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFcvtzu(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01101110101000011011100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorScvtf(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01001110001000011101100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorUcvtf(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        insn(0b01101110001000011101100000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void tbl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
+    {
+        const unsigned len = 0;
+        const unsigned Q = 1;
+        insn(0b00001110000000000000000000000000 | (Q << 30) | (vm << 16) | (len << 13) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void tbl2(FPRegisterID vd, FPRegisterID vn, FPRegisterID vn2, FPRegisterID vm)
+    {
+        RELEASE_ASSERT(vn2, vn2 == vn + 1);
+        const unsigned len = 1;
+        const unsigned Q = 1;
+        insn(0b00001110000000000000000000000000 | (Q << 30) | (vm << 16) | (len << 13) | (vn << 5) | vd);
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void ld1r(FPRegisterID vt, RegisterID rn)
+    {
+        CHECK_MEMOPSIZE();
+        int sizeEncoding;
+        switch (datasize) {
+        case 8:
+            sizeEncoding = 0;
+            break;
+        case 16:
+            sizeEncoding = 1;
+            break;
+        case 32:
+            sizeEncoding = 2;
+            break;
+        case 64:
+            sizeEncoding = 3;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        insn(0b01001101010000001100000000000000 | (sizeEncoding << 10) | (rn << 5) | vt);
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void ld1(FPRegisterID vt, RegisterID rn, int32_t laneIndex)
+    {
+        CHECK_MEMOPSIZE();
+        int opcode;
+        int Q; // 1 bit
+        int S; // 1 bit
+        int size; // 2 bits
+        switch (datasize) {
+        case 8:
+            RELEASE_ASSERT(laneIndex < 16);
+            opcode = 0;
+            // Encode index in, Q:S:size
+            Q = laneIndex & 0b1000;
+            S = laneIndex & 0b0100;
+            size = laneIndex & 0b0011;
+            break;
+        case 16:
+            RELEASE_ASSERT(laneIndex < 8);
+            // Encode index in, Q:S:size<1>
+            Q = laneIndex & 0b100;
+            S = laneIndex & 0b010;
+            size = (laneIndex & 0b001) << 1;
+            opcode = 1;
+            break;
+        case 32:
+            RELEASE_ASSERT(laneIndex < 4);
+            opcode = 2;
+            size = 0;
+            // Encode index in, Q:S
+            Q = laneIndex & 0b10;
+            S = laneIndex & 0b01;
+            break;
+        case 64:
+            RELEASE_ASSERT(laneIndex < 2);
+            opcode = 2;
+            size = 1;
+            S = 0;
+            // Encode index in, Q
+            Q = laneIndex & 0b1;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        insn(0b00001101010000000000000000000000 | (Q << 30) | (opcode << 14) | (S << 12) | (size << 10) | (rn << 5) | vt);
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void st1(FPRegisterID vt, RegisterID rn, int32_t laneIndex)
+    {
+        CHECK_MEMOPSIZE();
+        int opcode;
+        int Q; // 1 bit
+        int S; // 1 bit
+        int size; // 2 bits
+        switch (datasize) {
+        case 8:
+            RELEASE_ASSERT(laneIndex < 16);
+            opcode = 0;
+            // Encode index in, Q:S:size
+            Q = laneIndex & 0b1000;
+            S = laneIndex & 0b0100;
+            size = laneIndex & 0b0011;
+            break;
+        case 16:
+            RELEASE_ASSERT(laneIndex < 8);
+            // Encode index in, Q:S:size<1>
+            Q = laneIndex & 0b100;
+            S = laneIndex & 0b010;
+            size = (laneIndex & 0b001) << 1;
+            opcode = 1;
+            break;
+        case 32:
+            RELEASE_ASSERT(laneIndex < 4);
+            opcode = 2;
+            size = 0;
+            // Encode index in, Q:S
+            Q = laneIndex & 0b10;
+            S = laneIndex & 0b01;
+            break;
+        case 64:
+            RELEASE_ASSERT(laneIndex < 2);
+            opcode = 2;
+            size = 1;
+            S = 0;
+            // Encode index in, Q
+            Q = laneIndex & 0b1;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        insn(0b0'0'0011010'0'0'000000000000000000000 | (Q << 30) | (opcode << 14) | (S << 12) | (size << 10) | (rn << 5) | vt);
     }
 
     template<int datasize>
@@ -2389,14 +3004,21 @@ public:
     ALWAYS_INLINE void vand(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
     {
         CHECK_VECTOR_DATASIZE();
-        insn(vectorDataProcessingLogical(SIMD_LogicalOp_AND, vm, vn, vd));
+        insn(vectorDataProcessingLogical(datasize, SIMD_LogicalOp_AND, vm, vn, vd));
     }
 
     template<int datasize>
     ALWAYS_INLINE void vorr(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
     {
         CHECK_VECTOR_DATASIZE();
-        insn(vectorDataProcessingLogical(SIMD_LogicalOp_ORR, vm, vn, vd));
+        insn(vectorDataProcessingLogical(datasize, SIMD_LogicalOp_ORR, vm, vn, vd));
+    }
+
+    template<int datasize>
+    ALWAYS_INLINE void vbic(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
+    {
+        CHECK_VECTOR_DATASIZE();
+        insn(vectorDataProcessingLogical(datasize, SIMD_LogicalOp_BIC, vm, vn, vd));
     }
 
     template<int datasize>
@@ -2557,7 +3179,7 @@ public:
     template<int datasize>
     ALWAYS_INLINE void stur(FPRegisterID rt, RegisterID rn, int simm)
     {
-        CHECK_DATASIZE();
+        CHECK_DATASIZE_SIMD();
         insn(loadStoreRegisterUnscaledImmediate(MEMOPSIZE, true, datasize == 128 ? MemOp_STORE_V128 : MemOp_STORE, simm, rn, rt));
     }
 
@@ -3553,9 +4175,9 @@ protected:
         return (0x1e200800 | M << 31 | S << 29 | type << 22 | rm << 16 | opcode << 12 | rn << 5 | rd);
     }
 
-    ALWAYS_INLINE static int vectorDataProcessingLogical(SIMD3SameLogical uAndSize, FPRegisterID vm, FPRegisterID vn, FPRegisterID vd)
+    ALWAYS_INLINE static int vectorDataProcessingLogical(int datasize, SIMD3SameLogical uAndSize, FPRegisterID vm, FPRegisterID vn, FPRegisterID vd)
     {
-        const int Q = 0;
+        int Q = datasize == 128;
         return (0xe200400 | Q << 30 | uAndSize << 22 | vm << 16 | SIMD_LogicalOp << 11 | vn << 5 | vd);
     }
 
@@ -3816,6 +4438,18 @@ protected:
     static int fjcvtzsInsn(FPRegisterID dn, RegisterID rd)
     {
         return 0x1e7e0000 | (dn << 5) | rd;
+    }
+    
+    static int simdGeneral(bool Q, int imm5, int imm4, int rn, int rd)
+    {
+        return 0b0'0'0'01110000'00000'0'00'1'1'1'00000'00000 | (Q << 30) | (imm5 << 16) | (imm4 << 11) | (rn << 5) | rd;
+    }
+
+    static int simdFloatingPointVectorCompare(bool U, bool E, bool ac, SIMDLane lane, FPRegisterID rd, FPRegisterID rn, FPRegisterID rm)
+    {
+        bool sz = sizeForFloatingPointSIMDOp(lane);
+        int insn = 0b01001110001000001110010000000000 | (U << 29) | (E << 23) | (sz << 22) | (rm << 16) | (ac << 11) | (rn << 5) | rd;
+        return insn;
     }
 
     Vector<LinkRecord, 0, UnsafeVectorOverflow> m_jumpsToLink;

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -29,6 +29,32 @@
 
 #include "JSCJSValue.h"
 
+#define DEFINE_SIMD_FUNC(name, func, lane) \
+    template <typename ...Args> \
+    void name(Args&&... args) { func(lane, std::forward<Args>(args)...); }
+
+#define DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name, func, lane, mode) \
+    template <typename ...Args> \
+    void name(Args&&... args) { func(lane, mode, std::forward<Args>(args)...); }
+
+#define DEFINE_SIMD_FUNCS(name) \
+    DEFINE_SIMD_FUNC(name##Int8, name, SIMDLane::i8x16) \
+    DEFINE_SIMD_FUNC(name##Int16, name, SIMDLane::i16x8) \
+    DEFINE_SIMD_FUNC(name##Int32, name, SIMDLane::i32x4) \
+    DEFINE_SIMD_FUNC(name##Int64, name, SIMDLane::i64x2) \
+    DEFINE_SIMD_FUNC(name##Float32, name, SIMDLane::f32x4) \
+    DEFINE_SIMD_FUNC(name##Float64, name, SIMDLane::f64x2)
+
+#define DEFINE_SIGNED_SIMD_FUNCS(name) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##SignedInt8, name, SIMDLane::i8x16, SIMDSignMode::Signed) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##UnsignedInt8, name, SIMDLane::i8x16, SIMDSignMode::Unsigned) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##SignedInt16, name, SIMDLane::i16x8, SIMDSignMode::Signed) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##UnsignedInt16, name, SIMDLane::i16x8, SIMDSignMode::Unsigned) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##Int32, name, SIMDLane::i32x4, SIMDSignMode::None) \
+    DEFINE_SIMD_FUNC_WITH_SIGN_EXTEND_MODE(name##Int64, name, SIMDLane::i64x2, SIMDSignMode::None) \
+    DEFINE_SIMD_FUNC(name##Float32, name, SIMDLane::f32x4) \
+    DEFINE_SIMD_FUNC(name##Float64, name, SIMDLane::f64x2)
+
 #if CPU(ARM_THUMB2)
 #define TARGET_ASSEMBLER ARMv7Assembler
 #define TARGET_MACROASSEMBLER MacroAssemblerARMv7

--- a/Source/JavaScriptCore/b3/B3Bank.h
+++ b/Source/JavaScriptCore/b3/B3Bank.h
@@ -58,6 +58,7 @@ inline Bank bankForType(Type type)
         return GP;
     case Float:
     case Double:
+    case V128:
         return FP;
     }
     ASSERT_NOT_REACHED();
@@ -66,7 +67,7 @@ inline Bank bankForType(Type type)
 
 inline Bank bankForReg(Reg reg)
 {
-    return reg.isGPR() ? GP : FP;
+    return reg.isFPR() ? FP : GP;
 }
 
 inline Width minimumWidth(Bank bank)
@@ -81,7 +82,7 @@ ALWAYS_INLINE constexpr Width conservativeWidthWithoutVectors(Bank bank)
 
 ALWAYS_INLINE constexpr Width conservativeWidth(Bank bank)
 {
-    return bank == FP ? Width64 : widthForBytes(sizeof(CPURegister));
+    return bank == FP ? Width128 : widthForBytes(sizeof(CPURegister));
 }
 
 ALWAYS_INLINE constexpr unsigned conservativeRegisterBytes(Bank bank)

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -772,6 +772,9 @@ private:
         case Double:
             opcode = opcodeDouble;
             break;
+        case V128:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
         default:
             opcode = Air::Oops;
             break;
@@ -1190,6 +1193,7 @@ private:
             }
             break;
         case Width128:
+            RELEASE_ASSERT_NOT_REACHED();
             break;
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -1858,6 +1862,7 @@ private:
                     }
                     return Inst();
                 case Width128:
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 ASSERT_NOT_REACHED();
@@ -1890,6 +1895,7 @@ private:
                     }
                     return Inst();
                 case Width128:
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 ASSERT_NOT_REACHED();
@@ -1940,6 +1946,7 @@ private:
                     }
                     return Inst();
                 case Width128:
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 ASSERT_NOT_REACHED();
@@ -1967,6 +1974,7 @@ private:
                     }
                     return Inst();
                 case Width128:
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 ASSERT_NOT_REACHED();
@@ -2037,6 +2045,7 @@ private:
                 case Width64:
                     return createSelectInstruction(config.moveConditionally64, relCond, left, right);
                 case Width128:
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 ASSERT_NOT_REACHED();
@@ -2054,6 +2063,7 @@ private:
                 case Width64:
                     return createSelectInstruction(config.moveConditionallyTest64, resCond, left, right);
                 case Width128:
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 ASSERT_NOT_REACHED();
@@ -2331,7 +2341,7 @@ private:
                 case Width64:
                     break;
                 case Width128:
-                    ASSERT_NOT_REACHED();
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
             }
@@ -2350,7 +2360,7 @@ private:
                     appendTrapping(Air::Branch64, Arg::relCond(MacroAssembler::Equal), valueResultTmp, expectedValueTmp);
                     break;
                 case Width128:
-                    ASSERT_NOT_REACHED();
+                    RELEASE_ASSERT_NOT_REACHED();
                     break;
                 }
                 m_blockToBlock[m_block]->setSuccessors(success, failure);
@@ -2511,7 +2521,7 @@ private:
                 prepareOpcode = Move;
                 break;
             case Width128:
-                ASSERT_NOT_REACHED();
+                RELEASE_ASSERT_NOT_REACHED();
                 break;
             }
         } else {
@@ -3697,6 +3707,7 @@ private:
                 switch (type.kind()) {
                 case Void:
                 case Tuple:
+                case V128:
                     RELEASE_ASSERT_NOT_REACHED();
                     break;
                 case Int32:
@@ -4260,6 +4271,7 @@ private:
             switch (value->type().kind()) {
             case Void:
             case Tuple:
+            case V128:
                 // It's impossible for a void value to be used as a child. We use RetVoid
                 // for void returns.
                 RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -73,7 +73,7 @@ void PatchpointSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgC
     for (unsigned i = patchpoint->numGPScratchRegisters; i--;)
         callback(inst.args[argIndex++], Arg::Scratch, GP, conservativeWidth(GP));
     for (unsigned i = patchpoint->numFPScratchRegisters; i--;)
-        callback(inst.args[argIndex++], Arg::Scratch, FP, conservativeWidth(FP));
+        callback(inst.args[argIndex++], Arg::Scratch, FP, Options::useWebAssemblySIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
 }
 
 bool PatchpointSpecial::isValid(Inst& inst)

--- a/Source/JavaScriptCore/b3/B3Type.cpp
+++ b/Source/JavaScriptCore/b3/B3Type.cpp
@@ -52,6 +52,9 @@ void printInternal(PrintStream& out, Type type)
     case Double:
         out.print("Double");
         return;
+    case V128:
+        out.print("V128");
+        return;
     case Tuple:
         out.print("Tuple");
         return;

--- a/Source/JavaScriptCore/b3/B3TypeMap.h
+++ b/Source/JavaScriptCore/b3/B3TypeMap.h
@@ -56,6 +56,8 @@ public:
             return m_double;
         case Tuple:
             return m_tuple;
+        case V128:
+            return m_vector;
         }
         ASSERT_NOT_REACHED();
     }
@@ -82,7 +84,9 @@ public:
             ", int32 = ", m_int32,
             ", int64 = ", m_int64,
             ", float = ", m_float,
-            ", double = ", m_double, "}");
+            ", double = ", m_double,
+            ", vector = ", m_vector,
+            ", tuple = ", m_tuple, "}");
     }
     
 private:
@@ -91,6 +95,7 @@ private:
     T m_int64 { };
     T m_float { };
     T m_double { };
+    T m_vector { };
     T m_tuple { };
 };
 

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -922,6 +922,7 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
             return Int32;
         case Void:
         case Tuple:
+        case V128:
             ASSERT_NOT_REACHED();
         }
         return Void;

--- a/Source/JavaScriptCore/b3/B3ValueRep.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueRep.cpp
@@ -47,7 +47,7 @@ void ValueRep::addUsedRegistersTo(RegisterSetBuilder& set) const
         return;
     case LateRegister:
     case Register:
-        set.add(reg(), conservativeWidth(reg()));
+        set.add(reg(), Options::useWebAssemblySIMD() ? conservativeWidth(reg()) : conservativeWidthWithoutVectors(reg()));
         return;
     case Stack:
     case StackArgument:

--- a/Source/JavaScriptCore/b3/B3Width.h
+++ b/Source/JavaScriptCore/b3/B3Width.h
@@ -29,6 +29,7 @@
 
 #include "B3Bank.h"
 #include "B3Type.h"
+#include "SIMDInfo.h"
 #include "Width.h"
 
 #if !ASSERT_ENABLED
@@ -50,6 +51,8 @@ inline Width widthForType(Type type)
     case Int64:
     case Double:
         return Width64;
+    case V128:
+        return Width128;
     }
     ASSERT_NOT_REACHED();
     return Width8;

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp
@@ -687,6 +687,7 @@ private:
 
 void allocateRegistersAndStackByLinearScan(Code& code)
 {
+    RELEASE_ASSERT(!Options::useWebAssemblySIMD());
     PhaseScope phaseScope(code, "allocateRegistersAndStackByLinearScan");
     if (verbose())
         dataLog("Air before linear scan:\n", code);

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp
@@ -2193,6 +2193,7 @@ private:
 
 void allocateRegistersByGraphColoring(Code& code)
 {
+    RELEASE_ASSERT(!Options::useWebAssemblySIMD());
     PhaseScope phaseScope(code, "allocateRegistersByGraphColoring");
     
     if (traceDebug)

--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -372,6 +372,7 @@ bool tryTrivialStackAllocation(Code& code)
 
 void allocateStackByGraphColoring(Code& code)
 {
+    RELEASE_ASSERT(!Options::useWebAssemblySIMD());
     PhaseScope phaseScope(code, "allocateStackByGraphColoring");
 
     handleCalleeSaves(code);

--- a/Source/JavaScriptCore/b3/air/AirArg.cpp
+++ b/Source/JavaScriptCore/b3/air/AirArg.cpp
@@ -72,6 +72,8 @@ bool Arg::usesTmp(Air::Tmp tmp) const
 
 bool Arg::canRepresent(Type type) const
 {
+    if (UNLIKELY(type == V128))
+        return isFPTmp();
     return isBank(bankForType(type));
 }
 
@@ -96,6 +98,7 @@ unsigned Arg::jsHash() const
     switch (m_kind) {
     case Invalid:
     case Special:
+    case SIMDInfo:
         break;
     case Tmp:
         result += m_base.internalValue();
@@ -219,6 +222,9 @@ void Arg::dump(PrintStream& out) const
     case WidthArg:
         out.print(width());
         return;
+    case SIMDInfo:
+        out.print("{ ", simdInfo().lane, ", ", simdInfo().signMode, " }");
+        return;
     }
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -295,6 +301,9 @@ void printInternal(PrintStream& out, Arg::Kind kind)
         return;
     case Arg::WidthArg:
         out.print("WidthArg");
+        return;
+    case Arg::SIMDInfo:
+        out.print("SIMDInfo");
         return;
     }
 

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
@@ -34,7 +34,7 @@ namespace JSC { namespace B3 { namespace Air {
 
 CCallSpecial::CCallSpecial()
 {
-    m_clobberedRegs = RegisterSetBuilder::registersToSaveForCCall(RegisterSetBuilder::allScalarRegisters());
+    m_clobberedRegs = RegisterSetBuilder::registersToSaveForCCall(Options::useWebAssemblySIMD() ? RegisterSetBuilder::allRegisters() : RegisterSetBuilder::allScalarRegisters());
     m_clobberedRegs.remove(GPRInfo::returnValueGPR);
     m_clobberedRegs.remove(GPRInfo::returnValueGPR2);
     m_clobberedRegs.remove(FPRInfo::returnValueFPR);
@@ -51,13 +51,13 @@ void CCallSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallba
     for (unsigned i = 0; i < numReturnGPArgs; ++i)
         callback(inst.args[returnGPArgOffset + i], Arg::Def, GP, pointerWidth());
     for (unsigned i = 0; i < numReturnFPArgs; ++i)
-        callback(inst.args[returnFPArgOffset + i], Arg::Def, FP, Width64);
+        callback(inst.args[returnFPArgOffset + i], Arg::Def, FP, Options::useWebAssemblySIMD() ? conservativeWidth(FP) : conservativeWidthWithoutVectors(FP));
     
     for (unsigned i = argArgOffset; i < inst.args.size(); ++i) {
         // For the type, we can just query the arg's bank. The arg will have a bank, because we
         // require these args to be argument registers.
         Bank bank = inst.args[i].bank();
-        callback(inst.args[i], Arg::Use, bank, conservativeWidth(bank));
+        callback(inst.args[i], Arg::Use, bank, Options::useWebAssemblySIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
     }
 }
 

--- a/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp
@@ -99,6 +99,7 @@ Tmp cCallResult(Type type)
     case Float:
     case Double:
         return Tmp(FPRInfo::returnValueFPR);
+    case V128:
     case Tuple:
         break;
     }

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
@@ -309,7 +309,7 @@ Vector<Inst> emitShuffle(
         return moveFor(bank, width);
     };
 
-    Opcode conservativeMove = moveForWidth(conservativeWidth(bank));
+    Opcode conservativeMove = moveForWidth(Options::useWebAssemblySIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank));
 
     // We will emit things in reverse. We maintain a list of packs of instructions, and then we emit
     // append them together in reverse (for example the thing at the end of resultPacks is placed

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.h
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.h
@@ -46,6 +46,9 @@ inline Opcode moveFor(Bank bank, Width width)
         return bank == GP ? Move32 : MoveFloat;
     case Width64:
         return bank == GP ? Move : MoveDouble;
+    case Width128:
+        RELEASE_ASSERT(bank == FP);
+        return MoveVector;
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return Oops;

--- a/Source/JavaScriptCore/b3/air/AirHelpers.h
+++ b/Source/JavaScriptCore/b3/air/AirHelpers.h
@@ -43,6 +43,9 @@ inline Air::Opcode moveForType(Type type)
         return MoveFloat;
     case Double:
         return MoveDouble;
+    case V128:
+        ASSERT(Options::useWebAssemblySIMD());
+        return MoveVector;
     case Void:
     case Tuple:
         break;
@@ -77,6 +80,8 @@ inline Air::Opcode relaxedMoveForType(Type type)
         return MoveFloat;
     case Double:
         return MoveDouble;
+    case V128:
+        return MoveVector;
     case Void:
     case Tuple:
         break;

--- a/Source/JavaScriptCore/b3/air/AirInstInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirInstInlines.h
@@ -349,6 +349,16 @@ inline bool isBranchAtomicStrongCAS64Valid(const Inst& inst)
     return isBranchAtomicStrongCASValid(inst);
 }
 
+inline bool isVectorSwizzle2Valid(const Inst& inst)
+{
+#if CPU(ARM64)
+    return inst.args[0].fpr() == inst.args[0].fpr() + 1;
+#else
+    UNUSED_PARAM(inst);
+    return false;
+#endif
+}
+
 } } } // namespace JSC::B3::Air
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
@@ -59,7 +59,7 @@ void logRegisterPressure(Code& code)
             Inst::forEachDefWithExtraClobberedRegs<Reg>(
                 prevInst, &inst,
                 [&] (Reg reg, Arg::Role, Bank, Width width) {
-                    ASSERT(width <= Width64);
+                    ASSERT(width <= Width64 || Options::useWebAssemblySIMD());
                     set.add(reg, width);
                 });
 

--- a/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp
@@ -135,7 +135,7 @@ void lowerAfterRegAlloc(Code& code)
             if (!found) {
                 StackSlot*& slot = slots[bank][i];
                 if (!slot)
-                    slot = code.addStackSlot(conservativeRegisterBytes(bank), StackSlotKind::Spill);
+                    slot = code.addStackSlot(Options::useWebAssemblySIMD() ? conservativeRegisterBytes(bank) : conservativeRegisterBytesWithoutVectors(bank), StackSlotKind::Spill);
                 result[i] = Arg::stack(slots[bank][i]);
             }
         }
@@ -246,6 +246,7 @@ void lowerAfterRegAlloc(Code& code)
                         Tmp tmp(reg);
                         Arg arg(tmp);
                         StackSlot* stackSlot = stackSlots[stackSlotIndex++];
+                        ASSERT(stackSlot->byteSize() >= bytesForWidth(width));
                         pairs.append(ShufflePair(Arg::stack(stackSlot), arg, width));
                     });
                 if (result) {

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -114,6 +114,9 @@ void lowerMacros(Code& code)
                 case Int64:
                     insertionSet.insert(instIndex + 1, Move, value, result, resultDst);
                     break;
+                case V128:
+                    insertionSet.insert(instIndex + 1, MoveVector, value, result, resultDst);
+                    break;
                 }
             };
 

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -48,7 +48,8 @@ void lowerStackArgs(Code& code)
                     // such an awesome assumption.
                     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=150454
                     ASSERT(arg.offset() >= 0);
-                    code.requestCallArgAreaSizeInBytes(arg.offset() + 8);
+                    ASSERT(!arg.canRepresent(V128));
+                    code.requestCallArgAreaSizeInBytes(arg.offset() + conservativeRegisterBytesWithoutVectors(arg.bank()));
                 }
             }
         }

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -740,6 +740,13 @@ MoveDouble U:F:64, D:F:64
 
 MoveDouble U:F:64, D:F:64, S:F:64
     Addr, Addr, Tmp
+    
+MoveVector U:F:128, D:F:128
+    Tmp, Tmp
+    Addr, Tmp as loadVector
+    Index, Tmp as loadVector
+    Tmp, Addr as storeVector
+    Tmp, Index as storeVector
 
 MoveZeroToDouble D:F:64
     Tmp
@@ -1614,6 +1621,37 @@ RetFloat U:F:32 /return
 
 RetDouble U:F:64 /return
     Tmp
+
+# SIMD
+VectorReplaceLaneInt64 U:G:8, U:G:64, UD:F:128
+    Imm, Tmp, Tmp
+VectorReplaceLaneInt32 U:G:8, U:G:32, UD:F:128
+    Imm, Tmp, Tmp
+VectorReplaceLaneInt16 U:G:8, U:G:16, UD:F:128
+    Imm, Tmp, Tmp
+VectorReplaceLaneInt8 U:G:8, U:G:8, UD:F:128
+    Imm, Tmp, Tmp
+VectorReplaceLaneFloat64 U:G:8, U:F:64, UD:F:128
+    Imm, Tmp, Tmp
+VectorReplaceLaneFloat32 U:G:8, U:F:32, UD:F:128
+    Imm, Tmp, Tmp
+
+VectorExtractLaneInt64 U:G:8, U:F:128, D:G:64
+    Imm, Tmp, Tmp
+VectorExtractLaneInt32 U:G:8, U:F:128, ZD:G:32
+    Imm, Tmp, Tmp
+VectorExtractLaneSignedInt16 U:G:8, U:F:128, ZD:G:32
+    Imm, Tmp, Tmp
+VectorExtractLaneUnsignedInt16 U:G:8, U:F:128, ZD:G:16
+    Imm, Tmp, Tmp
+VectorExtractLaneSignedInt8 U:G:8, U:F:128, ZD:G:32
+    Imm, Tmp, Tmp
+VectorExtractLaneUnsignedInt8 U:G:8, U:F:128, ZD:G:8
+    Imm, Tmp, Tmp
+VectorExtractLaneFloat64 U:G:8, U:F:128, D:F:64
+    Imm, Tmp, Tmp
+VectorExtractLaneFloat32 U:G:8, U:F:128, D:F:32
+    Imm, Tmp, Tmp
 
 Oops /terminal
 

--- a/Source/JavaScriptCore/b3/air/AirRegLiveness.cpp
+++ b/Source/JavaScriptCore/b3/air/AirRegLiveness.cpp
@@ -65,7 +65,7 @@ RegLiveness::RegLiveness(Code& code)
             
         block->last().forEach<Reg>(
             [&] (Reg& reg, Arg::Role role, Bank, Width width) {
-                ASSERT(width <= Width64);
+                ASSERT(width <= Width64 || Options::useWebAssemblySIMD());
                 if (Arg::isLateUse(role))
                     liveAtTail.add(reg, width);
             });
@@ -128,7 +128,7 @@ RegLiveness::LocalCalcForUnifiedTmpLiveness::LocalCalcForUnifiedTmpLiveness(Unif
 {
     for (Tmp tmp : liveness.liveAtTail(block)) {
         if (tmp.isReg())
-            m_workset.add(tmp.reg(), conservativeWidth(tmp.reg()));
+            m_workset.add(tmp.reg(), Options::useWebAssemblySIMD() ? conservativeWidth(tmp.reg()) : conservativeWidthWithoutVectors(tmp.reg()));
     }
 }
 
@@ -142,7 +142,7 @@ void RegLiveness::LocalCalcForUnifiedTmpLiveness::execute(unsigned instIndex)
     for (unsigned index : m_actions[instIndex].use) {
         Tmp tmp = Tmp::tmpForLinearIndex(m_code, index);
         if (tmp.isReg())
-            m_workset.add(tmp.reg(), conservativeWidth(tmp.reg()));
+            m_workset.add(tmp.reg(), Options::useWebAssemblySIMD() ? conservativeWidth(tmp.reg()) : conservativeWidthWithoutVectors(tmp.reg()));
     }
 }
 

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -68,7 +68,7 @@ void TmpWidth::recompute(Code& code)
     
     auto assumeTheWorst = [&] (Tmp tmp) {
         if (bank == Arg(tmp).bank()) {
-            Width conservative = conservativeWidth(bank);
+            Width conservative = Options::useWebAssemblySIMD() ? conservativeWidth(bank) : conservativeWidthWithoutVectors(bank);
             addWidths(tmp, { conservative, conservative });
         }
     };
@@ -129,7 +129,7 @@ void TmpWidth::recompute(Code& code)
                     if (Arg::isZDef(role))
                         tmpWidths.def = std::max(tmpWidths.def, width);
                     else if (Arg::isAnyDef(role))
-                        tmpWidths.def = conservativeWidth(tmpBank);
+                        tmpWidths.def = Options::useWebAssemblySIMD() ? conservativeWidth(tmpBank) : conservativeWidthWithoutVectors(tmpBank);
                 });
         }
     }

--- a/Source/JavaScriptCore/b3/air/AirValidate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirValidate.cpp
@@ -91,9 +91,14 @@ public:
 
                 // forEachArg must return Arg&'s that point into the args array.
                 inst.forEachArg(
-                    [&] (Arg& arg, Arg::Role, Bank, Width) {
+                    [&] (Arg& arg, Arg::Role role, Bank, Width width) {
                         VALIDATE(&arg >= &inst.args[0], ("At ", arg, " in ", inst, " in ", *block));
                         VALIDATE(&arg <= &inst.args.last(), ("At ", arg, " in ", inst, " in ", *block));
+
+                        // FIXME: replace with a check for wasm simd instructions.
+                        VALIDATE(Options::useWebAssemblySIMD()
+                            || !Arg::isAnyUse(role)
+                            || width <= Width64, ("At ", inst, " in ", *block, " arg ", arg));
                     });
                 
                 switch (inst.kind.opcode) {

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -229,7 +229,7 @@ def isGF(token)
 end
 
 def isKind(token)
-    token =~ /\A((Tmp)|(Imm)|(BigImm)|(BitImm)|(BitImm64)|(ZeroReg)|(SimpleAddr)|(Addr)|(ExtendedOffsetAddr)|(Index)|(PreIndex)|(PostIndex)|(RelCond)|(ResCond)|(DoubleCond)|(StatusCond))\Z/
+    token =~ /\A((Tmp)|(Imm)|(BigImm)|(BitImm)|(BitImm64)|(ZeroReg)|(SimpleAddr)|(Addr)|(ExtendedOffsetAddr)|(Index)|(PreIndex)|(PostIndex)|(RelCond)|(ResCond)|(DoubleCond)|(StatusCond)|(SIMDInfo))\Z/
 end
 
 def isArch(token)
@@ -237,7 +237,7 @@ def isArch(token)
 end
 
 def isWidth(token)
-    token =~ /\A((8)|(16)|(32)|(64)|(Ptr))\Z/
+    token =~ /\A((8)|(16)|(32)|(64)|(Ptr)|(128))\Z/
 end
 
 def isKeyword(token)
@@ -310,7 +310,7 @@ class Parser
 
     def consumeWidth
         result = token.string
-        parseError("Expected width (8, 16, 32, or 64)") unless isWidth(result)
+        parseError("Expected width (8, 16, 32, 64, or 128)") unless isWidth(result)
         advance
         result
     end
@@ -712,7 +712,6 @@ writeH("OpcodeUtils") {
     outp.puts "    const uint8_t* formBase = g_formTable + kind.opcode * #{formTableWidth} + formOffset;"
     outp.puts "    for (size_t i = 0; i < numOperands; ++i) {"
     outp.puts "        uint8_t form = formBase[i];"
-    outp.puts "        ASSERT(!(form & (1 << formInvalidShift)));"
     outp.puts "        func(args[i], decodeFormRole(form), decodeFormBank(form), decodeFormWidth(form));"
     outp.puts "    }"
     outp.puts "}"
@@ -941,6 +940,7 @@ writeH("OpcodeGenerated") {
                 when "DoubleCond"
                 when "StatusCond"
                 when "ZeroReg"
+                when "SIMDInfo"
                 else
                     raise "Unexpected kind: #{kind.name}"
                 end
@@ -1253,6 +1253,8 @@ writeH("OpcodeGenerated") {
                     outp.print "args[#{index}].asDoubleCondition()"
                 when "StatusCond"
                     outp.print "args[#{index}].asStatusCondition()"
+                when "SIMDInfo"
+                    outp.print "args[#{index}].simdInfo()"
                 end
             }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -89,6 +89,8 @@ int BytecodeDumper<Block>::outOfLineJumpOffset(JSInstructionStream::Offset offse
 template<class Block>
 CString BytecodeDumper<Block>::constantName(VirtualRegister reg) const
 {
+    if (reg.toConstantIndex() >= (int) block()->constantRegisters().size())
+        return toCString("INVALID_CONSTANT(", reg, ")");
     auto value = block()->getConstant(reg);
     return toCString(value, "(", reg, ")");
 }
@@ -422,6 +424,9 @@ CString BytecodeDumper::formatConstant(Type type, uint64_t constant) const
         break;
     case TypeKind::F64:
         return toCString(bitwise_cast<double>(constant));
+        break;
+    case TypeKind::V128:
+        return toCString(constant);
         break;
     default: {
         if (isFuncref(type) || isExternref(type)) {

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -84,6 +84,8 @@ static const OpcodeGroupInitializer opcodeGroupList[] = {
     OPCODE_GROUP_ENTRY(0x0b, A64DOpcodeAddSubtractShiftedRegister),
     OPCODE_GROUP_ENTRY(0x0c, A64DOpcodeLoadStoreRegisterPair),
     OPCODE_GROUP_ENTRY(0x0d, A64DOpcodeLoadStoreRegisterPair),
+    OPCODE_GROUP_ENTRY(0x0e, A64DOpcodeVectorDataProcessingLogical1Source),
+    OPCODE_GROUP_ENTRY(0x0e, A64DOpcodeVectorDataProcessingLogical2Source),
     OPCODE_GROUP_ENTRY(0x11, A64DOpcodeAddSubtractImmediate),
     OPCODE_GROUP_ENTRY(0x12, A64DOpcodeMoveWide),
     OPCODE_GROUP_ENTRY(0x12, A64DOpcodeLogicalImmediate),
@@ -237,6 +239,11 @@ void A64DOpcode::appendRegisterName(unsigned registerNumber, bool is64Bit)
 void A64DOpcode::appendFPRegisterName(unsigned registerNumber, unsigned registerSize)
 {
     bufferPrintf("%c%u", FPRegisterPrefix(registerSize), registerNumber);
+}
+
+void A64DOpcode::appendVectorRegisterName(unsigned registerNumber)
+{
+    bufferPrintf("%c%u", 'Q', registerNumber);
 }
 
 const char* const A64DOpcodeAddSubtract::s_opNames[4] = { "add", "adds", "sub", "subs" };
@@ -1173,7 +1180,9 @@ const char* A64DOpcodeLoadStoreImmediate::format()
         return A64DOpcode::format();
 
     appendInstructionName(thisOpName);
-    if (vBit())
+    if (vBit() && opc())
+        appendVectorRegisterName(rt());
+    else if (vBit())
         appendFPRegisterName(rt(), size());
     else if (!opc())
         appendZROrRegisterName(rt(), is64BitRT());
@@ -1849,6 +1858,66 @@ const char* A64DOpcodeUnconditionalBranchRegister::format()
     if (opcValue <= 2)
         appendRegisterName(rn());
     return m_formatBuffer;
+}
+
+const char* A64DOpcodeVectorDataProcessingLogical1Source::format()
+{
+    appendInstructionName(opName());
+    appendSIMDLaneIndexAndType((q() << 6) | imm5());
+    appendSeparator();
+    appendCharacter('v');
+    appendCharacter('/');
+    appendRegisterName(rd());
+    appendSeparator();
+    appendCharacter('v');
+    appendCharacter('/');
+    appendRegisterName(rt());
+    appendSeparator();
+    return m_formatBuffer;
+}
+
+const char* A64DOpcodeVectorDataProcessingLogical1Source::opName()
+{
+    switch (op10_15()) {
+    case 0b000111:
+        return "ins";
+    case 0b001111:
+        return "umov";
+    default:
+        dataLogLn("Dissassembler saw unknown simd one source instruction opcode ", op10_15());
+        return "SIMDUK";
+    }
+}
+
+const char* A64DOpcodeVectorDataProcessingLogical2Source::format()
+{
+    appendInstructionName(opName());
+    appendSIMDLaneType(q());
+    appendSeparator();
+    appendCharacter('v');
+    appendCharacter('/');
+    appendRegisterName(rd());
+    appendSeparator();
+    appendCharacter('v');
+    appendCharacter('/');
+    appendRegisterName(rn());
+    appendSeparator();
+    appendCharacter('v');
+    appendCharacter('/');
+    appendRegisterName(rm());
+    appendSeparator();
+    return m_formatBuffer;
+}
+
+const char* A64DOpcodeVectorDataProcessingLogical2Source::opName()
+{
+    switch (op10_15()) {
+    case 0b00111:
+        return "orr";
+    default:
+        dataLogLn("Dissassembler saw unknown simd 2 source instruction opcode ", op10_15());
+        return "SIMDUK";
+    }
 }
 
 } } // namespace JSC::ARM64Disassembler

--- a/Source/JavaScriptCore/generator/DSL.rb
+++ b/Source/JavaScriptCore/generator/DSL.rb
@@ -60,7 +60,83 @@ module DSL
         assert("`op_group` can only be called in between `begin_section` and `end_section`") { not @current_section.nil? }
         @current_section.add_opcode_group(desc, ops, config)
     end
+    
+    def self.simd_op_group(desc, ops, config)
+        assert("`simd_op_group` can only be called in between `begin_section` and `end_section`") { not @current_section.nil? }
 
+        for op in ops do
+            variants = ["i32x4", "i64x2", "f32x4", "f64x2"]
+            if config[:makeSignedVariants] then
+                variants += ["i8x16_u", "i8x16_s", "i16x8_u", "i16x8_s"]
+            else
+                variants += ["i8x16", "i16x8"]
+            end
+
+            if config[:makeAllSignedAndUnsignedVariants] then
+                variants = ["i8x16_u", "i8x16_s", "i16x8_u", "i16x8_s", "i32x4_u", "i32x4_s", "i64x2_u", "i64x2_s", "f32x4", "f64x2"]
+            end
+
+            if config[:makeOnlyFloatingPointVariants] then
+                variants = ["f32x4", "f64x2"]
+            end
+
+            if config[:makeOnlyV128] then
+                variants = ["v128"]
+            end
+
+            if config[:makeOnlyI8] then
+                variants = ["i8x16"]
+            end
+
+            if config[:makeOnlyF32] then
+                variants = ["f32x4"]
+            end
+
+            if config[:makeOnlyF64] then
+                variants = ["f64x2"]
+            end
+            
+
+            if config[:skipI64Variant] then
+                variants = variants.filter do |v| 
+                    isI64 = v =~ /i64x2/
+                    !isI64
+                end
+            end
+
+            if config[:skipI32Variant] then
+                variants = variants.filter do |v| 
+                    isI32 = v =~ /i32x4/
+                    !isI32
+                end
+            end
+
+            if config[:skipI8Variant] then
+                variants = variants.filter do |v| 
+                    isI8 = v =~ /i8x16/
+                    !isI8
+                end
+            end
+
+            if config[:skipFloatVariants] then
+                variants = variants.filter do |v| 
+                    isFloat = v =~ /f32x4|f64x2/
+                    !isFloat
+                end
+            end
+
+            if config[:variants] then
+                variants = config[:variants]
+            end
+
+            opList = []
+            for v in variants do
+                opList << ((op.to_s + "_" + v).to_sym)
+            end
+            @current_section.add_opcode_group((desc.to_s + op.to_s).to_sym, opList, config)
+        end
+    end
+    
     def self.types(types)
         types.map do |type|
             type = (@namespaces + [type]).join "::"

--- a/Source/JavaScriptCore/generator/Opcode.rb
+++ b/Source/JavaScriptCore/generator/Opcode.rb
@@ -71,7 +71,14 @@ class Opcode
     end
 
     def capitalized_name
-        name.split('_').map(&:capitalize).join
+        (name.split('_').map do |s|
+            s = s.capitalize
+            if s.match(/^\d/)
+                i = s.match(/^\d+/)[0].size
+                s = s[0..i-1] + s[i..-1].capitalize
+            end
+            s
+        end).join
     end
 
     def typed_args

--- a/Source/JavaScriptCore/generator/Section.rb
+++ b/Source/JavaScriptCore/generator/Section.rb
@@ -59,7 +59,10 @@ class Section
               raise "Bytecodes with checkpoints should have metadata: #{a.name}" if a.checkpoints and a.metadata.empty?
               raise "Bytecodes with checkpoints should have metadata: #{b.name}" if b.checkpoints and b.metadata.empty?
               result = a.checkpoints ? b.checkpoints ? 0 : -1 : 1
-          elsif
+          # SIMD opcodes should always use higher bytecode ids since they are more rare.
+          elsif a.name.downcase.include?("simd") or b.name.downcase.include?("simd")
+              result = a.name.include?("simd") ? b.name.include?("simd") ? 0 : 1 : -1 
+          else
               result = a.metadata.empty? ? b.metadata.empty? ? 0 : 1 : -1 
           end
           result

--- a/Source/JavaScriptCore/generator/main.rb
+++ b/Source/JavaScriptCore/generator/main.rb
@@ -31,6 +31,7 @@ DSL::types [
   :int,
   :unsigned,
   :uintptr_t,
+  :uint8_t,
 ]
 
 options = Options::parse(ARGV)

--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -237,7 +237,7 @@ ALWAYS_INLINE constexpr Width conservativeWidthWithoutVectors(const Reg reg)
 
 ALWAYS_INLINE constexpr Width conservativeWidth(const Reg reg)
 {
-    return reg.isFPR() ? Width64 : widthForBytes(sizeof(CPURegister));
+    return reg.isFPR() ? Width128 : widthForBytes(sizeof(CPURegister));
 }
 
 ALWAYS_INLINE constexpr unsigned conservativeRegisterBytes(const Reg reg)

--- a/Source/JavaScriptCore/jit/RegisterAtOffset.h
+++ b/Source/JavaScriptCore/jit/RegisterAtOffset.h
@@ -44,7 +44,7 @@ public:
         , m_offsetBits((offset >> 2) & 0xFFFFFFFFFFFFFF)
     {
         ASSERT(!(offset & 0b11));
-        ASSERT(width == conservativeWidthWithoutVectors(reg));
+        ASSERT(width == conservativeWidthWithoutVectors(reg) || Options::useWebAssemblySIMD());
         ASSERT(reg.index() < (1 << 6));
         ASSERT(Reg::last().index() < (1 << 6));
         ASSERT(this->reg() == reg);

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/PrintStream.h>
+
+namespace JSC {
+
+typedef union v128_u {
+    float f32x4[4];
+    double f64x2[2];
+    uint8_t u8x16[16];
+    uint16_t u16x8[8];
+    uint32_t u32x4[4];
+    uint64_t u64x2[2] = { 0, 0 };
+} v128_t;
+
+enum class SIMDLane : uint8_t {
+    v128,
+    i8x16,
+    i16x8,
+    i32x4,
+    i64x2,
+    f32x4,
+    f64x2
+};
+
+enum class SIMDSignMode : uint8_t {
+    None, 
+    Signed,
+    Unsigned
+};
+
+struct SIMDInfo {
+    SIMDLane lane { SIMDLane::v128 };
+    SIMDSignMode signMode { SIMDSignMode::None };
+};
+
+constexpr uint8_t elementCount(SIMDLane lane)
+{
+    switch (lane) {
+    case SIMDLane::i8x16:
+        return 16;
+    case SIMDLane::i16x8:
+        return 8;
+    case SIMDLane::f32x4:
+    case SIMDLane::i32x4:
+        return 4;
+    case SIMDLane::f64x2:
+    case SIMDLane::i64x2:
+        return 2;
+    case SIMDLane::v128:
+        RELEASE_ASSERT_NOT_REACHED();
+        return 0;
+    }
+}
+
+constexpr bool scalarTypeIsFloatingPoint(SIMDLane lane)
+{
+    switch (lane) {
+    case SIMDLane::f32x4:
+    case SIMDLane::f64x2:
+        return true;
+    default:
+        return false;
+    }
+}
+
+constexpr bool scalarTypeIsIntegral(SIMDLane lane)
+{
+    switch (lane) {
+    case SIMDLane::i8x16:
+    case SIMDLane::i16x8:
+    case SIMDLane::i32x4:
+    case SIMDLane::i64x2:
+        return true;
+    default:
+        return false;
+    }
+}
+
+constexpr SIMDLane narrowedLane(SIMDLane lane)
+{
+    switch (lane) {
+    case SIMDLane::v128:
+    case SIMDLane::i8x16:
+    case SIMDLane::f32x4:
+        RELEASE_ASSERT_NOT_REACHED();
+        return lane;
+    case SIMDLane::i16x8:
+        return SIMDLane::i8x16;
+    case SIMDLane::i32x4:
+        return SIMDLane::i16x8;
+    case SIMDLane::i64x2:
+        return SIMDLane::i32x4;
+    case SIMDLane::f64x2:
+        return SIMDLane::f32x4;
+    }
+}
+
+constexpr SIMDLane promotedLane(SIMDLane lane)
+{
+    switch (lane) {
+    case SIMDLane::v128:
+    case SIMDLane::i64x2:
+    case SIMDLane::f64x2:
+        RELEASE_ASSERT_NOT_REACHED();
+        return lane;
+    case SIMDLane::i8x16:
+        return SIMDLane::i16x8;
+    case SIMDLane::i16x8:
+        return SIMDLane::i32x4;
+    case SIMDLane::i32x4:
+        return SIMDLane::i64x2;
+    case SIMDLane::f32x4:
+        return SIMDLane::f64x2;
+    }
+}
+
+constexpr unsigned elementByteSize(SIMDLane simdLane)
+{
+    switch (simdLane) {
+    case SIMDLane::i8x16:
+        return 1;
+    case SIMDLane::i16x8:
+        return 2;
+    case SIMDLane::i32x4:
+    case SIMDLane::f32x4:
+        return 4;
+    case SIMDLane::i64x2:
+    case SIMDLane::f64x2:
+        return 8;
+    case SIMDLane::v128:
+        return 16;
+    }
+}
+
+} // namespace JSC
+
+namespace WTF {
+
+inline void printInternal(PrintStream& out, JSC::SIMDLane lane)
+{
+    switch (lane) {
+    case JSC::SIMDLane::i8x16:
+        out.print("i8x16");
+        break;
+    case JSC::SIMDLane::i16x8:
+        out.print("i16x8");
+        break;
+    case JSC::SIMDLane::i32x4:
+        out.print("i32x4");
+        break;
+    case JSC::SIMDLane::f32x4:
+        out.print("f32x4");
+        break;
+    case JSC::SIMDLane::i64x2:
+        out.print("i64x2");
+        break;
+    case JSC::SIMDLane::f64x2:
+        out.print("f64x2");
+        break;
+    case JSC::SIMDLane::v128:
+        out.print("v128");
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+inline void printInternal(PrintStream& out, JSC::SIMDSignMode mode)
+{
+    switch (mode) {
+    case JSC::SIMDSignMode::None:
+        out.print("SignMode::None");
+        break;
+    case JSC::SIMDSignMode::Signed:
+        out.print("SignMode::Signed");
+        break;
+    case JSC::SIMDSignMode::Unsigned:
+        out.print("SignMode::Unsigned");
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+} // namespace WTF

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -676,6 +676,18 @@ void Options::recomputeDependentOptions()
 
     if (Options::verboseVerifyGC())
         Options::verifyGC() = true;
+    
+    // FIXME: This should be removed when we add LLint/OMG support for WASM SIMD
+    if (Options::useWebAssemblySIMD()) {
+        Options::useWasmLLInt() = false;
+        Options::useBBQJIT() = true;
+        Options::useOMGJIT() = false;
+        Options::wasmBBQUsesAir() = true;
+        Options::webAssemblyBBQAirModeThreshold() = 0;
+        Options::webAssemblyBBQAirOptimizationLevel() = 0;
+        Options::defaultB3OptLevel() = 0;
+        Options::airRandomizeRegs() = 0;
+    }
 
 #if ASAN_ENABLED && OS(LINUX) && ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
     if (Options::useWasmFaultSignalHandler()) {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -558,6 +558,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
     v(Bool, useWebAssemblyExceptions, true, Normal, "Allow the new section and instructions from the wasm exception handling spec.") \
     v(Bool, useWebAssemblyBranchHints, true, Normal, "Allow the new section from the wasm branch hinting spec.") \
+    v(Bool, useWebAssemblySIMD, false, Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
 
 
 enum OptionEquivalence {

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -95,6 +95,8 @@ public:
     using ExpressionType = Variable*;
     using ResultList = Vector<ExpressionType, 8>;
 
+    static constexpr bool tierSupportsSIMD = false;
+
     struct ControlData {
         ControlData(Procedure& proc, Origin origin, BlockSignature signature, BlockType type, unsigned stackSize, BasicBlock* continuation, BasicBlock* special = nullptr)
             : controlBlockType(type)

--- a/Source/JavaScriptCore/wasm/WasmCallingConvention.h
+++ b/Source/JavaScriptCore/wasm/WasmCallingConvention.h
@@ -135,6 +135,7 @@ private:
             return marshallLocationImpl(role, jsrArgs, gpArgumentCount, stackOffset, alignedWidth);
         case TypeKind::F32:
         case TypeKind::F64:
+        case TypeKind::V128:
             return marshallLocationImpl(role, fprArgs, fpArgumentCount, stackOffset, alignedWidth);
         default:
             break;

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -74,6 +74,8 @@ inline bool isValueType(Type type)
     case TypeKind::Ref:
     case TypeKind::RefNull:
         return Options::useWebAssemblyTypedFunctionReferences();
+    case TypeKind::V128:
+        return Options::useWebAssemblySIMD();
     default:
         break;
     }

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -28,8 +28,10 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "WasmParser.h"
+#include "WasmSIMDOpcodes.h"
 #include "WasmTypeDefinitionInlines.h"
 #include <wtf/DataLog.h>
+#include <wtf/ListDump.h>
 
 namespace JSC { namespace Wasm {
 
@@ -86,6 +88,11 @@ public:
         operator ExpressionType() const { return m_value; }
 
         ExpressionType operator->() const { return m_value; }
+        
+        void dump(PrintStream& out) const
+        {
+            out.print(m_value, ": ", m_type);
+        }
 
     private:
         Type m_type;
@@ -147,6 +154,11 @@ private:
     PartialResult WARN_UNUSED_RETURN atomicWait(ExtAtomicOpType, Type memoryType);
     PartialResult WARN_UNUSED_RETURN atomicNotify(ExtAtomicOpType);
     PartialResult WARN_UNUSED_RETURN atomicFence(ExtAtomicOpType);
+
+    template<bool isReachable, typename = void>
+    PartialResult
+    WARN_UNUSED_RETURN
+    simd(SIMDLaneOperation, SIMDLane, SIMDSignMode);
 
     PartialResult WARN_UNUSED_RETURN parseTableIndex(unsigned&);
     PartialResult WARN_UNUSED_RETURN parseElementIndex(unsigned&);
@@ -566,6 +578,102 @@ auto FunctionParser<Context>::atomicFence(ExtAtomicOpType op) -> PartialResult
     WASM_PARSER_FAIL_IF(!parseUInt8(flags), "can't get flags");
     WASM_PARSER_FAIL_IF(flags != 0x0, "flags should be 0x0 but got ", flags);
     WASM_TRY_ADD_TO_CONTEXT(atomicFence(op, flags));
+    return { };
+}
+
+template<typename Context>
+template<bool isReachable, typename>
+auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSignMode signMode) -> PartialResult
+{
+    auto pushUnreachable = [&](auto type) -> PartialResult {
+        // Appease generators without SIMD support.
+        m_expressionStack.constructAndAppend(type, m_context.addConstant(Types::F64, 0));
+        return { };
+    };
+
+    auto parseMemOp = [&] (uint32_t& offset, TypedExpression& pointer) -> PartialResult {
+        uint32_t maxAlignment;
+        switch (op) {
+        case SIMDLaneOperation::Load:
+        case SIMDLaneOperation::Store:
+            maxAlignment = 16;
+            break;
+        default: RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        WASM_VALIDATOR_FAIL_IF(!m_info.memory, "simd memory instructions need a memory defined in the module");
+
+        uint32_t alignment;
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment");
+        WASM_PARSER_FAIL_IF(alignment > maxAlignment, "alignment: ", alignment, " can't be larger than max alignment for simd operation: ", maxAlignment);
+        WASM_PARSER_FAIL_IF(!parseVarUInt32(offset), "can't get simd memory op offset");
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "simd memory op pointer");
+        WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), "pointer must be i32");
+
+        return { };
+    };
+
+    switch (op) {
+    case SIMDLaneOperation::Const: {
+        v128_t constant;
+        ASSERT(lane == SIMDLane::v128);
+        ASSERT(signMode == SIMDSignMode::None);
+        WASM_PARSER_FAIL_IF(!parseImmByteArray16(constant), "can't parse 128-bit vector constant");
+        if constexpr (isReachable) {
+            m_expressionStack.constructAndAppend(Types::V128, m_context.addConstant(constant));
+            return { };
+        } else 
+            return pushUnreachable(Types::V128);
+    }
+    case SIMDLaneOperation::ExtractLane: {
+        uint8_t laneIdx;
+        TypedExpression v;
+        ASSERT(lane != SIMDLane::v128);
+        WASM_FAIL_IF_HELPER_FAILS(parseImmLaneIdx(elementCount(lane), laneIdx));        
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(v, "vector argument");
+        WASM_VALIDATOR_FAIL_IF(v.type() != Types::V128, "type mismatch for argument 0");
+        
+        if constexpr (isReachable) {
+            ExpressionType result;
+            WASM_TRY_ADD_TO_CONTEXT(addExtractLane(SIMDInfo { lane, signMode }, laneIdx, v, result));
+            m_expressionStack.constructAndAppend(simdScalarType(lane), result);
+            return { };
+        } else 
+            return pushUnreachable(simdScalarType(lane));
+    }
+    case SIMDLaneOperation::Load: {
+        uint32_t offset;
+        TypedExpression pointer;
+        WASM_FAIL_IF_HELPER_FAILS(parseMemOp(offset, pointer));
+        
+        if constexpr (isReachable) {
+            ExpressionType result;
+            WASM_TRY_ADD_TO_CONTEXT(addSIMDLoad(pointer, offset, result));
+            m_expressionStack.constructAndAppend(Types::V128, result);
+            return { };
+        } else 
+            return pushUnreachable(Types::V128);
+    }
+    case SIMDLaneOperation::Store: {
+        TypedExpression val;
+        WASM_TRY_POP_EXPRESSION_STACK_INTO(val, "val");
+        WASM_VALIDATOR_FAIL_IF(!val.type().isV128(), "store vector must be v128");
+        
+        uint32_t offset;
+        TypedExpression pointer;
+        WASM_FAIL_IF_HELPER_FAILS(parseMemOp(offset, pointer));
+
+        if constexpr (isReachable) {
+            WASM_TRY_ADD_TO_CONTEXT(addSIMDStore(val, pointer, offset));
+            return { };
+        } else 
+            return { };
+    }
+    default:
+        ASSERT_NOT_REACHED();
+        WASM_PARSER_FAIL_IF(true, "invalid simd op ", SIMDLaneOperationDump(op));
+        break;
+    }
     return { };
 }
 
@@ -1927,6 +2035,23 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         return { };
     }
+
+    case ExtSIMD: {
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "wasm-simd is not enabled");
+        uint8_t simdOp;
+        WASM_PARSER_FAIL_IF(!parseUInt8(simdOp), "can't parse wasm extended opcode");
+
+        ExtSIMDOpType op = static_cast<ExtSIMDOpType>(simdOp);
+        switch (op) {
+        #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<Context::tierSupportsSIMD>(laneOp, lane, signMode);
+        FOR_EACH_WASM_EXT_SIMD_OP(CREATE_SIMD_CASE)
+        #undef CREATE_SIMD_CASE
+        default:
+            WASM_PARSER_FAIL_IF(true, "invalid extended simd op ", simdOp);
+            break;
+        }
+        return { };
+    }
     }
 
     ASSERT_NOT_REACHED();
@@ -2335,6 +2460,23 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         return { };
     }
 #undef CREATE_ATOMIC_CASE
+
+    case ExtSIMD: {
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblySIMD(), "wasm-simd is not enabled");
+        uint8_t simdOp;
+        WASM_PARSER_FAIL_IF(!parseUInt8(simdOp), "can't parse wasm extended opcode");
+
+        ExtSIMDOpType op = static_cast<ExtSIMDOpType>(simdOp);
+        switch (op) {
+        #define CREATE_SIMD_CASE(name, id, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<false>(laneOp, lane, signMode);
+        FOR_EACH_WASM_EXT_SIMD_OP(CREATE_SIMD_CASE)
+        #undef CREATE_SIMD_CASE
+        default:
+            WASM_PARSER_FAIL_IF(true, "invalid extended simd op ", simdOp);
+            break;
+        }
+        return { };
+    }
 
     // no immediate cases
     FOR_EACH_WASM_BINARY_OP(CREATE_CASE)

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -48,6 +48,8 @@ class LLIntGenerator : public BytecodeGeneratorBase<GeneratorTraits> {
 public:
     using ExpressionType = VirtualRegister;
 
+    static constexpr bool tierSupportsSIMD = false;
+
     struct ControlLoop  {
         Ref<Label> m_body;
     };
@@ -660,6 +662,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
             break;
         case TypeKind::F32:
         case TypeKind::F64:
+        case TypeKind::V128:
             if (fprIndex < fprCount)
                 ++fprIndex;
             else if (stackIndex++ >= stackCount)
@@ -722,6 +725,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
             break;
         case TypeKind::F32:
         case TypeKind::F64:
+        case TypeKind::V128:
             if (fprIndex > fprLimit)
                 arguments[i] = virtualRegisterForLocal(--fprIndex);
             else
@@ -756,6 +760,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
             break;
         case TypeKind::F32:
         case TypeKind::F64:
+        case TypeKind::V128:
             if (fprIndex > fprLimit)
                 temporaryResults[i] = virtualRegisterForLocal(--fprIndex);
             else
@@ -818,6 +823,7 @@ auto LLIntGenerator::callInformationForCallee(const FunctionSignature& signature
             break;
         case TypeKind::F32:
         case TypeKind::F64:
+        case TypeKind::V128:
             if (fprIndex < maxFPRIndex)
                 m_results.append(virtualRegisterForLocal(numberOfLLIntCalleeSaveRegisters + fprIndex++));
             else
@@ -876,6 +882,7 @@ auto LLIntGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
             break;
         case TypeKind::F32:
         case TypeKind::F64:
+        case TypeKind::V128:
             addArgument(i, fprIndex, maxFPRIndex);
             break;
         case TypeKind::Void:
@@ -1163,6 +1170,7 @@ auto LLIntGenerator::addCatchToUnreachable(unsigned exceptionIndex, const TypeDe
         case Wasm::TypeKind::I64:
         case Wasm::TypeKind::Externref:
         case Wasm::TypeKind::Funcref:
+        case Wasm::TypeKind::V128:
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
+++ b/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <wtf/PrintStream.h>
+
+enum class SIMDLaneOperation : uint8_t {
+    Const,
+    ExtractLane,
+    Load,
+    Store,
+};
+
+#define FOR_EACH_WASM_EXT_SIMD_OP(macro) \
+    macro(V128Load,                 0x00, SIMDLaneOperation::Load,                      SIMDLane::v128,     SIMDSignMode::None) \
+    macro(V128Store,                0x0b, SIMDLaneOperation::Store,                     SIMDLane::v128,     SIMDSignMode::None) \
+    macro(V128Const,                0x0c, SIMDLaneOperation::Const,                     SIMDLane::v128,     SIMDSignMode::None) \
+    macro(I8x16ExtractLaneS,        0x15, SIMDLaneOperation::ExtractLane,               SIMDLane::i8x16,    SIMDSignMode::Signed) \
+    macro(I8x16ExtractLaneU,        0x16, SIMDLaneOperation::ExtractLane,               SIMDLane::i8x16,    SIMDSignMode::Unsigned) \
+    macro(I16x8ExtractLaneS,        0x18, SIMDLaneOperation::ExtractLane,               SIMDLane::i16x8,    SIMDSignMode::Signed) \
+    macro(I16x8ExtractLaneU,        0x19, SIMDLaneOperation::ExtractLane,               SIMDLane::i16x8,    SIMDSignMode::Unsigned) \
+    macro(I32x4ExtractLane,         0x1b, SIMDLaneOperation::ExtractLane,               SIMDLane::i32x4,    SIMDSignMode::None) \
+    macro(I64x2ExtractLane,         0x1d, SIMDLaneOperation::ExtractLane,               SIMDLane::i64x2,    SIMDSignMode::None) \
+    macro(F32x4ExtractLane,         0x1f, SIMDLaneOperation::ExtractLane,               SIMDLane::f32x4,    SIMDSignMode::None) \
+    macro(F64x2ExtractLane,         0x21, SIMDLaneOperation::ExtractLane,               SIMDLane::f64x2,    SIMDSignMode::None) \
+
+static void dumpSIMDLaneOperation(PrintStream& out, SIMDLaneOperation op)
+{
+    switch (op) {
+    case SIMDLaneOperation::Const: out.print("Const"); break;
+    case SIMDLaneOperation::ExtractLane: out.print("ExtractLane"); break;
+    case SIMDLaneOperation::Load: out.print("Load"); break;
+    case SIMDLaneOperation::Store: out.print("Store"); break;
+    }
+}
+MAKE_PRINT_ADAPTOR(SIMDLaneOperationDump, SIMDLaneOperation, dumpSIMDLaneOperation);
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -87,7 +87,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> triggerOMGEntryTierUpThunkGenerator(const 
     jit.emitFunctionPrologue();
 
     const unsigned extraPaddingBytes = 0;
-    auto registersToSpill = RegisterSetBuilder::registersToSaveForCCall(RegisterSetBuilder::allScalarRegisters()).buildWithLowerBits();
+    auto registersToSpill = RegisterSetBuilder::registersToSaveForCCall(Options::useWebAssemblySIMD() ? RegisterSetBuilder::allRegisters() : RegisterSetBuilder::allScalarRegisters()).buildWithLowerBits();
     unsigned numberOfStackBytesUsedForRegisterPreservation = ScratchRegisterAllocator::preserveRegistersToStackForCall(jit, registersToSpill, extraPaddingBytes);
 
     jit.loadWasmContextInstance(GPRInfo::argumentGPR0);

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -160,6 +160,7 @@ defines.append("\n\n")
 defines = "".join(defines)
 
 opValueSet = set([op for op in wasm.opcodeIterator(lambda op: True, lambda op: opcodes[op]["value"])])
+opValueSet.add(0xFD)  # ExtSIMD
 maxOpValue = max(opValueSet)
 
 
@@ -328,6 +329,7 @@ inline TypeKind linearizedToType(int i)
     FOR_EACH_WASM_MEMORY_LOAD_OP(macro) \\
     FOR_EACH_WASM_MEMORY_STORE_OP(macro) \\
     macro(Ext1,  0xFC, Oops, 0) \\
+    macro(ExtSIMD, 0xFD, Oops, 0) \\
     macro(GCPrefix,  0xFB, Oops, 0) \\
     macro(ExtAtomic, 0xFE, Oops, 0)
 
@@ -365,6 +367,8 @@ enum class Ext1OpType : uint8_t {
     FOR_EACH_WASM_TABLE_OP(CREATE_ENUM_VALUE)
     FOR_EACH_WASM_TRUNC_SATURATED_OP(CREATE_ENUM_VALUE)
 };
+
+enum class ExtSIMDOpType : uint8_t;
 
 enum class GCOpType : uint8_t {
     FOR_EACH_WASM_GC_OP(CREATE_ENUM_VALUE)

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -277,6 +277,9 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, const
     result->entrypoint.calleeSaveRegisters = registersToSpill;
 
     size_t totalFrameSize = registersToSpill.sizeOfAreaInBytes();
+#if USE(JSVALUE64)
+    ASSERT(totalFrameSize == toSave.numberOfSetGPRs() * sizeof(CPURegister));
+#endif
     CallInformation wasmFrameConvention = wasmCallingConvention().callInformationFor(typeDefinition);
     RegisterAtOffsetList savedResultRegisters = wasmFrameConvention.computeResultsOffsetList();
     totalFrameSize += wasmFrameConvention.headerAndArgumentStackSizeInBytes;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -131,6 +131,7 @@ void JSWebAssemblyStruct::set(JSGlobalObject* globalObject, uint32_t fieldIndex,
         bitwise_cast<WriteBarrierBase<Unknown>*>(targetPointer)->set(vm(), this, argument);
         return;
     }
+    case TypeKind::V128:
     case TypeKind::Func:
     case TypeKind::Struct:
     case TypeKind::Array:

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -146,6 +146,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Arrayref:
             case TypeKind::I31ref:
             case TypeKind::Rec:
+            case TypeKind::V128:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
             case TypeKind::Ref:
@@ -231,6 +232,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Arrayref:
             case TypeKind::I31ref:
             case TypeKind::Rec:
+            case TypeKind::V128:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
             case TypeKind::Ref:

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -11,6 +11,7 @@
         "i64":       { "type": "varint7", "value":   -2, "b3type": "B3::Int64",  "width": 64 },
         "f32":       { "type": "varint7", "value":   -3, "b3type": "B3::Float",  "width": 32 },
         "f64":       { "type": "varint7", "value":   -4, "b3type": "B3::Double", "width": 64 },
+        "v128":      { "type": "varint7", "value":   -5, "b3type": "B3::V128",   "width": 128 },
         "funcref":   { "type": "varint7", "value":  -16, "b3type": "B3::Int64",  "width": 64 },
         "externref": { "type": "varint7", "value":  -17, "b3type": "B3::Int64",  "width": 64 },
         "ref_null":  { "type": "varint7", "value":  -20, "b3type": "B3::Int64",  "width": 64 },
@@ -23,8 +24,8 @@
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
     },
-    "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref"],
-    "block_type": ["i32", "i64", "f32", "f64", "void", "externref", "funcref"],
+    "value_type": ["i32", "i64", "f32", "f64", "externref", "funcref", "v128"],
+    "block_type": ["i32", "i64", "f32", "f64", "void", "externref", "funcref", "v128"],
     "ref_type": ["funcref", "externref", "ref", "ref_null"],
     "external_kind": {
         "Function":    { "type": "uint8", "value": 0 },


### PR DESCRIPTION
#### baab8dd057cfc07c8ba516883f0f1395bc0b1fda
<pre>
Support v128 const load store and extract lane in bbq only with O0 register allocation
<a href="https://bugs.webkit.org/show_bug.cgi?id=245897">https://bugs.webkit.org/show_bug.cgi?id=245897</a>
rdar://problem/100772941

Reviewed by Yusuke Suzuki.

This is the first patch to support the WASM SIMD proposal:
<a href="https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md">https://github.com/WebAssembly/simd/blob/main/proposals/simd/SIMD.md</a>

- Add a feature flag and support for parsing the new SIMD opcodes and the V128 type
When this flag is enabled, we disable LLInt and OMG, as well as the Linear Scan
and Graph Coloring register allocators (for now).

- Implement load, store, extract_lane and v128.const on both Intel and ARM64.
This is meant to be enough instruction implementation to test that the other parts
of this patch work.

- Spill and fill 128-bit vectors when they are used

Next steps
- Every place where we see an Options::useWebAssemblySIMD() ? should eventually be removed.
These were added for now so that the patch would be perf-neutral on JS2, but
the register allocator should eventually be able to see that if the full width is
never used, we should only spill a double.

* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
(JSC::ARM64Assembler::add):
(JSC::ARM64Assembler::simdQBit):
(JSC::ARM64Assembler::encodeLaneAndIndex):
(JSC::ARM64Assembler::ins):
(JSC::ARM64Assembler::umov):
(JSC::ARM64Assembler::smov):
(JSC::ARM64Assembler::dupElement):
(JSC::ARM64Assembler::dupGeneral):
(JSC::ARM64Assembler::fcmeq):
(JSC::ARM64Assembler::fcmgt):
(JSC::ARM64Assembler::fcmge):
(JSC::ARM64Assembler::vectorNot):
(JSC::ARM64Assembler::sizeForIntegralSIMDOp):
(JSC::ARM64Assembler::sizeForFloatingPointSIMDOp):
(JSC::ARM64Assembler::cmeq):
(JSC::ARM64Assembler::cmeqz):
(JSC::ARM64Assembler::cmhi):
(JSC::ARM64Assembler::cmhs):
(JSC::ARM64Assembler::cmgt):
(JSC::ARM64Assembler::cmge):
(JSC::ARM64Assembler::vectorAdd):
(JSC::ARM64Assembler::urhadd):
(JSC::ARM64Assembler::addpv):
(JSC::ARM64Assembler::addv):
(JSC::ARM64Assembler::vectorSub):
(JSC::ARM64Assembler::vectorMul):
(JSC::ARM64Assembler::smullv):
(JSC::ARM64Assembler::smull2v):
(JSC::ARM64Assembler::umullv):
(JSC::ARM64Assembler::umull2v):
(JSC::ARM64Assembler::sqrdmlahv):
(JSC::ARM64Assembler::vectorFadd):
(JSC::ARM64Assembler::vectorFsub):
(JSC::ARM64Assembler::vectorFmul):
(JSC::ARM64Assembler::vectorFdiv):
(JSC::ARM64Assembler::umax):
(JSC::ARM64Assembler::umaxv):
(JSC::ARM64Assembler::uminv):
(JSC::ARM64Assembler::smax):
(JSC::ARM64Assembler::umin):
(JSC::ARM64Assembler::smin):
(JSC::ARM64Assembler::vectorFmax):
(JSC::ARM64Assembler::vectorFmin):
(JSC::ARM64Assembler::bsl):
(JSC::ARM64Assembler::vectorEor):
(JSC::ARM64Assembler::vectorAbs):
(JSC::ARM64Assembler::vectorFabs):
(JSC::ARM64Assembler::vectorNeg):
(JSC::ARM64Assembler::vectorFneg):
(JSC::ARM64Assembler::vectorCnt):
(JSC::ARM64Assembler::vectorFcvtps):
(JSC::ARM64Assembler::vectorFcvtms):
(JSC::ARM64Assembler::vectorFrintz):
(JSC::ARM64Assembler::vectorFcvtns):
(JSC::ARM64Assembler::vectorFsqrt):
(JSC::ARM64Assembler::immhForExtend):
(JSC::ARM64Assembler::uxtl):
(JSC::ARM64Assembler::uxtl2):
(JSC::ARM64Assembler::sxtl):
(JSC::ARM64Assembler::sxtl2):
(JSC::ARM64Assembler::fcvtl):
(JSC::ARM64Assembler::fcvtn):
(JSC::ARM64Assembler::sqxtn):
(JSC::ARM64Assembler::sqxtn2):
(JSC::ARM64Assembler::sqxtun):
(JSC::ARM64Assembler::sqxtun2):
(JSC::ARM64Assembler::ushl):
(JSC::ARM64Assembler::sshl):
(JSC::ARM64Assembler::sshr_vi):
(JSC::ARM64Assembler::sqadd):
(JSC::ARM64Assembler::sqsub):
(JSC::ARM64Assembler::uqadd):
(JSC::ARM64Assembler::uqsub):
(JSC::ARM64Assembler::vectorFcvtzs):
(JSC::ARM64Assembler::vectorFcvtzu):
(JSC::ARM64Assembler::vectorScvtf):
(JSC::ARM64Assembler::vectorUcvtf):
(JSC::ARM64Assembler::tbl):
(JSC::ARM64Assembler::tbl2):
(JSC::ARM64Assembler::ld1r):
(JSC::ARM64Assembler::ld1):
(JSC::ARM64Assembler::st1):
(JSC::ARM64Assembler::mov): Deleted.
(JSC::ARM64Assembler::movi): Deleted.
(JSC::ARM64Assembler::movk): Deleted.
(JSC::ARM64Assembler::movn): Deleted.
(JSC::ARM64Assembler::movz): Deleted.
(JSC::ARM64Assembler::msub): Deleted.
(JSC::ARM64Assembler::mul): Deleted.
(JSC::ARM64Assembler::mvn): Deleted.
(JSC::ARM64Assembler::neg): Deleted.
(JSC::ARM64Assembler::ngc): Deleted.
(JSC::ARM64Assembler::nop): Deleted.
(JSC::ARM64Assembler::fillNops): Deleted.
(JSC::ARM64Assembler::dmbISH): Deleted.
(JSC::ARM64Assembler::dmbISHST): Deleted.
(JSC::ARM64Assembler::ldar): Deleted.
(JSC::ARM64Assembler::ldxr): Deleted.
(JSC::ARM64Assembler::ldaxr): Deleted.
(JSC::ARM64Assembler::stxr): Deleted.
(JSC::ARM64Assembler::stlr): Deleted.
(JSC::ARM64Assembler::stlxr): Deleted.
(JSC::ARM64Assembler::mrs_TPIDRRO_EL0): Deleted.
(JSC::ARM64Assembler::orn): Deleted.
(JSC::ARM64Assembler::orr): Deleted.
(JSC::ARM64Assembler::rbit): Deleted.
(JSC::ARM64Assembler::ret): Deleted.
(JSC::ARM64Assembler::rev): Deleted.
(JSC::ARM64Assembler::rev16): Deleted.
(JSC::ARM64Assembler::rev32): Deleted.
(JSC::ARM64Assembler::ror): Deleted.
(JSC::ARM64Assembler::rorv): Deleted.
(JSC::ARM64Assembler::sbc): Deleted.
(JSC::ARM64Assembler::sbfiz): Deleted.
(JSC::ARM64Assembler::sbfm): Deleted.
(JSC::ARM64Assembler::sbfx): Deleted.
(JSC::ARM64Assembler::sdiv): Deleted.
(JSC::ARM64Assembler::smaddl): Deleted.
(JSC::ARM64Assembler::smnegl): Deleted.
(JSC::ARM64Assembler::smsubl): Deleted.
(JSC::ARM64Assembler::smulh): Deleted.
(JSC::ARM64Assembler::smull): Deleted.
(JSC::ARM64Assembler::isValidSTPImm): Deleted.
(JSC::ARM64Assembler::isValidSTPFPImm): Deleted.
(JSC::ARM64Assembler::stp): Deleted.
(JSC::ARM64Assembler::stnp): Deleted.
(JSC::ARM64Assembler::str): Deleted.
(JSC::ARM64Assembler::strb): Deleted.
(JSC::ARM64Assembler::strh): Deleted.
(JSC::ARM64Assembler::stur): Deleted.
(JSC::ARM64Assembler::sturb): Deleted.
(JSC::ARM64Assembler::sturh): Deleted.
(JSC::ARM64Assembler::sub): Deleted.
(JSC::ARM64Assembler::sxtb): Deleted.
(JSC::ARM64Assembler::sxth): Deleted.
(JSC::ARM64Assembler::sxtw): Deleted.
(JSC::ARM64Assembler::tbz): Deleted.
(JSC::ARM64Assembler::tbnz): Deleted.
(JSC::ARM64Assembler::tst): Deleted.
(JSC::ARM64Assembler::ubfiz): Deleted.
(JSC::ARM64Assembler::ubfm): Deleted.
(JSC::ARM64Assembler::ubfx): Deleted.
(JSC::ARM64Assembler::udiv): Deleted.
(JSC::ARM64Assembler::umaddl): Deleted.
(JSC::ARM64Assembler::umnegl): Deleted.
(JSC::ARM64Assembler::umsubl): Deleted.
(JSC::ARM64Assembler::umulh): Deleted.
(JSC::ARM64Assembler::umull): Deleted.
(JSC::ARM64Assembler::uxtb): Deleted.
(JSC::ARM64Assembler::uxth): Deleted.
(JSC::ARM64Assembler::uxtw): Deleted.
(JSC::ARM64Assembler::fabs): Deleted.
(JSC::ARM64Assembler::fadd): Deleted.
(JSC::ARM64Assembler::fccmp): Deleted.
(JSC::ARM64Assembler::fccmpe): Deleted.
(JSC::ARM64Assembler::fcmp): Deleted.
(JSC::ARM64Assembler::fcmp_0): Deleted.
(JSC::ARM64Assembler::fcmpe): Deleted.
(JSC::ARM64Assembler::fcmpe_0): Deleted.
(JSC::ARM64Assembler::fcsel): Deleted.
(JSC::ARM64Assembler::fcvt): Deleted.
(JSC::ARM64Assembler::fcvtas): Deleted.
(JSC::ARM64Assembler::fcvtau): Deleted.
(JSC::ARM64Assembler::fcvtms): Deleted.
(JSC::ARM64Assembler::fcvtmu): Deleted.
(JSC::ARM64Assembler::fcvtns): Deleted.
(JSC::ARM64Assembler::fcvtnu): Deleted.
(JSC::ARM64Assembler::fcvtps): Deleted.
(JSC::ARM64Assembler::fcvtpu): Deleted.
(JSC::ARM64Assembler::fcvtzs): Deleted.
(JSC::ARM64Assembler::fcvtzu): Deleted.
(JSC::ARM64Assembler::fdiv): Deleted.
(JSC::ARM64Assembler::fmadd): Deleted.
(JSC::ARM64Assembler::fmax): Deleted.
(JSC::ARM64Assembler::fmaxnm): Deleted.
(JSC::ARM64Assembler::fmin): Deleted.
(JSC::ARM64Assembler::fminnm): Deleted.
(JSC::ARM64Assembler::fmov): Deleted.
(JSC::ARM64Assembler::fmov_top): Deleted.
(JSC::ARM64Assembler::fmsub): Deleted.
(JSC::ARM64Assembler::fmul): Deleted.
(JSC::ARM64Assembler::fneg): Deleted.
(JSC::ARM64Assembler::fnmadd): Deleted.
(JSC::ARM64Assembler::fnmsub): Deleted.
(JSC::ARM64Assembler::fnmul): Deleted.
(JSC::ARM64Assembler::vand): Deleted.
(JSC::ARM64Assembler::vorr): Deleted.
(JSC::ARM64Assembler::frinta): Deleted.
(JSC::ARM64Assembler::frinti): Deleted.
(JSC::ARM64Assembler::frintm): Deleted.
(JSC::ARM64Assembler::frintn): Deleted.
(JSC::ARM64Assembler::frintp): Deleted.
(JSC::ARM64Assembler::frintx): Deleted.
(JSC::ARM64Assembler::frintz): Deleted.
(JSC::ARM64Assembler::fsqrt): Deleted.
(JSC::ARM64Assembler::fsub): Deleted.
(JSC::ARM64Assembler::scvtf): Deleted.
(JSC::ARM64Assembler::ucvtf): Deleted.
(JSC::ARM64Assembler::fjcvtzs): Deleted.
(JSC::ARM64Assembler::labelIgnoringWatchpoints): Deleted.
(JSC::ARM64Assembler::labelForWatchpoint): Deleted.
(JSC::ARM64Assembler::label): Deleted.
(JSC::ARM64Assembler::align): Deleted.
(JSC::ARM64Assembler::getRelocatedAddress): Deleted.
(JSC::ARM64Assembler::getDifferenceBetweenLabels): Deleted.
(JSC::ARM64Assembler::codeSize const): Deleted.
(JSC::ARM64Assembler::getCallReturnOffset): Deleted.
(JSC::ARM64Assembler::linkJump): Deleted.
(JSC::ARM64Assembler::linkCall): Deleted.
(JSC::ARM64Assembler::linkPointer): Deleted.
(JSC::ARM64Assembler::replaceWithVMHalt): Deleted.
(JSC::ARM64Assembler::replaceWithJump): Deleted.
(JSC::ARM64Assembler::maxJumpReplacementSize): Deleted.
(JSC::ARM64Assembler::patchableJumpSize): Deleted.
(JSC::ARM64Assembler::replaceWithLoad): Deleted.
(JSC::ARM64Assembler::replaceWithAddressComputation): Deleted.
(JSC::ARM64Assembler::repatchPointer): Deleted.
(JSC::ARM64Assembler::setPointer): Deleted.
(JSC::ARM64Assembler::repatchInt32): Deleted.
(JSC::ARM64Assembler::readPointer): Deleted.
(JSC::ARM64Assembler::readCallTarget): Deleted.
(JSC::ARM64Assembler::relinkJump): Deleted.
(JSC::ARM64Assembler::relinkCall): Deleted.
(JSC::ARM64Assembler::relinkTailCall): Deleted.
(JSC::ARM64Assembler::prepareForAtomicRelinkJumpConcurrently): Deleted.
(JSC::ARM64Assembler::prepareForAtomicRelinkCallConcurrently): Deleted.
(JSC::ARM64Assembler::debugOffset): Deleted.
(JSC::ARM64Assembler::linuxPageFlush): Deleted.
(JSC::ARM64Assembler::cacheFlush): Deleted.
(JSC::ARM64Assembler::jumpSizeDelta): Deleted.
(JSC::ARM64Assembler::linkRecordSourceComparator): Deleted.
(JSC::ARM64Assembler::canCompact): Deleted.
(JSC::ARM64Assembler::computeJumpType): Deleted.
(JSC::ARM64Assembler::jumpsToLink): Deleted.
(JSC::ARM64Assembler::link): Deleted.
(JSC::ARM64Assembler::canEmitJump): Deleted.
(JSC::ARM64Assembler::checkMovk): Deleted.
(JSC::ARM64Assembler::linkJumpOrCall): Deleted.
(JSC::ARM64Assembler::linkCompareAndBranch): Deleted.
(JSC::ARM64Assembler::linkConditionalBranch): Deleted.
(JSC::ARM64Assembler::linkTestAndBranch): Deleted.
(JSC::ARM64Assembler::relinkJumpOrCall): Deleted.
(JSC::ARM64Assembler::addressOf): Deleted.
(JSC::ARM64Assembler::disassembleXOrSp): Deleted.
(JSC::ARM64Assembler::disassembleXOrZr): Deleted.
(JSC::ARM64Assembler::disassembleXOrZrOrSp): Deleted.
(JSC::ARM64Assembler::disassembleAddSubtractImmediate): Deleted.
(JSC::ARM64Assembler::disassembleLoadStoreRegisterUnsignedImmediate): Deleted.
(JSC::ARM64Assembler::disassembleMoveWideImediate): Deleted.
(JSC::ARM64Assembler::disassembleNop): Deleted.
(JSC::ARM64Assembler::disassembleCompareAndBranchImmediate): Deleted.
(JSC::ARM64Assembler::disassembleConditionalBranchImmediate): Deleted.
(JSC::ARM64Assembler::disassembleTestAndBranchImmediate): Deleted.
(JSC::ARM64Assembler::disassembleUnconditionalBranchImmediate): Deleted.
(JSC::ARM64Assembler::xOrSp): Deleted.
(JSC::ARM64Assembler::xOrZr): Deleted.
(JSC::ARM64Assembler::xOrZrAsFPR): Deleted.
(JSC::ARM64Assembler::xOrZrOrSp): Deleted.
(JSC::ARM64Assembler::insn): Deleted.
(JSC::ARM64Assembler::addSubtractExtendedRegister): Deleted.
(JSC::ARM64Assembler::addSubtractImmediate): Deleted.
(JSC::ARM64Assembler::addSubtractShiftedRegister): Deleted.
(JSC::ARM64Assembler::addSubtractWithCarry): Deleted.
(JSC::ARM64Assembler::bitfield): Deleted.
(JSC::ARM64Assembler::compareAndBranchImmediate): Deleted.
(JSC::ARM64Assembler::conditionalBranchImmediate): Deleted.
(JSC::ARM64Assembler::conditionalCompareImmediate): Deleted.
(JSC::ARM64Assembler::conditionalCompareRegister): Deleted.
(JSC::ARM64Assembler::conditionalSelect): Deleted.
(JSC::ARM64Assembler::dataProcessing1Source): Deleted.
(JSC::ARM64Assembler::dataProcessing2Source): Deleted.
(JSC::ARM64Assembler::dataProcessing3Source): Deleted.
(JSC::ARM64Assembler::excepnGeneration): Deleted.
(JSC::ARM64Assembler::excepnGenerationImmMask): Deleted.
(JSC::ARM64Assembler::extract): Deleted.
(JSC::ARM64Assembler::floatingPointCompare): Deleted.
(JSC::ARM64Assembler::floatingPointConditionalCompare): Deleted.
(JSC::ARM64Assembler::floatingPointConditionalSelect): Deleted.
(JSC::ARM64Assembler::floatingPointImmediate): Deleted.
(JSC::ARM64Assembler::floatingPointIntegerConversions): Deleted.
(JSC::ARM64Assembler::floatingPointDataProcessing1Source): Deleted.
(JSC::ARM64Assembler::floatingPointDataProcessing2Source): Deleted.
(JSC::ARM64Assembler::vectorDataProcessingLogical): Deleted.
(JSC::ARM64Assembler::floatingPointDataProcessing3Source): Deleted.
(JSC::ARM64Assembler::loadRegisterLiteral): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterPostIndex): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterPairPostIndex): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterPreIndex): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterPairPreIndex): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterPairOffset): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterPairNonTemporal): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterRegisterOffset): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterUnscaledImmediate): Deleted.
(JSC::ARM64Assembler::loadStoreRegisterUnsignedImmediate): Deleted.
(JSC::ARM64Assembler::logicalImmediate): Deleted.
(JSC::ARM64Assembler::logicalShiftedRegister): Deleted.
(JSC::ARM64Assembler::moveWideImediate): Deleted.
(JSC::ARM64Assembler::unconditionalBranchImmediate): Deleted.
(JSC::ARM64Assembler::pcRelative): Deleted.
(JSC::ARM64Assembler::system): Deleted.
(JSC::ARM64Assembler::hintPseudo): Deleted.
(JSC::ARM64Assembler::nopPseudo): Deleted.
(JSC::ARM64Assembler::dataCacheZeroVirtualAddress): Deleted.
(JSC::ARM64Assembler::testAndBranchImmediate): Deleted.
(JSC::ARM64Assembler::unconditionalBranchRegister): Deleted.
(JSC::ARM64Assembler::exoticLoad): Deleted.
(JSC::ARM64Assembler::storeRelease): Deleted.
(JSC::ARM64Assembler::exoticStore): Deleted.
(JSC::ARM64Assembler::fjcvtzsInsn): Deleted.
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::loadVector):
(JSC::MacroAssemblerARM64::moveVector):
(JSC::MacroAssemblerARM64::storeVector):
(JSC::MacroAssemblerARM64::vectorReplaceLane):
(JSC::MacroAssemblerARM64::vectorExtractLane):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::move32ToFloat):
(JSC::MacroAssemblerX86_64::moveVector):
(JSC::MacroAssemblerX86_64::loadVector):
(JSC::MacroAssemblerX86_64::storeVector):
(JSC::MacroAssemblerX86_64::signExtendForSIMDLane):
(JSC::MacroAssemblerX86_64::vectorReplaceLane):
(JSC::MacroAssemblerX86_64::vectorExtractLane):
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::pinsr):
(JSC::X86Assembler::pextr):
(JSC::X86Assembler::vextractps):
(JSC::X86Assembler::shufps):
(JSC::X86Assembler::vmovups_mr):
(JSC::X86Assembler::vmovups_rm):
(JSC::X86Assembler::X86InstructionFormatter::SingleInstructionBufferWriter::memoryModRM):
* Source/JavaScriptCore/b3/B3Bank.h:
(JSC::B3::bankForType):
(JSC::B3::bankForReg):
(JSC::B3::conservativeWidth):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp:
(JSC::B3::PatchpointSpecial::forEachArg):
* Source/JavaScriptCore/b3/B3Type.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Type.h:
(JSC::B3::simdB3ScalarTypeKind):
(JSC::B3::simdB3ScalarType):
(JSC::B3::Type::isNumeric const):
(JSC::B3::Type::isVector const):
(JSC::B3::sizeofType):
* Source/JavaScriptCore/b3/B3TypeMap.h:
(JSC::B3::TypeMap::at):
(JSC::B3::TypeMap::dump const):
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3ValueRep.cpp:
(JSC::B3::ValueRep::addUsedRegistersTo const):
* Source/JavaScriptCore/b3/B3Width.h:
(JSC::B3::widthForType):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::flush):
(JSC::B3::Air::GenerateAndAllocateRegisters::alloc):
(JSC::B3::Air::GenerateAndAllocateRegisters::assignTmp):
(JSC::B3::Air::GenerateAndAllocateRegisters::prepareForGeneration):
(JSC::B3::Air::GenerateAndAllocateRegisters::generate):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackByLinearScan.cpp:
(JSC::B3::Air::allocateRegistersAndStackByLinearScan):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
(JSC::B3::Air::allocateRegistersByGraphColoring):
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
(JSC::B3::Air::allocateStackByGraphColoring):
* Source/JavaScriptCore/b3/air/AirArg.cpp:
(JSC::B3::Air::Arg::canRepresent const):
(JSC::B3::Air::Arg::jsHash const):
(JSC::B3::Air::Arg::dump const):
(WTF::printInternal):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::simdInfo):
(JSC::B3::Air::Arg::logScale):
(JSC::B3::Air::Arg::isSIMDInfo const):
(JSC::B3::Air::Arg::isGP const):
(JSC::B3::Air::Arg::isFP const):
(JSC::B3::Air::Arg::isValidForm const):
(JSC::B3::Air::Arg::simdInfo const):
(JSC::B3::Air::Arg::simdSignMode const):
* Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp:
(JSC::B3::Air::CCallSpecial::CCallSpecial):
(JSC::B3::Air::CCallSpecial::forEachArg):
* Source/JavaScriptCore/b3/air/AirCCallingConvention.cpp:
(JSC::B3::Air::cCallResult):
* Source/JavaScriptCore/b3/air/AirEmitShuffle.h:
(JSC::B3::Air::moveFor):
* Source/JavaScriptCore/b3/air/AirFormTable.h:
(JSC::B3::Air::encodeFormWidth):
(JSC::B3::Air::decodeFormWidth):
* Source/JavaScriptCore/b3/air/AirHelpers.h:
(JSC::B3::Air::moveForType):
(JSC::B3::Air::relaxedMoveForType):
* Source/JavaScriptCore/b3/air/AirInstInlines.h:
(JSC::B3::Air::isVectorSwizzle2Valid):
* Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp:
(JSC::B3::Air::logRegisterPressure):
* Source/JavaScriptCore/b3/air/AirLowerAfterRegAlloc.cpp:
(JSC::B3::Air::lowerAfterRegAlloc):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/AirRegLiveness.cpp:
(JSC::B3::Air::RegLiveness::RegLiveness):
(JSC::B3::Air::RegLiveness::LocalCalcForUnifiedTmpLiveness::LocalCalcForUnifiedTmpLiveness):
(JSC::B3::Air::RegLiveness::LocalCalcForUnifiedTmpLiveness::execute):
* Source/JavaScriptCore/b3/air/AirTmpWidth.cpp:
(JSC::B3::Air::TmpWidth::recompute):
* Source/JavaScriptCore/b3/air/AirValidate.cpp:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/bytecode/BytecodeDumper.cpp:
(JSC::BytecodeDumper&lt;Block&gt;::constantName const):
(JSC::Wasm::BytecodeDumper::formatConstant const):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64DOpcode::appendVectorRegisterName):
(JSC::ARM64Disassembler::A64DOpcodeLoadStoreImmediate::format):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::format):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::opName):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::format):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::opName):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h:
(JSC::ARM64Disassembler::A64DOpcode::appendSIMDLaneIndexAndType):
(JSC::ARM64Disassembler::A64DOpcode::appendSIMDLaneType):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::rd):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::rt):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::op10_15):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::imm5):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical1Source::q):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::rd):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::rn):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::op10_15):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::rm):
(JSC::ARM64Disassembler::A64DOpcodeVectorDataProcessingLogical2Source::q):
* Source/JavaScriptCore/generator/DSL.rb:
* Source/JavaScriptCore/generator/Opcode.rb:
* Source/JavaScriptCore/generator/Section.rb:
* Source/JavaScriptCore/generator/main.rb:
* Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h:
(JSC::AssemblyHelpers::Spooler::execute):
(JSC::AssemblyHelpers::Spooler::executeVector):
(JSC::AssemblyHelpers::LoadRegSpooler::loadVector):
(JSC::AssemblyHelpers::LoadRegSpooler::executeVector):
(JSC::AssemblyHelpers::StoreRegSpooler::storeVector):
(JSC::AssemblyHelpers::StoreRegSpooler::executeVector):
* Source/JavaScriptCore/jit/RegisterAtOffset.h:
(JSC::RegisterAtOffset::RegisterAtOffset):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::allocateScratch):
(JSC::ScratchRegisterAllocator::preserveReusedRegistersByPushing):
(JSC::ScratchRegisterAllocator::restoreReusedRegistersByPopping):
(JSC::ScratchRegisterAllocator::preserveRegistersToStackForCall):
(JSC::ScratchRegisterAllocator::restoreRegistersFromStackForCall):
* Source/JavaScriptCore/jit/Width.h:
(JSC::conservativeWidth):
(JSC::elementSize):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::recomputeDependentOptions):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::extractLaneAirOp):
(JSC::Wasm::AirIRGenerator::addExtractLane):
(JSC::Wasm::AirIRGenerator::v128):
(JSC::Wasm::AirIRGenerator::tmpForType):
(JSC::Wasm::AirIRGenerator::moveOpForValueType):
(JSC::Wasm::AirIRGenerator::AirIRGenerator):
(JSC::Wasm::AirIRGenerator::addLocal):
(JSC::Wasm::AirIRGenerator::addConstant):
(JSC::Wasm::AirIRGenerator::addSIMDLoad):
(JSC::Wasm::AirIRGenerator::addSIMDStore):
(JSC::Wasm::AirIRGenerator::emitCatchImpl):
(JSC::Wasm::AirIRGenerator::addThrow):
(JSC::Wasm::AirIRGenerator::addRethrow):
(JSC::Wasm::AirIRGenerator::emitCallPatchpoint):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmCallingConvention.h:
(JSC::Wasm::WasmCallingConvention::marshallLocation const):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isValueType):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser::TypedExpression::dump const):
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::callInformationForCaller):
(JSC::Wasm::LLIntGenerator::callInformationForCallee):
(JSC::Wasm::LLIntGenerator::addArguments):
(JSC::Wasm::LLIntGenerator::addCatchToUnreachable):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseImmByteArray16):
(JSC::Wasm::Parser&lt;SuccessType&gt;::parseImmLaneIdx):
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::triggerOMGEntryTierUpThunkGenerator):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::scalarType):
(JSC::Wasm::typeKindSizeInBytes):
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::set):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/255931@main">https://commits.webkit.org/255931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e644436e2522caddddf239e43ea27b59fca6059c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93747 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103391 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163713 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2958 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31195 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99423 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2105 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80187 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29132 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72086 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85005 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37591 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17590 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80130 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35440 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18850 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27656 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41404 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82773 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38081 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18714 "Passed tests") | 
<!--EWS-Status-Bubble-End-->