### PR TITLE
Use min-intrinsic size to compute min-content size for non-replaced flex items.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4791,7 +4791,6 @@ webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/slotted-plac
 
 # aspect-ratio (some of these rely on contain-intrinsic-size)
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/abspos-014.html [ ImageOnlyFailure ]
-webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-004.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-038.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-002.html
@@ -10,9 +10,9 @@
 
 <div style="display: flex;">
   <!-- No transferred size suggestion since the flex item is non-replaced.
-       Content size suggestion is 50px because 50px is item's min-content size. -->
+       Content size suggestion is 100px because min-intrinsic width is 100px.
+  -->
   <div style="background: green; height: 100px; aspect-ratio: 1/2; flex-basis: 0;">
     <div style="width: 100px;"></div>
   </div>
-  <div style="background: green; height: 100px; width: 50px;"></div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-004.html
@@ -8,10 +8,9 @@
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
-<div style="background: green; width: 100px; height:50px;"></div>
 <div style="display: flex; flex-direction: column;">
   <!-- No transferred size suggestion since the flex item is non-replaced.
-       Content size suggestion is 50px because min-content size is 50px. -->
+       Content size suggestion is 100px because min-intrinsic height is 100px. -->
   <div style="background: green; width: 100px; aspect-ratio: 2/1; flex-basis: 0;">
     <div style="height: 100px;"></div>
   </div>

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1430,23 +1430,12 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
         LayoutUnit contentSize;
         Length childCrossSizeLength = crossSizeLengthForChild(MainOrPreferredSize, child);
 
+        bool canComputeSizeThroughAspectRatio = child.isRenderReplaced() && childHasComputableAspectRatio(child) && childCrossSizeIsDefinite(child, childCrossSizeLength);
 
-        
-        bool mainSizeAxisIsInline = mainAxisIsChildInlineAxis(child);
-        bool canComputeSizeThroughAspectRatio = childHasComputableAspectRatio(child) && childCrossSizeIsDefinite(child, childCrossSizeLength);
-        auto computeMinContentSize = [this](RenderBox &child) -> LayoutUnit {
-            return computeMainAxisExtentForChild(child, MinSize, Length(LengthType::MinContent)).value_or(0);
-        };
-        auto computeSizeThroughAspectRatio = [this, canComputeSizeThroughAspectRatio] (RenderBox &child, Length childCrossSizeLength) {
-            return canComputeSizeThroughAspectRatio ? computeMainSizeFromAspectRatioUsing(child, childCrossSizeLength) : 0_lu; 
-        };
-        
-        if (mainSizeAxisIsInline && canComputeSizeThroughAspectRatio)
-            contentSize = computeSizeThroughAspectRatio(child, childCrossSizeLength);
-        else if (mainSizeAxisIsInline)
-            contentSize = computeMinContentSize(child);
+        if (canComputeSizeThroughAspectRatio)
+            contentSize = computeMainSizeFromAspectRatioUsing(child, childCrossSizeLength);
         else
-            contentSize = std::max(computeSizeThroughAspectRatio(child, childCrossSizeLength), computeMinContentSize(child));
+            contentSize = computeMainAxisExtentForChild(child, MinSize, Length(LengthType::MinContent)).value_or(0_lu);
 
         if (childHasComputableAspectRatio(child) && (!crossSizeLengthForChild(MinSize, child).isAuto() || !crossSizeLengthForChild(MaxSize, child).isAuto()))
             contentSize = adjustChildSizeForAspectRatioCrossAxisMinAndMax(child, contentSize);


### PR DESCRIPTION
#### eaf5e543e50d3ece7200e2ba6c9b24347d654bd9
<pre>
Use min-intrinsic size to compute min-content size for non-replaced flex items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246755">https://bugs.webkit.org/show_bug.cgi?id=246755</a>
rdar://101346126

Reviewed by Rob Buis.

There has been a lot of conversation on computing the min-content size
for flex items when computing the content size suggestion. In
particular, there were potential issues when computing the min-content
size for non-replaced flex items that were given an aspect-ratio
property. This issue was brought up in the following CSSWG
conversation: <a href="https://github.com/w3c/csswg-drafts/issues/6794">https://github.com/w3c/csswg-drafts/issues/6794</a>

When the conversation was initially created, browsers all had different
behaviors. A patch was added to make WebKit behavior similar to the
behavior of Blink: <a href="https://github.com/WebKit/WebKit/pull/3025">https://github.com/WebKit/WebKit/pull/3025</a>
The patch added behavior to take the aspect ratio into consideration
when computing these sizes.

This behavior ended up being incorrect by the time consensus was
reached. The final decision seems to be that we should be computing
the min-intrinsic size, which does not take into consideration the
aspect-ratio and is just based off of the content. The idea of the
min-intrinsic size was introduced here: <a href="https://github.com/w3c/csswg-drafts/issues/5305">https://github.com/w3c/csswg-drafts/issues/5305</a>
Since our initial behavior was close to the behavior that was eventually
agreed upon, this patch ends up being mostly a revert. It is not
completely a revert, however, since there are still some pieces left in
from the initial patch.

If the item is a replaced element, we will start take into consideration
the aspect-ratio and compute the size using
computeMainSizeFromAspectRatioUsing. If the item is a non-replaced
element, instead we will compute the size using
computeMainAxisExtentForChild. This will compute the min-intrinsic
size by calling either child.computeLogicalWidthInFragmentUsing or
child.computeContentLogicalHeight.

Spec reference: <a href="https://drafts.csswg.org/css-flexbox-1/#min-size-auto">https://drafts.csswg.org/css-flexbox-1/#min-size-auto</a>
Follow up discussion: <a href="https://github.com/web-platform-tests/interop/issues/139">https://github.com/web-platform-tests/interop/issues/139</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-004.html:
Newest version of the tests

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeFlexItemMinMaxSizes):

Canonical link: <a href="https://commits.webkit.org/255858@main">https://commits.webkit.org/255858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b3bab7961ef00ad4089f55179269e2a83a974e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103415 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163734 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2982 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31216 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86105 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2123 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80207 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29151 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84049 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72106 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37611 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17600 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35463 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18860 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4046 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41422 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38091 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->