### PR TITLE
[GTK] -Wunused-function warnings when building with GTK 4

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp
@@ -827,7 +827,7 @@ static void testDownloadEphemeralContext(Test* test, gconstpointer)
     g_file_delete(destFile.get(), nullptr, nullptr);
 }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) && !USE(GTK4)
 static void testContextMenuDownloadActions(WebViewDownloadTest* test, gconstpointer)
 {
     test->showInWindow();
@@ -858,7 +858,9 @@ static void testContextMenuDownloadActions(WebViewDownloadTest* test, gconstpoin
     g_assert_cmpint(g_file_info_get_size(downloadFileInfo.get()), >, 0);
     g_file_delete(downloadFile.get(), nullptr, nullptr);
 }
+#endif // PLATFORM(GTK) && !USE(GTK4)
 
+#if PLATFORM(GTK)
 static void testBlobDownload(WebViewDownloadTest* test, gconstpointer)
 {
     test->showInWindow();

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestOptionMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestOptionMenu.cpp
@@ -28,6 +28,7 @@ using PlatformRectangle = GdkRectangle;
 using PlatformRectangle = WebKitRectangle;
 #endif
 
+#if !PLATFORM(GTK) || !USE(GTK4)
 class OptionMenuTest : public WebViewTest {
 public:
     MAKE_GLIB_TEST_FIXTURE(OptionMenuTest);
@@ -301,11 +302,12 @@ static void testOptionMenuSelect(OptionMenuTest* test, gconstpointer)
     g_assert_nonnull(result);
     g_assert_cmpfloat(WebViewTest::javascriptResultToNumber(result), ==, 1);
 }
+#endif // !PLATFORM(GTK) || !USE(GTK4)
 
 void beforeAll()
 {
 #if !PLATFORM(GTK) || !USE(GTK4)
-    // FIXME: Rework option menu API in GTK4 to not expose GdkEvent.
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=246716
     OptionMenuTest::add("WebKitWebView", "option-menu-simple", testOptionMenuSimple);
     OptionMenuTest::add("WebKitWebView", "option-menu-groups", testOptionMenuGroups);
     OptionMenuTest::add("WebKitWebView", "option-menu-activate", testOptionMenuActivate);


### PR DESCRIPTION
#### 40b5b869ceceb107925027310108cb33122122d7
<pre>
[GTK] -Wunused-function warnings when building with GTK 4
<a href="https://bugs.webkit.org/show_bug.cgi?id=246713">https://bugs.webkit.org/show_bug.cgi?id=246713</a>

Reviewed by Yusuke Suzuki.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestOptionMenu.cpp:
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/255760@main">https://commits.webkit.org/255760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5477d8d5e8001f6d95a12b6ddb7fecc05eb6537

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103159 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163479 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2704 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30989 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85858 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1908 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79945 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83829 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37369 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35200 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3983 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39076 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37920 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->