### PR TITLE
WebCodecsVideoDecoderConfig description should be undefined instead of null if there is no description to provide

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,7 +1,4 @@
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: Error: assert_unreached: Decoder failure Reached unreachable code
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "AbortError: aborting flush as decoder is reset"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
@@ -1,6 +1,11 @@
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: DataError: Key frame is required
+CONSOLE MESSAGE: DataError: Key frame is required
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+Harness Error (FAIL), message = DataError: Key frame is required
+
+TIMEOUT Encoding and decoding cycle Test timed out
+
+Harness Error (FAIL), message = DataError: Key frame is required
+
+TIMEOUT Encoding and decoding cycle Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt
@@ -1,21 +1,3 @@
-CONSOLE MESSAGE: TypeError: Type error
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 
-Harness Error (FAIL), message = InvalidStateError: VideoDecoder is not configured
-
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: TypeError: Type error
+CONSOLE MESSAGE: TypeError: Config is not valid
 CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured


### PR DESCRIPTION
#### 35adb599351f1c594427c58b25feabd8ae413183
<pre>
WebCodecsVideoDecoderConfig description should be undefined instead of null if there is no description to provide
<a href="https://bugs.webkit.org/show_bug.cgi?id=246685">https://bugs.webkit.org/show_bug.cgi?id=246685</a>
rdar://problem/101288923

Reviewed by Eric Carlson.

When the description size is 0, we should keep the comnfig description be a std::nullopt instead of a null array buffer.
Also fix the creation of the array buffer by providing a proper sampel size.

Covered by rebased tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_vp9_p2-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::createEncodedChunkMetadata):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::paintInContext): Drive-by fix.

Canonical link: <a href="https://commits.webkit.org/255780@main">https://commits.webkit.org/255780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0fef3e08e8cd4c1b2518167a7bec9e142f4b088

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103224 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163544 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2777 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31049 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85923 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1966 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80015 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/28998 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83888 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71951 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37432 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/3997 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39146 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37975 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->