### PR TITLE
RegisterSet build fix

### DIFF
--- a/Source/JavaScriptCore/jit/Reg.h
+++ b/Source/JavaScriptCore/jit/Reg.h
@@ -28,6 +28,7 @@
 #if ENABLE(ASSEMBLER)
 
 #include "MacroAssembler.h"
+#include "Width.h"
 
 namespace JSC {
 
@@ -228,6 +229,26 @@ struct RegHash {
     static bool equal(const Reg& a, const Reg& b) { return a == b; }
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
+
+ALWAYS_INLINE constexpr Width conservativeWidthWithoutVectors(const Reg reg)
+{
+    return reg.isFPR() ? Width64 : widthForBytes(sizeof(CPURegister));
+}
+
+ALWAYS_INLINE constexpr Width conservativeWidth(const Reg reg)
+{
+    return reg.isFPR() ? Width64 : widthForBytes(sizeof(CPURegister));
+}
+
+ALWAYS_INLINE constexpr unsigned conservativeRegisterBytes(const Reg reg)
+{
+    return bytesForWidth(conservativeWidth(reg));
+}
+
+ALWAYS_INLINE constexpr unsigned conservativeRegisterBytesWithoutVectors(const Reg reg)
+{
+    return bytesForWidth(conservativeWidthWithoutVectors(reg));
+}
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/Width.h
+++ b/Source/JavaScriptCore/jit/Width.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "Reg.h"
 #include <wtf/PrintStream.h>
 
 namespace JSC {
@@ -114,26 +113,6 @@ inline Width canonicalWidth(Width width)
 inline bool isCanonicalWidth(Width width)
 {
     return width >= Width32;
-}
-
-ALWAYS_INLINE constexpr Width conservativeWidthWithoutVectors(const Reg reg)
-{
-    return reg.isFPR() ? Width64 : widthForBytes(sizeof(CPURegister));
-}
-
-ALWAYS_INLINE constexpr Width conservativeWidth(const Reg reg)
-{
-    return reg.isFPR() ? Width64 : widthForBytes(sizeof(CPURegister));
-}
-
-ALWAYS_INLINE constexpr unsigned conservativeRegisterBytes(const Reg reg)
-{
-    return bytesForWidth(conservativeWidth(reg));
-}
-
-ALWAYS_INLINE constexpr unsigned conservativeRegisterBytesWithoutVectors(const Reg reg)
-{
-    return bytesForWidth(conservativeWidthWithoutVectors(reg));
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### 2c27883ce75e71ba2df3b145111f31fc17a1f766
<pre>
RegisterSet build fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=246781">https://bugs.webkit.org/show_bug.cgi?id=246781</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/jit/Reg.h:
(JSC::conservativeWidthWithoutVectors):
(JSC::conservativeWidth):
(JSC::conservativeRegisterBytes):
(JSC::conservativeRegisterBytesWithoutVectors):
* Source/JavaScriptCore/jit/Width.h:
(JSC::conservativeWidthWithoutVectors): Deleted.
(JSC::conservativeWidth): Deleted.
(JSC::conservativeRegisterBytes): Deleted.
(JSC::conservativeRegisterBytesWithoutVectors): Deleted.

Canonical link: <a href="https://commits.webkit.org/255769@main">https://commits.webkit.org/255769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ace33587ce978d13cea9989466ce7f7841ea566d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2743 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2754 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99212 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/1949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/79993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/85901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/83870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/85901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/84834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/79933 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/35249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/27601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/39124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/79993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82569 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1871 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41062 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/18662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->