### PR TITLE
Web Inspector: Support editing @rules in the Styles sidebar

### DIFF
--- a/LayoutTests/inspector/css/generateFormattedText-expected.txt
+++ b/LayoutTests/inspector/css/generateFormattedText-expected.txt
@@ -50,8 +50,8 @@ a: 1; b: 2; c: 3;
 a: 1; b: 2; c: 3;
 
 -- Running test case: CSS.generateFormattedText.MatchedRules.includeGroupingsAndSelectors
-@media only screen and (min-width: 0px) {@media only screen and (min-height: 0px) {body > div#test-node {a: 1; b: 2; c: 3;}}}
-@media only screen and (min-width: 0px) {body > #test-node {a: 1; b: 2; c: 3;}}
+@media only screen and (min-width:0px) {@media only screen and (min-height:0px) {body > div#test-node {a: 1; b: 2; c: 3;}}}
+@media only screen and (min-width:0px) {body > #test-node {a: 1; b: 2; c: 3;}}
 body > div {a: 1; b: 2; c: 3;}
 body > * {a: 1; b: 2; c: 3;}
 * {a: 1; b: 2; c: 3;}
@@ -84,8 +84,8 @@ body > * {a: 1; b: 2; c: 3;}
 
 
 -- Running test case: CSS.generateFormattedText.MatchedRules.includeGroupingsAndSelectors.Multiline
-@media only screen and (min-width: 0px) {
-    @media only screen and (min-height: 0px) {
+@media only screen and (min-width:0px) {
+    @media only screen and (min-height:0px) {
         body > div#test-node {
             a: 1;
             b: 2;
@@ -93,7 +93,7 @@ body > * {a: 1; b: 2; c: 3;}
         }
     }
 }
-@media only screen and (min-width: 0px) {
+@media only screen and (min-width:0px) {
     body > #test-node {
         a: 1;
         b: 2;
@@ -124,8 +124,8 @@ a: 1; /* b: 2; */ c: 3;
 a: 1; /* b: 2; */ c: 3;
 
 -- Running test case: CSS.generateFormattedText.MatchedRules.WithCommentedProperties.includeGroupingsAndSelectors
-@media only screen and (min-width: 0px) {@media only screen and (min-height: 0px) {body > div#test-node {a: 1; /* b: 2; */ c: 3;}}}
-@media only screen and (min-width: 0px) {body > #test-node {a: 1; /* b: 2; */ c: 3;}}
+@media only screen and (min-width:0px) {@media only screen and (min-height:0px) {body > div#test-node {a: 1; /* b: 2; */ c: 3;}}}
+@media only screen and (min-width:0px) {body > #test-node {a: 1; /* b: 2; */ c: 3;}}
 body > div {a: 1; /* b: 2; */ c: 3;}
 body > * {a: 1; /* b: 2; */ c: 3;}
 * {a: 1; /* b: 2; */ c: 3;}
@@ -158,8 +158,8 @@ body > * {a: 1; /* b: 2; */ c: 3;}
 
 
 -- Running test case: CSS.generateFormattedText.MatchedRules.WithCommentedProperties.includeGroupingsAndSelectors.Multiline
-@media only screen and (min-width: 0px) {
-    @media only screen and (min-height: 0px) {
+@media only screen and (min-width:0px) {
+    @media only screen and (min-height:0px) {
         body > div#test-node {
             a: 1;
             /* b: 2; */
@@ -167,7 +167,7 @@ body > * {a: 1; /* b: 2; */ c: 3;}
         }
     }
 }
-@media only screen and (min-width: 0px) {
+@media only screen and (min-width:0px) {
     body > #test-node {
         a: 1;
         /* b: 2; */

--- a/LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt
@@ -998,7 +998,9 @@ Inherited:
           "groupings": [
             {
               "type": "media-rule",
+              "ruleId": "<filtered>",
               "text": "(min-width: 1px)",
+              "range": "<filtered>",
               "sourceURL": "<filtered>"
             }
           ]
@@ -1048,12 +1050,16 @@ Inherited:
           "groupings": [
             {
               "type": "supports-rule",
+              "ruleId": "<filtered>",
               "text": "(display: block)",
+              "range": "<filtered>",
               "sourceURL": "<filtered>"
             },
             {
               "type": "media-rule",
+              "ruleId": "<filtered>",
               "text": "(min-width: 2px)",
+              "range": "<filtered>",
               "sourceURL": "<filtered>"
             }
           ]

--- a/LayoutTests/inspector/css/setGroupingHeaderText-expected.txt
+++ b/LayoutTests/inspector/css/setGroupingHeaderText-expected.txt
@@ -1,0 +1,188 @@
+Tests for the CSS.setGroupingHeaderText command.
+
+
+== Running test suite: CSS.setGroupingHeaderText
+-- Running test case: CSS.setGroupingHeaderText.MediaRule
+PASS: Should have 2 authored rule.
+PASS: Should find grouping of type 'media-rule'.
+Setting text to 'not print'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(max-width: 9999px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'screen and (max-width: 9999px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'screen, (max-width: 9999px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'not all'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(totally-not-supported-but-valid-syntactivally: 42em)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'invalidkeyword, (max-width: 9999px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(max-width: 9999px), invalidkeyword'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'screen {} @media screen'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to ''.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'screen'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+
+-- Running test case: CSS.setGroupingHeaderText.SupportsRule
+PASS: Should have 2 authored rule.
+PASS: Should find grouping of type 'supports-rule'.
+Setting text to '(color: purple)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(color: purple) and (color: green)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'selector(h2 > p)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'not (display: grid)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'not (not (display: grid))'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'not (not (not (display: grid)))'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(totally-not-supported-but-valid-syntactivally: 42em)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'not all'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '|| and (max-width: 9999px)'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '(max-width: 9999px) and ||'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '(color: red) {} @supports(color: red)'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to ''.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '(color: red)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+
+-- Running test case: CSS.setGroupingHeaderText.LayerRule
+PASS: Should have 2 authored rule.
+PASS: Should find grouping of type 'layer-rule'.
+Setting text to 'howdy'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'hello.howdy'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'hello, howdy'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'hello howdy'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'hello {} @layer hello'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to ''.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'hello'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+
+-- Running test case: CSS.setGroupingHeaderText.ContainerRule
+PASS: Should have 2 authored rule.
+PASS: Should find grouping of type 'container-rule'.
+Setting text to 'name (min-width: 42px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(max-width: 9999px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to '(totally-not-supported-but-valid-syntactivally: 42em)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+Setting text to 'screen and (max-width: 9999px)'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'screen, (max-width: 9999px)'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'not all'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to 'invalidkeyword, (max-width: 9999px)'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '(max-width: 9999px), invalidkeyword'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '(min-width:1px) {} @container(min-width:1px)'.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to ''.
+PASS: Setting text should fail.
+PASS: Text should not change.
+PASS: Text should not change on the same grouping attached to a different rule.
+Setting text to '(min-width: 1px)'.
+PASS: Setting text should succeed.
+PASS: Text should change.
+PASS: Text should change on the same grouping attached to a different rule.
+

--- a/LayoutTests/inspector/css/setGroupingHeaderText.html
+++ b/LayoutTests/inspector/css/setGroupingHeaderText.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.setGroupingHeaderText");
+
+    function addTestCase({name, description, groupingType, subtestCases})
+    {
+        suite.addTestCase({
+            name,
+            description,
+            async test() {
+                let documentNode = await WI.domManager.requestDocument();
+                let nodeId = await documentNode.querySelector("#test");
+                let domNode = WI.domManager.nodeForId(nodeId);
+                InspectorTest.assert(domNode, `Should find DOM Node for selector '#test'.`);
+
+                let domNodeStyles = WI.cssManager.stylesForNode(domNode);
+                InspectorTest.assert(domNodeStyles, `Should find CSS Styles for DOM Node.`);
+                await domNodeStyles.refreshIfNeeded();
+
+                let authoredRules = domNodeStyles.matchedRules.filter((rule) => rule.type === WI.CSSStyleSheet.Type.Author);
+                InspectorTest.expectEqual(authoredRules.length, 2, `Should have 2 authored rule.`);
+
+                let grouping = authoredRules[0].groupings.find((grouping) => grouping.type === groupingType);
+                let sameGroupingAttachedToADifferentRule = authoredRules[1].groupings.find((grouping) => grouping.type === groupingType);
+
+                InspectorTest.expectNotNull(grouping, `Should find grouping of type '${groupingType}'.`);
+
+                // Restore the current text so that the next grouping type is able to resolve the style again.
+                subtestCases.push({text: grouping.text});
+
+                for (let test of subtestCases) {
+                    let initialText = grouping.text;
+                    let didFail = false;
+
+                    InspectorTest.log(`Setting text to '${test.text}'.`);
+                    await grouping.setText(test.text).catch(() => {
+                        didFail = true;
+                    });
+
+                    if (test.expectsFailure) {
+                        InspectorTest.expectTrue(didFail, "Setting text should fail.");
+                        InspectorTest.expectEqual(grouping.text, initialText, "Text should not change.");
+                        InspectorTest.expectEqual(sameGroupingAttachedToADifferentRule.text, initialText, "Text should not change on the same grouping attached to a different rule.");
+                        continue;
+                    }
+
+                    InspectorTest.expectFalse(didFail, "Setting text should succeed.");
+                    InspectorTest.expectEqual(grouping.text, test.text, "Text should change.");
+                    InspectorTest.expectEqual(sameGroupingAttachedToADifferentRule.text, test.text, "Text should change on the same grouping attached to a different rule.");
+                }
+            },
+        });
+    }
+
+    addTestCase({
+        name: "CSS.setGroupingHeaderText.MediaRule",
+        description: "@media rules should be mutable and should only accept syntactically correct text.",
+        groupingType: WI.CSSGrouping.Type.MediaRule,
+        subtestCases: [
+            { text: "not print" },
+            { text: "(max-width: 9999px)" },
+            { text: "screen and (max-width: 9999px)" },
+            { text: "screen, (max-width: 9999px)" },
+            { text: "not all" },
+            { text: "(totally-not-supported-but-valid-syntactivally: 42em)" },
+            { text: "invalidkeyword, (max-width: 9999px)"},
+            { text: "(max-width: 9999px), invalidkeyword"},
+            { text: "screen {} @media screen", expectsFailure: true },
+            { text: "", expectsFailure: true },
+        ],
+    });
+
+    addTestCase({
+        name: "CSS.setGroupingHeaderText.SupportsRule",
+        description: "@supports rules should be mutable and should only accept syntactically correct text.",
+        groupingType: WI.CSSGrouping.Type.SupportsRule,
+        subtestCases: [
+            { text: "(color: purple)" },
+            { text: "(color: purple) and (color: green)" },
+            { text: "selector(h2 > p)" },
+            { text: "not (display: grid)" },
+            { text: "not (not (display: grid))" },
+            { text: "not (not (not (display: grid)))" },
+            { text: "(totally-not-supported-but-valid-syntactivally: 42em)" },
+            { text: "not all", expectsFailure: true },
+            { text: "|| and (max-width: 9999px)", expectsFailure: true },
+            { text: "(max-width: 9999px) and ||", expectsFailure: true },
+            { text: "(color: red) {} @supports(color: red)", expectsFailure: true },
+            { text: "", expectsFailure: true },
+        ],
+    });
+
+    addTestCase({
+        name: "CSS.setGroupingHeaderText.LayerRule",
+        description: "@layer rules should be mutable and should only accept syntactically correct text.",
+        groupingType: WI.CSSGrouping.Type.LayerRule,
+        subtestCases: [
+            { text: "howdy" },
+            { text: "hello.howdy" },
+            { text: "hello, howdy", expectsFailure: true },
+            { text: "hello howdy", expectsFailure: true },
+            { text: "hello {} @layer hello", expectsFailure: true },
+            { text: "", expectsFailure: true },
+        ],
+    });
+
+    addTestCase({
+        name: "CSS.setGroupingHeaderText.ContainerRule",
+        description: "@container rules should be mutable and should only accept syntactically correct text.",
+        groupingType: WI.CSSGrouping.Type.ContainerRule,
+        subtestCases: [
+            { text: "name (min-width: 42px)" },
+            { text: "(max-width: 9999px)" },
+            { text: "(totally-not-supported-but-valid-syntactivally: 42em)" },
+            { text: "screen and (max-width: 9999px)", expectsFailure: true },
+            { text: "screen, (max-width: 9999px)", expectsFailure: true },
+            { text: "not all", expectsFailure: true },
+            { text: "invalidkeyword, (max-width: 9999px)", expectsFailure: true },
+            { text: "(max-width: 9999px), invalidkeyword", expectsFailure: true },
+            { text: "(min-width:1px) {} @container(min-width:1px)", expectsFailure: true },
+            { text: "", expectsFailure: true },
+        ],
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<style>
+    body {
+        container-type: size;
+    }
+
+    @supports(color: red) {
+        @layer hello {
+            @media screen {
+                @container (min-width: 1px) {
+                    #test {
+                        color: lawngreen;
+                    }
+
+                    .test {
+                        color: papayawhip;
+                    }
+                }
+            }
+        }
+    }
+</style>
+</head>
+<body onload="runTest()">
+    <p>Tests for the CSS.setGroupingHeaderText command.</p>
+    <div id="test" class="test"></div>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -243,8 +243,10 @@
             "description": "CSS @media (as well as other users of media queries, like @import, <style>, <link>, etc.), @supports, and @layer descriptor.",
             "properties": [
                 { "name": "type", "type": "string", "enum": ["media-rule", "media-import-rule", "media-link-node", "media-style-node", "supports-rule", "layer-rule", "layer-import-rule", "container-rule"], "description": "Source of the media query: \"media-rule\" if specified by a @media rule, \"media-import-rule\" if specified by an @import rule, \"media-link-node\" if specified by a \"media\" attribute in a linked style sheet's LINK tag, \"media-style-node\" if specified by a \"media\" attribute in an inline style sheet's STYLE tag, \"supports-rule\" if specified by an @supports rule, \"layer-rule\" if specified by an @layer rule, \"container-rule\" if specified by an @container rule." },
+                { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier for the `@rule` (absent for non-editable grouping rules). In CSSOM terms, this is the parent rule of either the previous Grouping for a CSSRule, or of a CSSRule itself."},
                 { "name": "text", "type": "string", "optional": true, "description": "Query text if specified by a @media, @supports, or @container rule. Layer name (or not present for anonymous layers) for @layer rules." },
-                { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the CSS grouping." }
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the CSS grouping." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "@-rule's header text range in the enclosing stylesheet (if available). This is from the first non-whitespace character after the @ declarartion to the last non-whitespace character before an opening curly bracket or semicolon." }
             ]
         },
         {
@@ -400,6 +402,18 @@
             ],
             "returns": [
                 { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+            ]
+        },
+        {
+            "name": "setGroupingHeaderText",
+            "description": "Modifies an @rule grouping's header text.",
+            "targetTypes": ["page"],
+            "parameters": [
+                { "name": "ruleId", "$ref": "CSSRuleId" },
+                { "name": "headerText", "type": "string" }
+            ],
+            "returns": [
+                { "name": "grouping", "$ref": "Grouping", "description": "The resulting grouping after the header text modification." }
             ]
         },
         {

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -69,7 +69,7 @@ public:
     
     RefPtr<StyleRuleKeyframe> parseKeyframeRule(const String&);
     static Vector<double> parseKeyframeKeyList(const String&);
-    
+
     bool parseSupportsCondition(const String&);
 
     static void parseSheetForInspector(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserObserver&);

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -927,6 +927,8 @@ RefPtr<StyleRuleContainer> CSSParserImpl::consumeContainerRule(CSSParserTokenRan
     if (prelude.atEnd())
         return nullptr;
 
+    auto originalPreludeRange = prelude;
+
     auto query = ContainerQueryParser::consumeContainerQuery(prelude, m_context);
     if (!query)
         return nullptr;
@@ -938,8 +940,8 @@ RefPtr<StyleRuleContainer> CSSParserImpl::consumeContainerRule(CSSParserTokenRan
     Vector<RefPtr<StyleRuleBase>> rules;
 
     if (m_observerWrapper) {
-        m_observerWrapper->observer().startRuleHeader(StyleRuleType::Container, m_observerWrapper->startOffset(prelude));
-        m_observerWrapper->observer().endRuleHeader(m_observerWrapper->endOffset(prelude));
+        m_observerWrapper->observer().startRuleHeader(StyleRuleType::Container, m_observerWrapper->startOffset(originalPreludeRange));
+        m_observerWrapper->observer().endRuleHeader(m_observerWrapper->endOffset(originalPreludeRange));
         m_observerWrapper->observer().startRuleBody(m_observerWrapper->previousTokenStartOffset(block));
     }
 

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -102,6 +102,9 @@ public:
     bool supportsDeclaration(CSSParserTokenRange&);
     const CSSParserContext& context() const { return m_context; }
 
+    // This function updates the range it's given.
+    RefPtr<StyleRuleBase> consumeAtRule(CSSParserTokenRange&, AllowedRulesType);
+
     static void parseDeclarationListForInspector(const String&, const CSSParserContext&, CSSParserObserver&);
     static void parseStyleSheetForInspector(const String&, const CSSParserContext&, StyleSheetContents*, CSSParserObserver&);
 
@@ -121,8 +124,7 @@ private:
     template<typename T>
     bool consumeRuleList(CSSParserTokenRange, RuleListType, T callback);
 
-    // These two functions update the range they're given
-    RefPtr<StyleRuleBase> consumeAtRule(CSSParserTokenRange&, AllowedRulesType);
+    // This function updates the range it's given.
     RefPtr<StyleRuleBase> consumeQualifiedRule(CSSParserTokenRange&, AllowedRulesType);
 
     static RefPtr<StyleRuleCharset> consumeCharsetRule(CSSParserTokenRange prelude);

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -88,8 +88,6 @@ public:
         ContentSecurityPolicy* m_contentSecurityPolicy;
     };
 
-    static CSSStyleRule* asCSSStyleRule(CSSRule&);
-
     static std::optional<Inspector::Protocol::CSS::PseudoId> protocolValueForPseudoId(PseudoId);
 
     // InspectorAgentBase
@@ -109,6 +107,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> setStyleSheetText(const Inspector::Protocol::CSS::StyleSheetId&, const String& text);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSStyle>> setStyleText(Ref<JSON::Object>&& styleId, const String& text);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> setRuleSelector(Ref<JSON::Object>&& ruleId, const String& selector);
+    Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::Grouping>> setGroupingHeaderText(Ref<JSON::Object>&& ruleId, const String& headerText);
     Inspector::Protocol::ErrorStringOr<Inspector::Protocol::CSS::StyleSheetId> createStyleSheet(const Inspector::Protocol::Network::FrameId&);
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> addRule(const Inspector::Protocol::CSS::StyleSheetId&, const String& selector);
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> getSupportedCSSProperties();
@@ -148,7 +147,7 @@ private:
     class StyleSheetAction;
     class SetStyleSheetTextAction;
     class SetStyleTextAction;
-    class SetRuleSelectorAction;
+    class SetRuleHeaderTextAction;
     class AddRuleAction;
 
     typedef HashMap<Inspector::Protocol::CSS::StyleSheetId, RefPtr<InspectorStyleSheet>> IdToInspectorStyleSheet;

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -878,7 +878,7 @@
     <script src="Views/SpreadsheetCSSStyleDeclarationEditor.js"></script>
     <script src="Views/SpreadsheetCSSStyleDeclarationSection.js"></script>
     <script src="Views/SpreadsheetRulesStyleDetailsPanel.js"></script>
-    <script src="Views/SpreadsheetSelectorField.js"></script>
+    <script src="Views/SpreadsheetRuleHeaderField.js"></script>
     <script src="Views/SpreadsheetStyleProperty.js"></script>
     <script src="Views/SpreadsheetTextField.js"></script>
     <script src="Views/StyleOriginView.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
@@ -141,11 +141,11 @@
     content: url(../Images/Locked.svg);
 }
 
-.spreadsheet-css-declaration .selector.spreadsheet-selector-field {
+.spreadsheet-css-declaration :is(.selector, .grouping).spreadsheet-rule-header-field {
     outline: none;
 }
 
-.spreadsheet-css-declaration .selector.spreadsheet-selector-field.editing {
+.spreadsheet-css-declaration :is(.selector, .grouping).spreadsheet-rule-header-field.editing {
     display: inline-block;
     box-shadow: hsla(0, 0%, 0%, 0.5) 0 1px 3px;
     outline: none !important;

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRuleHeaderField.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRuleHeaderField.js
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
+WI.SpreadsheetRuleHeaderField = class SpreadsheetRuleHeaderField extends WI.Object
 {
     constructor(delegate, element)
     {
@@ -31,7 +31,7 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
 
         this._delegate = delegate;
         this._element = element;
-        this._element.classList.add("spreadsheet-selector-field");
+        this._element.classList.add("spreadsheet-rule-header-field");
 
         this._element.addEventListener("mousedown", this._handleMouseDown.bind(this));
         this._element.addEventListener("mouseup", this._handleMouseUp.bind(this));
@@ -45,6 +45,7 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
 
     // Public
 
+    get element() { return this._element; }
     get editing() { return this._editing; }
 
     startEditing()
@@ -66,7 +67,7 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
 
         this._selectText();
 
-        this.dispatchEventToListeners(WI.SpreadsheetSelectorField.Event.StartedEditing);
+        this.dispatchEventToListeners(WI.SpreadsheetRuleHeaderField.Event.StartedEditing);
     }
 
     stopEditing()
@@ -79,7 +80,7 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
         this._element.classList.remove("editing");
         this._element.contentEditable = false;
 
-        this.dispatchEventToListeners(WI.SpreadsheetSelectorField.Event.StoppedEditing);
+        this.dispatchEventToListeners(WI.SpreadsheetRuleHeaderField.Event.StoppedEditing);
     }
 
     // Private
@@ -110,9 +111,9 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
         if (document.activeElement === this._element)
             return;
 
-        if (this._delegate && typeof this._delegate.spreadsheetSelectorFieldDidCommit === "function") {
+        if (this._delegate?.spreadsheetRuleHeaderFieldDidCommit) {
             let changed = this._element.textContent !== this._valueBeforeEditing;
-            this._delegate.spreadsheetSelectorFieldDidCommit(changed);
+            this._delegate.spreadsheetRuleHeaderFieldDidCommit(this, changed);
         }
 
         this.stopEditing();
@@ -133,9 +134,9 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
         if (event.key === "Enter" || event.key === "Tab") {
             event.stop();
 
-            if (this._delegate && typeof this._delegate.spreadsheetSelectorFieldWillNavigate === "function") {
+            if (this._delegate?.spreadsheetRuleHeaderFieldWillNavigate) {
                 let direction = (event.shiftKey && event.key === "Tab") ? "backward" : "forward";
-                this._delegate.spreadsheetSelectorFieldWillNavigate(direction);
+                this._delegate.spreadsheetRuleHeaderFieldWillNavigate(this, direction);
             }
             this.stopEditing();
             return;
@@ -146,13 +147,12 @@ WI.SpreadsheetSelectorField = class SpreadsheetSelectorField extends WI.Object
 
             this.stopEditing();
 
-            if (this._delegate && typeof this._delegate.spreadsheetSelectorFieldDidDiscard === "function")
-                this._delegate.spreadsheetSelectorFieldDidDiscard();
+            this._delegate?.spreadsheetRuleHeaderFieldDidDiscard?.(this);
         }
     }
 };
 
-WI.SpreadsheetSelectorField.Event = {
-    StartedEditing: "spreadsheet-selector-field-started-editing",
-    StoppedEditing: "spreadsheet-selector-field-stopped-editing",
+WI.SpreadsheetRuleHeaderField.Event = {
+    StartedEditing: "spreadsheet-rule-header-field-started-editing",
+    StoppedEditing: "spreadsheet-rule-header-field-stopped-editing",
 };

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetRulesStyleDetailsPanel.js
@@ -42,7 +42,7 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
         this._propertyToSelectAndHighlight = null;
         this._filterText = null;
         this._shouldRefreshSubviews = false;
-        this._suppressLayoutAfterSelectorChange = false;
+        this._suppressLayoutAfterSelectorOrGroupChange = false;
 
         this._emptyFilterResultsElement = WI.createMessageTextView(WI.UIString("No Results Found"));
     }
@@ -228,8 +228,8 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
 
         this._shouldRefreshSubviews = false;
 
-        if (this._suppressLayoutAfterSelectorChange) {
-            this._suppressLayoutAfterSelectorChange = false;
+        if (this._suppressLayoutAfterSelectorOrGroupChange) {
+            this._suppressLayoutAfterSelectorOrGroupChange = false;
             return;
         }
 
@@ -276,7 +276,7 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
             if (!section) {
                 section = new WI.SpreadsheetCSSStyleDeclarationSection(this, style);
                 section.addEventListener(WI.SpreadsheetCSSStyleDeclarationSection.Event.FilterApplied, this._handleSectionFilterApplied, this);
-                section.addEventListener(WI.SpreadsheetCSSStyleDeclarationSection.Event.SelectorWillChange, this._handleSectionSelectorWillChange, this);
+                section.addEventListener(WI.SpreadsheetCSSStyleDeclarationSection.Event.SelectorOrGroupingWillChange, this._handleSectionSelectorOrGroupingWillChange, this);
                 style[SpreadsheetRulesStyleDetailsPanel.StyleSectionSymbol] = section;
             }
 
@@ -362,9 +362,9 @@ WI.SpreadsheetRulesStyleDetailsPanel = class SpreadsheetRulesStyleDetailsPanel e
         this.nodeStyles.addRule(this._newRuleSelector, text, stylesheetId);
     }
 
-    _handleSectionSelectorWillChange(event)
+    _handleSectionSelectorOrGroupingWillChange(event)
     {
-        this._suppressLayoutAfterSelectorChange = true;
+        this._suppressLayoutAfterSelectorOrGroupChange = true;
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js
@@ -49,7 +49,7 @@ WI.StyleOriginView = class StyleOriginView
                     ignoreSearchTab: true,
                 };
 
-                if (style.ownerStyleSheet.isInspectorStyleSheet()) {
+                if (style.ownerStyleSheet?.isInspectorStyleSheet()) {
                     options.nameStyle = WI.SourceCodeLocation.NameStyle.None;
                     options.prefix = WI.UIString("Inspector Style Sheet") + ":";
                 }


### PR DESCRIPTION
#### 33803c89a12929f179cf29e76afc037e6c5fdf85
<pre>
Web Inspector: Support editing @rules in the Styles sidebar
<a href="https://bugs.webkit.org/show_bug.cgi?id=246768">https://bugs.webkit.org/show_bug.cgi?id=246768</a>
rdar://99871652

Reviewed by Devin Rousso.

This work is best thought of in three interlocking pieces:
- Rework chunks of InspectorStyleSheet to allow us to determine source data for @rules, including the header range,
which is the range of the text between `@media` (and friends) and the opening curly bracket for the rule set.
- Generalizing setting a rule&apos;s selector to just be setting its header text so we can do so with non-style rules.
- Implement frontend support for editing these rules in the same way selectors are currently editable.

* LayoutTests/inspector/css/setGroupingHeaderText-expected.txt: Added.
* LayoutTests/inspector/css/setGroupingHeaderText.html: Added.

* LayoutTests/inspector/css/generateFormattedText-expected.txt:
* LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt:
- Rebaseline expectations for new CSS.Grouping properties.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
- Add rule ID to CSS.Grouping so that we can use it later to edit the header text of the grouping.
- Add method CSS.setGroupingHeaderText to change a CSS.Grouping&apos;s header text.

* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeContainerRule):
- Provide a correct header range by keeping a copy of the original prelude before consumption to use for informing the
observer.

* Source/WebCore/css/parser/CSSParserImpl.h:
- Expose `consumeAtRule` publicly for use in InspectorStyleSheet

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
- Move the logic for determining how we unflatten rules to a shared static method so that the source data and flat CSSOM
rule lists always consider the same set of rules in the same way.

(WebCore::parserContextForDocument):
(WebCore::isValidRuleHeaderText):
(WebCore::protocolGroupingTypeForStyleRuleType):
- Abstract logic that relies on rule type into static methods so that the various bits that need implemented when adding
an editable rule type are in close proximity to each other.

(WebCore::flattenSourceData):
(WebCore::ParsedStyleSheet::setSourceData):
- Use `flatteningStrategyForStyleRuleType` to determine how we should handle each piece of source data.

(WebCore::StyleSheetHandler::startRuleHeader):
(WebCore::StyleSheetHandler::setRuleHeaderEnd):
- Fix to never produce a range end that occurs before the range&apos;s start.

(WebCore::sourceURLForCSSRule):
(WebCore::InspectorStyleSheet::buildObjectForGrouping):
(WebCore::InspectorStyleSheet::buildArrayForGroupings):
- Split building the grouping array into a few discrete, reusable pieces. For the four types of rules we are making
editable, we will use `buildObjectForGrouping` to build those rule objects. For other real that are currently turned
into fake groupings, we leave the logic mostly intact (which means they are not editable).

(WebCore::InspectorStyleSheet::ruleHeaderText):
(WebCore::InspectorStyleSheet::setRuleHeaderText):
(WebCore::InspectorStyleSheet::ruleSelector): Deleted.
(WebCore::isValidSelectorListString): Deleted.
(WebCore::InspectorStyleSheet::setRuleSelector): Deleted.
- Setting a rule&apos;s header text and setting a rule&apos;s selector(s) are (except for some optimizations) the same operation.
For CSSStyleRule we still follow the existing logic of modifying a selector via CSSOM, which saves us from reparsing the
entire style sheet. For other rules, this is more complicated because our CSSOM implementation doesn&apos;t allow mutating
the header text, and changing these rules could change which rules apply to which nodes beyond just the rule we are
mutating.

(WebCore::InspectorStyleSheet::deleteRule):
(WebCore::InspectorStyleSheet::ruleForId const):
(WebCore::InspectorStyleSheet::cssStyleRulesSplitFromSameRule):
(WebCore::InspectorStyleSheet::buildObjectForSelectorList):
(WebCore::InspectorStyleSheet::buildObjectForRule):
(WebCore::InspectorStyleSheet::styleForId const):
(WebCore::InspectorStyleSheet::ruleOrStyleId const):
(WebCore::InspectorStyleSheet::ruleSourceDataFor const):
(WebCore::InspectorStyleSheet::ruleIndexByStyle const):
(WebCore::InspectorStyleSheet::buildArrayForRuleList):
(WebCore::InspectorStyleSheet::collectFlatRules):
(WebCore::InspectorStyleSheet::ruleId const): Deleted.
- Don&apos;t assume that a CSSRule will always be a CSSStyleRule.
- Allow both styles and rules to be used to look up the ID for a rule/style.

* Source/WebCore/inspector/InspectorStyleSheet.h:
(WebCore::InspectorStyleSheet::canBind const):
(WebCore::InspectorStyleSheet::styleId const): Deleted.

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::setRuleSelector):
(WebCore::InspectorCSSAgent::setGroupingHeaderText):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
- Generalize setting selectors to also support setting header text of @rules.

(WebCore::InspectorCSSAgent::addRule):
- Don&apos;t assume that all rules are CSSStyleRules.

(WebCore::InspectorCSSAgent::asCSSStyleRule): Deleted.
- Remove helper that was only used in a few places and is better served by a dynamicDowncast anyways.

* Source/WebInspectorUI/UserInterface/Main.html:

* Source/WebInspectorUI/UserInterface/Models/CSSGrouping.js:
(WI.CSSGrouping.prototype.get ownerStyleSheet):
(WI.CSSGrouping.prototype.get id):
(WI.CSSGrouping.prototype.get type):
(WI.CSSGrouping.prototype.get editable):
(WI.CSSGrouping.prototype.get text):
- Add necessary information for editing, which is mostly keeping track of our nodeStyles and ownerStyleSheet like style
rules do, and accepting an optional ID, which when present allows us to perform edits.

(WI.CSSGrouping.prototype.async setText):
- Handle setting the text for the grouping. For groupings that no longer apply after modification, we need to update the
current grouping object so that it is accurate to the current state, as it will remain visible to the user until they
switch to a different node.

* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles):
(WI.DOMNodeStyles.prototype.set ignoreNextContentDidChangeForStyleSheet):
(WI.DOMNodeStyles.prototype.refresh.fetchedMatchedStyles):
(WI.DOMNodeStyles.prototype._parseRulePayload):
- Parse the additional data in the payload to support editing.
- Use a shared representation of CSSGrouping&apos;s with an ID so that we can update the common representation during an
edit, thus allowing that same rule to update in all the locations it is visible for the current node. (It is not
necessary to update for other nodes, since they will have been invalidated by the stylesheet change and will reload
their styles.)

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css:
(.spreadsheet-css-declaration :is(.selector, .grouping).spreadsheet-rule-header-field):
(.spreadsheet-css-declaration :is(.selector, .grouping).spreadsheet-rule-header-field.editing):
- Style the grouping editor field the same way we style the selector editor field.

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.js:
(WI.SpreadsheetCSSStyleDeclarationSection):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.initialLayout):
- Remove logic that lays out the CSS groupings, since those are dynamic and may change on future updates.

(WI.SpreadsheetCSSStyleDeclarationSection.prototype.layout):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._layoutGroupings.this._groupingElements.groupings.map.):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._layoutGroupings):
- Update groupings when layout is called to get the latest information from DOMNodeStyles.
- No longer merge together adjacent @rules like multiple @media or @layer rules, as those rules are editable now, and we
need to accurately represent the author&apos;s rules.
- Associate a text field with the grouping header text when applicable to enable editing.

(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetRuleHeaderFieldDidCommit):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetRuleHeaderFieldWillNavigate):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetRuleHeaderFieldDidDiscard):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetSelectorFieldDidCommit): Deleted.
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetSelectorFieldWillNavigate): Deleted.
(WI.SpreadsheetCSSStyleDeclarationSection.prototype.spreadsheetSelectorFieldDidDiscard): Deleted.
- Share the delegate methods for the selector and the grouping fields.

(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetSelectorFieldStartedEditing):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetSelectorFieldStoppedEditing):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetSelectorFieldDidCommit):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetSelectorFieldWillNavigate):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetGroupingFieldDidCommit):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetGroupingFieldWillNavigate):
(WI.SpreadsheetCSSStyleDeclarationSection.prototype._handleSpreadsheetGroupingFieldDidDiscard):

* Source/WebInspectorUI/UserInterface/Views/SpreadsheetRuleHeaderField.js: Renamed from Source/WebInspectorUI/UserInterface/Views/SpreadsheetSelectorField.js.
(WI.SpreadsheetRuleHeaderField):
(WI.SpreadsheetRuleHeaderField.prototype.get element):
(WI.SpreadsheetRuleHeaderField.prototype.startEditing):
(WI.SpreadsheetRuleHeaderField.prototype.stopEditing):
(WI.SpreadsheetRuleHeaderField.prototype._handleBlur):
(WI.SpreadsheetRuleHeaderField.prototype._handleKeyDown):
- Delegate methods should provide the current text field as their first parameter to allow the delegate to determine the
appropriate action.

* Source/WebInspectorUI/UserInterface/Views/StyleOriginView.js:
(WI.StyleOriginView.prototype.update):
(WI.StyleOriginView):

Canonical link: <a href="https://commits.webkit.org/256043@main">https://commits.webkit.org/256043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/666b41965bc363291b79c24d0cc64de192c875e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104030 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164313 "Hash 666b4196 for PR 5566 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3587 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31746 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100029 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2573 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80757 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29620 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84495 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72511 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38141 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17929 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80734 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36018 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19201 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39905 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83400 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38430 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18833 "Passed tests") | 
<!--EWS-Status-Bubble-End-->