### PR TITLE
Run in-process render server

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -225,6 +225,7 @@ typedef struct _CARenderUpdate CARenderUpdate;
 CARenderCGContext *CARenderCGNew(uint32_t feature_flags);
 CARenderUpdate* CARenderUpdateBegin(void* buffer, size_t, CFTimeInterval, const CVTimeStamp*, uint32_t finished_seed, const CGRect* bounds);
 bool CARenderServerStart();
+bool CARenderServerRegister(const char *name);
 mach_port_t CARenderServerGetPort();
 void CARenderCGDestroy(CARenderCGContext*);
 void CARenderCGRender(CARenderCGContext*, CARenderUpdate*, CGContextRef);

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -90,6 +90,8 @@ public:
     // with this context is desired.
     WTF::MachSendRight createFencePort();
 
+    static void setServerName(const char*);
+
 private:
     LayerHostingMode m_layerHostingMode;
     RetainPtr<CAContext> m_context;

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -355,6 +355,11 @@
     (allow mach-lookup
         (global-name "com.apple.CARenderServer"))
 
+    (allow mach-register
+        (global-name "com.apple.WebKit.WebContent.CARenderServer"))
+    (allow mach-lookup
+        (global-name "com.apple.WebKit.WebContent.CARenderServer")) ; Needed for [CAContext remoteContextWithOptions]
+
     ; UIKit-required IOKit nodes.
     (deny iokit-open (with telemetry)
         (iokit-user-client-class "IOSurfaceSendRight")
@@ -1375,6 +1380,7 @@
         MSC__kernelrpc_mach_port_insert_member_trap
         MSC__kernelrpc_mach_port_insert_right_trap
         MSC__kernelrpc_mach_port_mod_refs_trap
+        MSC__kernelrpc_mach_port_move_member_trap
         MSC__kernelrpc_mach_port_request_notification_trap
         MSC__kernelrpc_mach_port_type_trap
         MSC__kernelrpc_mach_port_unguard_trap

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -925,6 +925,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     m_contextForVisibilityPropagation = LayerHostingContext::createForExternalHostingProcess({
         m_canShowWhileLocked
     });
+    WTFLogAlways("WebPage: Created context with ID %u for visibility propagation from UIProcess", m_contextForVisibilityPropagation->contextID());
     WEBPAGE_RELEASE_LOG(Process, "WebPage: Created context with ID %u for visibility propagation from UIProcess", m_contextForVisibilityPropagation->contextID());
     send(Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation(m_contextForVisibilityPropagation->contextID()));
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -157,6 +157,8 @@
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
 #endif
 
+#import "LayerHostingContext.h"
+
 #if ENABLE(DATA_DETECTION) && PLATFORM(IOS_FAMILY)
 #import <pal/spi/ios/DataDetectorsUISPI.h>
 #endif
@@ -459,6 +461,11 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
     WebCore::IOSurface::setBytesPerRowAlignment(parameters.bytesPerRowIOSurfaceAlignment);
 
+    const char* serverName = "com.apple.WebKit.WebContent.CARenderServer";
+    CARenderServerStart();
+    CARenderServerRegister(serverName);
+    LayerHostingContext::setServerName(serverName);
+    
     accessibilityPreferencesDidChange(parameters.accessibilityPreferences);
 #if PLATFORM(IOS_FAMILY)
     _AXSApplicationAccessibilitySetEnabled(parameters.applicationAccessibilityEnabled);

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1395,9 +1395,13 @@
 ;; Various services required by AppKit and other frameworks
 (allow mach-lookup
        (global-name "com.apple.logd")
-       (global-name "com.apple.logd.events")
-       (global-name "com.apple.CARenderServer") ; Needed for [CAContext remoteContextWithOptions]
-)
+       (global-name "com.apple.logd.events"))
+
+(allow mach-register
+    (global-name "com.apple.WebKit.WebContent.CARenderServer"))
+(allow mach-lookup
+    (global-name "com.apple.CARenderServer") ; Needed for [CAContext remoteContextWithOptions]
+    (global-name "com.apple.WebKit.WebContent.CARenderServer")) ; Needed for [CAContext remoteContextWithOptions]
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED <= 110000
 (allow mach-lookup
@@ -2173,6 +2177,8 @@
 
 (define (syscall-mach-common)
     (machtrap-number
+        MSC__kernelrpc_mach_port_move_member_trap
+        MSC_task_self_trap
         MSC__kernelrpc_mach_port_allocate_trap
         MSC__kernelrpc_mach_port_construct_trap
         MSC__kernelrpc_mach_port_deallocate_trap


### PR DESCRIPTION
#### 0fe31521a461e513797ee3091278843e9e74bc07
<pre>
Run in-process render server
<a href="https://bugs.webkit.org/show_bug.cgi?id=246817">https://bugs.webkit.org/show_bug.cgi?id=246817</a>
rdar://101387770

Reviewed by NOBODY (OOPS!).

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::renderServerName):
(WebKit::LayerHostingContext::createForExternalHostingProcess):
(WebKit::LayerHostingContext::setServerName):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe31521a461e513797ee3091278843e9e74bc07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2796 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24242 "Hash 0fe31521 for PR 5592 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103255 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163575 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2808 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31080 "Hash 0fe31521 for PR 5592 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99327 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/1993 "Passed tests") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80046 "Hash 0fe31521 for PR 5592 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29025 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83915 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/24242 "Hash 0fe31521 for PR 5592 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/71978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37462 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/24242 "Hash 0fe31521 for PR 5592 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35302 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/24242 "Hash 0fe31521 for PR 5592 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39178 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/80046 "Hash 0fe31521 for PR 5592 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41114 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/24242 "Hash 0fe31521 for PR 5592 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->