### PR TITLE
[Live Range Selection] Tests for inserting paragraph separator fails

### DIFF
--- a/LayoutTests/editing/inserting/insert-paragraph-after-non-editable-node-before-text-live-range-expected.txt
+++ b/LayoutTests/editing/inserting/insert-paragraph-after-non-editable-node-before-text-live-range-expected.txt
@@ -1,0 +1,11 @@
+Testcase for bug https://webkit.org/b/115023: Editing: wrong text position when you click enter on the text behind the image.
+The test passes if "text2" appears on a new line with the caret placed at the beginning of that line.
+
+Dump of markup 1:
+| "<#selection-caret>text2"
+
+Dump of markup 2:
+| "<#selection-caret>text2"
+
+Dump of markup 3:
+| "<#selection-caret>text2"

--- a/LayoutTests/editing/inserting/insert-paragraph-after-non-editable-node-before-text-live-range.html
+++ b/LayoutTests/editing/inserting/insert-paragraph-after-non-editable-node-before-text-live-range.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div contenteditable="true">
+<span id="imgTest">text1<img src="abe.png"/>text2</span>
+<br>
+<span id="inputTest">text1<input type="text"></input>text2</span>
+<br>
+<span id="objectTest">text1<object style="display: inline" border="1"></object>text2</span>
+</div>
+<script>
+Markup.description('Testcase for bug https://webkit.org/b/115023: Editing: wrong text position when you click enter on the text behind the image.\n'+
+'The test passes if "text2" appears on a new line with the caret placed at the beginning of that line.');
+
+Markup.waitUntilDone();
+
+var test = document.getElementById('imgTest');
+test.focus();
+var selection = window.getSelection();
+selection.collapse(test, test.childNodes.length - 1);
+document.execCommand("InsertParagraph");
+Markup.dump(test);
+
+test = document.getElementById('inputTest');
+test.focus();
+selection = window.getSelection();
+selection.collapse(test, test.childNodes.length - 1);
+document.execCommand("InsertParagraph");
+Markup.dump(test);
+
+test = document.getElementById('objectTest');
+test.focus();
+selection = window.getSelection();
+selection.collapse(test, test.childNodes.length - 1);
+document.execCommand("InsertParagraph");
+Markup.dump(test);
+
+Markup.notifyDone();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/inserting/insert-paragraph-before-space-live-range-expected.txt
+++ b/LayoutTests/editing/inserting/insert-paragraph-before-space-live-range-expected.txt
@@ -1,0 +1,15 @@
+Verifies that inserting a paragraph before a space does not cause text after the insertion position to be deleted.
+
+Before inserting paragraph:
+| "\n    "
+| <p>
+|   "Hello<#selection-caret> world"
+| "\n\n\n"
+
+After inserting paragraph:
+| "\n    "
+| <p>
+|   "Hello"
+| <p>
+|   "<#selection-caret> world"
+| "\n\n\n"

--- a/LayoutTests/editing/inserting/insert-paragraph-before-space-live-range.html
+++ b/LayoutTests/editing/inserting/insert-paragraph-before-space-live-range.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html><!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+<html>
+<head>
+    <meta charset="utf8">
+    <script src="../../resources/dump-as-markup.js"></script>
+    <script>
+        addEventListener("DOMContentLoaded", () => {
+            document.designMode = "on";
+            Markup.description("Verifies that inserting a paragraph before a space does not cause text after the insertion position to be deleted.");
+
+            getSelection().setPosition(document.querySelector("p").childNodes[0], 5);
+
+            Markup.dump(document.body, "Before inserting paragraph");
+            document.execCommand("InsertParagraph");
+            Markup.dump(document.body, "After inserting paragraph");
+        });
+    </script>
+</head>
+<body>
+    <p>Hello world</p>
+</body>
+</html>

--- a/LayoutTests/editing/inserting/insert-paragraph-between-text-live-range-expected.txt
+++ b/LayoutTests/editing/inserting/insert-paragraph-between-text-live-range-expected.txt
@@ -1,0 +1,9 @@
+Testcase for bug https://webkit.org/b/113007: Unable to insert a paragraph in between some text whose previous sibling is a non-editable block.
+The test has passed if three lines are displayed instead of two, with the last line consisting of the letter "e".
+| "\n"
+| <div>
+|   contenteditable="false"
+|   "1"
+| "tryToInsertLineBreakInThisLin"
+| <div>
+|   "<#selection-caret>e"

--- a/LayoutTests/editing/inserting/insert-paragraph-between-text-live-range.html
+++ b/LayoutTests/editing/inserting/insert-paragraph-between-text-live-range.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="test" contenteditable="true">
+<div contenteditable="false">1</div>tryToInsertLineBreakInThisLine</div>
+
+<script>
+Markup.description('Testcase for bug https://webkit.org/b/113007: Unable to insert a paragraph in between some text whose previous sibling is a non-editable block.\n'+
+'The test has passed if three lines are displayed instead of two, with the last line consisting of the letter "e".');
+
+var test = document.getElementById('test');
+test.focus();
+
+var selection = window.getSelection();
+selection.collapse(test, test.childNodes.length);
+selection.modify("move", "backward", "character");
+document.execCommand("InsertParagraph");
+
+Markup.dump(test);
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/inserting/insert-paragraph-in-designmode-document-live-range-expected.txt
+++ b/LayoutTests/editing/inserting/insert-paragraph-in-designmode-document-live-range-expected.txt
@@ -1,0 +1,18 @@
+Verifies that after inserting a newline after a period doesn't insert an extra space in front of the newly inserted line.
+| <!DOCTYPE html>
+| <!--   webkit-test-runner [ LiveRangeSelectionEnabled=true ]   -->
+| <html>
+|   <head>
+|     "\n    "
+|     "\n    "
+|     "\n"
+|   "\n"
+|   <body>
+|     "\n    "
+|     <div>
+|       class="container"
+|       "Hello."
+|     <div>
+|       class="container"
+|       "<#selection-caret>This is a test."
+|     "\n\n\n"

--- a/LayoutTests/editing/inserting/insert-paragraph-in-designmode-document-live-range.html
+++ b/LayoutTests/editing/inserting/insert-paragraph-in-designmode-document-live-range.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+<html>
+<head>
+    <script src="../../resources/dump-as-markup.js"></script>
+    <script>
+        addEventListener("DOMContentLoaded", () => {
+            document.designMode = "on";
+
+            const container = document.querySelector(".container");
+            getSelection().setPosition(container.childNodes[0], 6);
+            document.execCommand("InsertParagraph");
+            document.querySelectorAll("script").forEach(script => script.remove());
+            Markup.description("Verifies that after inserting a newline after a period doesn't insert an extra space in front of the newly inserted line.");
+            Markup.dump("document.body");
+        });
+    </script>
+</head>
+<body>
+    <div class="container">Hello.This is a test.</div>
+</body>
+</html>

--- a/LayoutTests/editing/inserting/return-key-before-br-in-span-live-range-expected.txt
+++ b/LayoutTests/editing/inserting/return-key-before-br-in-span-live-range-expected.txt
@@ -1,0 +1,10 @@
+This sets the selection to the end of the first line, and hits the enter key.
+Expected behavior: a div is created around the second line, and the cursor is placed at the start of the second line. See bug 61594.
+| <span>
+|   id="wrapper"
+|   "First line"
+| <div>
+|   <span>
+|     <#selection-caret>
+|     <br>
+|     "Second line"

--- a/LayoutTests/editing/inserting/return-key-before-br-in-span-live-range.html
+++ b/LayoutTests/editing/inserting/return-key-before-br-in-span-live-range.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+<html>
+<body>
+<div contenteditable id="root"><span id="wrapper">First line<br>Second line</span></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description("This sets the selection to the end of the first line, and hits the enter key.\n"
+    + "Expected behavior: a div is created around the second line, and the cursor is placed at the "
+    + "start of the second line. See bug 61594.");
+var sel = window.getSelection();
+sel.setPosition(document.getElementById("wrapper"), 1);
+document.execCommand("InsertParagraph", false, null);
+Markup.dump(root);
+</script>
+</html>

--- a/LayoutTests/editing/inserting/return-key-middle-of-span-live-range-expected.txt
+++ b/LayoutTests/editing/inserting/return-key-middle-of-span-live-range-expected.txt
@@ -1,0 +1,10 @@
+This sets the selection to the middle of the first line, and hits the enter key.
+Expected behavior: the text node is split at the cursor. The span is cloned, and everything that was split out is placed inside the clone in a new div which is a child of the root. See bug 61594.
+| <span>
+|   id="wrapper"
+|   "First"
+| <div>
+|   <span>
+|     "<#selection-caret> line"
+|     <br>
+|     "Second line"

--- a/LayoutTests/editing/inserting/return-key-middle-of-span-live-range.html
+++ b/LayoutTests/editing/inserting/return-key-middle-of-span-live-range.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><!--  webkit-test-runner [ LiveRangeSelectionEnabled=true ]  -->
+<html>
+<body>
+<div contenteditable id="root"><span id="wrapper">First line<br>Second line</span></div>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description("This sets the selection to the middle of the first line, and hits the enter key.\n"
+    + "Expected behavior: the text node is split at the cursor. The span is cloned, and everything "
+    + "that was split out is placed inside the clone in a new div which is a child of the root. See bug 61594.");
+var sel = window.getSelection();
+sel.setPosition(document.getElementById("wrapper").firstChild, 5);
+document.execCommand("InsertParagraph", false, null);
+Markup.dump(root);
+</script>
+</html>

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -259,7 +259,7 @@ void InsertParagraphSeparatorCommand::doApply()
         if (!appendBlockPlaceholder(WTFMove(parent)))
             return;
 
-        setEndingSelection(VisibleSelection(firstPositionInNode(parentPtr), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(parentPtr), Affinity::Downstream), endingSelection().isDirectional()));
         return;
     }
     
@@ -299,7 +299,7 @@ void InsertParagraphSeparatorCommand::doApply()
             return;
         
         // In this case, we need to set the new ending selection.
-        setEndingSelection(VisibleSelection(insertionPosition, Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().isDirectional()));
         return;
     }
 
@@ -319,7 +319,7 @@ void InsertParagraphSeparatorCommand::doApply()
         // If the insertion point is a break element, there is nothing else
         // we need to do.
         if (auto* renderer = visiblePos.deepEquivalent().anchorNode()->renderer(); renderer && renderer->isBR()) {
-            setEndingSelection(VisibleSelection(insertionPosition, Affinity::Downstream, endingSelection().isDirectional()));
+            setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().isDirectional()));
             return;
         }
     }
@@ -422,7 +422,7 @@ void InsertParagraphSeparatorCommand::doApply()
         }
     }
 
-    setEndingSelection(VisibleSelection(firstPositionInNode(blockToInsert.get()), Affinity::Downstream, endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(blockToInsert.get()), Affinity::Downstream), endingSelection().isDirectional()));
     applyStyleAfterInsertion(startBlock.get());
 }
 


### PR DESCRIPTION
#### 8d82a00a0670ac79057c0a7ee0a9320f320cea49
<pre>
[Live Range Selection] Tests for inserting paragraph separator fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=246836">https://bugs.webkit.org/show_bug.cgi?id=246836</a>

Reviewed by Darin Adler.

Explicitly canonicalize ending positions after inserting a paragraph separator so that the test results won&apos;t change
before and after enabling live range selection.

* LayoutTests/editing/inserting/insert-paragraph-after-non-editable-node-before-text-live-range-expected.txt: Added.
* LayoutTests/editing/inserting/insert-paragraph-after-non-editable-node-before-text-live-range.html: Added.
* LayoutTests/editing/inserting/insert-paragraph-before-space-live-range-expected.txt: Added.
* LayoutTests/editing/inserting/insert-paragraph-before-space-live-range.html: Added.
* LayoutTests/editing/inserting/insert-paragraph-between-text-live-range-expected.txt: Added.
* LayoutTests/editing/inserting/insert-paragraph-between-text-live-range.html: Added.
* LayoutTests/editing/inserting/insert-paragraph-in-designmode-document-live-range-expected.txt: Added.
* LayoutTests/editing/inserting/insert-paragraph-in-designmode-document-live-range.html: Added.
* LayoutTests/editing/inserting/return-key-before-br-in-span-live-range-expected.txt: Added.
* LayoutTests/editing/inserting/return-key-before-br-in-span-live-range.html: Added.
* LayoutTests/editing/inserting/return-key-middle-of-span-live-range-expected.txt: Added.
* LayoutTests/editing/inserting/return-key-middle-of-span-live-range.html: Added.
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:

Canonical link: <a href="https://commits.webkit.org/255872@main">https://commits.webkit.org/255872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e2d831dd459657de726d95029e4077a1d185553

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103481 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163814 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3057 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31276 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99486 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2178 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80272 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29200 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84104 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37672 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17636 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35536 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18898 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41468 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38128 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->