### PR TITLE
Introduce StructuredSerializeInternal forStorage parameter

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt
@@ -1,4 +1,5 @@
 
 FAIL Verify EncodedAudioChunk is serializable. Can't find variable: EncodedAudioChunk
 PASS Verify EncodedVideoChunk is serializable.
+PASS Verify EncodedVideoChunk cannot be stored
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any.js
@@ -72,3 +72,9 @@ async_test(t => {
 async_test(t => {
   runTest(t, 'video');
 }, 'Verify EncodedVideoChunk is serializable.');
+
+test(() => {
+  const chunk = createDefaultChunk("video", defaultVideoInit);
+  if (window.history)
+      assert_throws_dom("DataCloneError", () => history.pushState({ chunk }, null));
+}, "Verify EncodedVideoChunk cannot be stored");

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -126,7 +126,7 @@ ExceptionOr<Ref<IDBRequest>> IDBCursor::update(JSGlobalObject& state, JSValue va
     // Transaction should be inactive during structured clone.
     Ref transaction = effectiveObjectStore().transaction();
     transaction->deactivate();
-    auto serializedValue = SerializedScriptValue::create(state, value);
+    auto serializedValue = SerializedScriptValue::create(state, value, SerializationForStorage::Yes);
     transaction->activate();
 
     if (UNLIKELY(scope.exception()))

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -340,7 +340,7 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::putOrAdd(JSGlobalObject& state, JSV
     if (!serializedValue) {
         // Transaction should be inactive during structured clone.
         m_transaction.deactivate();
-        serializedValue = SerializedScriptValue::create(state, value);
+        serializedValue = SerializedScriptValue::create(state, value, SerializationForStorage::Yes);
         m_transaction.activate();
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -90,7 +90,7 @@ ExceptionOr<Ref<AudioWorkletNode>> AudioWorkletNode::create(JSC::JSGlobalObject&
     {
         auto lock = JSC::JSLockHolder { &globalObject };
         auto* jsOptions = convertDictionaryToJS(globalObject, *JSC::jsCast<JSDOMGlobalObject*>(&globalObject), options);
-        serializedOptions = SerializedScriptValue::create(globalObject, jsOptions, SerializationErrorMode::NonThrowing, SerializationContext::WorkerPostMessage);
+        serializedOptions = SerializedScriptValue::create(globalObject, jsOptions, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::WorkerPostMessage);
         if (!serializedOptions)
             serializedOptions = SerializedScriptValue::nullValue();
     }

--- a/Source/WebCore/bindings/js/JSDOMConvertSerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertSerializedScriptValue.h
@@ -33,7 +33,7 @@ namespace WebCore {
 template<typename T> struct Converter<IDLSerializedScriptValue<T>> : DefaultConverter<IDLSerializedScriptValue<T>> {
     static RefPtr<T> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
     {
-        return T::create(lexicalGlobalObject, value);
+        return T::convert(lexicalGlobalObject, value);
     }
 };
 

--- a/Source/WebCore/bindings/js/JSDOMWrapper.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.cpp
@@ -49,7 +49,7 @@ JSC::JSValue cloneAcrossWorlds(JSC::JSGlobalObject& lexicalGlobalObject, const J
     if (isWorldCompatible(lexicalGlobalObject, value))
         return value;
     // FIXME: Is it best to handle errors by returning null rather than throwing an exception?
-    auto serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationErrorMode::NonThrowing);
+    auto serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
     if (!serializedValue)
         return JSC::jsNull();
     // FIXME: Why is owner->globalObject() better than lexicalGlobalObject.lexicalGlobalObject() here?

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -68,6 +68,7 @@ class WebCodecsEncodedVideoChunkStorage;
 
 enum class SerializationErrorMode { NonThrowing, Throwing };
 enum class SerializationContext { Default, WorkerPostMessage, WindowPostMessage };
+enum class SerializationForStorage : bool { No, Yes };
 
 using ArrayBufferContentsArray = Vector<JSC::ArrayBufferContents>;
 #if ENABLE(WEBASSEMBLY)
@@ -79,8 +80,9 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 public:
-    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationContext = SerializationContext::Default);
-    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default);
+    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);
+    WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default);
+    static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject& globalObject, JSC::JSValue value) { return create(globalObject, value, SerializationForStorage::Yes); }
 
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(StringView);
 
@@ -118,7 +120,7 @@ public:
     WEBCORE_EXPORT ~SerializedScriptValue();
 
 private:
-    static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationErrorMode, SerializationContext);
+    static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext);
     WEBCORE_EXPORT SerializedScriptValue(Vector<unsigned char>&&, std::unique_ptr<ArrayBufferContentsArray>&& = nullptr
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& = { }

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -96,7 +96,7 @@ JSValue ErrorEvent::error(JSGlobalObject& globalObject)
 RefPtr<SerializedScriptValue> ErrorEvent::trySerializeError(JSGlobalObject& exec)
 {
     if (!m_serializedError && !m_triedToSerialize) {
-        m_serializedError = SerializedScriptValue::create(exec, m_error.getValue(), SerializationErrorMode::NonThrowing);
+        m_serializedError = SerializedScriptValue::create(exec, m_error.getValue(), SerializationForStorage::No, SerializationErrorMode::NonThrowing);
         m_triedToSerialize = true;
     }
     return m_serializedError;

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -71,7 +71,7 @@ RefPtr<SerializedScriptValue> PopStateEvent::trySerializeState(JSC::JSGlobalObje
     ASSERT(m_state);
     
     if (!m_serializedState && !m_triedToSerialize) {
-        m_serializedState = SerializedScriptValue::create(executionState, m_state.getValue(), SerializationErrorMode::NonThrowing);
+        m_serializedState = SerializedScriptValue::create(executionState, m_state.getValue(), SerializationForStorage::No, SerializationErrorMode::NonThrowing);
         m_triedToSerialize = true;
     }
     

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -914,7 +914,7 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObjec
     }
 
     Vector<RefPtr<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, messageValue, WTFMove(options.transfer), ports, SerializationContext::WindowPostMessage);
+    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -49,7 +49,7 @@ void WindowOrWorkerGlobalScope::reportError(JSDOMGlobalObject& globalObject, JSC
 ExceptionOr<JSC::JSValue> WindowOrWorkerGlobalScope::structuredClone(JSDOMGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& relevantGlobalObject, JSC::JSValue value, StructuredSerializeOptions&& options)
 {
     Vector<RefPtr<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTFMove(options.transfer), ports, SerializationContext::WindowPostMessage);
+    auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -92,7 +92,7 @@ void DedicatedWorkerGlobalScope::prepareForDestruction()
 ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     Vector<RefPtr<MessagePort>> ports;
-    auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationContext::WorkerPostMessage);
+    auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (message.hasException())
         return message.releaseException();
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -136,7 +136,7 @@ Worker::~Worker()
 ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     Vector<RefPtr<MessagePort>> ports;
-    auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationContext::WorkerPostMessage);
+    auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (message.hasException())
         return message.releaseException();
 

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -42,7 +42,7 @@ Ref<ExtendableMessageEvent> ExtendableMessageEvent::create(Vector<RefPtr<Message
 
 ExtendableMessageEvent::ExtendableMessageEvent(JSC::JSGlobalObject& state, const AtomString& type, const Init& init, IsTrusted isTrusted)
     : ExtendableEvent(type, init, isTrusted)
-    , m_data(SerializedScriptValue::create(state, init.data, SerializationErrorMode::NonThrowing))
+    , m_data(SerializedScriptValue::create(state, init.data, SerializationForStorage::No, SerializationErrorMode::NonThrowing))
     , m_origin(init.origin)
     , m_lastEventId(init.lastEventId)
     , m_source(init.source)

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -106,7 +106,7 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
         return Exception { InvalidStateError };
 
     Vector<RefPtr<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTFMove(options.transfer), ports, SerializationContext::WorkerPostMessage);
+    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -80,7 +80,7 @@ String ServiceWorkerClient::id() const
 ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     Vector<RefPtr<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTFMove(options.transfer), ports, SerializationContext::WorkerPostMessage);
+    auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
 


### PR DESCRIPTION
#### 664fe9493a72508a29a3e6a3018bd55d4fca8985
<pre>
Introduce StructuredSerializeInternal forStorage parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=246744">https://bugs.webkit.org/show_bug.cgi?id=246744</a>
rdar://problem/101367447

Reviewed by Alex Christensen.

We introduce a SerializationForStorage (No/Yes) parameter to SerializedScriptValue::create.
This allows to throw in case we are serializing objects that are serializable but are throwing for forStorage=yes cases.
Make use of SerializationForStorage parameter for WebCodecsEncodedVideoChunk as per <a href="https://w3c.github.io/webcodecs/#encodedvideochunk-serialization.">https://w3c.github.io/webcodecs/#encodedvideochunk-serialization.</a>

The default is SerializationForStorage = No.
We set SerializationForStorage = Yes for IDB and IDLSerializedScriptValue, which is used for History pushState.
Both IDB and History.pushState are using <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage.">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage.</a>

Covered by added tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/chunk-serialization.any.js:
(test):
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
(WebCore::IDBCursor::update):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::putOrAdd):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::create):
* Source/WebCore/bindings/js/JSDOMConvertSerializedScriptValue.h:
(WebCore::Converter&lt;IDLSerializedScriptValue&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMWrapper.cpp:
(WebCore::cloneAcrossWorlds):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serialize):
(WebCore::CloneSerializer::CloneSerializer):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::SerializedScriptValue::create):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::convert):
* Source/WebCore/dom/ErrorEvent.cpp:
(WebCore::ErrorEvent::trySerializeError):
* Source/WebCore/dom/PopStateEvent.cpp:
(WebCore::PopStateEvent::trySerializeState):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::postMessage):
* Source/WebCore/page/WindowOrWorkerGlobalScope.cpp:
(WebCore::WindowOrWorkerGlobalScope::structuredClone):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::postMessage):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::postMessage):
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
(WebCore::ExtendableMessageEvent::ExtendableMessageEvent):
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::postMessage):
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
(WebCore::ServiceWorkerClient::postMessage):

Canonical link: <a href="https://commits.webkit.org/255788@main">https://commits.webkit.org/255788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58063337133a0ebc754f460d06d0fd65d7e456ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93590 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103242 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163562 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2796 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31067 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99315 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1984 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80033 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83653 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37450 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18762 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4002 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41281 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37993 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->