### PR TITLE
Implement font-variant-alternates matching

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3763,23 +3763,10 @@ webkit.org/b/182042 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-0
 webkit.org/b/86071 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-05.html [ ImageOnlyFailure ]
 
 # font-variant-alternates
+# (failing because of font-family case matching, and multiple properties unimplemented)
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/alternates-order.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-03.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-04.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-05.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-06.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-07.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-08.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-09.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-10.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-11.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-12.html [ ImageOnlyFailure ]
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-13.html [ ImageOnlyFailure ]
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-14.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-15.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-16.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-17.html [ ImageOnlyFailure ]
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-18.html [ ImageOnlyFailure ]
 
 # font-size-adjust CSS Fonts Module level 5 (current implementation is at level 4)
 webkit.org/b/15257 imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-009.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1962,3 +1962,19 @@ webkit.org/b/245900 [ Debug ] fast/inline/inline-box-adjust-position-crash2.html
 
 # http version of this test fails, but https passes. May be a PingLoad issue in GTK
 webkit.org/b/246766 imported/w3c/web-platform-tests/reporting/generateTestReport-honors-endpoint.http.sub.html [ Failure ]
+
+# font-variant-alternates https://bugs.webkit.org/show_bug.cgi?id=246952
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-03.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-04.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-05.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-06.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-07.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-08.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-09.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-10.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-11.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-12.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-15.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-16.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-17.html [ ImageOnlyFailure ]
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-18.html [ ImageOnlyFailure ]

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1577,6 +1577,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FontCreationContext.h
     platform/graphics/FontDescription.h
     platform/graphics/FontFamilySpecificationNull.h
+    platform/graphics/FontFeatureValues.h
     platform/graphics/FontGenericFamilies.h
     platform/graphics/FontMetrics.h
     platform/graphics/FontPalette.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2120,6 +2120,7 @@ platform/graphics/FontCascadeDescription.cpp
 platform/graphics/FontCascadeFonts.cpp
 platform/graphics/FontDescription.cpp
 platform/graphics/FontFamilySpecificationNull.cpp
+platform/graphics/FontFeatureValues.cpp
 platform/graphics/FontGenericFamilies.cpp
 platform/graphics/FontPlatformData.cpp
 platform/graphics/FontRanges.cpp

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -702,7 +702,7 @@ static Font::Visibility visibility(CSSFontFace::Status status, CSSFontFace::Font
     }
 }
 
-RefPtr<Font> CSSFontFace::font(const FontDescription& fontDescription, bool syntheticBold, bool syntheticItalic, ExternalResourceDownloadPolicy policy, const FontPaletteValues& fontPaletteValues)
+RefPtr<Font> CSSFontFace::font(const FontDescription& fontDescription, bool syntheticBold, bool syntheticItalic, ExternalResourceDownloadPolicy policy, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues)
 {
     if (computeFailureState())
         return nullptr;
@@ -730,7 +730,7 @@ RefPtr<Font> CSSFontFace::font(const FontDescription& fontDescription, bool synt
             return Font::create(FontCache::forCurrentThread().lastResortFallbackFont(fontDescription)->platformData(), Font::Origin::Local, Font::Interstitial::Yes, visibility);
         }
         case CSSFontFaceSource::Status::Success: {
-            FontCreationContext fontCreationContext { m_featureSettings, m_fontSelectionCapabilities, fontPaletteValues };
+            FontCreationContext fontCreationContext { m_featureSettings, m_fontSelectionCapabilities, fontPaletteValues, fontFeatureValues };
             if (auto result = source->font(fontDescription, syntheticBold, syntheticItalic, fontCreationContext))
                 return result;
             break;

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -46,6 +46,7 @@ class Document;
 class Font;
 class FontDescription;
 class FontFace;
+class FontFeatureValues;
 class FontPaletteValues;
 class MutableStyleProperties;
 class ScriptExecutionContext;
@@ -116,7 +117,7 @@ public:
 
     void load();
 
-    RefPtr<Font> font(const FontDescription&, bool syntheticBold, bool syntheticItalic, ExternalResourceDownloadPolicy, const FontPaletteValues&);
+    RefPtr<Font> font(const FontDescription&, bool syntheticBold, bool syntheticItalic, ExternalResourceDownloadPolicy, const FontPaletteValues&, RefPtr<FontFeatureValues>);
 
     static void appendSources(CSSFontFace&, CSSValueList&, ScriptExecutionContext*, bool isInitiatingElementInUserAgentShadowTree);
 

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.cpp
@@ -51,9 +51,9 @@ String CSSFontFeatureValuesRule::cssText() const
     };
     joinFontFamiliesWithSeparator(m_fontFeatureValuesRule->fontFamilies(), ", "_s);
     builder.append(" { ");
-    auto& value = m_fontFeatureValuesRule->value();
+    const auto& value = m_fontFeatureValuesRule->value();
     
-    auto addVariant = [&builder] (String variantName, Tags tags) {
+    auto addVariant = [&builder] (const String& variantName, const auto& tags) {
         if (!tags.isEmpty()) {
             builder.append("@", variantName, " { ");
             for (auto tag : tags) {
@@ -69,12 +69,12 @@ String CSSFontFeatureValuesRule::cssText() const
     
     // WPT expects the order used in Servo.
     // https://searchfox.org/mozilla-central/source/servo/components/style/stylesheets/font_feature_values_rule.rs#430
-    addVariant("swash"_s, value.swash);
-    addVariant("stylistic"_s, value.stylistic);
-    addVariant("ornaments"_s, value.ornaments);
-    addVariant("annotation"_s, value.annotation);
-    addVariant("character-variant"_s, value.characterVariant);
-    addVariant("styleset"_s, value.styleset);
+    addVariant("swash"_s, value->swash());
+    addVariant("stylistic"_s, value->stylistic());
+    addVariant("ornaments"_s, value->ornaments());
+    addVariant("annotation"_s, value->annotation());
+    addVariant("character-variant"_s, value->characterVariant());
+    addVariant("styleset"_s, value->styleset());
     
     builder.append('}');
     return builder.toString();

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -47,6 +47,7 @@ class CSSValueList;
 class CachedFont;
 class ScriptExecutionContext;
 class StyleRuleFontFace;
+class StyleRuleFontFeatureValues;
 class StyleRuleFontPaletteValues;
 
 class CSSFontSelector final : public FontSelector, public CSSFontFace::Client, public CanMakeWeakPtr<CSSFontSelector>, public ActiveDOMObject {
@@ -67,7 +68,8 @@ public:
     void buildCompleted();
 
     void addFontFaceRule(StyleRuleFontFace&, bool isInitiatingElementInUserAgentShadowTree);
-    void addFontPaletteValuesRule(StyleRuleFontPaletteValues&);
+    void addFontPaletteValuesRule(const StyleRuleFontPaletteValues&);
+    void addFontFeatureValuesRule(const StyleRuleFontFeatureValues&);
 
     void fontCacheInvalidated() final;
 
@@ -102,6 +104,7 @@ private:
     std::optional<AtomString> resolveGenericFamily(const FontDescription&, const AtomString& family);
 
     const FontPaletteValues& lookupFontPaletteValues(const AtomString& familyName, const FontDescription&);
+    RefPtr<FontFeatureValues> lookupFontFeatureValues(const AtomString& familyName);
 
     // CSSFontFace::Client
     void fontLoaded(CSSFontFace&) final;
@@ -135,6 +138,7 @@ private:
         }
     };
     HashMap<std::pair<AtomString, AtomString>, FontPaletteValues, PaletteMapHash> m_paletteMap;
+    HashMap<AtomString, Ref<FontFeatureValues>> m_featureValues;
 
     HashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
     HashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;

--- a/Source/WebCore/css/CSSSegmentedFontFace.cpp
+++ b/Source/WebCore/css/CSSSegmentedFontFace.cpp
@@ -60,16 +60,16 @@ void CSSSegmentedFontFace::fontLoaded(CSSFontFace&)
 
 class CSSFontAccessor final : public FontAccessor {
 public:
-    static Ref<CSSFontAccessor> create(CSSFontFace& fontFace, const FontDescription& fontDescription, const FontPaletteValues& fontPaletteValues, bool syntheticBold, bool syntheticItalic)
+    static Ref<CSSFontAccessor> create(CSSFontFace& fontFace, const FontDescription& fontDescription, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, bool syntheticBold, bool syntheticItalic)
     {
-        return adoptRef(*new CSSFontAccessor(fontFace, fontDescription, fontPaletteValues, syntheticBold, syntheticItalic));
+        return adoptRef(*new CSSFontAccessor(fontFace, fontDescription, fontPaletteValues, fontFeatureValues, syntheticBold, syntheticItalic));
     }
 
     const Font* font(ExternalResourceDownloadPolicy policy) const final
     {
         if (!m_result || (policy == ExternalResourceDownloadPolicy::Allow
             && (m_fontFace->status() == CSSFontFace::Status::Pending || m_fontFace->status() == CSSFontFace::Status::Loading || m_fontFace->status() == CSSFontFace::Status::TimedOut))) {
-            const auto result = m_fontFace->font(m_fontDescription, m_syntheticBold, m_syntheticItalic, policy, m_fontPaletteValues);
+            const auto result = m_fontFace->font(m_fontDescription, m_syntheticBold, m_syntheticItalic, policy, m_fontPaletteValues, m_fontFeatureValues);
             if (!m_result)
                 m_result = result;
         }
@@ -77,9 +77,10 @@ public:
     }
 
 private:
-    CSSFontAccessor(CSSFontFace& fontFace, const FontDescription& fontDescription, const FontPaletteValues& fontPaletteValues, bool syntheticBold, bool syntheticItalic)
+    CSSFontAccessor(CSSFontFace& fontFace, const FontDescription& fontDescription, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues, bool syntheticBold, bool syntheticItalic)
         : m_fontFace(fontFace)
         , m_fontDescription(fontDescription)
+        , m_fontFeatureValues(fontFeatureValues)
         , m_fontPaletteValues(fontPaletteValues)
         , m_syntheticBold(syntheticBold)
         , m_syntheticItalic(syntheticItalic)
@@ -94,6 +95,7 @@ private:
     mutable std::optional<RefPtr<Font>> m_result; // Caches nullptr too
     mutable Ref<CSSFontFace> m_fontFace;
     FontDescription m_fontDescription;
+    RefPtr<FontFeatureValues> m_fontFeatureValues;
     FontPaletteValues m_fontPaletteValues;
     bool m_syntheticBold;
     bool m_syntheticItalic;
@@ -110,7 +112,7 @@ static void appendFont(FontRanges& ranges, Ref<FontAccessor>&& fontAccessor, con
         ranges.appendRange({ range.from, range.to, fontAccessor.copyRef() });
 }
 
-FontRanges CSSSegmentedFontFace::fontRanges(const FontDescription& fontDescription, const FontPaletteValues& fontPaletteValues)
+FontRanges CSSSegmentedFontFace::fontRanges(const FontDescription& fontDescription, const FontPaletteValues& fontPaletteValues, RefPtr<FontFeatureValues> fontFeatureValues)
 {
     auto addResult = m_cache.add(std::make_tuple(FontDescriptionKey(fontDescription), fontPaletteValues), FontRanges());
     auto& ranges = addResult.iterator->value;
@@ -130,7 +132,7 @@ FontRanges CSSSegmentedFontFace::fontRanges(const FontDescription& fontDescripti
         bool syntheticItalic = fontDescription.hasAutoFontSynthesisStyle() && !isItalic(selectionCapabilities.slope.maximum) && isItalic(desiredRequest.slope);
 
         // Metrics used for layout come from FontRanges::fontForFirstRange(), which assumes that the first font is non-null.
-        auto fontAccessor = CSSFontAccessor::create(face, fontDescription, fontPaletteValues, syntheticBold, syntheticItalic);
+        auto fontAccessor = CSSFontAccessor::create(face, fontDescription, fontPaletteValues, fontFeatureValues, syntheticBold, syntheticItalic);
         if (ranges.isNull() && !fontAccessor->font(ExternalResourceDownloadPolicy::Forbid))
             continue;
         

--- a/Source/WebCore/css/CSSSegmentedFontFace.h
+++ b/Source/WebCore/css/CSSSegmentedFontFace.h
@@ -50,7 +50,7 @@ public:
 
     void appendFontFace(Ref<CSSFontFace>&&);
 
-    FontRanges fontRanges(const FontDescription&, const FontPaletteValues&);
+    FontRanges fontRanges(const FontDescription&, const FontPaletteValues&, RefPtr<FontFeatureValues>);
 
     Vector<Ref<CSSFontFace>, 1>& constituentFaces() { return m_fontFaces; }
 

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -327,23 +327,23 @@ MutableStyleProperties& StyleRuleFontFace::mutableProperties()
     return downcast<MutableStyleProperties>(m_properties.get());
 }
 
-StyleRuleFontFeatureValues::StyleRuleFontFeatureValues(const Vector<AtomString>& fontFamilies, const FontFeatureValuesValue& value)
+StyleRuleFontFeatureValues::StyleRuleFontFeatureValues(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&& value)
     : StyleRuleBase(StyleRuleType::FontFeatureValues)
     , m_fontFamilies(fontFamilies)
-    , m_value(value)
+    , m_value(WTFMove(value))
 {
 }
 
-StyleRuleFontFeatureValuesBlock::StyleRuleFontFeatureValuesBlock(FontFeatureValuesType type, const Vector<Tag>& tags)
+StyleRuleFontFeatureValuesBlock::StyleRuleFontFeatureValuesBlock(FontFeatureValuesType type, const Vector<FontFeatureValuesTag>& tags)
     : StyleRuleBase(StyleRuleType::FontFeatureValuesBlock)
     , m_type(type)
     , m_tags(tags)
 {
 }
 
-Ref<StyleRuleFontFeatureValues> StyleRuleFontFeatureValues::create(const Vector<AtomString>& fontFamilies, const FontFeatureValuesValue& values)
+Ref<StyleRuleFontFeatureValues> StyleRuleFontFeatureValues::create(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&& values)
 {
-    return adoptRef(*new StyleRuleFontFeatureValues(fontFamilies, values));
+    return adoptRef(*new StyleRuleFontFeatureValues(fontFamilies, WTFMove(values)));
 }
 
 Ref<StyleRuleFontPaletteValues> StyleRuleFontPaletteValues::create(const AtomString& name, const AtomString& fontFamily, std::optional<FontPaletteIndex> basePalette, Vector<FontPaletteValues::OverriddenColor>&& overrideColors)

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -24,6 +24,7 @@
 #include "CSSSelectorList.h"
 #include "CompiledSelector.h"
 #include "ContainerQuery.h"
+#include "FontFeatureValues.h"
 #include "FontPaletteValues.h"
 #include "StyleRuleType.h"
 #include <map>
@@ -182,30 +183,9 @@ private:
     FontPaletteValues m_fontPaletteValues;
 };
 
-using Tag = std::pair<String, Vector<int>>;
-using Tags = HashMap<String, Vector<int>>;
-
-struct FontFeatureValuesValue {
-    Tags styleset;
-    Tags stylistic;
-    Tags characterVariant;
-    Tags swash;
-    Tags ornaments;
-    Tags annotation;
-};
-
-enum class FontFeatureValuesType {
-    Styleset,
-    Stylistic,
-    CharacterVariant,
-    Swash,
-    Ornaments,
-    Annotation
-};
-
 class StyleRuleFontFeatureValuesBlock final : public StyleRuleBase {
 public:
-    static Ref<StyleRuleFontFeatureValuesBlock> create(FontFeatureValuesType type, const Vector<Tag>& tags)
+    static Ref<StyleRuleFontFeatureValuesBlock> create(FontFeatureValuesType type, const Vector<FontFeatureValuesTag>& tags)
     {
         return adoptRef(*new StyleRuleFontFeatureValuesBlock(type, tags));
     }
@@ -214,35 +194,35 @@ public:
 
     FontFeatureValuesType fontFeatureValuesType() const { return m_type; }
 
-    Vector<Tag> tags() const { return m_tags; }
+    const Vector<FontFeatureValuesTag>& tags() const { return m_tags; }
 
     Ref<StyleRuleFontFeatureValuesBlock> copy() const { return adoptRef(*new StyleRuleFontFeatureValuesBlock(*this)); }
 private:
-    StyleRuleFontFeatureValuesBlock(FontFeatureValuesType, const Vector<Tag>&);
+    StyleRuleFontFeatureValuesBlock(FontFeatureValuesType, const Vector<FontFeatureValuesTag>&);
     StyleRuleFontFeatureValuesBlock(const StyleRuleFontFeatureValuesBlock&) = default;
 
     FontFeatureValuesType m_type;
-    Vector<Tag> m_tags;
+    Vector<FontFeatureValuesTag> m_tags;
 };
 
 class StyleRuleFontFeatureValues final : public StyleRuleBase {
 public:
-    static Ref<StyleRuleFontFeatureValues> create(const Vector<AtomString>& fontFamilies, const FontFeatureValuesValue&);
+    static Ref<StyleRuleFontFeatureValues> create(const Vector<AtomString>& fontFamilies, Ref<FontFeatureValues>&&);
     
     ~StyleRuleFontFeatureValues() = default;
 
     const Vector<AtomString>& fontFamilies() const { return m_fontFamilies; }
 
-    const FontFeatureValuesValue& value() const { return m_value; }
+    Ref<FontFeatureValues> value() const { return m_value; }
 
     Ref<StyleRuleFontFeatureValues> copy() const { return adoptRef(*new StyleRuleFontFeatureValues(*this)); }
 
 private:
-    StyleRuleFontFeatureValues(const Vector<AtomString>&, const FontFeatureValuesValue&);
+    StyleRuleFontFeatureValues(const Vector<AtomString>&, Ref<FontFeatureValues>&&);
     StyleRuleFontFeatureValues(const StyleRuleFontFeatureValues&) = default;
 
     Vector<AtomString> m_fontFamilies;
-    FontFeatureValuesValue m_value;
+    Ref<FontFeatureValues> m_value;
 };
 
 class StyleRulePage final : public StyleRuleBase {

--- a/Source/WebCore/platform/graphics/FontFeatureValues.cpp
+++ b/Source/WebCore/platform/graphics/FontFeatureValues.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontFeatureValues.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+void add(Hasher& hasher, const FontFeatureValues& fontFeatureValues)
+{
+    auto hashTags = [&hasher](const auto& tags) {
+        add(hasher, tags.isEmpty());
+        for (const auto& tag : tags)
+            add(hasher, tag.key, tag.value);
+    };
+    hashTags(fontFeatureValues.m_styleset);
+    hashTags(fontFeatureValues.m_stylistic);
+    hashTags(fontFeatureValues.m_characterVariant);
+    hashTags(fontFeatureValues.m_swash);
+    hashTags(fontFeatureValues.m_ornaments);
+    hashTags(fontFeatureValues.m_annotation);
+}
+
+void FontFeatureValues::updateOrInsert(const FontFeatureValues& other)
+{
+    if (this == &other)
+        return;
+    
+    auto updateOrInsertTags = [](auto& into, const auto& tags) {
+        for (const auto& tag : tags)
+            into.set(tag.key, tag.value);
+    };
+    updateOrInsertTags(m_styleset, other.styleset());
+    updateOrInsertTags(m_stylistic, other.stylistic());
+    updateOrInsertTags(m_characterVariant, other.characterVariant());
+    updateOrInsertTags(m_swash, other.swash());
+    updateOrInsertTags(m_ornaments, other.ornaments());
+    updateOrInsertTags(m_annotation, other.annotation());
+}
+
+void FontFeatureValues::updateOrInsertForType(FontFeatureValuesType type, const Vector<FontFeatureValuesTag>& tags)
+{
+    auto updateOrInsertTags = [](auto& into, const Vector<FontFeatureValuesTag>& tags) {
+        for (const FontFeatureValuesTag& tag : tags)
+            into.set(tag.first, tag.second);
+    };
+    switch (type) {
+    case FontFeatureValuesType::Styleset:
+        updateOrInsertTags(m_styleset, tags);
+        break;
+    case FontFeatureValuesType::Stylistic:
+        updateOrInsertTags(m_stylistic, tags);
+        break;
+    case FontFeatureValuesType::CharacterVariant:
+        updateOrInsertTags(m_characterVariant, tags);
+        break;
+    case FontFeatureValuesType::Swash:
+        updateOrInsertTags(m_swash, tags);
+        break;
+    case FontFeatureValuesType::Ornaments:
+        updateOrInsertTags(m_ornaments, tags);
+        break;
+    case FontFeatureValuesType::Annotation:
+        updateOrInsertTags(m_annotation, tags);
+        break;
+    }
+    
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const FontFeatureValues& fontFeatureValues)
+{
+    auto printTags = [&ts](const auto& name, const auto& tags) {
+        if (tags.isEmpty())
+            return;
+
+        ts << "{" << name << ": ";
+        for (const auto& tag : tags)
+            ts << "{" << tag.key << ":" << tag.value << "} ";
+        ts << "}";
+    };
+    printTags("styleset", fontFeatureValues.m_styleset);
+    printTags("stylistic", fontFeatureValues.m_stylistic);
+    printTags("characterVariant", fontFeatureValues.m_characterVariant);
+    printTags("swash", fontFeatureValues.m_swash);
+    printTags("ornaments", fontFeatureValues.m_ornaments);
+    printTags("annotation", fontFeatureValues.m_annotation);
+    return ts;  
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontFeatureValues.h
+++ b/Source/WebCore/platform/graphics/FontFeatureValues.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/HashMap.h>
+#include <wtf/Hasher.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+using FontFeatureValuesTag = std::pair<String, Vector<unsigned>>;
+
+enum class FontFeatureValuesType {
+    Styleset,
+    Stylistic,
+    CharacterVariant,
+    Swash,
+    Ornaments,
+    Annotation
+};
+
+class FontFeatureValues : public RefCounted<FontFeatureValues> {
+public:
+    using Tags = HashMap<String, Vector<unsigned>>;
+    static Ref<FontFeatureValues> create() { return adoptRef(*new FontFeatureValues()); }
+    virtual ~FontFeatureValues() = default;
+
+    bool isEmpty() const
+    {
+        return m_styleset.isEmpty() 
+            && m_stylistic.isEmpty() 
+            && m_characterVariant.isEmpty() 
+            && m_swash.isEmpty()
+            && m_ornaments.isEmpty()
+            && m_annotation.isEmpty();
+    }
+    
+    bool operator==(const FontFeatureValues& other) const
+    {
+        return m_styleset == other.styleset()
+            && m_stylistic == other.stylistic()
+            && m_characterVariant == other.characterVariant()
+            && m_swash == other.swash()
+            && m_ornaments == other.ornaments()
+            && m_annotation == other.annotation();
+    }
+    
+    bool operator!=(const FontFeatureValues& other) const
+    {
+        return !(other == *this);
+    }
+    
+    const Tags& styleset() const
+    {
+        return m_styleset;
+    }
+
+    Tags& styleset()
+    {
+        return m_styleset;
+    }
+
+    const Tags& stylistic() const
+    {
+        return m_stylistic;
+    }
+
+    Tags& stylistic()
+    {
+        return m_stylistic;
+    }
+
+    const Tags& characterVariant() const
+    {
+        return m_characterVariant;
+    }
+
+    Tags& characterVariant()
+    {
+        return m_characterVariant;
+    }
+
+    const Tags& swash() const
+    {
+        return m_swash;
+    }
+
+    Tags& swash()
+    {
+        return m_swash;
+    }
+
+    const Tags& ornaments() const
+    {
+        return m_ornaments;
+    }
+
+    Tags& ornaments()
+    {
+        return m_ornaments;
+    }
+
+    const Tags& annotation() const
+    {
+        return m_annotation;
+    }
+
+    Tags& annotation()
+    {
+        return m_annotation;
+    }
+
+    friend void add(Hasher&, const FontFeatureValues&);
+    friend WTF::TextStream& operator<<(WTF::TextStream&, const FontFeatureValues&);
+    void updateOrInsert(const FontFeatureValues&);
+    void updateOrInsertForType(FontFeatureValuesType, const Vector<FontFeatureValuesTag>&);
+
+private:
+    FontFeatureValues() = default;
+    Tags m_styleset;
+    Tags m_stylistic;
+    Tags m_characterVariant;
+    Tags m_swash;
+    Tags m_ornaments;
+    Tags m_annotation;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -478,7 +478,7 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
     // FIXME: Implement Step 6: the font-variation-settings descriptor inside @font-face
 
     // Step 7: Consult with font-feature-settings inside @font-face
-    if (fontCreationContext.fontFaceFeatures() && !fontCreationContext.fontFaceFeatures()->isEmpty()) {
+    if (fontCreationContext.fontFaceFeatures()) {
         for (auto& fontFaceFeature : *fontCreationContext.fontFaceFeatures())
             applyFeature(fontFaceFeature.tag(), fontFaceFeature.value());
     }
@@ -486,7 +486,7 @@ RetainPtr<CTFontRef> preparePlatformFont(CTFontRef originalFont, const FontDescr
     // FIXME: Move font-optical-sizing handling here. It should be step 9.
 
     // Step 10: Font-variant
-    for (auto& newFeature : computeFeatureSettingsFromVariants(variantSettings))
+    for (auto& newFeature : computeFeatureSettingsFromVariants(variantSettings, fontCreationContext.fontFeatureValues()))
         applyFeature(newFeature.key, newFeature.value);
 
     // Step 11: Other properties

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the internal font implementation.
  *
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2022 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -27,6 +27,7 @@
 #include "SharedBuffer.h"
 #include <CoreText/CoreText.h>
 #include <wtf/text/StringConcatenateNumbers.h>
+#include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
 #include <pal/spi/cf/CoreTextSPI.h>

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -28,6 +28,7 @@
 
 #include "CairoUtilities.h"
 #include "FontCascade.h"
+#include "FontFeatureValues.h"
 #include "FontTaggedSettings.h"
 #include "HbUniquePtr.h"
 #include "SurrogatePairAwareTextIterator.h"
@@ -195,9 +196,12 @@ static Vector<hb_feature_t, 4> fontFeatures(const FontCascade& font, const FontP
 
     // 3. Font features implied by the value of the ‘font-variant’ property, the related ‘font-variant’
     //    subproperties and any other CSS property that uses OpenType features.
-    for (auto& feature : computeFeatureSettingsFromVariants(font.fontDescription().variantSettings()))
+
+    // FIXME: pass a proper FontFeatureValues object.
+    // https://bugs.webkit.org/show_bug.cgi?id=246121
+    for (auto& feature : computeFeatureSettingsFromVariants(font.fontDescription().variantSettings(), { }))
         featuresToBeApplied.set(feature.key, feature.value);
-        
+
     featuresToBeApplied.set(fontFeatureTag("kern"), font.enableKerning() ? 1 : 0);
 
     // 4. Feature settings determined by properties other than ‘font-variant’ or ‘font-feature-settings’.

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -27,6 +27,7 @@
 #include "TextFlags.h"
 
 #include "FontCascade.h"
+#include "FontFeatureValues.h"
 #include <functional>
 #include <numeric>
 #include <wtf/text/TextStream.h>
@@ -61,48 +62,33 @@ WTF::TextStream& operator<<(TextStream& ts, Kerning kerning)
     return ts;
 }
 
-template <typename T> using BinOp = std::function<T(T, T)>;
-
-template <typename T>
-T reduce(const std::vector<T>& vec, const BinOp<T>& binOp, std::optional<T> initial = { })
-{
-    if (vec.empty())
-        return initial ? *initial : T { };
-
-    auto accumulator = initial ? *initial : vec[0];
-    auto start = initial ? 0 : 1;
-    for (size_t i = start ; i < vec.size() ; i++)
-        accumulator = binOp(accumulator, vec[i]);
-
-    return accumulator;
-}
-
 WTF::TextStream& operator<<(TextStream& ts, FontVariantAlternates alternates)
 {
     if (alternates.isNormal())
         ts << "normal";
     else {
         auto values = alternates.values();
-        std::vector<String> result;
-        if (values.stylistic)
-            result.push_back("stylistic(" + *values.stylistic + ")");
-        if (values.historicalForms)
-            result.push_back("historical-forms"_s);
-        if (values.styleset)
-            result.push_back("styleset(" + *values.styleset + ")");
-        if (values.characterVariant)
-            result.push_back("character-variant(" + *values.characterVariant + ")");
-        if (values.swash)
-            result.push_back("swash(" + *values.swash + ")");
-        if (values.ornaments)
-            result.push_back("ornaments(" + *values.ornaments + ")");
-        if (values.annotation)
-            result.push_back("annotation(" + *values.annotation + ")");
-        
-        BinOp<String> addWithSpace = [](auto a, auto b) { 
-            return a + " " + b;
+        StringBuilder builder;
+        auto append = [&builder] <typename ...Ts> (Ts&& ...args) {
+            // Separate elements with a space.
+            builder.append(builder.isEmpty() ? "": " ", std::forward<Ts>(args)...);
         };
-        ts << reduce(result, addWithSpace);
+        if (values.stylistic)
+            append("stylistic(", *values.stylistic, ")");
+        if (values.historicalForms)
+            append("historical-forms"_s);
+        if (values.styleset)
+            append("styleset(", *values.styleset, ")");
+        if (values.characterVariant)
+            append("character-variant(", *values.characterVariant, ")");
+        if (values.swash)
+            append("swash(", *values.swash, ")");
+        if (values.ornaments)
+            append("ornaments(", *values.ornaments, ")");
+        if (values.annotation)
+            append("annotation(", *values.annotation, ")");
+        
+        ts << builder.toString();
     }
     return ts;
 }
@@ -115,9 +101,7 @@ void add(Hasher& hasher, const FontVariantAlternatesValues& key)
 void add(Hasher& hasher, const FontVariantAlternates& key)
 {
     add(hasher, key.m_val.index());
-    if (key.isNormal())
-        add(hasher, 0);
-    else
+    if (!key.isNormal())
         add(hasher, key.values());
 }
 
@@ -145,7 +129,7 @@ WTF::TextStream& operator<<(TextStream& ts, FontVariantCaps caps)
     return ts;
 }
 
-FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings& variantSettings)
+FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings& variantSettings, const RefPtr<FontFeatureValues> fontFeatureValues)
 {
     FeaturesMap features;
     
@@ -279,12 +263,54 @@ FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings& varian
     }
 
     if (!variantSettings.alternates.isNormal()) {
-        auto values = variantSettings.alternates.values();
+        const auto& values = variantSettings.alternates.values();
         if (values.historicalForms)
             features.set(fontFeatureTag("hist"), 1);
         
-        // TODO: handle other tags.
-        // https://bugs.webkit.org/show_bug.cgi?id=246121
+        if (fontFeatureValues) {
+            auto lookupTags = [](const auto& name, const auto& tags) -> Span<const unsigned> {
+                if (!name)
+                    return { };
+
+                return tags.get(*name);
+            };
+
+            auto addFeatureTagWithValue = [&features, &lookupTags] (const auto& name, const auto& tags, const FontTag& codename) {
+                for (unsigned value : lookupTags(name, tags)) {
+                    // The spec says that we ignore value greater than 99.
+                    if (value > 99)
+                        continue;
+
+                    features.set(codename, value);
+                }
+            };
+
+            // Some features (styleset, character-variant and historical-forms) don't have values,
+            // the tag name itself is the actual conveyor of information.
+            auto addFeatureTags = [&features, &lookupTags](const auto& name, const auto& tags, std::array<char, 2> codename) {
+                for (unsigned value : lookupTags(name, tags)) {
+                    // The spec says that we ignore value greater than 99.
+                    if (value > 99)
+                        continue;
+
+                    char rightDigit = '0' + (value % 10);
+                    char leftDigit = '0' + (value / 10);
+                    FontTag tag = { codename[0], codename[1], leftDigit, rightDigit };
+                    features.set(tag, 1);
+                }
+            };
+
+            addFeatureTags(values.styleset, fontFeatureValues->styleset(), { 's', 's' });
+            addFeatureTags(values.characterVariant, fontFeatureValues->characterVariant(), { 'c', 'v' });
+            addFeatureTagWithValue(values.stylistic, fontFeatureValues->stylistic(), fontFeatureTag("salt"));
+
+            // "swash" feature sets 2 flags.
+            addFeatureTagWithValue(values.swash, fontFeatureValues->swash(), fontFeatureTag("swsh"));
+            addFeatureTagWithValue(values.swash, fontFeatureValues->swash(), fontFeatureTag("cswh"));
+
+            addFeatureTagWithValue(values.ornaments, fontFeatureValues->ornaments(), fontFeatureTag("ornm"));
+            addFeatureTagWithValue(values.annotation, fontFeatureValues->annotation(), fontFeatureTag("nalt"));
+        }
     }
 
     switch (variantSettings.eastAsianVariant) {

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -38,6 +38,8 @@ class TextStream;
 
 namespace WebCore {
 
+class FontFeatureValues;
+
 enum class TextRenderingMode : uint8_t {
     AutoTextRendering,
     OptimizeSpeed,
@@ -192,6 +194,8 @@ struct FontVariantAlternatesValues {
     }
 
     std::optional<String> stylistic;
+    // FIXME: supports a list of strings for styleset and characterVariant.
+    // https://bugs.webkit.org/show_bug.cgi?id=246811
     std::optional<String> styleset;
     std::optional<String> characterVariant;
     std::optional<String> swash;
@@ -483,6 +487,6 @@ enum class AllowUserInstalledFonts : uint8_t {
 };
 
 using FeaturesMap = HashMap<FontTag, int, FourCharacterTagHash, FourCharacterTagHashTraits>;
-FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings&);
+FeaturesMap computeFeatureSettingsFromVariants(const FontVariantSettings&, RefPtr<FontFeatureValues>);
 
 }

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -137,7 +137,7 @@ void RuleSetBuilder::addChildRules(const Vector<RefPtr<StyleRuleBase>>& rules)
             popCascadeLayer(layerRule.name());
             continue;
         }
-        if (is<StyleRuleFontFace>(*rule) || is<StyleRuleFontPaletteValues>(*rule) || is<StyleRuleKeyframes>(*rule)) {
+        if (is<StyleRuleFontFace>(*rule) || is<StyleRuleFontPaletteValues>(*rule) || is<StyleRuleFontFeatureValues>(*rule) || is<StyleRuleKeyframes>(*rule)) {
             disallowDynamicMediaQueryEvaluationIfNeeded();
 
             if (m_resolver)
@@ -332,6 +332,11 @@ void RuleSetBuilder::addMutatingRulesToResolver()
         }
         if (is<StyleRuleFontPaletteValues>(rule)) {
             m_resolver->document().fontSelector().addFontPaletteValuesRule(downcast<StyleRuleFontPaletteValues>(rule.get()));
+            m_resolver->invalidateMatchedDeclarationsCache();
+            continue;
+        }
+        if (is<StyleRuleFontFeatureValues>(rule)) {
+            m_resolver->document().fontSelector().addFontFeatureValuesRule(downcast<StyleRuleFontFeatureValues>(rule.get()));
             m_resolver->invalidateMatchedDeclarationsCache();
             continue;
         }


### PR DESCRIPTION
#### a14a556da51f33eb6557c948e684c7f783d5da77
<pre>
Implement font-variant-alternates matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=246121">https://bugs.webkit.org/show_bug.cgi?id=246121</a>
rdar://100830615

Reviewed by Myles C. Maxfield.

There are still some parts of the spec missing:
  * mutiple ident in font-variant-alternates for styleset and character-variant
  * serialization of overwritten declarations
The FontFeatureValues object is reference-counted
because it is fairly large (it contains 6 HashMaps).

* LayoutTests/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::font):
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFeatureValuesRule.cpp:
(WebCore::CSSFontFeatureValuesRule::cssText const):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontPaletteValuesRule):
(WebCore::CSSFontSelector::addFontFeatureValuesRule):
(WebCore::CSSFontSelector::lookupFontFeatureValues):
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSSegmentedFontFace.cpp:
(WebCore::CSSSegmentedFontFace::fontRanges):
* Source/WebCore/css/CSSSegmentedFontFace.h:
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleFontFeatureValues::StyleRuleFontFeatureValues):
(WebCore::StyleRuleFontFeatureValuesBlock::StyleRuleFontFeatureValuesBlock):
(WebCore::StyleRuleFontFeatureValues::create):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::fontFeatureValuesTypeMappings):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRuleBlock):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
* Source/WebCore/platform/graphics/FontCreationContext.h:
(WebCore::FontCreationContextRareData::create):
(WebCore::FontCreationContextRareData::fontFeatureValues const):
(WebCore::FontCreationContextRareData::operator== const):
(WebCore::FontCreationContextRareData::FontCreationContextRareData):
(WebCore::FontCreationContext::FontCreationContext):
(WebCore::FontCreationContext::fontFeatureValues const):
(WebCore::add):
* Source/WebCore/platform/graphics/FontFeatureValues.cpp: Added.
(WebCore::add):
(WebCore::FontFeatureValues::updateOrInsert):
(WebCore::FontFeatureValues::updateOrInsertForType):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontFeatureValues.h: Added.
(WebCore::FontFeatureValues::create):
(WebCore::FontFeatureValues::isEmpty const):
(WebCore::FontFeatureValues::operator== const):
(WebCore::FontFeatureValues::operator!= const):
(WebCore::FontFeatureValues::styleset const):
(WebCore::FontFeatureValues::styleset):
(WebCore::FontFeatureValues::stylistic const):
(WebCore::FontFeatureValues::stylistic):
(WebCore::FontFeatureValues::characterVariant const):
(WebCore::FontFeatureValues::characterVariant):
(WebCore::FontFeatureValues::swash const):
(WebCore::FontFeatureValues::swash):
(WebCore::FontFeatureValues::ornaments const):
(WebCore::FontFeatureValues::ornaments):
(WebCore::FontFeatureValues::annotation const):
(WebCore::FontFeatureValues::annotation):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::preparePlatformFont):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
* Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp:
(WebCore::fontFeatures):
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::add):
(WebCore::computeFeatureSettingsFromVariants):
(WebCore::reduce): Deleted.
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRules):
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):

Canonical link: <a href="https://commits.webkit.org/256002@main">https://commits.webkit.org/256002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e33ec7ba828420cfa7b9ce8982c22b17374cd2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103789 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164120 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3378 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31572 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99808 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2426 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80579 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29448 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84351 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72396 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37956 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17852 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35841 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4152 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41708 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38355 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->