### PR TITLE
Throw a DataCloneError when attempting to serialize an ImageBitmap without the origin-clean flag.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
 
 PASS Serialize ImageBitmap created from an HTMLCanvasElement
 PASS Serialize ImageBitmap created from an HTMLVideoElement
@@ -11,5 +10,5 @@ PASS Serialize ImageBitmap created from an OffscreenCanvas
 PASS Serialize ImageBitmap created from an ImageData
 PASS Serialize ImageBitmap created from an ImageBitmap
 PASS Serialize ImageBitmap created from a Blob
-FAIL Serializing a non-origin-clean ImageBitmap throws. assert_throws_dom: function "() => worker.postMessage(bitmap)" did not throw
+PASS Serializing a non-origin-clean ImageBitmap throws.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
 
 PASS Transfer ImageBitmap created from an HTMLCanvasElement
 PASS Transfer ImageBitmap created from an HTMLVideoElement
@@ -11,5 +10,5 @@ PASS Transfer ImageBitmap created from an OffscreenCanvas
 PASS Transfer ImageBitmap created from an ImageData
 PASS Transfer ImageBitmap created from an ImageBitmap
 PASS Transfer ImageBitmap created from a Blob
-FAIL Transferring a non-origin-clean ImageBitmap throws. assert_throws_dom: function "() => worker.postMessage(bitmap, [bitmap])" did not throw
+PASS Transferring a non-origin-clean ImageBitmap throws.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
 
 PASS Serialize ImageBitmap created from an HTMLCanvasElement
 PASS Serialize ImageBitmap created from an HTMLVideoElement
@@ -11,5 +10,5 @@ PASS Serialize ImageBitmap created from an OffscreenCanvas
 PASS Serialize ImageBitmap created from an ImageData
 PASS Serialize ImageBitmap created from an ImageBitmap
 PASS Serialize ImageBitmap created from a Blob
-FAIL Serializing a non-origin-clean ImageBitmap throws. assert_throws_dom: function "() => worker.postMessage(bitmap)" did not throw
+PASS Serializing a non-origin-clean ImageBitmap throws.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
 
 PASS Transfer ImageBitmap created from an HTMLCanvasElement
 PASS Transfer ImageBitmap created from an HTMLVideoElement
@@ -11,5 +10,5 @@ PASS Transfer ImageBitmap created from an OffscreenCanvas
 PASS Transfer ImageBitmap created from an ImageData
 PASS Transfer ImageBitmap created from an ImageBitmap
 PASS Transfer ImageBitmap created from a Blob
-FAIL Transferring a non-origin-clean ImageBitmap throws. assert_throws_dom: function "() => worker.postMessage(bitmap, [bitmap])" did not throw
+PASS Transferring a non-origin-clean ImageBitmap throws.
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
 
 PASS Serialize ImageBitmap created from an HTMLCanvasElement
 PASS Serialize ImageBitmap created from an HTMLVideoElement
@@ -11,5 +10,5 @@ FAIL Serialize ImageBitmap created from an OffscreenCanvas promise_test: Unhandl
 PASS Serialize ImageBitmap created from an ImageData
 PASS Serialize ImageBitmap created from an ImageBitmap
 PASS Serialize ImageBitmap created from a Blob
-FAIL Serializing a non-origin-clean ImageBitmap throws. assert_throws_dom: function "() => worker.postMessage(bitmap)" did not throw
+PASS Serializing a non-origin-clean ImageBitmap throws.
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
 
 PASS Transfer ImageBitmap created from an HTMLCanvasElement
 PASS Transfer ImageBitmap created from an HTMLVideoElement
@@ -11,5 +10,5 @@ FAIL Transfer ImageBitmap created from an OffscreenCanvas promise_test: Unhandle
 PASS Transfer ImageBitmap created from an ImageData
 PASS Transfer ImageBitmap created from an ImageBitmap
 PASS Transfer ImageBitmap created from a Blob
-FAIL Transferring a non-origin-clean ImageBitmap throws. assert_throws_dom: function "() => worker.postMessage(bitmap, [bitmap])" did not throw
+PASS Transferring a non-origin-clean ImageBitmap throws.
 


### PR DESCRIPTION
#### ad6383440b738cb4399a32876f902df43a886675
<pre>
Throw a DataCloneError when attempting to serialize an ImageBitmap without the origin-clean flag.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246783">https://bugs.webkit.org/show_bug.cgi?id=246783</a>
&lt;rdar://100901435&gt;

Reviewed by Youenn Fablet.

The HTML spec expects us to reject serialization/transfer of ImageBitmaps that don&apos;t have the origin-clean flag, rather
than tansferring them and tainting any &lt;canvas&gt; elements they get drawn to.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer-expected.txt:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::SerializedScriptValue::create):

Canonical link: <a href="https://commits.webkit.org/255882@main">https://commits.webkit.org/255882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b31476b97dd88b0ab4817c9c050a42803eee6f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103310 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163633 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2866 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31132 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99372 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2043 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80103 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29075 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72031 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37517 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17547 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4061 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41342 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38038 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->