### PR TITLE
REGRESSION(255600@main): [ iOS ] ASSERTION FAILED: threadLikeAssertion.isCurrent() hit by TestWebKitAPI.WebKit.RequestRectForFoundTextRange every time

### DIFF
--- a/Source/WebKit/Shared/WebFoundTextRange.cpp
+++ b/Source/WebKit/Shared/WebFoundTextRange.cpp
@@ -32,6 +32,11 @@ namespace WebKit {
 
 bool WebFoundTextRange::operator==(const WebFoundTextRange& other) const
 {
+    if (frameIdentifier.isHashTableDeletedValue())
+        return other.frameIdentifier.isHashTableDeletedValue();
+    if (other.frameIdentifier.isHashTableDeletedValue())
+        return false;
+
     return location == other.location
         && length == other.length
         && frameIdentifier == other.frameIdentifier
@@ -57,6 +62,9 @@ std::optional<WebFoundTextRange> WebFoundTextRange::decode(IPC::Decoder& decoder
         return std::nullopt;
 
     if (!decoder.decode(result.frameIdentifier))
+        return std::nullopt;
+
+    if (result.frameIdentifier.isHashTableDeletedValue())
         return std::nullopt;
 
     if (!decoder.decode(result.order))

--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -55,10 +55,9 @@ struct WebFoundTextRangeHash {
 
 template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebKit::WebFoundTextRange> {
     static WebKit::WebFoundTextRange emptyValue() { return { }; }
-    static WebKit::WebFoundTextRange deletedValue() { return { std::numeric_limits<uint64_t>::max(), 0, { }, 0 }; }
 
-    static void constructDeletedValue(WebKit::WebFoundTextRange& range) { range = deletedValue(); }
-    static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range == deletedValue(); }
+    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) AtomString { HashTableDeletedValue }; }
+    static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.frameIdentifier.isHashTableDeletedValue(); }
 };
 
 template<> struct DefaultHash<WebKit::WebFoundTextRange> : WebFoundTextRangeHash { };


### PR DESCRIPTION
#### 9c64727f1f366960f1d56d31a68a190b8c03d85a
<pre>
REGRESSION(255600@main): [ iOS ] ASSERTION FAILED: threadLikeAssertion.isCurrent() hit by TestWebKitAPI.WebKit.RequestRectForFoundTextRange every time
<a href="https://bugs.webkit.org/show_bug.cgi?id=246656">https://bugs.webkit.org/show_bug.cgi?id=246656</a>
rdar://101266728

Reviewed by Darin Adler.

The deleted value of a `WebFoundTextRange` is currently constructed using copy
assignment. This is incorrect as the deleted value is intended to be written
into an uninitialized storage buffer. The use of copy assignment results in
the destruction of an uninitialized StringImpl, followed by an OOB write in
`StringImpl::deref()`.

Note that 255600@main is not the root cause of the issue. However, after
255600@main, the OOB write results in the address of the `completionHandler`
passed into `WebFoundTextRangeController::requestRectForFoundTextRange` being
modified. Consequently, `completionHandler.m_callThread.m_uid` is set to a
garbage value, and the assertion is hit as there is now a mismatch between the
calling thread and stored initialization thread.

To fix, use operator new to construct the deleted value. Additionally, use
`HashTableDeletedValue` when contructed the deleted AtomString for correctness.

* Source/WebKit/Shared/WebFoundTextRange.cpp:
(WebKit::WebFoundTextRange::operator== const):
(WebKit::WebFoundTextRange::decode):
* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::emptyValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::isDeletedValue):
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::deletedValue): Deleted.

Canonical link: <a href="https://commits.webkit.org/255832@main">https://commits.webkit.org/255832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c97f29abfb7f44c5f56f0fae949a54e16bad261

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103333 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2895 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31149 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86031 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2059 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80126 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29086 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83983 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37537 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17556 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4033 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41359 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38047 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->