### PR TITLE
WebFrame should own an AbstractFrame instead of a Frame

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -203,7 +203,7 @@ public:
 private:
     WebFrame(WebPage&);
 
-    WeakPtr<WebCore::Frame> m_coreFrame;
+    WeakPtr<WebCore::AbstractFrame> m_coreFrame;
     WeakPtr<WebPage> m_page;
 
     struct PolicyCheck {


### PR DESCRIPTION
#### 5279fe3e185ec4c931e46135eec6355fd6b7560b
<pre>
WebFrame should own an AbstractFrame instead of a Frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=246774">https://bugs.webkit.org/show_bug.cgi?id=246774</a>
rdar://101355716

Reviewed by Chris Dumez.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::initWithCoreMainFrame):
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::frameLoaderClient const):
(WebKit::WebFrame::coreFrame const):
(WebKit::WebFrame::info const):
(WebKit::WebFrame::didReceivePolicyDecision):
(WebKit::WebFrame::addConsoleMessage):
(WebKit::WebFrame::source const):
(WebKit::WebFrame::contentsAsString const):
(WebKit::WebFrame::selectionAsString const):
(WebKit::WebFrame::size const):
(WebKit::WebFrame::isFrameSet const):
(WebKit::WebFrame::isMainFrame const):
(WebKit::WebFrame::url const):
(WebKit::WebFrame::certificateInfo const):
(WebKit::WebFrame::innerText const):
(WebKit::WebFrame::parentFrame const):
(WebKit::WebFrame::layerTreeAsText const):
(WebKit::WebFrame::pendingUnloadCount const):
(WebKit::WebFrame::allowsFollowingLink const):
(WebKit::WebFrame::jsContext):
(WebKit::WebFrame::jsContextForWorld):
(WebKit::WebFrame::jsContextForServiceWorkerWorld):
(WebKit::WebFrame::setAccessibleName):
(WebKit::WebFrame::contentBounds const):
(WebKit::WebFrame::visibleContentBounds const):
(WebKit::WebFrame::visibleContentBoundsExcludingScrollbars const):
(WebKit::WebFrame::scrollOffset const):
(WebKit::WebFrame::hasHorizontalScrollbar const):
(WebKit::WebFrame::hasVerticalScrollbar const):
(WebKit::WebFrame::hitTest const):
(WebKit::WebFrame::getDocumentBackgroundColor):
(WebKit::WebFrame::containsAnyFormElements const):
(WebKit::WebFrame::containsAnyFormControls const):
(WebKit::WebFrame::stopLoading):
(WebKit::WebFrame::jsWrapperForWorld):
(WebKit::WebFrame::provisionalURL const):
(WebKit::WebFrame::suggestedFilenameForResourceWithURL const):
(WebKit::WebFrame::mimeTypeForResourceWithURL const):
(WebKit::WebFrame::setTextDirection):
(WebKit::WebFrame::isTopFrameNavigatingToAppBoundDomain const):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:

Canonical link: <a href="https://commits.webkit.org/255765@main">https://commits.webkit.org/255765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e26f7eeaea4547312168726e47f22d8050678146

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2728 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103189 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2739 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99194 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/79979 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35234 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39109 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1869 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41046 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->