### PR TITLE
[css-typed-om] support reification of <transform-list>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative-expected.txt
@@ -25,6 +25,6 @@ PASS Normalizing a skewX() returns a CSSSkewX
 PASS Normalizing a skewY() returns a CSSSkewY
 PASS Normalizing a perspective() returns a CSSPerspective
 PASS Normalizing a perspective(none) returns a CSSPerspective
-FAIL Normalizing a <transform-list> returns a CSSTransformValue containing all the transforms assert_equals: expected 7 but got 1
-FAIL Normalizing transforms with calc values contains CSSMathValues assert_equals: expected 2 but got 1
+PASS Normalizing a <transform-list> returns a CSSTransformValue containing all the transforms
+FAIL Normalizing transforms with calc values contains CSSMathValues assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -605,6 +605,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/CSSStyleSheet.h
     css/CSSSubgridValue.h
     css/CSSToLengthConversionData.h
+    css/CSSTransformListValue.h
     css/CSSUnits.h
     css/CSSUnknownRule.h
     css/CSSValue.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -809,6 +809,7 @@ css/CSSSupportsRule.cpp
 css/CSSTimingFunctionValue.cpp
 css/CSSToLengthConversionData.cpp
 css/CSSToStyleMap.cpp
+css/CSSTransformListValue.cpp
 css/CSSUnicodeRangeValue.cpp
 css/CSSUnits.cpp
 css/CSSValue.cpp

--- a/Source/WebCore/css/CSSTransformListValue.cpp
+++ b/Source/WebCore/css/CSSTransformListValue.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSTransformListValue.h"
+
+namespace WebCore {
+
+CSSTransformListValue::CSSTransformListValue()
+    : CSSValueList(TransformListClass, SpaceSeparator)
+{
+}
+
+}

--- a/Source/WebCore/css/CSSTransformListValue.h
+++ b/Source/WebCore/css/CSSTransformListValue.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSValueList.h"
+
+namespace WebCore {
+
+class CSSTransformListValue final : public CSSValueList {
+public:
+    static Ref<CSSTransformListValue> create()
+    {
+        return adoptRef(*new CSSTransformListValue);
+    }
+
+private:
+    CSSTransformListValue();
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSTransformListValue, isTransformListValue());

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -68,6 +68,7 @@
 #include "CSSShadowValue.h"
 #include "CSSSubgridValue.h"
 #include "CSSTimingFunctionValue.h"
+#include "CSSTransformListValue.h"
 #include "CSSUnicodeRangeValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
@@ -171,6 +172,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSStepsTimingFunctionValue>(*this));
     case SpringTimingFunctionClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSSpringTimingFunctionValue>(*this));
+    case TransformListClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSTransformListValue>(*this));
     case UnicodeRangeClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSUnicodeRangeValue>(*this));
     case ValueListClass:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -105,6 +105,7 @@ public:
     bool isGridTemplateAreasValue() const { return m_classType == GridTemplateAreasClass; }
     bool isGridLineNamesValue() const { return m_classType == GridLineNamesClass; }
     bool isSubgridValue() const { return m_classType == SubgridClass; }
+    bool isTransformListValue() const { return m_classType == TransformListClass; }
     bool isUnicodeRangeValue() const { return m_classType == UnicodeRangeClass; }
 
     bool isVariableReferenceValue() const { return m_classType == VariableReferenceClass; }
@@ -203,6 +204,7 @@ protected:
         GridAutoRepeatClass,
         GridIntegerRepeatClass,
         SubgridClass,
+        TransformListClass,
         // Do not append non-list class types here.
     };
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -45,6 +45,7 @@
 #include "CSSReflectValue.h"
 #include "CSSShadowValue.h"
 #include "CSSTimingFunctionValue.h"
+#include "CSSTransformListValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "ComposedTreeAncestorIterator.h"
@@ -735,7 +736,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
     if (renderer) {
         TransformationMatrix transform;
         style.applyTransform(transform, renderer->transformReferenceBoxRect(style), { });
-        auto list = CSSValueList::createSpaceSeparated();
+        auto list = CSSTransformListValue::create();
         list->append(matrixTransformValue(transform, style));
         return list;
     }
@@ -746,7 +747,7 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
     if (valueType == ComputedStyleExtractor::PropertyValueType::Resolved)
         return cssValuePool.createIdentifierValue(CSSValueNone);
 
-    auto list = CSSValueList::createSpaceSeparated();
+    auto list = CSSTransformListValue::create();
 
     auto translateLengthAsCSSValue = [&](const Length& length) {
         if (length.isZero())

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -37,6 +37,7 @@
 #include "CSSProperty.h"
 #include "CSSPropertyParser.h"
 #include "CSSPropertyParserHelpers.h"
+#include "CSSTransformListValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "DeprecatedGlobalSettings.h"
@@ -1339,7 +1340,7 @@ static RefPtr<CSSValueList> parseSimpleTransformList(const CharType* chars, unsi
         return nullptr;
     const CharType*& pos = chars;
     const CharType* end = chars + length;
-    RefPtr<CSSValueList> transformList;
+    RefPtr<CSSTransformListValue> transformList;
     while (pos < end) {
         while (pos < end && isCSSSpace(*pos))
             ++pos;
@@ -1349,7 +1350,7 @@ static RefPtr<CSSValueList> parseSimpleTransformList(const CharType* chars, unsi
         if (!transformValue)
             return nullptr;
         if (!transformList)
-            transformList = CSSValueList::createSpaceSeparated();
+            transformList = CSSTransformListValue::create();
         transformList->append(*transformValue);
     }
     return transformList;

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -64,6 +64,7 @@
 #include "CSSShadowValue.h"
 #include "CSSSubgridValue.h"
 #include "CSSTimingFunctionValue.h"
+#include "CSSTransformListValue.h"
 #include "CSSUnicodeRangeValue.h"
 #include "CSSVariableParser.h"
 #include "CSSVariableReferenceValue.h"
@@ -2072,7 +2073,7 @@ static RefPtr<CSSValue> consumeTransform(CSSParserTokenRange& range, CSSParserMo
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
 
-    RefPtr<CSSValueList> list = CSSValueList::createSpaceSeparated();
+    RefPtr<CSSTransformListValue> list = CSSTransformListValue::create();
     do {
         RefPtr<CSSValue> parsedTransformValue = consumeTransformValue(range, cssParserMode);
         if (!parsedTransformValue)

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -32,7 +32,17 @@
 
 #if ENABLE(CSS_TYPED_OM)
 
+#include "CSSFunctionValue.h"
+#include "CSSMatrixComponent.h"
+#include "CSSPerspective.h"
+#include "CSSRotate.h"
+#include "CSSScale.h"
+#include "CSSSkew.h"
+#include "CSSSkewX.h"
+#include "CSSSkewY.h"
 #include "CSSTransformComponent.h"
+#include "CSSTransformListValue.h"
+#include "CSSTranslate.h"
 #include "DOMMatrix.h"
 #include "ExceptionOr.h"
 #include <wtf/Algorithms.h>
@@ -42,6 +52,64 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransformValue);
+
+static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(CSSFunctionValue& functionValue)
+{
+    auto makeTransformComponent = [&](auto exceptionOrTransformComponent) -> ExceptionOr<Ref<CSSTransformComponent>> {
+        if (exceptionOrTransformComponent.hasException())
+            return exceptionOrTransformComponent.releaseException();
+        return Ref<CSSTransformComponent> { exceptionOrTransformComponent.releaseReturnValue() };
+    };
+
+    switch (functionValue.name()) {
+    case CSSValueTranslateX:
+    case CSSValueTranslateY:
+    case CSSValueTranslateZ:
+    case CSSValueTranslate:
+    case CSSValueTranslate3d:
+        return makeTransformComponent(CSSTranslate::create(functionValue));
+    case CSSValueScaleX:
+    case CSSValueScaleY:
+    case CSSValueScaleZ:
+    case CSSValueScale:
+    case CSSValueScale3d:
+        return makeTransformComponent(CSSScale::create(functionValue));
+    case CSSValueRotateX:
+    case CSSValueRotateY:
+    case CSSValueRotateZ:
+    case CSSValueRotate:
+    case CSSValueRotate3d:
+        return makeTransformComponent(CSSRotate::create(functionValue));
+    case CSSValueSkewX:
+        return makeTransformComponent(CSSSkewX::create(functionValue));
+    case CSSValueSkewY:
+        return makeTransformComponent(CSSSkewY::create(functionValue));
+    case CSSValueSkew:
+        return makeTransformComponent(CSSSkew::create(functionValue));
+    case CSSValuePerspective:
+        return makeTransformComponent(CSSPerspective::create(functionValue));
+    case CSSValueMatrix:
+    case CSSValueMatrix3d:
+        return makeTransformComponent(CSSMatrixComponent::create(functionValue));
+    default:
+        return Exception { TypeError, "Unexpected function value type"_s };
+    }
+}
+
+ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(CSSTransformListValue& transformList)
+{
+    Vector<RefPtr<CSSTransformComponent>> components;
+    for (auto transformFunction : transformList) {
+        if (!is<CSSFunctionValue>(transformFunction))
+            return Exception { TypeError, "Expected only function values in a transform list."_s };
+        auto& functionValue = downcast<CSSFunctionValue>(transformFunction.get());
+        auto transformComponentOrException = createTransformComponent(functionValue);
+        if (transformComponentOrException.hasException())
+            return transformComponentOrException.releaseException();
+        components.append(transformComponentOrException.releaseReturnValue());
+    }
+    return adoptRef(*new CSSTransformValue(WTFMove(components)));
+}
 
 ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Vector<RefPtr<CSSTransformComponent>>&& transforms)
 {

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -34,12 +34,14 @@
 namespace WebCore {
 
 class CSSTransformComponent;
+class CSSTransformListValue;
 class DOMMatrix;
 template<typename> class ExceptionOr;
 
 class CSSTransformValue final : public CSSStyleValue {
     WTF_MAKE_ISO_ALLOCATED(CSSTransformValue);
 public:
+    static ExceptionOr<Ref<CSSTransformValue>> create(CSSTransformListValue&);
     static ExceptionOr<Ref<CSSTransformValue>> create(Vector<RefPtr<CSSTransformComponent>>&&);
 
     size_t length() const { return m_components.size(); }


### PR DESCRIPTION
#### e042b03d0d518d05ca6bb17c3ef323055cd16403
<pre>
[css-typed-om] support reification of &lt;transform-list&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=246797">https://bugs.webkit.org/show_bug.cgi?id=246797</a>

Reviewed by Antti Koivisto.

We need to be able to distinguish a &lt;transform-list&gt; from any other type of list. So we
introduce a new CSSValueList subclass for this purpose: CSSTransformListValue. Now, when
reifying values, we can handle CSSTransformListValue specifically and create the individual
components from function values there rather than in CSSStyleValueFactory::reifyValue().

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::computedTransform):
* Source/WebCore/css/CSSTransformListValue.cpp: Added.
(WebCore::CSSTransformListValue::CSSTransformListValue):
* Source/WebCore/css/CSSTransformListValue.h: Added.
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isTransformListValue const):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseSimpleTransformList):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeTransform):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::createTransformComponent):
(WebCore::CSSTransformValue::create):
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:

Canonical link: <a href="https://commits.webkit.org/255795@main">https://commits.webkit.org/255795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66fbbf7d229fbe2edd25517b6cf0ba07b7e3b4fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103234 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163554 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2788 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31059 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99307 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1976 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80025 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29009 "Found 1 new test failure: imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-waitingforkey.https.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71962 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37442 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35281 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18752 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41273 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1880 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37983 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->