### PR TITLE
[WGSL] Convert AST into string representation

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -1,0 +1,397 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ASTStringDumper.h"
+
+#include "AST.h"
+#include <wtf/DataLog.h>
+#include <wtf/EnumTraits.h>
+#include <wtf/SetForScope.h>
+
+namespace WGSL::AST {
+
+struct Indent {
+    Indent(StringDumper& dumper)
+        : m_scope(dumper.m_indent, dumper.m_indent + "    ")
+    { }
+    SetForScope<String> m_scope;
+};
+
+static Indent bumpIndent(StringDumper& dumper)
+{
+    return Indent(dumper);
+}
+
+template<typename T, typename J>
+void StringDumper::visitVector(T& nodes, J joiner)
+{
+    if (nodes.isEmpty())
+        return;
+
+    visit(nodes[0]);
+    for (size_t n = 1; n < nodes.size(); ++n) {
+        m_out.print(joiner);
+        visit(nodes[n]);
+    }
+}
+
+String StringDumper::toString()
+{
+    return m_out.toString();
+}
+
+// Shader Module
+void StringDumper::visit(ShaderModule& shaderModule)
+{
+    for (auto& directive : shaderModule.directives())
+        visit(directive);
+    if (!shaderModule.directives().isEmpty())
+        m_out.print("\n\n");
+
+    for (auto& structure : shaderModule.structs())
+        visit(structure);
+    if (!shaderModule.structs().isEmpty())
+        m_out.printf("\n\n");
+
+    for (auto& variable : shaderModule.globalVars())
+        visit(variable);
+    if (!shaderModule.globalVars().isEmpty())
+        m_out.printf("\n\n");
+
+    for (auto& function : shaderModule.functions())
+        visit(function);
+    if (!shaderModule.functions().isEmpty())
+        m_out.printf("\n\n");
+}
+
+void StringDumper::visit(GlobalDirective& directive)
+{
+    m_out.print(m_indent, "enable ", directive.name(), ";");
+}
+
+// Attribute
+void StringDumper::visit(BindingAttribute& binding)
+{
+    m_out.print("@binding(", binding.binding(), ")");
+}
+
+void StringDumper::visit(BuiltinAttribute& builtin)
+{
+    m_out.print("@builtin(", builtin.name(), ")");
+}
+
+void StringDumper::visit(GroupAttribute& group)
+{
+    m_out.print("@group(", group.group(), ")");
+}
+
+void StringDumper::visit(LocationAttribute& location)
+{
+    m_out.print("@location(", location.location(), ")");
+}
+
+void StringDumper::visit(StageAttribute& stage)
+{
+    switch (stage.stage()) {
+    case StageAttribute::Stage::Compute:
+        m_out.print("@compute");
+        break;
+    case StageAttribute::Stage::Fragment:
+        m_out.print("@fragment");
+        break;
+    case StageAttribute::Stage::Vertex:
+        m_out.print("@vertex");
+        break;
+    }
+}
+
+// Declaration
+void StringDumper::visit(FunctionDecl& function)
+{
+    m_out.print(m_indent);
+    if (!function.attributes().isEmpty()) {
+        visitVector(function.attributes(), " ");
+        m_out.print("\n", m_indent);
+    }
+    m_out.print("fn ", function.name(), "(");
+    if (!function.parameters().isEmpty()) {
+        m_out.print("\n");
+        {
+            auto indent = bumpIndent(*this);
+            visitVector(function.parameters(), "\n");
+        }
+        m_out.print("\n", m_indent);
+    }
+    m_out.print(")");
+    if (function.maybeReturnType()) {
+        m_out.print(" -> ");
+        visitVector(function.returnAttributes(), " ");
+        m_out.print(" ");
+        visit(*function.maybeReturnType());
+    }
+    m_out.print("\n", m_indent);
+    visit(function.body());
+}
+
+void StringDumper::visit(StructDecl& structure)
+{
+    m_out.print(m_indent);
+    if (!structure.attributes().isEmpty()) {
+        visitVector(structure.attributes(), " ");
+        m_out.print("\n", m_indent);
+    }
+    m_out.print("struct ", structure.name(), " {");
+    if (!structure.members().isEmpty()) {
+        m_out.print("\n");
+        {
+            auto indent = bumpIndent(*this);
+            visitVector(structure.members(), ",\n");
+        }
+        m_out.print("\n", m_indent);
+    }
+    m_out.print("}\n");
+}
+
+void StringDumper::visit(VariableDecl& variable)
+{
+    if (!variable.attributes().isEmpty()) {
+        visitVector(variable.attributes(), " ");
+        m_out.print(" ");
+    }
+    m_out.print("var");
+    if (variable.maybeQualifier())
+        visit(*variable.maybeQualifier());
+    m_out.print(" ", variable.name());
+    if (variable.maybeTypeDecl()) {
+        m_out.print(": ");
+        visit(*variable.maybeTypeDecl());
+    }
+    if (variable.maybeInitializer()) {
+        m_out.print(" = ");
+        visit(*variable.maybeInitializer());
+    }
+    m_out.print(";");
+}
+
+// Expression
+void StringDumper::visit(AbstractFloatLiteral& literal)
+{
+    m_out.print(literal.value());
+}
+
+void StringDumper::visit(AbstractIntLiteral& literal)
+{
+    m_out.print(literal.value());
+}
+
+void StringDumper::visit(ArrayAccess& arrayAccess)
+{
+    visit(arrayAccess.base());
+    m_out.print("[");
+    visit(arrayAccess.index());
+    m_out.print("]");
+}
+
+void StringDumper::visit(BoolLiteral& literal)
+{
+    m_out.print(literal.value() ? "true": "false");
+}
+
+void StringDumper::visit(CallableExpression& expression)
+{
+    visit(expression.target());
+    m_out.print("(");
+    if (!expression.arguments().isEmpty()) {
+        auto indent = bumpIndent(*this);
+        visitVector(expression.arguments(), ", ");
+    }
+    m_out.print(")");
+}
+
+void StringDumper::visit(Float32Literal& literal)
+{
+    m_out.print(literal.value(), "f");
+}
+
+void StringDumper::visit(IdentifierExpression& identifier)
+{
+    m_out.print(identifier.identifier());
+}
+
+void StringDumper::visit(Int32Literal& literal)
+{
+    m_out.print(literal.value(), "i");
+}
+
+void StringDumper::visit(StructureAccess& structureAccess)
+{
+    visit(structureAccess.base());
+    m_out.print(".", structureAccess.fieldName());
+}
+
+void StringDumper::visit(Uint32Literal& literal)
+{
+    m_out.print(literal.value(), "u");
+}
+
+void StringDumper::visit(UnaryExpression& expression)
+{
+    constexpr ASCIILiteral unaryOperator[] = { "-"_s };
+    auto op = WTF::enumToUnderlyingType(expression.operation());
+    m_out.print(unaryOperator[op]);
+    visit(expression.expression());
+}
+
+// Statement
+void StringDumper::visit(AssignmentStatement& statement)
+{
+    m_out.print(m_indent);
+    if (statement.maybeLhs())
+        visit(*statement.maybeLhs());
+    else
+        m_out.print("_");
+    m_out.print(" = ");
+    visit(statement.rhs());
+    m_out.print(";");
+}
+
+void StringDumper::visit(CompoundStatement& block)
+{
+    m_out.print(m_indent, "{");
+    if (!block.statements().isEmpty()) {
+        {
+            auto indent = bumpIndent(*this);
+            m_out.print("\n");
+            visitVector(block.statements(), "\n");
+        }
+        m_out.print("\n", m_indent);
+    }
+    m_out.print("}\n");
+}
+
+void StringDumper::visit(ReturnStatement& statement)
+{
+    m_out.print(m_indent, "return");
+    if (statement.maybeExpression()) {
+        m_out.print(" ");
+        visit(*statement.maybeExpression());
+    }
+    m_out.print(";");
+}
+
+void StringDumper::visit(VariableStatement& statement)
+{
+    m_out.print(m_indent);
+    visit(statement.declaration());
+}
+
+// Types
+void StringDumper::visit(ArrayType& type)
+{
+    m_out.print("array");
+    if (type.maybeElementType()) {
+        m_out.print("<");
+        visit(*type.maybeElementType());
+        if (type.maybeElementCount()) {
+            m_out.print(", ");
+            visit(*type.maybeElementCount());
+        }
+        m_out.print(">");
+    }
+}
+
+void StringDumper::visit(NamedType& type)
+{
+    m_out.print(type.name());
+}
+
+void StringDumper::visit(ParameterizedType& type)
+{
+    constexpr ASCIILiteral base[] = {
+        "Vec2"_s,
+        "Vec3"_s,
+        "Vec4"_s,
+        "Mat2x2"_s,
+        "Mat2x3"_s,
+        "Mat2x4"_s,
+        "Mat3x2"_s,
+        "Mat3x3"_s,
+        "Mat3x4"_s,
+        "Mat4x2"_s,
+        "Mat4x3"_s,
+        "Mat4x4"_s
+    };
+    auto b = WTF::enumToUnderlyingType(type.base());
+    m_out.print(base[b], "<");
+    visit(type.elementType());
+    m_out.print(">");
+}
+
+void StringDumper::visit(Parameter& parameter)
+{
+    m_out.print(m_indent);
+    if (!parameter.attributes().isEmpty()) {
+        visitVector(parameter.attributes(), " ");
+        m_out.print(" ");
+    }
+    m_out.print(parameter.name(), ": ");
+    visit(parameter.type());
+}
+
+void StringDumper::visit(StructMember& member)
+{
+    m_out.print(m_indent);
+    if (!member.attributes().isEmpty()) {
+        visitVector(member.attributes(), " ");
+        m_out.print(" ");
+    }
+    m_out.print(member.name(), ": ");
+    visit(member.type());
+}
+
+void StringDumper::visit(VariableQualifier& qualifier)
+{
+    constexpr ASCIILiteral accessMode[]= { "read"_s, "write"_s, "read_write"_s };
+    constexpr ASCIILiteral storageClass[] = { "function"_s, "private"_s, "workgroup"_s, "uniform"_s, "storage"_s };
+    auto sc = WTF::enumToUnderlyingType(qualifier.storageClass());
+    auto am = WTF::enumToUnderlyingType(qualifier.accessMode());
+    m_out.print("<", storageClass[sc], ",", accessMode[am], ">");
+}
+
+template<typename T>
+void dumpNode(PrintStream& out, T& node)
+{
+    StringDumper dumper;
+    dumper.visit(node);
+    out.print(dumper.toString());
+}
+
+void dumpAST(ShaderModule& shaderModule)
+{
+    dataLogLn(ShaderModuleDumper(shaderModule));
+}
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTVisitor.h"
+#include <wtf/StringPrintStream.h>
+
+namespace WGSL::AST {
+
+class StringDumper final : public Visitor {
+    friend struct Indent;
+public:
+    using Visitor::visit;
+
+    ~StringDumper() = default;
+
+    String toString();
+
+    // Visitor
+    void visit(ShaderModule&) override;
+    void visit(GlobalDirective&) override;
+
+    // Attribute
+    void visit(BindingAttribute&) override;
+    void visit(BuiltinAttribute&) override;
+    void visit(GroupAttribute&) override;
+    void visit(LocationAttribute&) override;
+    void visit(StageAttribute&) override;
+
+    // Declaration
+    void visit(FunctionDecl&) override;
+    void visit(StructDecl&) override;
+    void visit(VariableDecl&) override;
+
+    // Expression
+    void visit(AbstractFloatLiteral&) override;
+    void visit(AbstractIntLiteral&) override;
+    void visit(ArrayAccess&) override;
+    void visit(BoolLiteral&) override;
+    void visit(CallableExpression&) override;
+    void visit(Float32Literal&) override;
+    void visit(IdentifierExpression&) override;
+    void visit(Int32Literal&) override;
+    void visit(StructureAccess&) override;
+    void visit(Uint32Literal&) override;
+    void visit(UnaryExpression&) override;
+
+    // Statement
+    void visit(AssignmentStatement&) override;
+    void visit(CompoundStatement&) override;
+    void visit(ReturnStatement&) override;
+    void visit(VariableStatement&) override;
+
+    // Types
+    void visit(ArrayType&) override;
+    void visit(NamedType&) override;
+    void visit(ParameterizedType&) override;
+
+    void visit(Parameter&) override;
+    void visit(StructMember&) override;
+    void visit(VariableQualifier&) override;
+
+private:
+
+    template<typename T, typename J>
+    void visitVector(T&, J);
+
+    StringPrintStream m_out;
+    String m_indent;
+};
+
+template<typename T> void dumpNode(PrintStream&, T&);
+
+MAKE_PRINT_ADAPTOR(ShaderModuleDumper, ShaderModule&, dumpNode);
+
+void dumpAST(ShaderModule&);
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -54,7 +54,7 @@ template<typename T> void Visitor::maybeCheckErrorAndVisit(T* x)
 
 // Shader Module
 
-void Visitor::visit(AST::ShaderModule& shaderModule)
+void Visitor::visit(ShaderModule& shaderModule)
 {
     for (auto& directive : shaderModule.directives())
         checkErrorAndVisit(directive);
@@ -66,71 +66,71 @@ void Visitor::visit(AST::ShaderModule& shaderModule)
         checkErrorAndVisit(functionDecl);
 }
 
-void Visitor::visit(AST::GlobalDirective&)
+void Visitor::visit(GlobalDirective&)
 {
 }
 
 // Attribute
 
-void Visitor::visit(AST::Attribute& attribute)
+void Visitor::visit(Attribute& attribute)
 {
     switch (attribute.kind()) {
-    case AST::Attribute::Kind::Binding:
-        checkErrorAndVisit(downcast<AST::BindingAttribute>(attribute));
+    case Attribute::Kind::Binding:
+        checkErrorAndVisit(downcast<BindingAttribute>(attribute));
         break;
-    case AST::Attribute::Kind::Builtin:
-        checkErrorAndVisit(downcast<AST::BuiltinAttribute>(attribute));
+    case Attribute::Kind::Builtin:
+        checkErrorAndVisit(downcast<BuiltinAttribute>(attribute));
         break;
-    case AST::Attribute::Kind::Group:
-        checkErrorAndVisit(downcast<AST::GroupAttribute>(attribute));
+    case Attribute::Kind::Group:
+        checkErrorAndVisit(downcast<GroupAttribute>(attribute));
         break;
-    case AST::Attribute::Kind::Location:
-        checkErrorAndVisit(downcast<AST::LocationAttribute>(attribute));
+    case Attribute::Kind::Location:
+        checkErrorAndVisit(downcast<LocationAttribute>(attribute));
         break;
-    case AST::Attribute::Kind::Stage:
-        checkErrorAndVisit(downcast<AST::StageAttribute>(attribute));
+    case Attribute::Kind::Stage:
+        checkErrorAndVisit(downcast<StageAttribute>(attribute));
         break;
     }
 }
 
-void Visitor::visit(AST::BindingAttribute&)
+void Visitor::visit(BindingAttribute&)
 {
 }
 
-void Visitor::visit(AST::BuiltinAttribute&)
+void Visitor::visit(BuiltinAttribute&)
 {
 }
 
-void Visitor::visit(AST::GroupAttribute&)
+void Visitor::visit(GroupAttribute&)
 {
 }
 
-void Visitor::visit(AST::LocationAttribute&)
+void Visitor::visit(LocationAttribute&)
 {
 }
 
-void Visitor::visit(AST::StageAttribute&)
+void Visitor::visit(StageAttribute&)
 {
 }
 
 // Declaration
 
-void Visitor::visit(AST::Decl& declaration)
+void Visitor::visit(Decl& declaration)
 {
     switch (declaration.kind()) {
-    case AST::Decl::Kind::Function:
-        checkErrorAndVisit(downcast<AST::FunctionDecl>(declaration));
+    case Decl::Kind::Function:
+        checkErrorAndVisit(downcast<FunctionDecl>(declaration));
         break;
-    case AST::Decl::Kind::Struct:
-        checkErrorAndVisit(downcast<AST::StructDecl>(declaration));
+    case Decl::Kind::Struct:
+        checkErrorAndVisit(downcast<StructDecl>(declaration));
         break;
-    case AST::Decl::Kind::Variable:
-        checkErrorAndVisit(downcast<AST::VariableDecl>(declaration));
+    case Decl::Kind::Variable:
+        checkErrorAndVisit(downcast<VariableDecl>(declaration));
         break;
     }
 }
 
-void Visitor::visit(AST::FunctionDecl& functionDeclaration)
+void Visitor::visit(FunctionDecl& functionDeclaration)
 {
     for (auto& attribute : functionDeclaration.attributes())
         checkErrorAndVisit(attribute);
@@ -142,7 +142,7 @@ void Visitor::visit(AST::FunctionDecl& functionDeclaration)
     checkErrorAndVisit(functionDeclaration.body());
 }
 
-void Visitor::visit(AST::StructDecl& structDeclaration)
+void Visitor::visit(StructDecl& structDeclaration)
 {
     for (auto& attribute : structDeclaration.attributes())
         checkErrorAndVisit(attribute);
@@ -150,7 +150,7 @@ void Visitor::visit(AST::StructDecl& structDeclaration)
         checkErrorAndVisit(member);
 }
 
-void Visitor::visit(AST::VariableDecl& varDeclaration)
+void Visitor::visit(VariableDecl& varDeclaration)
 {
     for (auto& attribute : varDeclaration.attributes())
         checkErrorAndVisit(attribute);
@@ -161,187 +161,187 @@ void Visitor::visit(AST::VariableDecl& varDeclaration)
 
 // Expression
 
-void Visitor::visit(AST::Expression& expression)
+void Visitor::visit(Expression& expression)
 {
     switch (expression.kind()) {
-    case AST::Expression::Kind::AbstractFloatLiteral:
-        checkErrorAndVisit(downcast<AST::AbstractFloatLiteral>(expression));
+    case Expression::Kind::AbstractFloatLiteral:
+        checkErrorAndVisit(downcast<AbstractFloatLiteral>(expression));
         break;
-    case AST::Expression::Kind::AbstractIntLiteral:
-        checkErrorAndVisit(downcast<AST::AbstractIntLiteral>(expression));
+    case Expression::Kind::AbstractIntLiteral:
+        checkErrorAndVisit(downcast<AbstractIntLiteral>(expression));
         break;
-    case AST::Expression::Kind::ArrayAccess:
-        checkErrorAndVisit(downcast<AST::ArrayAccess>(expression));
+    case Expression::Kind::ArrayAccess:
+        checkErrorAndVisit(downcast<ArrayAccess>(expression));
         break;
-    case AST::Expression::Kind::BoolLiteral:
-        checkErrorAndVisit(downcast<AST::BoolLiteral>(expression));
+    case Expression::Kind::BoolLiteral:
+        checkErrorAndVisit(downcast<BoolLiteral>(expression));
         break;
-    case AST::Expression::Kind::CallableExpression:
-        checkErrorAndVisit(downcast<AST::CallableExpression>(expression));
+    case Expression::Kind::CallableExpression:
+        checkErrorAndVisit(downcast<CallableExpression>(expression));
         break;
-    case AST::Expression::Kind::Float32Literal:
-        checkErrorAndVisit(downcast<AST::Float32Literal>(expression));
+    case Expression::Kind::Float32Literal:
+        checkErrorAndVisit(downcast<Float32Literal>(expression));
         break;
-    case AST::Expression::Kind::Identifier:
-        checkErrorAndVisit(downcast<AST::IdentifierExpression>(expression));
+    case Expression::Kind::Identifier:
+        checkErrorAndVisit(downcast<IdentifierExpression>(expression));
         break;
-    case AST::Expression::Kind::Int32Literal:
-        checkErrorAndVisit(downcast<AST::Int32Literal>(expression));
+    case Expression::Kind::Int32Literal:
+        checkErrorAndVisit(downcast<Int32Literal>(expression));
         break;
-    case AST::Expression::Kind::StructureAccess:
-        checkErrorAndVisit(downcast<AST::StructureAccess>(expression));
+    case Expression::Kind::StructureAccess:
+        checkErrorAndVisit(downcast<StructureAccess>(expression));
         break;
-    case AST::Expression::Kind::Uint32Literal:
-        checkErrorAndVisit(downcast<AST::Uint32Literal>(expression));
+    case Expression::Kind::Uint32Literal:
+        checkErrorAndVisit(downcast<Uint32Literal>(expression));
         break;
-    case AST::Expression::Kind::UnaryExpression:
-        checkErrorAndVisit(downcast<AST::UnaryExpression>(expression));
+    case Expression::Kind::UnaryExpression:
+        checkErrorAndVisit(downcast<UnaryExpression>(expression));
         break;
     }
 }
 
-void Visitor::visit(AST::AbstractFloatLiteral&)
+void Visitor::visit(AbstractFloatLiteral&)
 {
 }
 
-void Visitor::visit(AST::AbstractIntLiteral&)
+void Visitor::visit(AbstractIntLiteral&)
 {
 }
 
-void Visitor::visit(AST::ArrayAccess& arrayAccess)
+void Visitor::visit(ArrayAccess& arrayAccess)
 {
     checkErrorAndVisit(arrayAccess.base());
     checkErrorAndVisit(arrayAccess.index());
 }
 
-void Visitor::visit(AST::BoolLiteral&)
+void Visitor::visit(BoolLiteral&)
 {
 }
 
-void Visitor::visit(AST::CallableExpression& callableExpression)
+void Visitor::visit(CallableExpression& callableExpression)
 {
     checkErrorAndVisit(callableExpression.target());
     for (auto& argument : callableExpression.arguments())
         checkErrorAndVisit(argument);
 }
 
-void Visitor::visit(AST::Float32Literal&)
+void Visitor::visit(Float32Literal&)
 {
 }
 
-void Visitor::visit(AST::IdentifierExpression&)
+void Visitor::visit(IdentifierExpression&)
 {
 }
 
-void Visitor::visit(AST::Int32Literal&)
+void Visitor::visit(Int32Literal&)
 {
 }
 
-void Visitor::visit(AST::StructureAccess& structureAccess)
+void Visitor::visit(StructureAccess& structureAccess)
 {
     checkErrorAndVisit(structureAccess.base());
 }
 
-void Visitor::visit(AST::Uint32Literal&)
+void Visitor::visit(Uint32Literal&)
 {
 }
 
-void Visitor::visit(AST::UnaryExpression& unaryExpression)
+void Visitor::visit(UnaryExpression& unaryExpression)
 {
     checkErrorAndVisit(unaryExpression.expression());
 }
 
 // Statement
 
-void Visitor::visit(AST::Statement& statement)
+void Visitor::visit(Statement& statement)
 {
     switch (statement.kind()) {
-    case AST::Statement::Kind::Assignment:
-        checkErrorAndVisit(downcast<AST::AssignmentStatement>(statement));
+    case Statement::Kind::Assignment:
+        checkErrorAndVisit(downcast<AssignmentStatement>(statement));
         break;
-    case AST::Statement::Kind::Compound:
-        checkErrorAndVisit(downcast<AST::CompoundStatement>(statement));
+    case Statement::Kind::Compound:
+        checkErrorAndVisit(downcast<CompoundStatement>(statement));
         break;
-    case AST::Statement::Kind::Return:
-        checkErrorAndVisit(downcast<AST::ReturnStatement>(statement));
+    case Statement::Kind::Return:
+        checkErrorAndVisit(downcast<ReturnStatement>(statement));
         break;
-    case AST::Statement::Kind::Variable:
-        checkErrorAndVisit(downcast<AST::VariableStatement>(statement));
+    case Statement::Kind::Variable:
+        checkErrorAndVisit(downcast<VariableStatement>(statement));
         break;
     }
 }
 
-void Visitor::visit(AST::AssignmentStatement& assignStatement)
+void Visitor::visit(AssignmentStatement& assignStatement)
 {
     maybeCheckErrorAndVisit(assignStatement.maybeLhs());
     checkErrorAndVisit(assignStatement.rhs());
 }
 
-void Visitor::visit(AST::CompoundStatement& compoundStatement)
+void Visitor::visit(CompoundStatement& compoundStatement)
 {
     for (auto& statement : compoundStatement.statements())
         checkErrorAndVisit(statement);
 }
 
-void Visitor::visit(AST::ReturnStatement& returnStatement)
+void Visitor::visit(ReturnStatement& returnStatement)
 {
     maybeCheckErrorAndVisit(returnStatement.maybeExpression());
 }
 
-void Visitor::visit(AST::VariableStatement& varStatement)
+void Visitor::visit(VariableStatement& varStatement)
 {
     checkErrorAndVisit(varStatement.declaration());
 }
 
 // Types
 
-void Visitor::visit(AST::TypeDecl& typeDecl)
+void Visitor::visit(TypeDecl& typeDecl)
 {
     switch (typeDecl.kind()) {
-    case AST::TypeDecl::Kind::Array:
-        checkErrorAndVisit(downcast<AST::ArrayType>(typeDecl));
+    case TypeDecl::Kind::Array:
+        checkErrorAndVisit(downcast<ArrayType>(typeDecl));
         break;
-    case AST::TypeDecl::Kind::Named:
-        checkErrorAndVisit(downcast<AST::NamedType>(typeDecl));
+    case TypeDecl::Kind::Named:
+        checkErrorAndVisit(downcast<NamedType>(typeDecl));
         break;
-    case AST::TypeDecl::Kind::Parameterized:
-        checkErrorAndVisit(downcast<AST::ParameterizedType>(typeDecl));
+    case TypeDecl::Kind::Parameterized:
+        checkErrorAndVisit(downcast<ParameterizedType>(typeDecl));
         break;
     }
 }
 
-void Visitor::visit(AST::ArrayType& arrayType)
+void Visitor::visit(ArrayType& arrayType)
 {
     maybeCheckErrorAndVisit(arrayType.maybeElementType());
     maybeCheckErrorAndVisit(arrayType.maybeElementCount());
 }
 
-void Visitor::visit(AST::NamedType&)
+void Visitor::visit(NamedType&)
 {
 }
 
-void Visitor::visit(AST::ParameterizedType& parameterizedType)
+void Visitor::visit(ParameterizedType& parameterizedType)
 {
     checkErrorAndVisit(parameterizedType.elementType());
 }
 
 //
 
-void Visitor::visit(AST::Parameter& parameter)
+void Visitor::visit(Parameter& parameter)
 {
     for (auto& attribute : parameter.attributes())
         checkErrorAndVisit(attribute);
     checkErrorAndVisit(parameter.type());
 }
 
-void Visitor::visit(AST::StructMember& structMember)
+void Visitor::visit(StructMember& structMember)
 {
     for (auto& attribute : structMember.attributes())
         checkErrorAndVisit(attribute);
     checkErrorAndVisit(structMember.type());
 }
 
-void Visitor::visit(AST::VariableQualifier&)
+void Visitor::visit(VariableQualifier&)
 {
 }
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -37,53 +37,53 @@ public:
     virtual ~Visitor() = default;
 
     // Shader Module
-    virtual void visit(AST::ShaderModule&);
-    virtual void visit(AST::GlobalDirective&);
+    virtual void visit(ShaderModule&);
+    virtual void visit(GlobalDirective&);
 
     // Attribute
-    virtual void visit(AST::Attribute&);
-    virtual void visit(AST::BindingAttribute&);
-    virtual void visit(AST::BuiltinAttribute&);
-    virtual void visit(AST::GroupAttribute&);
-    virtual void visit(AST::LocationAttribute&);
-    virtual void visit(AST::StageAttribute&);
+    virtual void visit(Attribute&);
+    virtual void visit(BindingAttribute&);
+    virtual void visit(BuiltinAttribute&);
+    virtual void visit(GroupAttribute&);
+    virtual void visit(LocationAttribute&);
+    virtual void visit(StageAttribute&);
 
     // Declaration
-    virtual void visit(AST::Decl&);
-    virtual void visit(AST::FunctionDecl&);
-    virtual void visit(AST::StructDecl&);
-    virtual void visit(AST::VariableDecl&);
+    virtual void visit(Decl&);
+    virtual void visit(FunctionDecl&);
+    virtual void visit(StructDecl&);
+    virtual void visit(VariableDecl&);
 
     // Expression
-    virtual void visit(AST::Expression&);
-    virtual void visit(AST::AbstractFloatLiteral&);
-    virtual void visit(AST::AbstractIntLiteral&);
-    virtual void visit(AST::ArrayAccess&);
-    virtual void visit(AST::BoolLiteral&);
-    virtual void visit(AST::CallableExpression&);
-    virtual void visit(AST::Float32Literal&);
-    virtual void visit(AST::IdentifierExpression&);
-    virtual void visit(AST::Int32Literal&);
-    virtual void visit(AST::StructureAccess&);
-    virtual void visit(AST::Uint32Literal&);
-    virtual void visit(AST::UnaryExpression&);
+    virtual void visit(Expression&);
+    virtual void visit(AbstractFloatLiteral&);
+    virtual void visit(AbstractIntLiteral&);
+    virtual void visit(ArrayAccess&);
+    virtual void visit(BoolLiteral&);
+    virtual void visit(CallableExpression&);
+    virtual void visit(Float32Literal&);
+    virtual void visit(IdentifierExpression&);
+    virtual void visit(Int32Literal&);
+    virtual void visit(StructureAccess&);
+    virtual void visit(Uint32Literal&);
+    virtual void visit(UnaryExpression&);
 
     // Statement
-    virtual void visit(AST::Statement&);
-    virtual void visit(AST::AssignmentStatement&);
-    virtual void visit(AST::CompoundStatement&);
-    virtual void visit(AST::ReturnStatement&);
-    virtual void visit(AST::VariableStatement&);
+    virtual void visit(Statement&);
+    virtual void visit(AssignmentStatement&);
+    virtual void visit(CompoundStatement&);
+    virtual void visit(ReturnStatement&);
+    virtual void visit(VariableStatement&);
 
     // Types
-    virtual void visit(AST::TypeDecl&);
-    virtual void visit(AST::ArrayType&);
-    virtual void visit(AST::NamedType&);
-    virtual void visit(AST::ParameterizedType&);
+    virtual void visit(TypeDecl&);
+    virtual void visit(ArrayType&);
+    virtual void visit(NamedType&);
+    virtual void visit(ParameterizedType&);
 
-    virtual void visit(AST::Parameter&);
-    virtual void visit(AST::StructMember&);
-    virtual void visit(AST::VariableQualifier&);
+    virtual void visit(Parameter&);
+    virtual void visit(StructMember&);
+    virtual void visit(VariableQualifier&);
     
     bool hasError() const;
     Expected<void, Error> result();

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		3A7E164C28C57BB8003F49C9 /* ASTArrayAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A7E164B28C57BB7003F49C9 /* ASTArrayAccess.h */; };
 		3AAE4EB428C56E9A00DA484B /* ASTUnaryExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AAE4EB328C56E9A00DA484B /* ASTUnaryExpression.h */; };
 		3ACCE80628FE1872004A0914 /* AST.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ACCE80528FE1872004A0914 /* AST.h */; };
+		3ADB94442900F7D700CFFDC2 /* ASTStringDumper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3ADB94422900F7D600CFFDC2 /* ASTStringDumper.cpp */; };
+		3ADB94452900F7D700CFFDC2 /* ASTStringDumper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ADB94432900F7D600CFFDC2 /* ASTStringDumper.h */; };
 		3AE27DB528C1BA480043A8E0 /* ASTVariableStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */; };
 		664C92FD286A66090008D143 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 664C92FC286A66090008D143 /* IOSurface.framework */; };
 		66DC575528627E0B0014CABD /* ParserPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 66DC575428627E0B0014CABD /* ParserPrivate.h */; };
@@ -329,6 +331,8 @@
 		3A7E164B28C57BB7003F49C9 /* ASTArrayAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTArrayAccess.h; sourceTree = "<group>"; };
 		3AAE4EB328C56E9A00DA484B /* ASTUnaryExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTUnaryExpression.h; sourceTree = "<group>"; };
 		3ACCE80528FE1872004A0914 /* AST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AST.h; sourceTree = "<group>"; };
+		3ADB94422900F7D600CFFDC2 /* ASTStringDumper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTStringDumper.cpp; sourceTree = "<group>"; };
+		3ADB94432900F7D600CFFDC2 /* ASTStringDumper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTStringDumper.h; sourceTree = "<group>"; };
 		3AE27DB428C1BA480043A8E0 /* ASTVariableStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTVariableStatement.h; sourceTree = "<group>"; };
 		664C92FC286A66090008D143 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		66DC575428627E0B0014CABD /* ParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParserPrivate.h; sourceTree = "<group>"; };
@@ -683,6 +687,8 @@
 				33EA187D27BC249000A1DD52 /* ASTReturnStatement.h */,
 				33EA186F27BC1E8A00A1DD52 /* ASTShaderModule.h */,
 				33EA187827BC22AA00A1DD52 /* ASTStatement.h */,
+				3ADB94422900F7D600CFFDC2 /* ASTStringDumper.cpp */,
+				3ADB94432900F7D600CFFDC2 /* ASTStringDumper.h */,
 				33EA188327BC268600A1DD52 /* ASTStructureAccess.h */,
 				33EA187327BC204900A1DD52 /* ASTStructureDecl.h */,
 				33EA186D27BC1D4C00A1DD52 /* ASTTypeDecl.h */,
@@ -734,6 +740,7 @@
 				33EA187E27BC249000A1DD52 /* ASTReturnStatement.h in Headers */,
 				33EA187027BC1E8A00A1DD52 /* ASTShaderModule.h in Headers */,
 				33EA187927BC22AA00A1DD52 /* ASTStatement.h in Headers */,
+				3ADB94452900F7D700CFFDC2 /* ASTStringDumper.h in Headers */,
 				33EA188427BC268600A1DD52 /* ASTStructureAccess.h in Headers */,
 				33EA187427BC204900A1DD52 /* ASTStructureDecl.h in Headers */,
 				33EA186E27BC1D4C00A1DD52 /* ASTTypeDecl.h in Headers */,
@@ -968,6 +975,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3ADB94442900F7D700CFFDC2 /* ASTStringDumper.cpp in Sources */,
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -223,6 +223,8 @@
 		3A5DDB2C28D5525E004DA950 /* libWTF.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0291D0A5CDF00FEBCF3 /* libWTF.a */; };
 		3A5DDB2D28D55265004DA950 /* libwgsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A5DDB2028D54269004DA950 /* libwgsl.a */; };
 		3A7AA56028E28E99009E09C2 /* ConstLiteralTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A7AA55F28E28E99009E09C2 /* ConstLiteralTests.cpp */; };
+		3A9C438828E3E057002F7294 /* ASTStringDumperTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A9C438028E3E057002F7294 /* ASTStringDumperTests.cpp */; };
+		3A9C438B28E3E240002F7294 /* TestWGSLAPI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3A9C438928E3E240002F7294 /* TestWGSLAPI.cpp */; };
 		3FBD1B4A1D3D66AB00E6D6FA /* FullscreenLayoutConstraints.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */; };
 		3FCC4FE81EC4E8CA0076E37C /* PictureInPictureDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 3FCC4FE61EC4E87E0076E37C /* PictureInPictureDelegate.html */; };
 		4102EE1727845ED500D6BE74 /* ServiceWorkerRoutines.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4102EE1627845ED500D6BE74 /* ServiceWorkerRoutines.cpp */; };
@@ -2215,6 +2217,9 @@
 		3A5DDAF428D1638A004DA950 /* libicucore.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libicucore.tbd; path = usr/lib/libicucore.tbd; sourceTree = SDKROOT; };
 		3A5DDB2028D54269004DA950 /* libwgsl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libwgsl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A7AA55F28E28E99009E09C2 /* ConstLiteralTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConstLiteralTests.cpp; sourceTree = "<group>"; };
+		3A9C438028E3E057002F7294 /* ASTStringDumperTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTStringDumperTests.cpp; sourceTree = "<group>"; };
+		3A9C438928E3E240002F7294 /* TestWGSLAPI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestWGSLAPI.cpp; sourceTree = "<group>"; };
+		3A9C438A28E3E240002F7294 /* TestWGSLAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestWGSLAPI.h; sourceTree = "<group>"; };
 		3F1B52681D3D7129008D60C4 /* FullscreenLayoutConstraints.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLayoutConstraints.mm; sourceTree = "<group>"; };
 		3FBD1B491D39D1DB00E6D6FA /* FullscreenLayoutConstraints.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenLayoutConstraints.html; sourceTree = "<group>"; };
 		3FCC4FE41EC4E8520076E37C /* PictureInPictureDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PictureInPictureDelegate.mm; sourceTree = "<group>"; };
@@ -4105,9 +4110,12 @@
 		3A15785D28D150BB00142DB1 /* WGSL */ = {
 			isa = PBXGroup;
 			children = (
+				3A9C438028E3E057002F7294 /* ASTStringDumperTests.cpp */,
 				3A7AA55F28E28E99009E09C2 /* ConstLiteralTests.cpp */,
 				3A5DDAD228D15169004DA950 /* LexerTests.cpp */,
 				3A5DDAED28D156FC004DA950 /* ParserTests.cpp */,
+				3A9C438928E3E240002F7294 /* TestWGSLAPI.cpp */,
+				3A9C438A28E3E240002F7294 /* TestWGSLAPI.h */,
 			);
 			path = WGSL;
 			sourceTree = "<group>";
@@ -5905,12 +5913,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A9C438828E3E057002F7294 /* ASTStringDumperTests.cpp in Sources */,
 				3A7AA56028E28E99009E09C2 /* ConstLiteralTests.cpp in Sources */,
 				3A5DDADA28D15169004DA950 /* LexerTests.cpp in Sources */,
 				3A15784128D1505B00142DB1 /* mainIOS.mm in Sources */,
 				3A15784228D1505B00142DB1 /* mainMac.mm in Sources */,
 				3A5DDAEE28D156FC004DA950 /* ParserTests.cpp in Sources */,
 				3A15784428D1505B00142DB1 /* TestsController.cpp in Sources */,
+				3A9C438B28E3E240002F7294 /* TestWGSLAPI.cpp in Sources */,
 				3A15784528D1505B00142DB1 /* UtilitiesCocoa.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ASTStringDumperTests.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ASTStringDumper.h"
+
+#include "AST.h"
+#include "Parser.h"
+#include "TestWGSLAPI.h"
+#include "WGSL.h"
+
+namespace TestWGSLAPI {
+
+static String toString(WGSL::AST::ShaderModule& shaderModule)
+{
+    WGSL::AST::StringDumper dumper;
+    dumper.visit(shaderModule);
+    return dumper.toString();
+}
+
+TEST(WGSLASTDumperTests, dumpTriangleVert)
+{
+    auto shader = WGSL::parseLChar(
+        "@vertex\n"
+        "fn main(\n"
+        "    @builtin(vertex_index) VertexIndex : u32\n"
+        ") -> @builtin(position) vec4<f32> {\n"
+        "    var pos = array<vec2<f32>, 3>(\n"
+        "        vec2<f32>(0.0, 0.5),\n"
+        "        vec2<f32>(-0.5, -0.5),\n"
+        "        vec2<f32>(0.5, -0.5)\n"
+        "    );\n\n"
+        "    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);\n"
+        "}\n"_s);
+
+    EXPECT_SHADER(shader);
+    EXPECT_EQ(
+        toString(shader.value()),
+        "@vertex\n"
+        "fn main(\n"
+        "    @builtin(vertex_index) VertexIndex: u32\n"
+        ") -> @builtin(position) Vec4<f32>\n"
+        "{\n"
+        "    var pos = array<Vec2<f32>, 3>(Vec2<f32>(0.000000, 0.500000), Vec2<f32>(-0.500000, -0.500000), Vec2<f32>(0.500000, -0.500000));\n"
+        "    return Vec4<f32>(pos[VertexIndex], 0.000000, 1.000000);\n"
+        "}\n\n\n"_str);
+}
+
+} // namespace TestWGSLAPI

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -26,27 +26,10 @@
 #include "config.h"
 #include "Parser.h"
 
-#include "ASTArrayAccess.h"
-#include "ASTAssignmentStatement.h"
-#include "ASTCallableExpression.h"
-#include "ASTIdentifierExpression.h"
-#include "ASTLiteralExpressions.h"
-#include "ASTReturnStatement.h"
-#include "ASTStructureAccess.h"
-#include "ASTUnaryExpression.h"
-#include "ASTVariableStatement.h"
+#include "AST.h"
 #include "Lexer.h"
+#include "TestWGSLAPI.h"
 #include "WGSL.h"
-
-#include <wtf/Assertions.h>
-
-#define EXPECT_SHADER(shader) \
-    do { \
-        if (!shader.has_value()) { \
-            logCompilationError(shader.error()); \
-            return; \
-        } \
-    } while (false)
 
 static void checkBuiltin(WGSL::AST::Attribute& attr, ASCIILiteral attrName)
 {
@@ -78,12 +61,6 @@ static void checkVec2F32Type(WGSL::AST::TypeDecl& type)
 static void checkVec4F32Type(WGSL::AST::TypeDecl& type)
 {
     checkVecType(type, WGSL::AST::ParameterizedType::Base::Vec4, "f32"_s);
-}
-
-static void logCompilationError(WGSL::CompilationMessage& error)
-{
-    WTFLogAlways("%u:%u length:%u %s", error.lineNumber(), error.lineOffset(), error.length(), error.message().utf8().data());
-    GTEST_FAIL();
 }
 
 namespace TestWGSLAPI {

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWGSLAPI.h"
+
+#include "WGSL.h"
+#include <wtf/Assertions.h>
+
+namespace TestWGSLAPI {
+
+void logCompilationError(WGSL::CompilationMessage& error)
+{
+    WTFLogAlways("%u:%u length:%u %s", error.lineNumber(), error.lineOffset(), error.length(), error.message().utf8().data());
+    GTEST_FAIL();
+}
+
+} // namespace TestWGSLAPI

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#define EXPECT_SHADER(shader) \
+    do { \
+        if (!shader.has_value()) { \
+            ::TestWGSLAPI::logCompilationError(shader.error()); \
+            return; \
+        } \
+    } while (false)
+
+namespace WGSL {
+class CompilationMessage;
+}
+
+namespace TestWGSLAPI {
+
+void logCompilationError(WGSL::CompilationMessage& error);
+
+} // namespace TestWGSLAPI


### PR DESCRIPTION
#### 7e29ffc25c726581465a62874ef92ff8ea7bfabc
<pre>
[WGSL] Convert AST into string representation
<a href="https://bugs.webkit.org/show_bug.cgi?id=246791">https://bugs.webkit.org/show_bug.cgi?id=246791</a>
rdar://problem/101366942

Reviewed by Myles C. Maxfield.

As a debugging aid, AST::Dumper converts a given WGSL AST into a string
representation that approximates the original WGSL source code.

Tested by ASTDumperTests.

* Source/WebGPU/WGSL/AST/ASTDumper.cpp: Added.
(WGSL::AST::Indent::Indent):
(WGSL::AST::bumpIndent):
(WGSL::AST::Dumper::visitVector):
(WGSL::AST::Dumper::toString):
(WGSL::AST::Dumper::visit):
(WGSL::AST::dumpNode):
(WGSL::AST::dumpAST):
* Source/WebGPU/WGSL/AST/ASTDumper.h: Added.
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WGSL/ASTDumperTests.cpp: Added.
(TestWGSLAPI::toString):
(TestWGSLAPI::TEST):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(logCompilationError): Deleted.
* Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp: Added.
(TestWGSLAPI::logCompilationError):
* Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h: Added.

Canonical link: <a href="https://commits.webkit.org/255812@main">https://commits.webkit.org/255812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5e873c8da5e7e2286102d4931187886c52d10e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2844 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103300 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163623 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2855 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31122 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86001 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2033 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80093 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83957 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37507 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35349 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4013 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41160 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->