### PR TITLE
Move FrameIdentifier from Frame to AbstractFrame

### DIFF
--- a/Source/WebCore/page/AbstractFrame.cpp
+++ b/Source/WebCore/page/AbstractFrame.cpp
@@ -33,8 +33,9 @@
 
 namespace WebCore {
 
-AbstractFrame::AbstractFrame(Page& page, HTMLFrameOwnerElement* ownerElement)
+AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement)
     : m_page(page)
+    , m_frameID(frameID)
     , m_treeNode(*this, ownerElement ? ownerElement->document().frame() : nullptr)
     , m_windowProxy(WindowProxy::create(*this))
 {

--- a/Source/WebCore/page/AbstractFrame.h
+++ b/Source/WebCore/page/AbstractFrame.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FrameIdentifier.h"
 #include "FrameTree.h"
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -49,17 +50,19 @@ public:
     const WindowProxy& windowProxy() const { return m_windowProxy; }
     AbstractDOMWindow* window() const { return virtualWindow(); }
     FrameTree& tree() const { return m_treeNode; }
+    FrameIdentifier frameID() const { return m_frameID; }
     WEBCORE_EXPORT Page* page() const;
     WEBCORE_EXPORT void detachFromPage();
 
 protected:
-    AbstractFrame(Page&, HTMLFrameOwnerElement*);
+    AbstractFrame(Page&, FrameIdentifier, HTMLFrameOwnerElement*);
     void resetWindowProxy();
 
 private:
     virtual AbstractDOMWindow* virtualWindow() const = 0;
 
     WeakPtr<Page> m_page;
+    const FrameIdentifier m_frameID;
     mutable FrameTree m_treeNode;
     Ref<WindowProxy> m_windowProxy;
 };

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -151,12 +151,11 @@ static inline float parentTextZoomFactor(Frame* frame)
 }
 
 Frame::Frame(Page& page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoaderClient>&& frameLoaderClient)
-    : AbstractFrame(page, ownerElement)
+    : AbstractFrame(page, FrameIdentifier::generate(), ownerElement)
     , m_mainFrame(ownerElement ? page.mainFrame() : *this)
     , m_settings(&page.settings())
     , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(frameLoaderClient)))
     , m_navigationScheduler(makeUniqueRef<NavigationScheduler>(*this))
-    , m_frameID(FrameIdentifier::generate())
     , m_ownerElement(ownerElement)
     , m_script(makeUniqueRef<ScriptController>(*this))
     , m_pageZoomFactor(parentPageZoomFactor(this))

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -30,7 +30,6 @@
 #include "AbstractFrame.h"
 #include "AdjustViewSizeOrNot.h"
 #include "Document.h"
-#include "FrameIdentifier.h"
 #include "PageIdentifier.h"
 #include "ScrollTypes.h"
 #include "UserScriptTypes.h"
@@ -163,7 +162,6 @@ public:
     void resetScript();
 
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
-    FrameIdentifier frameID() const { return m_frameID; }
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
     WEBCORE_EXPORT RenderWidget* ownerRenderer() const; // Renderer for the element that contains this frame.
@@ -320,7 +318,6 @@ private:
     const RefPtr<Settings> m_settings;
     UniqueRef<FrameLoader> m_loader;
     mutable UniqueRef<NavigationScheduler> m_navigationScheduler;
-    const FrameIdentifier m_frameID;
 
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_ownerElement;
     RefPtr<FrameView> m_view;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -30,8 +30,8 @@
 
 namespace WebCore {
 
-RemoteFrame::RemoteFrame(Page& page, GlobalFrameIdentifier&& frameIdentifier)
-    : AbstractFrame(page, nullptr)
+RemoteFrame::RemoteFrame(Page& page, FrameIdentifier frameID, GlobalFrameIdentifier&& frameIdentifier)
+    : AbstractFrame(page, frameID, nullptr)
     , m_identifier(WTFMove(frameIdentifier))
 {
 }

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -39,9 +39,9 @@ class RemoteDOMWindow;
 // and FrameTree::m_thisFrame is an AbstractFrame&. Otherwise we will have some invalid pointer use.
 class RemoteFrame final : public AbstractFrame {
 public:
-    static Ref<RemoteFrame> create(Page& page, GlobalFrameIdentifier&& frameIdentifier)
+    static Ref<RemoteFrame> create(Page& page, FrameIdentifier frameID, GlobalFrameIdentifier&& frameIdentifier)
     {
-        return adoptRef(* new RemoteFrame(page, WTFMove(frameIdentifier)));
+        return adoptRef(*new RemoteFrame(page, frameID, WTFMove(frameIdentifier)));
     }
     ~RemoteFrame();
 
@@ -54,7 +54,7 @@ public:
     AbstractFrame* opener() const { return m_opener.get(); }
 
 private:
-    WEBCORE_EXPORT explicit RemoteFrame(Page&, GlobalFrameIdentifier&&);
+    WEBCORE_EXPORT explicit RemoteFrame(Page&, FrameIdentifier, GlobalFrameIdentifier&&);
 
     bool isRemoteFrame() const final { return true; }
     bool isLocalFrame() const final { return false; }


### PR DESCRIPTION
#### dc8fb828be5c80536ff1dddc10a7dbba1cf945a9
<pre>
Move FrameIdentifier from Frame to AbstractFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=246758">https://bugs.webkit.org/show_bug.cgi?id=246758</a>
rdar://101347931

Reviewed by Chris Dumez.

* Source/WebCore/page/AbstractFrame.cpp:
(WebCore::AbstractFrame::AbstractFrame):
* Source/WebCore/page/AbstractFrame.h:
(WebCore::AbstractFrame::frameID const):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::RemoteFrame):
* Source/WebCore/page/RemoteFrame.h:

Canonical link: <a href="https://commits.webkit.org/255756@main">https://commits.webkit.org/255756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02899a21b8f143312a732f7394723da5658a0356

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103160 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163480 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2705 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/30990 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85859 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99158 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79946 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/28956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83832 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37370 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35201 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/18696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/3982 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39077 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1865 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37924 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->