### PR TITLE
Introduce platform-specific subclasses of RemoteScrollingTree

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -549,6 +549,7 @@ UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
 
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
 UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp
 UIProcess/RemoteLayerTree/mac/ScrollerMac.mm
 UIProcess/RemoteLayerTree/mac/ScrollerPairMac.mm
 UIProcess/RemoteLayerTree/mac/ScrollingTreeFrameScrollingNodeRemoteMac.cpp
@@ -557,6 +558,7 @@ UIProcess/RemoteLayerTree/mac/ScrollingTreeOverflowScrollingNodeRemoteMac.cpp
 UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
 UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
 UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
 UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteScrollingTreeIOS.h"
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
+
+#include "ScrollingTreeFrameScrollingNodeRemoteIOS.h"
+#include "ScrollingTreeOverflowScrollingNodeIOS.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
+{
+    return adoptRef(*new RemoteScrollingTreeIOS(scrollingCoordinator));
+}
+
+RemoteScrollingTreeIOS::RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy& scrollingCoordinatorProxy)
+    : RemoteScrollingTree(scrollingCoordinatorProxy)
+{
+}
+
+RemoteScrollingTreeIOS::~RemoteScrollingTreeIOS() = default;
+
+void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartPanGesture(ScrollingNodeID nodeID)
+{
+    m_scrollingCoordinatorProxy.scrollingTreeNodeWillStartPanGesture(nodeID);
+}
+
+void RemoteScrollingTreeIOS::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
+{
+    m_scrollingCoordinatorProxy.scrollingTreeNodeWillStartScroll(nodeID);
+}
+
+void RemoteScrollingTreeIOS::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
+{
+    m_scrollingCoordinatorProxy.scrollingTreeNodeDidEndScroll(nodeID);
+}
+
+Ref<ScrollingTreeNode> RemoteScrollingTreeIOS::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
+{
+    switch (nodeType) {
+    case ScrollingNodeType::MainFrame:
+    case ScrollingNodeType::Subframe:
+        return ScrollingTreeFrameScrollingNodeRemoteIOS::create(*this, nodeType, nodeID);
+
+    case ScrollingNodeType::Overflow:
+        return ScrollingTreeOverflowScrollingNodeIOS::create(*this, nodeID);
+
+    case ScrollingNodeType::FrameHosting:
+    case ScrollingNodeType::OverflowProxy:
+    case ScrollingNodeType::Fixed:
+    case ScrollingNodeType::Sticky:
+    case ScrollingNodeType::Positioned:
+        return RemoteScrollingTree::createScrollingTreeNode(nodeType, nodeID);
+    }
+    ASSERT_NOT_REACHED();
+    return ScrollingTreeFixedNodeCocoa::create(*this, nodeID);
+}
+
+} // namespace WebKit
+
+#endif // #if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
+
+#include "RemoteScrollingTree.h"
+
+namespace WebKit {
+
+class RemoteScrollingCoordinatorProxy;
+
+class RemoteScrollingTreeIOS final : public RemoteScrollingTree {
+public:
+    explicit RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy&);
+    virtual ~RemoteScrollingTreeIOS();
+
+private:
+    Ref<ScrollingTreeNode> createScrollingTreeNode(ScrollingNodeType, ScrollingNodeID) final;
+
+    void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) final;
+    void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) final;
+    void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) final;
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2014 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteScrollingTreeMac.h"
+
+#if PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)
+
+#include "RemoteScrollingCoordinatorProxy.h"
+#include "ScrollingTreeFrameScrollingNodeRemoteMac.h"
+#include "ScrollingTreeOverflowScrollingNodeRemoteMac.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
+{
+    return adoptRef(*new RemoteScrollingTreeMac(scrollingCoordinator));
+}
+
+RemoteScrollingTreeMac::RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
+    : RemoteScrollingTree(scrollingCoordinator)
+{
+}
+
+RemoteScrollingTreeMac::~RemoteScrollingTreeMac() = default;
+
+
+void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase)
+{
+    // FIXME: Is this needed?
+}
+
+Ref<ScrollingTreeNode> RemoteScrollingTreeMac::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
+{
+    switch (nodeType) {
+    case ScrollingNodeType::MainFrame:
+    case ScrollingNodeType::Subframe:
+        return ScrollingTreeFrameScrollingNodeRemoteMac::create(*this, nodeType, nodeID);
+
+    case ScrollingNodeType::Overflow:
+        return ScrollingTreeOverflowScrollingNodeRemoteMac::create(*this, nodeID);
+
+    case ScrollingNodeType::FrameHosting:
+    case ScrollingNodeType::OverflowProxy:
+    case ScrollingNodeType::Fixed:
+    case ScrollingNodeType::Sticky:
+    case ScrollingNodeType::Positioned:
+        return RemoteScrollingTree::createScrollingTreeNode(nodeType, nodeID);
+    }
+    ASSERT_NOT_REACHED();
+    return ScrollingTreeFixedNodeCocoa::create(*this, nodeID);
+}
+
+void RemoteScrollingTreeMac::handleMouseEvent(const WebCore::PlatformMouseEvent& event)
+{
+    if (!rootNode())
+        return;
+    static_cast<ScrollingTreeFrameScrollingNodeRemoteMac&>(*rootNode()).handleMouseEvent(event);
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
-#if ENABLE(UI_SIDE_COMPOSITING)
+#include "RemoteScrollingTree.h"
+
+#if PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)
 
 #include "RemoteScrollingCoordinator.h"
 #include <WebCore/ScrollingConstraints.h>
@@ -39,35 +41,19 @@ namespace WebKit {
 
 class RemoteScrollingCoordinatorProxy;
 
-class RemoteScrollingTree : public WebCore::ScrollingTree {
+class RemoteScrollingTreeMac final : public RemoteScrollingTree {
 public:
-    static Ref<RemoteScrollingTree> create(RemoteScrollingCoordinatorProxy&);
-    virtual ~RemoteScrollingTree();
+    explicit RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy&);
+    virtual ~RemoteScrollingTreeMac();
 
-    bool isRemoteScrollingTree() const final { return true; }
+    void handleMouseEvent(const WebCore::PlatformMouseEvent&) final;
 
-    void invalidate() final;
+private:
+    void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) final;
 
-    virtual void handleMouseEvent(const WebCore::PlatformMouseEvent&) { }
-
-    const RemoteScrollingCoordinatorProxy& scrollingCoordinatorProxy() const { return m_scrollingCoordinatorProxy; }
-
-    void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction = WebCore::ScrollingLayerPositionAction::Sync) final;
-    void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingTreeScrollingNode&) final;
-    bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) final;
-
-    void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) final;
-
-protected:
-    explicit RemoteScrollingTree(RemoteScrollingCoordinatorProxy&);
-
-    Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
-
-    RemoteScrollingCoordinatorProxy& m_scrollingCoordinatorProxy;
+    Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) final;
 };
 
 } // namespace WebKit
 
-SPECIALIZE_TYPE_TRAITS_SCROLLING_TREE(WebKit::RemoteScrollingTree, isRemoteScrollingTree());
-
-#endif // ENABLE(UI_SIDE_COMPOSITING)
+#endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3151,6 +3151,10 @@
 		0FF24A2B1879E4BC003ABF0D /* RemoteCaptureSampleManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteCaptureSampleManagerMessageReceiver.cpp; path = DerivedSources/WebKit/RemoteCaptureSampleManagerMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
 		0FF24A2C1879E4BC003ABF0C /* RemoteLayerTreeDrawingAreaProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteLayerTreeDrawingAreaProxyMessages.h; path = DerivedSources/WebKit/RemoteLayerTreeDrawingAreaProxyMessages.h; sourceTree = BUILT_PRODUCTS_DIR; };
 		0FF24A2F1879E4FE003ABF0C /* RemoteLayerTreeDrawingAreaProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteLayerTreeDrawingAreaProxy.messages.in; sourceTree = "<group>"; };
+		0FF7CE882901FDA500EA62D6 /* RemoteScrollingTreeIOS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteScrollingTreeIOS.cpp; sourceTree = "<group>"; };
+		0FF7CE892901FDA500EA62D6 /* RemoteScrollingTreeIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingTreeIOS.h; sourceTree = "<group>"; };
+		0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingTreeMac.h; sourceTree = "<group>"; };
+		0FF7CE8B2901FDAD00EA62D6 /* RemoteScrollingTreeMac.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteScrollingTreeMac.cpp; sourceTree = "<group>"; };
 		0FFED98C23A3200400EEF459 /* WKWebViewIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKWebViewIOS.h; sourceTree = "<group>"; };
 		0FFED98D23A3200500EEF459 /* WKWebViewIOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewIOS.mm; sourceTree = "<group>"; };
 		0FFED98F23A3203700EEF459 /* WKWebViewMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewMac.mm; sourceTree = "<group>"; };
@@ -9241,6 +9245,8 @@
 				2DC18FB1218A6E9E0025A88D /* RemoteLayerTreeViews.h */,
 				2DC18FB2218A6E9E0025A88D /* RemoteLayerTreeViews.mm */,
 				0F0C365B18C05CA100F607D7 /* RemoteScrollingCoordinatorProxyIOS.mm */,
+				0FF7CE882901FDA500EA62D6 /* RemoteScrollingTreeIOS.cpp */,
+				0FF7CE892901FDA500EA62D6 /* RemoteScrollingTreeIOS.h */,
 				E40C1F9321F0B96E00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h */,
 				E40C1F9521F0B97F00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.mm */,
 				0F931C1A18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.h */,
@@ -14162,6 +14168,8 @@
 				0F2E0DF828F0D04D006B9079 /* RemoteLayerTreeDrawingAreaProxyMac.mm */,
 				0F2E0DF728F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.h */,
 				0F2E0DF628F0CD35006B9079 /* RemoteScrollingCoordinatorProxyMac.mm */,
+				0FF7CE8B2901FDAD00EA62D6 /* RemoteScrollingTreeMac.cpp */,
+				0FF7CE8A2901FDAC00EA62D6 /* RemoteScrollingTreeMac.h */,
 				E404907521DE65F70037F0DB /* ScrollerMac.h */,
 				E404907421DE65F70037F0DB /* ScrollerMac.mm */,
 				E404907021DE65F70037F0DB /* ScrollerPairMac.h */,


### PR DESCRIPTION
#### 22dc6498963e547b90ff34d67b7635c1ef2acb59
<pre>
Introduce platform-specific subclasses of RemoteScrollingTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=246834">https://bugs.webkit.org/show_bug.cgi?id=246834</a>
rdar://101405405

Reviewed by Tim Horton.

Add RemoteScrollingTreeIOS and RemoteScrollingTreeMac.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::createScrollingTreeNode):
(WebKit::RemoteScrollingTree::create): Deleted.
(WebKit::RemoteScrollingTree::handleWheelEventPhase): Deleted.
(WebKit::RemoteScrollingTree::scrollingTreeNodeWillStartPanGesture): Deleted.
(WebKit::RemoteScrollingTree::scrollingTreeNodeWillStartScroll): Deleted.
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidEndScroll): Deleted.
(WebKit::RemoteScrollingTree::handleMouseEvent): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::handleMouseEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp: Added.
(WebKit::RemoteScrollingTree::create):
(WebKit::RemoteScrollingTreeIOS::RemoteScrollingTreeIOS):
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeWillStartPanGesture):
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingTreeIOS::scrollingTreeNodeDidEndScroll):
(WebKit::RemoteScrollingTreeIOS::createScrollingTreeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp: Added.
(WebKit::RemoteScrollingTree::create):
(WebKit::RemoteScrollingTreeMac::RemoteScrollingTreeMac):
(WebKit::RemoteScrollingTreeMac::handleWheelEventPhase):
(WebKit::RemoteScrollingTreeMac::createScrollingTreeNode):
(WebKit::RemoteScrollingTreeMac::handleMouseEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h: Copied from Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/255843@main">https://commits.webkit.org/255843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5f001a1a19ed44f4656581895e80276692a93c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103297 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2852 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31119 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/85998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99359 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2029 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80090 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29062 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83953 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37504 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17537 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41329 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38028 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->