### PR TITLE
[Live Range Selection] editing/execCommand/format-block-contenteditable-false.html fails

### DIFF
--- a/LayoutTests/editing/execCommand/format-block-contenteditable-false-live-range-expected.txt
+++ b/LayoutTests/editing/execCommand/format-block-contenteditable-false-live-range-expected.txt
@@ -1,0 +1,10 @@
+formatblock on selection with a contenteditable="false" child.
+| <h1>
+|   <i>
+|     "\n        <#selection-anchor>Will select from here\n        "
+|   <br>
+|   <i>
+|     "\n        until here.<#selection-focus>\n    "
+| <div>
+|   contenteditable="false"
+|   "\n            over this contenteditable=false div\n        "

--- a/LayoutTests/editing/execCommand/format-block-contenteditable-false-live-range.html
+++ b/LayoutTests/editing/execCommand/format-block-contenteditable-false-live-range.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+    <script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+    <div id="editorcontainer" contenteditable="true">
+        Will select from here
+        <div contenteditable="false">
+            over this contenteditable=false div
+        </div>
+        until here.
+    </div>
+</body>
+<script>
+    Markup.description('formatblock on selection with a contenteditable="false" child.');
+    
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+
+    var container = document.getElementById('editorcontainer');
+    var range = document.createRange()
+    range.setStartBefore(container.firstChild);
+    range.setEndAfter(container.lastChild);
+    selection.addRange(range);
+
+    document.execCommand('italic', false, "");
+    document.execCommand('formatblock', false, "<h1>");
+
+    Markup.dump(container);
+</script>
+</html>

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -105,8 +105,11 @@ void ApplyBlockElementCommand::doApply()
         // FIXME: Add a new TextIteratorBehavior to suppress it.
         if (start.isNotNull() && end.isNull())
             end = lastPositionInNode(endScope.get());
-        if (start.isNotNull() && end.isNotNull())
-            setEndingSelection(VisibleSelection(start, end, endingSelection().isDirectional()));
+        if (start.isNotNull() && end.isNotNull()) {
+            VisibleSelection selection { start, end, endingSelection().isDirectional() };
+            // Use canonicalized positions for start & end.
+            setEndingSelection(VisibleSelection(selection.start(), selection.end(), selection.isDirectional()));
+        }
     }
 }
 


### PR DESCRIPTION
#### b9267a2f3d90ffbf6503ed770b562d93a4f66f11
<pre>
[Live Range Selection] editing/execCommand/format-block-contenteditable-false.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=246833">https://bugs.webkit.org/show_bug.cgi?id=246833</a>

Reviewed by Wenson Hsieh.

Explicitly canonicalize the ending selection&apos;s start &amp; end in ApplyBlockElementCommand::doApply
so that the test result for format-block-contenteditable-false.html doesn&apos;t change before/after
enabling live range selection.

* LayoutTests/editing/execCommand/format-block-contenteditable-false-live-range-expected.txt: Added.
* LayoutTests/editing/execCommand/format-block-contenteditable-false-live-range.html: Added.
* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
(WebCore::ApplyBlockElementCommand::doApply):

Canonical link: <a href="https://commits.webkit.org/255861@main">https://commits.webkit.org/255861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/270528341552a416f6f1fe52afe4860987ced4dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103306 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163629 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2861 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31128 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99368 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2036 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80099 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29082 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83705 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72034 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37513 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17544 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18804 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4048 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41336 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38035 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->