### PR TITLE
Implement WebCodecs Validate VideoFrameInit algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -10,9 +10,7 @@ PASS Test constructing w/ unusable image argument throws: HAVE_NOTHING <video>.
 PASS Test constructing w/ unusable image argument throws: emtpy Canvas.
 PASS Test constructing w/ unusable image argument throws: closed ImageBitmap.
 PASS Test constructing w/ unusable image argument throws: closed VideoFrame.
-FAIL Test invalid CanvasImageSource constructed VideoFrames assert_throws_js: negative visibleRect x function "() => new VideoFrame(
-          image,
-          {timestamp: 10, visibleRect: {x: -1, y: 0, width: 10, height: 10}})" did not throw
+PASS Test invalid CanvasImageSource constructed VideoFrames
 PASS Test visibleRect metadata override where source display size = visible size
 PASS Test visibleRect metadata override where source display width = 2 * visible width (anamorphic)
 PASS Test visibleRect metadata override where source display size = 2 * visible size for both width and height
@@ -30,5 +28,5 @@ PASS Test we can construct a VideoFrame from an offscreen canvas.
 PASS Test I420 VideoFrame with odd visible size
 FAIL Test I420A VideoFrame and alpha={keep,discard} VideoPixelFormat is not supported
 PASS Test RGBA, BGRA VideoFrames with alpha={keep,discard}
-FAIL Test a VideoFrame constructed from canvas can drop the alpha channel. assert_true: plane format should not have alpha: BGRA expected true got false
+PASS Test a VideoFrame constructed from canvas can drop the alpha channel.
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -129,8 +129,8 @@ public:
     bool shoudlDiscardAlpha() const { return m_format && (*m_format == VideoPixelFormat::RGBX || *m_format == VideoPixelFormat::BGRX); }
 
 private:
-    static Ref<WebCodecsVideoFrame> initializeFrameFromOtherFrame(Ref<WebCodecsVideoFrame>&&, Init&&);
-    static Ref<WebCodecsVideoFrame> initializeFrameFromOtherFrame(Ref<VideoFrame>&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(Ref<WebCodecsVideoFrame>&&, Init&&);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(Ref<VideoFrame>&&, Init&&);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameWithResourceAndSize(Ref<NativeImage>&&, Init&&);
 
     RefPtr<VideoFrame> m_internalFrame;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
@@ -53,6 +53,8 @@ void initializeVisibleRectAndDisplaySize(WebCodecsVideoFrame&, const WebCodecsVi
 
 Ref<VideoColorSpace> videoFramePickColorSpace(const std::optional<VideoColorSpaceInit>&, VideoPixelFormat);
 
+bool validateVideoFrameInit(const WebCodecsVideoFrame::Init&, size_t codedWidth, size_t codedHeight, VideoPixelFormat);
+
 }
 
 #endif

--- a/Source/WebCore/platform/VideoPixelFormat.cpp
+++ b/Source/WebCore/platform/VideoPixelFormat.cpp
@@ -33,15 +33,15 @@
 
 namespace WebCore {
 
-VideoPixelFormat convertVideoFramePixelFormat(uint32_t format)
+VideoPixelFormat convertVideoFramePixelFormat(uint32_t format, bool shouldDiscardAlpha)
 {
 #if PLATFORM(COCOA)
     if (format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
         return VideoPixelFormat::NV12;
     if (format == kCVPixelFormatType_32BGRA)
-        return VideoPixelFormat::BGRA;
+        return shouldDiscardAlpha ? VideoPixelFormat::BGRX : VideoPixelFormat::BGRA;
     if (format == kCVPixelFormatType_32ARGB)
-        return VideoPixelFormat::RGBA;
+        return shouldDiscardAlpha ? VideoPixelFormat::RGBX : VideoPixelFormat::RGBA;
     ASSERT_NOT_REACHED();
 #else
     UNUSED_PARAM(format);

--- a/Source/WebCore/platform/VideoPixelFormat.h
+++ b/Source/WebCore/platform/VideoPixelFormat.h
@@ -39,7 +39,7 @@ enum class VideoPixelFormat {
     BGRX
 };
 
-VideoPixelFormat convertVideoFramePixelFormat(uint32_t);
+VideoPixelFormat convertVideoFramePixelFormat(uint32_t, bool shouldDiscardAlpha);
 
 inline bool isRGBVideoPixelFormat(VideoPixelFormat format)
 {


### PR DESCRIPTION
#### 9761a5d2141040ada1b594b913fd7adaf53ea266
<pre>
Implement WebCodecs Validate VideoFrameInit algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=246796">https://bugs.webkit.org/show_bug.cgi?id=246796</a>
rdar://problem/101373396

Reviewed by Eric Carlson.

Implement <a href="https://w3c.github.io/webcodecs/#validate-videoframeinit">https://w3c.github.io/webcodecs/#validate-videoframeinit</a> and add support for alpha from canvas.
Covered by rebased test.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
(WebCore::WebCodecsVideoFrame::initializeFrameWithResourceAndSize):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::isNegativeOrNonFinite):
(WebCore::validateVideoFrameInit):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h:
* Source/WebCore/platform/VideoPixelFormat.cpp:
(WebCore::convertVideoFramePixelFormat):
* Source/WebCore/platform/VideoPixelFormat.h:

Canonical link: <a href="https://commits.webkit.org/255786@main">https://commits.webkit.org/255786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/252077cdecc9964c6ad33635786bc4fadb724344

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103241 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/163561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2795 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31066 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99314 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1982 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80032 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29014 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71967 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37449 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18760 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39163 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37991 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->