### PR TITLE
Add the class FilterTargetSwitcher

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2227,6 +2227,7 @@ platform/graphics/filters/FilterImage.cpp
 platform/graphics/filters/FilterOperation.cpp
 platform/graphics/filters/FilterOperations.cpp
 platform/graphics/filters/FilterResults.cpp
+platform/graphics/filters/FilterTargetSwitcher.cpp
 platform/graphics/filters/PointLightSource.cpp
 platform/graphics/filters/SourceAlpha.cpp
 platform/graphics/filters/SourceGraphic.cpp

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FilterTargetSwitcher.h"
+
+#include "Filter.h"
+#include "FilterResults.h"
+#include "GraphicsContext.h"
+#include "ImageBuffer.h"
+
+namespace WebCore {
+
+FilterTargetSwitcher::FilterTargetSwitcher(Client& client, const DestinationColorSpace& colorSpace, const std::function<FloatRect()>& boundsProvider)
+    : m_client(client)
+{
+    auto* context = m_client.drawingContext();
+    if (!context)
+        return;
+
+    m_filter = m_client.createFilter([&]() {
+        m_bounds = boundsProvider();
+        return m_bounds;
+    });
+
+    if (!m_filter)
+        return;
+
+    ASSERT(!m_bounds.isEmpty());
+
+    m_imageBuffer = context->createScaledImageBuffer(m_bounds, { 1, 1 }, colorSpace);
+    if (!m_imageBuffer) {
+        m_filter = nullptr;
+        return;
+    }
+
+    auto state = context->state();
+    m_imageBuffer->context().mergeAllChanges(state);
+    m_client.setTargetSwitcher(this);
+}
+
+FilterTargetSwitcher::FilterTargetSwitcher(Client& client, const DestinationColorSpace& colorSpace, const FloatRect& bounds)
+    : FilterTargetSwitcher(client, colorSpace, [&]() {
+        return bounds;
+    })
+{
+}
+
+FilterTargetSwitcher::~FilterTargetSwitcher()
+{
+    if (!m_filter)
+        return;
+
+    ASSERT(m_imageBuffer);
+    ASSERT(!m_bounds.isEmpty());
+
+    m_client.setTargetSwitcher(nullptr);
+
+    auto* context = m_client.drawingContext();
+    FilterResults results;
+    context->drawFilteredImageBuffer(m_imageBuffer.get(), m_bounds, *m_filter, results);
+}
+
+GraphicsContext* FilterTargetSwitcher::drawingContext() const
+{
+    if (m_imageBuffer)
+        return &m_imageBuffer->context();
+    return m_client.drawingContext();
+}
+
+FloatBoxExtent FilterTargetSwitcher::outsets() const
+{
+    if (!m_filter)
+        return { };
+
+    ASSERT(!m_bounds.isEmpty());
+
+    auto outsets = m_client.calculateFilterOutsets(m_bounds);
+    return { outsets.top(), outsets.right(), outsets.bottom(), outsets.left() };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DestinationColorSpace.h"
+#include "FloatRect.h"
+
+namespace WebCore {
+
+class Filter;
+class GraphicsContext;
+class ImageBuffer;
+
+class FilterTargetSwitcher {
+public:
+    class Client {
+    public:
+        virtual ~Client() = default;
+        virtual RefPtr<Filter> createFilter(const std::function<FloatRect()>& boundsProvider) const = 0;
+        virtual IntOutsets calculateFilterOutsets(const FloatRect& bounds) const = 0;
+        virtual GraphicsContext* drawingContext() const = 0;
+        virtual void setTargetSwitcher(FilterTargetSwitcher*) = 0;
+    protected:
+        Client() = default;
+    };
+
+    FilterTargetSwitcher(Client&, const DestinationColorSpace&, const std::function<FloatRect()>& boundsProvider);
+    FilterTargetSwitcher(Client&, const DestinationColorSpace&, const FloatRect& bounds);
+    ~FilterTargetSwitcher();
+    GraphicsContext* drawingContext() const;
+    FloatBoxExtent outsets() const;
+
+private:
+    Client& m_client;
+    RefPtr<Filter> m_filter;
+    RefPtr<ImageBuffer> m_imageBuffer;
+    FloatRect m_bounds;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 5a02a23fcd7776eb83e24787354df6daf79a79cc
<pre>
Add the class FilterTargetSwitcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=246822">https://bugs.webkit.org/show_bug.cgi?id=246822</a>

Reviewed by Simon Fraser.

This class will manage applying a filter to a certain area of drawings with the
minimum changes in the existing code. All it needs is a set of callbacks in the
existing caller class. And the caller adds a line like this to the drawing
function:

        FilterTargetSwitcher targetSwitcher(*this, bounds);

The constructor of FilterTargetSwitcher will ask the client if there a filter to
apply or not. If there is a filter, it will switch the drawing to a temporary
ImageBuffer. The client has to make sure all the drawing code from now on will
use the context of this ImageBuffer. The destructor will apply the filter to the
temporary ImageBuffer and then composite filtered ImageBuffer back to the client
drawing context.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp: Added.
(WebCore::FilterTargetSwitcher::FilterTargetSwitcher):
(WebCore::FilterTargetSwitcher::~FilterTargetSwitcher):
(WebCore::FilterTargetSwitcher::drawingContext const):
(WebCore::FilterTargetSwitcher::outsets const):
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h: Added.

Canonical link: <a href="https://commits.webkit.org/255802@main">https://commits.webkit.org/255802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56c32d1c768ecd2c6e01feb3d1673e4813b3c29c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103264 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163585 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2817 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31090 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99335 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2001 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80056 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29034 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83923 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/71987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37471 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18777 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4011 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41302 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38008 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->