### PR TITLE
[ANGLE] Render pipeline descriptor missing casses GPU-Process crash

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm
@@ -1204,7 +1204,7 @@ angle::Result ProgramMtl::setupDraw(const gl::Context *glContext,
                                     bool uniformBuffersDirty)
 {
     ContextMtl *context = mtl::GetImpl(glContext);
-    if (pipelineDescChanged)
+    if (pipelineDescChanged || !cmdEncoder->hasPipelineState())
     {
         // Render pipeline state needs to be changed
         id<MTLRenderPipelineState> pipelineState =

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h
@@ -496,7 +496,7 @@ class RenderCommandEncoder final : public CommandEncoder
 
     const RenderPassDesc &renderPassDesc() const { return mRenderPassDesc; }
     bool hasDrawCalls() const { return mHasDrawCalls; }
-
+    bool hasPipelineState() const { return mPipelineStateSet; }
   private:
     // Override CommandEncoder
     id<MTLRenderCommandEncoder> get()


### PR DESCRIPTION
#### bb1da00b9ba878d228a5e9834a0767dbca2fee43
<pre>
[ANGLE] Render pipeline descriptor missing casses GPU-Process crash
    <a href="https://bugs.webkit.org/show_bug.cgi?id=246777">https://bugs.webkit.org/show_bug.cgi?id=246777</a>
    rdar://97847673

    Reviewed by Dean Jackson.

    Following on from <a href="https://bugs.webkit.org/show_bug.cgi?id=240896">https://bugs.webkit.org/show_bug.cgi?id=240896</a>, we are still experiencing some cases where the Metal backend does not
    correctly configure the render pipeline state. In rarer cases, we end up in a state where the render encoder is valid, but the pipeline state is not set.

    Attempt to correct this error with three additional checks

    1) When setting up a program, if the render encoder in question does not have a render pipeline state set, attempt to set it, even if the render pass descriptor has not changes.

    2) When validating if an encoder is valid, also check if it has a valid render pipeline state during setupDraw. After setupDrawImpl, it should either be invalid (Due to a flush and invalidate all)  or not have a render pipeline state (Due to a misconfiguration on the program, or within the state bits.)

    If we end up in the case of 2, attempt to set up the program one more time. (Usually due to a flush and invalidate all). If we&apos;ve failed to create a render encoder again, attempt to recover the graphics context by dropping flushing the command buffer, invalidating the entire GL state, and dropping the draw call. This may lead to a rendering error, but will not cause a browser crash.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::setupDraw):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm:
(rx::ProgramMtl::setupDraw):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h:

Canonical link: <a href="https://commits.webkit.org/256013@main">https://commits.webkit.org/256013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2a232ff42ee1818f179a80ec279a656ebbb646a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/25433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103924 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164202 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3464 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31648 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99944 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2486 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80654 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29523 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84405 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72435 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38032 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17883 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19155 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41742 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1961 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38384 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->