### PR TITLE
Update FEComponentTransfer filter effect when a child transfer function attribute changes

### DIFF
--- a/LayoutTests/svg/resource-invalidation/filter-resource-invalidation-expected.html
+++ b/LayoutTests/svg/resource-invalidation/filter-resource-invalidation-expected.html
@@ -37,6 +37,13 @@
         <filter id="f10c" xlink:href="#f10b">
             <feFlood flood-color="blue"/>
         </filter>
+        <filter id="f11">
+            <feComponentTransfer>
+                <feFuncR type="linear" slope="1" intercept="1"/>
+                <feFuncG type="linear" slope="1" intercept="0"/>
+                <feFuncB type="linear" slope="1" intercept="0"/>
+            </feComponentTransfer>
+        </filter>
     </defs>
 
     <rect id="r1" x="50" y="50" width="50" height="50" fill="purple" filter="url(#f1)"/>
@@ -49,4 +56,5 @@
     <rect id="r8" x="350" y="150" width="50" height="50" fill="purple" filter="url(#f8)"/>
     <rect id="r9" x="50" y="250" width="50" height="50" fill="purple" filter="url(#f9b)"/>
     <rect id="r10" x="150" y="250" width="50" height="50" fill="purple" filter="url(#f10c)"/>
+    <rect id="r11" x="250" y="250" width="50" height="50" fill="purple" filter="url(#f11)"/>
 </svg>

--- a/LayoutTests/svg/resource-invalidation/filter-resource-invalidation.html
+++ b/LayoutTests/svg/resource-invalidation/filter-resource-invalidation.html
@@ -38,6 +38,13 @@
         <filter id="f10c" xlink:href="#f10a">
             <feFlood flood-color="blue"/>
         </filter>
+        <filter id="f11">
+            <feComponentTransfer>
+                <feFuncR type="linear" slope="1" intercept="0"/>
+                <feFuncG type="linear" slope="1" intercept="0"/>
+                <feFuncB type="linear" slope="1" intercept="0"/>
+            </feComponentTransfer>
+        </filter>
     </defs>
 
     <rect id="r1" x="50" y="50" width="50" height="50" fill="purple"/>
@@ -50,6 +57,7 @@
     <rect id="r8" x="350" y="150" width="50" height="50" fill="purple" filter="url(#f8)"/>
     <rect id="r9" x="50" y="250" width="50" height="50" fill="purple" filter="url(#f9b)"/>
     <rect id="r10" x="150" y="250" width="50" height="50" fill="purple" filter="url(#f10c)"/>
+    <rect id="r11" x="250" y="250" width="50" height="50" fill="purple" filter="url(#f11)"/>
 </svg>
 <script>
 function run() {
@@ -66,6 +74,7 @@ function run() {
             f8.firstElementChild.setAttribute("values", "240"); // change other attribute of filter contents
             f9a.setAttribute("x", "50%"); // change linked filter resource attribute
             f10c.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", "#f10b"); // change xlink:href of filter resource
+            f11.querySelector("feFuncR").setAttribute("intercept", "1"); // change filter primitive child attribute
             testRunner.notifyDone();
         });
     }

--- a/Source/WTF/wtf/EnumeratedArray.h
+++ b/Source/WTF/wtf/EnumeratedArray.h
@@ -262,7 +262,7 @@ public:
     }
 
 private:
-    typename UnderlyingType::size_type index(size_type pos)
+    typename UnderlyingType::size_type index(size_type pos) const
     {
         return static_cast<typename UnderlyingType::size_type>(pos);
     }

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -40,12 +40,20 @@ Ref<FEComponentTransfer> FEComponentTransfer::create(const ComponentTransferFunc
     return adoptRef(*new FEComponentTransfer(redFunction, greenFunction, blueFunction, alphaFunction));
 }
 
+Ref<FEComponentTransfer> FEComponentTransfer::create(ComponentTransferFunctions&& functions)
+{
+    return adoptRef(*new FEComponentTransfer(WTFMove(functions)));
+}
+
 FEComponentTransfer::FEComponentTransfer(const ComponentTransferFunction& redFunction, const ComponentTransferFunction& greenFunction, const ComponentTransferFunction& blueFunction, const ComponentTransferFunction& alphaFunction)
     : FilterEffect(FilterEffect::Type::FEComponentTransfer)
-    , m_redFunction(redFunction)
-    , m_greenFunction(greenFunction)
-    , m_blueFunction(blueFunction)
-    , m_alphaFunction(alphaFunction)
+    , m_functions(std::array { redFunction, greenFunction, blueFunction, alphaFunction })
+{
+}
+
+FEComponentTransfer::FEComponentTransfer(ComponentTransferFunctions&& functions)
+    : FilterEffect(FilterEffect::Type::FEComponentTransfer)
+    , m_functions(WTFMove(functions))
 {
 }
 
@@ -70,6 +78,69 @@ std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createAcceleratedAppli
 std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createSoftwareApplier() const
 {
     return FilterEffectApplier::create<FEComponentTransferSoftwareApplier>(*this);
+}
+
+bool FEComponentTransfer::setType(ComponentTransferChannel channel, ComponentTransferType type)
+{
+    if (m_functions[channel].type == type)
+        return false;
+
+    m_functions[channel].type = type;
+    return true;
+}
+
+bool FEComponentTransfer::setSlope(ComponentTransferChannel channel, float value)
+{
+    if (m_functions[channel].slope == value)
+        return false;
+
+    m_functions[channel].slope = value;
+    return true;
+}
+
+bool FEComponentTransfer::setIntercept(ComponentTransferChannel channel, float value)
+{
+    if (m_functions[channel].intercept == value)
+        return false;
+
+    m_functions[channel].intercept = value;
+    return true;
+}
+
+bool FEComponentTransfer::setAmplitude(ComponentTransferChannel channel, float value)
+{
+    if (m_functions[channel].amplitude == value)
+        return false;
+
+    m_functions[channel].amplitude = value;
+    return true;
+}
+
+bool FEComponentTransfer::setExponent(ComponentTransferChannel channel, float value)
+{
+    if (m_functions[channel].exponent == value)
+        return false;
+
+    m_functions[channel].exponent = value;
+    return true;
+}
+
+bool FEComponentTransfer::setOffset(ComponentTransferChannel channel, float value)
+{
+    if (m_functions[channel].offset == value)
+        return false;
+
+    m_functions[channel].offset = value;
+    return true;
+}
+
+bool FEComponentTransfer::setTableValues(ComponentTransferChannel channel, Vector<float>&& values)
+{
+    if (m_functions[channel].tableValues == values)
+        return false;
+
+    m_functions[channel].tableValues = WTFMove(values);
+    return true;
 }
 
 static TextStream& operator<<(TextStream& ts, ComponentTransferType type)
@@ -131,10 +202,10 @@ TextStream& FEComponentTransfer::externalRepresentation(TextStream& ts, FilterRe
 
     {
         TextStream::IndentScope indentScope(ts, 2);
-        ts << indent << "{red: " << m_redFunction << "}\n";
-        ts << indent << "{green: " << m_greenFunction << "}\n";
-        ts << indent << "{blue: " << m_blueFunction << "}\n";
-        ts << indent << "{alpha: " << m_alphaFunction << "}";
+        ts << indent << "{red: " << m_functions[ComponentTransferChannel::Red] << "}\n";
+        ts << indent << "{green: " << m_functions[ComponentTransferChannel::Green] << "}\n";
+        ts << indent << "{blue: " << m_functions[ComponentTransferChannel::Blue] << "}\n";
+        ts << indent << "{alpha: " << m_functions[ComponentTransferChannel::Alpha] << "}";
     }
 
     ts << "]\n";

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -91,8 +91,13 @@ void SVGComponentTransferFunctionElement::parseAttribute(const QualifiedName& na
 void SVGComponentTransferFunctionElement::svgAttributeChanged(const QualifiedName& attrName)
 {
     if (PropertyRegistry::isKnownAttribute(attrName)) {
-        InstanceInvalidationGuard guard(*this);
-        SVGFilterPrimitiveStandardAttributes::invalidateFilterPrimitiveParent(this);
+        RefPtr parent = parentElement();
+
+        if (parent && is<SVGFEComponentTransferElement>(*parent)) {
+            InstanceInvalidationGuard guard(*this);
+            downcast<SVGFEComponentTransferElement>(*parent).transferFunctionAttributeChanged(*this, attrName);
+        }
+
         return;
     }
 

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "ElementName.h"
 #include "FEComponentTransfer.h"
 #include "SVGElement.h"
 #include <wtf/SortedArrayMap.h>
@@ -69,6 +70,7 @@ struct SVGPropertyTraits<ComponentTransferType> {
 class SVGComponentTransferFunctionElement : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGComponentTransferFunctionElement);
 public:
+    virtual ComponentTransferChannel channel() const = 0;
     ComponentTransferFunction transferFunction() const;
 
     ComponentTransferType type() const { return m_type->currentValue<ComponentTransferType>(); }

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "SVGElementTypeHelpers.h"
+#include "SVGFEFuncAElement.h"
+#include "SVGFEFuncBElement.h"
+#include "SVGFEFuncGElement.h"
+#include "SVGFEFuncRElement.h"
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGComponentTransferFunctionElement)
+    static bool isType(const WebCore::Element& element) { return is<WebCore::SVGFEFuncRElement>(element) || is<WebCore::SVGFEFuncGElement>(element) || is<WebCore::SVGFEFuncBElement>(element) || is<WebCore::SVGFEFuncAElement>(element); }
+    static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -26,6 +26,8 @@
 
 namespace WebCore {
 
+class SVGComponentTransferFunctionElement;
+
 class SVGFEComponentTransferElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_ISO_ALLOCATED(SVGFEComponentTransferElement);
 public:
@@ -33,6 +35,11 @@ public:
 
     String in1() const { return m_in1->currentValue(); }
     SVGAnimatedString& in1Animated() { return m_in1; }
+
+    void transferFunctionAttributeChanged(SVGComponentTransferFunctionElement&, const QualifiedName&);
+
+protected:
+    bool setFilterEffectAttributeFromChild(FilterEffect&, const Element&, const QualifiedName&) final;
 
 private:
     SVGFEComponentTransferElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGFEFuncAElement.h
+++ b/Source/WebCore/svg/SVGFEFuncAElement.h
@@ -28,6 +28,8 @@ class SVGFEFuncAElement final : public SVGComponentTransferFunctionElement {
 public:
     static Ref<SVGFEFuncAElement> create(const QualifiedName&, Document&);
 
+    ComponentTransferChannel channel() const final { return ComponentTransferChannel::Alpha; }
+
 private:
     SVGFEFuncAElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/svg/SVGFEFuncBElement.h
+++ b/Source/WebCore/svg/SVGFEFuncBElement.h
@@ -28,6 +28,8 @@ class SVGFEFuncBElement final : public SVGComponentTransferFunctionElement {
 public:
     static Ref<SVGFEFuncBElement> create(const QualifiedName&, Document&);
 
+    ComponentTransferChannel channel() const final { return ComponentTransferChannel::Blue; }
+
 private:
     SVGFEFuncBElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/svg/SVGFEFuncGElement.h
+++ b/Source/WebCore/svg/SVGFEFuncGElement.h
@@ -28,6 +28,8 @@ class SVGFEFuncGElement final : public SVGComponentTransferFunctionElement {
 public:
     static Ref<SVGFEFuncGElement> create(const QualifiedName&, Document&);
 
+    ComponentTransferChannel channel() const final { return ComponentTransferChannel::Green; }
+
 private:
     SVGFEFuncGElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/svg/SVGFEFuncRElement.h
+++ b/Source/WebCore/svg/SVGFEFuncRElement.h
@@ -28,6 +28,8 @@ class SVGFEFuncRElement final : public SVGComponentTransferFunctionElement {
 public:
     static Ref<SVGFEFuncRElement> create(const QualifiedName&, Document&);
 
+    ComponentTransferChannel channel() const final { return ComponentTransferChannel::Red; }
+
 private:
     SVGFEFuncRElement(const QualifiedName&, Document&);
 };

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -98,6 +98,17 @@ void SVGFilterPrimitiveStandardAttributes::primitiveAttributeChanged(const Quali
         static_cast<RenderSVGResourceFilterPrimitive*>(renderer)->markFilterEffectForRepaint(m_effect.get());
 }
 
+void SVGFilterPrimitiveStandardAttributes::primitiveAttributeOnChildChanged(const Element& child, const QualifiedName& attribute)
+{
+    ASSERT(child.parentNode() == this);
+
+    if (m_effect && !setFilterEffectAttributeFromChild(*m_effect, child, attribute))
+        return;
+
+    if (auto* renderer = this->renderer())
+        static_cast<RenderSVGResourceFilterPrimitive*>(renderer)->markFilterEffectForRepaint(m_effect.get());
+}
+
 void SVGFilterPrimitiveStandardAttributes::markFilterEffectForRebuild()
 {
     if (auto* renderer = this->renderer())

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h
@@ -69,8 +69,10 @@ protected:
     void parseAttribute(const QualifiedName&, const AtomString&) override;
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;
+    void primitiveAttributeOnChildChanged(const Element&, const QualifiedName&);
 
     virtual bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) { return false; }
+    virtual bool setFilterEffectAttributeFromChild(FilterEffect&, const Element&, const QualifiedName&) { return false; }
     virtual RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const = 0;
 
 private:


### PR DESCRIPTION
#### 4abefb791c7642bbf2f32d92d246010370c8183d
<pre>
Update FEComponentTransfer filter effect when a child transfer function attribute changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=246602">https://bugs.webkit.org/show_bug.cgi?id=246602</a>
&lt;rdar://problem/101232007&gt;

Reviewed by Said Abou-Hallawa.

Nothing currently causes the FEComponentTransfer effect to get updated
when an attribute on a child feFunc[RGBA] element changes.

Because we there are multiple child elements, we can&apos;t call
primitiveAttributeChanged on the parent SVGFEComponentTransferElement
and go through the normal setFilterEffectAttribute path like the
SVGFELightElement classes do. So instead we add a new function,
primitiveAttributeOnChildChanged, which takes the element as well.

* LayoutTests/svg/resource-invalidation/filter-resource-invalidation-expected.html:
* LayoutTests/svg/resource-invalidation/filter-resource-invalidation.html:

Add a sub-test for changing one of the feFuncX attributes.

* Source/WTF/wtf/EnumeratedArray.h:
(WTF::EnumeratedArray::index const):
(WTF::EnumeratedArray::index): Deleted.

This function needs to be const for `EnumeratedArray::operator[] const` to
work.

* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::create):
(WebCore::FEComponentTransfer::FEComponentTransfer):

(WebCore::FEComponentTransfer::setType):
(WebCore::FEComponentTransfer::setSlope):
(WebCore::FEComponentTransfer::setIntercept):
(WebCore::FEComponentTransfer::setAmplitude):
(WebCore::FEComponentTransfer::setExponent):
(WebCore::FEComponentTransfer::setOffset):
(WebCore::FEComponentTransfer::setTableValues):

Setters for individual attributes of a transfer function.

(WebCore::FEComponentTransfer::externalRepresentation const):

* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
(WebCore::FEComponentTransfer::redFunction const):
(WebCore::FEComponentTransfer::greenFunction const):
(WebCore::FEComponentTransfer::blueFunction const):
(WebCore::FEComponentTransfer::alphaFunction const):
(WebCore::FEComponentTransfer::encode const):

Store the four transfer functions in an EnumeratedArray to make access
from the new setter functions above more convenient.

* Source/WebCore/svg/SVGComponentTransferFunctionElementInlines.h: Added.

* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::svgAttributeChanged):

* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
(WebCore::SVGComponentTransferFunctionElement::channel const):
(isType):

Add type specialization support for SVGComponentTransferFunctionElement,
to avoid code that checks for each of the four feFuncX element types
explicitly.

* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::createFilterEffect const):

(WebCore::isRelevantTransferFunctionElement):

Used to ensure we only update the effect if it&apos;s the last transfer
function element of a given name that&apos;s being modified.

(WebCore::SVGFEComponentTransferElement::setFilterEffectAttributeFromChild):

Update the FEComponentTransfer effect when an attribute&apos;s changed.

(WebCore::SVGFEComponentTransferElement::transferFunctionAttributeChanged):

* Source/WebCore/svg/SVGFEComponentTransferElement.h:
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::primitiveAttributeOnChildChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.h:
(WebCore::SVGFilterPrimitiveStandardAttributes::setFilterEffectAttributeFromChild):

* Source/WebCore/svg/SVGFEFuncAElement.h:
* Source/WebCore/svg/SVGFEFuncBElement.h:
* Source/WebCore/svg/SVGFEFuncGElement.h:
* Source/WebCore/svg/SVGFEFuncRElement.h:

Canonical link: <a href="https://commits.webkit.org/255869@main">https://commits.webkit.org/255869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c26848385e63c4cc923505d3c4b3a4a8d4c0b3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103490 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3066 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31285 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86178 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2187 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80281 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29209 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84113 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72161 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85109 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37681 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80238 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18905 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27668 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39424 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82887 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38135 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18727 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.mini-mode (failure)") | 
<!--EWS-Status-Bubble-End-->