### PR TITLE
Support WebCodecsVideoFrame as input to canvas texImage2D

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any-expected.txt
@@ -1,8 +1,10 @@
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texImage2D: The video frame has been detached.
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: texSubImage2D: The video frame has been detached.
 
-FAIL texImage2D with 48x36 srgb VideoFrame. null is not an object (evaluating 'gl.VERTEX_SHADER')
-FAIL texSubImage2D with 48x36 srgb VideoFrame. null is not an object (evaluating 'gl.VERTEX_SHADER')
-FAIL texImage2D with 480x360 srgb VideoFrame. null is not an object (evaluating 'gl.VERTEX_SHADER')
-FAIL texSubImage2D with 480x360 srgb VideoFrame. null is not an object (evaluating 'gl.VERTEX_SHADER')
-FAIL texImage2D with a closed VideoFrame. null is not an object (evaluating 'gl.texImage2D')
-FAIL texSubImage2D with a closed VideoFrame. null is not an object (evaluating 'gl.texSubImage2D')
+PASS texImage2D with 48x36 srgb VideoFrame.
+PASS texSubImage2D with 48x36 srgb VideoFrame.
+PASS texImage2D with 480x360 srgb VideoFrame.
+PASS texSubImage2D with 480x360 srgb VideoFrame.
+PASS texImage2D with a closed VideoFrame.
+PASS texSubImage2D with a closed VideoFrame.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.js
@@ -30,8 +30,14 @@ function testTexImage2DFromVideoFrame(
   argbData.fill(0xFF966432);  // 'rgb(50, 100, 150)';
   let frame = new VideoFrame(argbData, vfInit);
 
-  let gl_canvas = new OffscreenCanvas(width, height);
-  let gl = gl_canvas.getContext('webgl');
+  let canvas;
+  if (self.HTMLCanvasElement) {
+    canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+  } else
+    canvas = new OffscreenCanvas(width, height);
+  let gl = canvas.getContext('webgl');
 
   let program = WebGLTestUtils.setupTexturedQuad(gl);
   gl.clearColor(0, 0, 0, 1);
@@ -91,8 +97,14 @@ function testTexImageWithClosedVideoFrame(useTexSubImage2D) {
   argbData.fill(0xFF966432);  // 'rgb(50, 100, 150)';
   let frame = new VideoFrame(argbData, vfInit);
 
-  let gl_canvas = new OffscreenCanvas(width, height);
-  let gl = gl_canvas.getContext('webgl');
+  let canvas;
+  if (self.HTMLCanvasElement) {
+    canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+  } else
+    canvas = new OffscreenCanvas(width, height);
+  let gl = canvas.getContext('webgl');
 
   frame.close();
   if (useTexSubImage2D) {

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -33,6 +33,9 @@
 
 namespace WebCore {
 
+#if ENABLE(WEB_CODECS)
+class WebCodecsVideoFrame;
+#endif
 class WebGLQuery;
 class WebGLSampler;
 class WebGLSync;
@@ -77,11 +80,14 @@ public:
     void texStorage2D(GCGLenum target, GCGLsizei levels, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height);
     void texStorage3D(GCGLenum target, GCGLsizei levels, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLsizei depth);
 
+    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>
 #if ENABLE(VIDEO)
-    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>, RefPtr<HTMLVideoElement>>;
-#else
-    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>>;
+        , RefPtr<HTMLVideoElement>
 #endif
+#if ENABLE(WEB_CODECS)
+        , RefPtr<WebCodecsVideoFrame>
+#endif
+    >;
 
     // Must override the WebGL 1.0 signatures to add extra validation.
     void texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&&) override;

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -44,11 +44,14 @@ typedef ([AllowShared] Float32Array or sequence<GLfloat>) Float32List;
 typedef ([AllowShared] Int32Array or sequence<GLint>) Int32List;
 typedef ([AllowShared] Uint32Array or sequence<GLuint>) Uint32List;
 
-#ifdef ENABLE_VIDEO
-typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement or HTMLVideoElement) TexImageSource;
-#else
-typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement) TexImageSource;
+typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
+#if defined(ENABLE_VIDEO) && ENABLE_VIDEO
+    or HTMLVideoElement
 #endif
+#if defined(ENABLE_WEB_CODECS) && ENABLE_WEB_CODECS
+    or WebCodecsVideoFrame
+#endif
+) TexImageSource;
 
 [
     ActiveDOMObject,

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.idl
@@ -27,11 +27,14 @@ typedef unsigned long GLenum;
 typedef long GLint;
 typedef long GLsizei;
 
-#ifdef ENABLE_VIDEO
-typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement or HTMLVideoElement) TexImageSource;
-#else
-typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement) TexImageSource;
+typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
+#if defined(ENABLE_VIDEO) && ENABLE_VIDEO
+    or HTMLVideoElement
 #endif
+#if defined(ENABLE_WEB_CODECS) && ENABLE_WEB_CODECS
+    or WebCodecsVideoFrame
+#endif
+) TexImageSource;
 
 [
     ActiveDOMObject,

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -51,6 +51,10 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/Lock.h>
 
+#if ENABLE(WEB_CODECS)
+#include "WebCodecsVideoFrame.h"
+#endif
+
 #if ENABLE(WEBGL2)
 #include "WebGLSampler.h"
 #include "WebGLTransformFeedback.h"
@@ -313,11 +317,14 @@ public:
     // These must be virtual so more validation can be added in WebGL 2.0.
     virtual void texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, RefPtr<ArrayBufferView>&&);
 
+    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>
 #if ENABLE(VIDEO)
-    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>, RefPtr<HTMLVideoElement>>;
-#else
-    using TexImageSource = std::variant<RefPtr<ImageBitmap>, RefPtr<ImageData>, RefPtr<HTMLImageElement>, RefPtr<HTMLCanvasElement>>;
+        , RefPtr<HTMLVideoElement>
 #endif
+#if ENABLE(WEB_CODECS)
+        , RefPtr<WebCodecsVideoFrame>
+#endif
+    >;
 
     virtual ExceptionOr<void> texImage2D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLenum format, GCGLenum type, std::optional<TexImageSource>);
 


### PR DESCRIPTION
#### 6f0bde86532b2eca057e6d313b2083dc71adc1fb
<pre>
Support WebCodecsVideoFrame as input to canvas texImage2D
<a href="https://bugs.webkit.org/show_bug.cgi?id=246798">https://bugs.webkit.org/show_bug.cgi?id=246798</a>
rdar://problem/101375988

Reviewed by Eric Carlson.

Update WebIDL to allow WebCodecsVideoFrame.
Add SW code path to texImage2D (optimized remote video frame path should be added later).

Update LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.js to work around a current OffscreenCanvas limitation with WebGL.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-texImage.any.js:
(testTexImage2DFromVideoFrame):
(testTexImageWithClosedVideoFrame):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
* Source/WebCore/html/canvas/WebGLRenderingContext.idl:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getTexImageSourceSize):
(WebCore::WebGLRenderingContextBase::texImageSourceHelper):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/255784@main">https://commits.webkit.org/255784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/885396fd4f24b841188dfd502d9399f52e2ecdc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103232 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163552 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2786 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31057 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99305 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1972 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80023 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29004 "Found 1 new test failure: storage/indexeddb/modern/leak-1.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83894 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71957 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37440 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35279 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4000 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39154 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/37979 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->