### PR TITLE
[GTK][WPE] Add heartbeat mechanism to check for web process responsiveness

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -389,6 +389,7 @@ UIProcess/MediaKeySystemPermissionRequestProxy.cpp
 UIProcess/ModelElementController.cpp
 UIProcess/OverrideLanguages.cpp
 UIProcess/PageLoadState.cpp
+UIProcess/PeriodicalResponsivenessTimer.cpp
 UIProcess/ProcessAssertion.cpp
 UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalFrameProxy.cpp

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -5515,3 +5515,16 @@ webkit_web_view_get_default_content_security_policy(WebKitWebView* webView)
 
     return webView->priv->defaultContentSecurityPolicy.data();
 }
+
+void webkitWebViewRestartWebProcessResponsivenessTimerForTesting(WebKitWebView* webView)
+{
+    ASSERT(WEBKIT_IS_WEB_VIEW(webView));
+
+    auto& page = getPage(webView);
+
+    if (!page.hasRunningProcess())
+        return;
+
+    Ref protectedProcessProxy { page.process() };
+    protectedProcessProxy->restartPeriodicalResponsivenessTimer();
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewInternal.h
@@ -30,3 +30,5 @@ WK_EXPORT void webkitWebViewRunJavascriptWithoutForcedUserGestures(WebKitWebView
 typedef void (*ForceRepaintCallback) (gpointer userData);
 WK_EXPORT void webkitWebViewForceRepaintForTesting(WebKitWebView*, ForceRepaintCallback, gpointer userData);
 WK_EXPORT void webkitSetCachedProcessSuspensionDelayForTesting(double seconds);
+
+WK_EXPORT void webkitWebViewRestartWebProcessResponsivenessTimerForTesting(WebKitWebView*);

--- a/Source/WebKit/UIProcess/PeriodicalResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/PeriodicalResponsivenessTimer.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PeriodicalResponsivenessTimer.h"
+
+#include "WebProcessProxy.h"
+
+namespace WebKit {
+
+PeriodicalResponsivenessTimer::PeriodicalResponsivenessTimer(WebProcessProxy& process)
+    : m_process(process)
+    , m_timer(RunLoop::main(), this, &PeriodicalResponsivenessTimer::timerFired)
+{
+}
+
+PeriodicalResponsivenessTimer::~PeriodicalResponsivenessTimer() = default;
+
+void PeriodicalResponsivenessTimer::start()
+{
+    if (m_timer.isActive())
+        return;
+
+    timerFired();
+    m_timer.startRepeating(10_s);
+}
+
+void PeriodicalResponsivenessTimer::stop()
+{
+    m_timer.stop();
+}
+
+void PeriodicalResponsivenessTimer::timerFired()
+{
+    // It is not needed to pass any callback here, because a consequence
+    // of calling isResponsive is start the ResponsivenessTimer which
+    // (in case of unresponsive web process) after 3 seconds sends signal
+    // 'notify::is-web-process-responsive'.
+    m_process.isResponsive(nullptr);
+}
+
+void PeriodicalResponsivenessTimer::restart()
+{ 
+    stop();
+    start();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/PeriodicalResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/PeriodicalResponsivenessTimer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/RunLoop.h>
+
+namespace WebKit {
+
+class WebProcessProxy;
+
+class PeriodicalResponsivenessTimer {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit PeriodicalResponsivenessTimer(WebProcessProxy&);
+    ~PeriodicalResponsivenessTimer();
+
+    void start();
+    void stop();
+
+    void restart();
+
+private:
+    void timerFired();
+
+    WebProcessProxy& m_process;
+
+    RunLoop::Timer m_timer;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1614,6 +1614,7 @@ public:
 
     bool isPlayingAudio() const { return !!(m_mediaState & WebCore::MediaProducerMediaState::IsPlayingAudio); }
     bool hasMediaStreaming() const { return !!(m_mediaState & WebCore::MediaProducerMediaState::HasStreamingActivity); }
+    bool isPlayingMedia() const;
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags);
     void updateReportedMediaCaptureState();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -95,6 +95,7 @@ namespace WebKit {
 class AudioSessionRoutingArbitratorProxy;
 class ObjCObjectGraph;
 class PageClient;
+class PeriodicalResponsivenessTimer;
 class ProvisionalFrameProxy;
 class ProvisionalPageProxy;
 class UserMediaCaptureManagerProxy;
@@ -479,6 +480,9 @@ public:
     static void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
     void sendPermissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
 
+    void restartPeriodicalResponsivenessTimer();
+    void startOrStopPeriodicalResponsivenessTimer();
+
 protected:
     WebProcessProxy(WebProcessPool&, WebsiteDataStore*, IsPrewarmed, WebCore::CrossOriginMode, LockdownMode);
 
@@ -624,6 +628,7 @@ private:
     };
 
     BackgroundProcessResponsivenessTimer m_backgroundResponsivenessTimer;
+    std::unique_ptr<PeriodicalResponsivenessTimer> m_periodicalResponsivenessTimer;
     
     RefPtr<WebConnectionToWebProcess> m_webConnection;
     WeakOrStrongPtr<WebProcessPool> m_processPool; // Pre-warmed and cached processes do not hold a strong reference to their pool.


### PR DESCRIPTION
#### 343defbe5012fbcd2033d5f742b7af9e14b05c21
<pre>
[GTK][WPE] Add heartbeat mechanism to check for web process responsiveness
<a href="https://bugs.webkit.org/show_bug.cgi?id=246330">https://bugs.webkit.org/show_bug.cgi?id=246330</a>

Reviewed by NOBODY (OOPS!).

The &quot;heartbeat&quot; mechanism checks is web process reponsiveness periodically.
It is needed in case no user interaction or API calls to detect if the
process becomes unresponsive.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
(webkitWebViewRestartWebProcessResponsivenessTimerForTesting):
* Source/WebKit/UIProcess/API/glib/WebKitWebViewInternal.h:
* Source/WebKit/UIProcess/PeriodicalResponsivenessTimer.cpp: Added.
(WebKit::PeriodicalResponsivenessTimer::PeriodicalResponsivenessTimer):
(WebKit::PeriodicalResponsivenessTimer::~PeriodicalResponsivenessTimer):
(WebKit::PeriodicalResponsivenessTimer::start):
(WebKit::PeriodicalResponsivenessTimer::stop):
(WebKit::PeriodicalResponsivenessTimer::timerFired):
(WebKit::PeriodicalResponsivenessTimer::restart):
* Source/WebKit/UIProcess/PeriodicalResponsivenessTimer.h: Added.
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebView.cpp:
(testWebViewIsWebProcessUnresponsive):
(beforeAll):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e0ec6a595987246809a803fa321c19991070879

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/106530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/15546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/39339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/115715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/115363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/110439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/17041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/6774 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/98722 "Built successfully") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/112298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/12949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/95919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/40507 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/94824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/27563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/82229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/8775 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/28915 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9318 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/5501 "Found 3 new test failures: css3/masking/mask-repeat-round-padding.html, fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-and-placeholder.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/48463 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/10856 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->