### PR TITLE
drawingBufferColorSpace support in WebGL canvas on macOS

### DIFF
--- a/LayoutTests/fast/canvas/webgl/colorspaces-test-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/colorspaces-test-expected.txt
@@ -1,0 +1,134 @@
+This test ensures WebGL implementations correctly implement drawingbufferColorSpace.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+test(w=4, h=4, drawingBufferColorSpace=DONT_SET, expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=DONT_SET, expectedDrawingBufferColorSpace="srgb", color="0,1,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=DONT_SET, expectedDrawingBufferColorSpace="srgb", color="0,0,1")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="srgb", expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="srgb"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="srgb", expectedDrawingBufferColorSpace="srgb", color="0,1,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="srgb"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="srgb", expectedDrawingBufferColorSpace="srgb", color="0,0,1")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="srgb"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="display-p3", expectedDrawingBufferColorSpace="display-p3", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="display-p3"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="display-p3", expectedDrawingBufferColorSpace="display-p3", color="0,1,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="display-p3"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="display-p3", expectedDrawingBufferColorSpace="display-p3", color="0,0,1")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="display-p3"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="invalid", expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace="invalid"
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace="", expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace=""
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=null, expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace=null
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=undefined, expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace=undefined
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=0, expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace=0
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=1, expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace=1
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+test(w=4, h=4, drawingBufferColorSpace=new Date, expectedDrawingBufferColorSpace="srgb", color="1,0,0")
+PASS context exists
+PASS gl.drawingBufferColorSpace is "srgb"
+Setting gl.drawingBufferColorSpace=new Date
+PASS gl.drawingBufferColorSpace is as_expected
+PASS gl.getError() is gl.NO_ERROR
+PASS Canvas color as expected
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/colorspaces-test.html
+++ b/LayoutTests/fast/canvas/webgl/colorspaces-test.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Canvas Test: Colorspaces</title>
+<script src="../../../resources/js-test.js"></script>
+<script src="resources/webgl-test.js"></script>
+<script src="resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+description("This test ensures WebGL implementations correctly implement drawingbufferColorSpace.");
+
+const DONT_SET = "<don't set>";
+
+function test(w, h, drawingBufferColorSpaceInString, expectedDrawingBufferColorSpace, color) {
+  debug("");
+  debug(`test(w=${w}, h=${h}, drawingBufferColorSpace=${drawingBufferColorSpaceInString}, expectedDrawingBufferColorSpace="${expectedDrawingBufferColorSpace}", color="${color}")`);
+  const drawingBufferColorSpace = eval(drawingBufferColorSpaceInString);
+
+  var canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+
+  var consoleDiv = document.getElementById("console");
+  document.body.insertBefore(canvas, consoleDiv);
+
+  gl = wtu.create3DContext(canvas, {antialias: false});
+  if (!gl) {
+    testFailed("context does not exist");
+  } else {
+    testPassed("context exists");
+
+    if ('drawingBufferColorSpace' in gl) {
+      shouldBe('gl.drawingBufferColorSpace', '"srgb"');
+
+      if (drawingBufferColorSpace !== DONT_SET) {
+        debug(`Setting gl.drawingBufferColorSpace=${drawingBufferColorSpaceInString}`);
+        gl.drawingBufferColorSpace = drawingBufferColorSpace;
+      }
+      as_expected = expectedDrawingBufferColorSpace;
+      shouldBe('gl.drawingBufferColorSpace', 'as_expected');
+    }
+
+    gl.clearColor(color[0], color[1], color[2], 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    shouldBe('gl.getError()', 'gl.NO_ERROR');
+
+    wtu.checkCanvas(gl, [color[0] * 255, color[1] * 255, color[2] * 255], "Canvas color as expected", 1);
+  }
+}
+
+var wtu = WebGLTestUtils;
+
+test(4, 4, 'DONT_SET', "srgb", [1, 0, 0]);
+test(4, 4, 'DONT_SET', "srgb", [0, 1, 0]);
+test(4, 4, 'DONT_SET', "srgb", [0, 0, 1]);
+
+test(4, 4, '"srgb"', "srgb", [1, 0, 0]);
+test(4, 4, '"srgb"', "srgb", [0, 1, 0]);
+test(4, 4, '"srgb"', "srgb", [0, 0, 1]);
+
+test(4, 4, '"display-p3"', "display-p3", [1, 0, 0]);
+test(4, 4, '"display-p3"', "display-p3", [0, 1, 0]);
+test(4, 4, '"display-p3"', "display-p3", [0, 0, 1]);
+
+test(4, 4, '"invalid"', "srgb", [1, 0, 0]);
+test(4, 4, '""', "srgb", [1, 0, 0]);
+test(4, 4, 'null', "srgb", [1, 0, 0]);
+test(4, 4, 'undefined', "srgb", [1, 0, 0]);
+test(4, 4, '0', "srgb", [1, 0, 0]);
+test(4, 4, '1', "srgb", [1, 0, 0]);
+test(4, 4, 'new Date', "srgb", [1, 0, 0]);
+
+debug("")
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/context-lost-restored-p3-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/context-lost-restored-p3-expected.txt
@@ -1,0 +1,34 @@
+Restored context should keep colorspace.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Test losing and restoring a context.
+Test valid context
+PASS gl.isContextLost() is false
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.drawingBufferColorSpace is "display-p3"
+
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS contextLostEventFired is false
+PASS gl.drawingBufferColorSpace is "display-p3"
+Test lost context
+PASS contextLostEventFired is false
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.NO_ERROR
+
+PASS extension.restoreContext() was expected value: NO_ERROR.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.NO_ERROR
+Test restored context
+PASS contextRestoredEventFired is false
+PASS gl.isContextLost() is false
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.drawingBufferColorSpace is "display-p3"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/context-lost-restored-p3.html
+++ b/LayoutTests/fast/canvas/webgl/context-lost-restored-p3.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="resources/webgl-test.js"></script>
+<script src="resources/webgl-test-utils.js"></script>
+<script>
+if (window.internals)
+    window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
+
+var wtu = WebGLTestUtils;
+var canvas;
+var gl;
+var shouldGenerateGLError;
+var extension;
+var allowRestore;
+var contextLostEventFired;
+var contextRestoredEventFired;
+
+function init()
+{
+    if (window.initNonKhronosFramework) {
+        window.initNonKhronosFramework(true);
+    }
+
+    description("Restored context should keep colorspace.");
+
+    shouldGenerateGLError = wtu.shouldGenerateGLError;
+    testLosingAndRestoringContext();
+}
+
+function setupTest()
+{
+    canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    gl = wtu.create3DContext(canvas);
+    if ("drawingBufferColorSpace" in gl) {
+        gl.drawingBufferColorSpace = "display-p3";
+        if (gl.drawingBufferColorSpace != "display-p3") {
+            debug("drawingBufferColorSpace did not store display-p3");
+            return false;
+        }
+    } else {
+        debug("No drawingBufferColorSpace in gl");
+        return false;
+    }
+
+    extension = gl.getExtension("WEBGL_lose_context");
+    if (!extension) {
+        debug("Could not find lose_context extension under the following names: WEBGL_lose_context");
+        return false;
+    }
+    return true;
+}
+
+function testLosingAndRestoringContext()
+{
+    if (!setupTest())
+        finishTest();
+
+    debug("");
+    debug("Test losing and restoring a context.");
+
+    canvas.addEventListener("webglcontextlost", function(e) {
+      testLostContext(e);
+      // restore the context after this event has exited.
+      setTimeout(function() {
+        shouldGenerateGLError(gl, gl.NO_ERROR, "extension.restoreContext()");
+        // The context should still be lost. It will not get restored until the 
+        // webglrestorecontext event is fired.
+        shouldBeTrue("gl.isContextLost()");
+        shouldBe("gl.getError()", "gl.NO_ERROR");
+      }, 0);
+    });
+    canvas.addEventListener("webglcontextrestored", function() {
+      testRestoredContext();
+      finishTest();
+    });
+    allowRestore = true;
+    contextLostEventFired = false;
+    contextRestoredEventFired = false;
+
+    testOriginalContext();
+    extension.loseContext();
+    // The context should be lost immediately.
+    shouldBeTrue("gl.isContextLost()");
+    shouldBe("gl.getError()", "gl.CONTEXT_LOST_WEBGL");
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+    // but the event should not have been fired.
+    shouldBeFalse("contextLostEventFired");
+
+    shouldBe("gl.drawingBufferColorSpace", '"display-p3"');
+}
+
+function testOriginalContext()
+{
+    debug("Test valid context");
+    shouldBeFalse("gl.isContextLost()");
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+    shouldBe("gl.drawingBufferColorSpace", '"display-p3"');
+    debug("");
+}
+
+function testLostContext(e)
+{
+    debug("Test lost context");
+    shouldBeFalse("contextLostEventFired");
+    contextLostEventFired = true;
+    shouldBeTrue("gl.isContextLost()");
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+    debug("");
+    if (allowRestore)
+      e.preventDefault();
+}
+
+function testRestoredContext()
+{
+    debug("Test restored context");
+    shouldBeFalse("contextRestoredEventFired");
+    contextRestoredEventFired = true;
+    shouldBeFalse("gl.isContextLost()");
+    shouldBe("gl.getError()", "gl.NO_ERROR");
+    shouldBe("gl.drawingBufferColorSpace", '"display-p3"');
+    debug("");
+}
+
+
+</script>
+</head>
+<body onload="init()">
+<div id="description"></div>
+<div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/match-page-color-space-p3-expected.html
+++ b/LayoutTests/fast/canvas/webgl/match-page-color-space-p3-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+.box {
+    position: relative;
+    display: inline-block;
+    margin: 5px;
+    width: 40px;
+    height: 40px;
+}
+</style>
+
+<p>The boxes below should all be uniform in color. Any difference is likely to be extremely subtle.</p>
+<div class="box" style="background-color: red"></div>
+<div class="box" style="background-color: green"></div>
+<div class="box" style="background-color: blue"></div>
+<p>rgb red, srgb red, display-p3 red (should be brighter):</p>
+<div class="box" style="background-color: rgb(255, 0, 0)"></div>
+<div class="box" style="background-color: color(srgb 1 0 0)"></div>
+<div class="box" style="background-color: color(display-p3 1 0 0)"></div>

--- a/LayoutTests/fast/canvas/webgl/match-page-color-space-p3.html
+++ b/LayoutTests/fast/canvas/webgl/match-page-color-space-p3.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<style>
+.box {
+    position: relative;
+    display: inline-block;
+    margin: 5px;
+    width: 40px;
+    height: 40px;
+}
+
+canvas {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    width: 20px;
+    height: 20px;
+    background-color: black;
+}
+</style>
+<script>
+
+function drawColorIntoCanvas(color, canvas) {
+    var gl = canvas.getContext("webgl");
+    gl.clearColor(color[0], color[1], color[2], 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+}
+
+function drawColorWithSpaceIntoCanvas(color, space, canvas) {
+    var gl = canvas.getContext("webgl");
+    if ("drawingBufferColorSpace" in gl) {
+        gl.drawingBufferColorSpace = space;
+    }
+    gl.clearColor(color[0], color[1], color[2], 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+}
+
+function run() {
+    var boxes = document.querySelectorAll(".box");
+    for (var i = 0; i < boxes.length; i++) {
+        var box = boxes[i];
+        var canvas = document.createElement("canvas");
+        canvas.width = 20;
+        canvas.height = 20;
+
+        var backgroundColor = window.getComputedStyle(box).backgroundColor;
+        var matches = /rgb\((\d+),\s(\d+),\s(\d+)\)/.exec(backgroundColor);
+        if (matches) {
+            drawColorIntoCanvas([matches[1] / 255, matches[2] / 255, matches[3] / 255], canvas);
+        } else {
+            matches = /color\(([^\s]+)\s(1|0(?:\.\d+)?)\s(1|0(?:\.\d+)?)\s(1|0(?:\.\d+)?)\)/.exec(backgroundColor);
+            if (matches) {
+                drawColorWithSpaceIntoCanvas([matches[2], matches[3], matches[4]], matches[1], canvas);
+            } else {
+                console.log(`Unrecognized backgroundColor '${backgroundColor}'`);
+                drawColorIntoCanvas([0, 0, 0], canvas);
+            }
+        }
+        box.appendChild(canvas);
+    }
+}
+
+window.addEventListener("load", run, false);
+</script>
+<body>
+<p>The boxes below should all be uniform in color. Any difference is likely to be extremely subtle.</p>
+<div class="box" style="background-color: red"></div>
+<div class="box" style="background-color: green"></div>
+<div class="box" style="background-color: blue"></div>
+<p>rgb red, srgb red, display-p3 red (should be brighter):</p>
+<div class="box" style="background-color: rgb(255, 0, 0)"></div>
+<div class="box" style="background-color: color(srgb 1 0 0)"></div>
+<div class="box" style="background-color: color(display-p3 1 0 0)"></div>
+</body>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -529,6 +529,11 @@ webkit.org/b/166536 webgl/2.0.y/ [ Skip ]
 webkit.org/b/166536 webgl/pending/conformance2/ [ Skip ]
 webkit.org/b/166536 http/tests/webgl/2.0.y/ [ Skip ]
 
+# No colorspaces in non-Cocoa WebGL.
+fast/canvas/webgl/colorspaces-test.html [ Failure ]
+fast/canvas/webgl/context-lost-restored-p3.html [ Failure ]
+fast/canvas/webgl/match-page-color-space-p3.html [ ImageOnlyFailure ]
+
 # These tests reference specific fonts on Mac port.
 Bug(GTK) fast/text/font-weights.html [ WontFix ]
 Bug(GTK) fast/text/font-weights-zh.html [ WontFix ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2607,6 +2607,11 @@ fast/canvas/webgl/texImage2D-video-flipY-true.html [ Skip ]
 # rendering to floating point FBOs not supported on iOS
 fast/canvas/webgl/readPixels-float.html [ Skip ]
 
+# No colorspaces in iOS WebGL yet.
+webkit.org/b/247166 fast/canvas/webgl/colorspaces-test.html [ Failure ]
+webkit.org/b/247166 fast/canvas/webgl/context-lost-restored-p3.html [ Failure ]
+webkit.org/b/247166 fast/canvas/webgl/match-page-color-space-p3.html [ ImageOnlyFailure ]
+
 # Skipped on iOS since UIHelper.activateAt() doesn't produce a user gesture that ITP captures on iOS
 webkit.org/b/174120 http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.html [ Skip ]
 http/tests/resourceLoadStatistics/user-interaction-only-reported-once-within-short-period-of-time.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2042,6 +2042,10 @@ webkit.org/b/222239 webgl/2.0.0/conformance/uniforms/uniform-default-values.html
 webkit.org/b/222844 fast/canvas/webgl/match-page-color-space.html [ Pass ImageOnlyFailure ]
 webkit.org/b/222844 imported/blink/compositing/draws-content/webgl-simple-background.html [ Pass ImageOnlyFailure ]
 
+# No WebGL drawingBufferColorSpace (because no PREDEFINED_COLOR_SPACE_DISPLAY_P3) until Monterey.
+webkit.org/b/247165 [ BigSur ] fast/canvas/webgl/colorspaces-test.html [ Failure ]
+webkit.org/b/247165 [ BigSur ] fast/canvas/webgl/context-lost-restored-p3.html [ Failure ]
+
 # ASTC may be supported on M1 macs, but we should skip it for now
 fast/canvas/webgl/webgl-compressed-texture-astc.html [ Skip ]
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -738,7 +738,9 @@ void WebGLRenderingContextBase::initializeNewContext()
     m_backDrawBuffer = GraphicsContextGL::BACK;
     m_drawBuffersWebGLRequirementsChecked = false;
     m_drawBuffersSupported = false;
-    
+
+    m_context->setDrawingBufferColorSpace(toDestinationColorSpace(m_drawingBufferColorSpace));
+
     IntSize canvasSize = clampedCanvasSize();
     m_context->reshape(canvasSize.width(), canvasSize.height());
     m_context->viewport(0, 0, canvasSize.width(), canvasSize.height());
@@ -1140,6 +1142,19 @@ int WebGLRenderingContextBase::drawingBufferHeight() const
         return 0;
 
     return m_context->getInternalFramebufferSize().height();
+}
+
+void WebGLRenderingContextBase::setDrawingBufferColorSpace(PredefinedColorSpace colorSpace)
+{
+    if (m_drawingBufferColorSpace == colorSpace)
+        return;
+
+    m_drawingBufferColorSpace = colorSpace;
+
+    if (isContextLost())
+        return;
+
+    m_context->setDrawingBufferColorSpace(toDestinationColorSpace(colorSpace));
 }
 
 unsigned WebGLRenderingContextBase::sizeInBytes(GCGLenum type)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -32,6 +32,7 @@
 #include "GPUBasedCanvasRenderingContext.h"
 #include "GraphicsContextGL.h"
 #include "ImageBuffer.h"
+#include "PredefinedColorSpace.h"
 #include "SuspendableTimer.h"
 #include "Timer.h"
 #include "WebGLAny.h"
@@ -182,6 +183,9 @@ public:
 
     int drawingBufferWidth() const;
     int drawingBufferHeight() const;
+
+    PredefinedColorSpace drawingBufferColorSpace() const { return m_drawingBufferColorSpace; }
+    void setDrawingBufferColorSpace(PredefinedColorSpace);
 
     void activeTexture(GCGLenum texture);
     void attachShader(WebGLProgram&, WebGLShader&);
@@ -693,6 +697,8 @@ protected:
 
     std::optional<ContextLostState>  m_contextLostState;
     WebGLContextAttributes m_attributes;
+
+    PredefinedColorSpace m_drawingBufferColorSpace { PredefinedColorSpace::SRGB };
 
     bool m_layerCleared;
     GCGLfloat m_clearColor[4];

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.idl
@@ -482,6 +482,12 @@ typedef (HTMLCanvasElement) WebGLCanvas;
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
 
+#if defined(ENABLE_PREDEFINED_COLOR_SPACE_DISPLAY_P3) && ENABLE_PREDEFINED_COLOR_SPACE_DISPLAY_P3
+# if defined(WTF_PLATFORM_MAC) && WTF_PLATFORM_MAC // iOS to be implemented in http://webkit.org/b/247166
+    [EnabledBySetting=CanvasColorSpaceEnabled] attribute PredefinedColorSpace drawingBufferColorSpace;
+# endif
+#endif
+
     undefined activeTexture(GLenum texture);
     undefined attachShader(WebGLProgram program, WebGLShader shader);
     undefined bindAttribLocation(WebGLProgram program, GLuint index, DOMString name);

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -61,6 +61,7 @@
 #include "JSExecState.h"
 #include "JSImageBitmapRenderingContext.h"
 #include "JSImageSmoothingQuality.h"
+#include "JSPredefinedColorSpace.h"
 #include "JSWebGL2RenderingContext.h"
 #include "JSWebGLRenderingContext.h"
 #include "OffscreenCanvas.h"
@@ -361,6 +362,11 @@ std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::pro
     if (!argument)
         return std::nullopt;
     return {{ valueIndexForData(buildStringFromPath(argument->path())), RecordingSwizzleType::Path2D }};
+}
+
+std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(PredefinedColorSpace argument)
+{
+    return { { valueIndexForData(convertEnumerationToString(argument)), RecordingSwizzleType::String } };
 }
 
 std::optional<InspectorCanvasCallTracer::ProcessedArgument> InspectorCanvas::processArgument(RefPtr<CanvasGradient>& argument)

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.h
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.h
@@ -78,6 +78,7 @@ enum class CanvasLineCap;
 enum class CanvasLineJoin;
 enum class CanvasTextAlign;
 enum class CanvasTextBaseline;
+enum class PredefinedColorSpace;
 enum ImageSmoothingQuality;
 
 #define FOR_EACH_INSPECTOR_CANVAS_CALL_TRACER_CSS_TYPED_OM_ARGUMENT(macro) \
@@ -161,6 +162,7 @@ enum ImageSmoothingQuality;
     macro(std::optional<float>&) \
     macro(std::optional<double>&) \
     macro(Path2D*) \
+    macro(PredefinedColorSpace) \
     macro(RefPtr<CanvasGradient>&) \
     macro(RefPtr<CanvasPattern>&) \
     macro(RefPtr<HTMLCanvasElement>&) \

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -600,6 +600,10 @@ bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGL
     return true;
 }
 
+void GraphicsContextGL::setDrawingBufferColorSpace(const DestinationColorSpace&)
+{
+}
+
 void GraphicsContextGL::markContextChanged()
 {
     m_layerComposited = false;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBGL)
 
+#include "DestinationColorSpace.h"
 #include "GraphicsContextGLAttributes.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "GraphicsTypesGL.h"
@@ -1449,6 +1450,8 @@ public:
     virtual void reshape(int width, int height) = 0;
 
     virtual void setContextVisibility(bool) = 0;
+
+    WEBCORE_EXPORT virtual void setDrawingBufferColorSpace(const DestinationColorSpace&);
 
     virtual bool isGLES2Compliant() const = 0;
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -86,6 +86,7 @@ public:
     RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() final;
 #endif
     void setContextVisibility(bool) final;
+    void setDrawingBufferColorSpace(const DestinationColorSpace&) final;
     void prepareForDisplay() override;
 
 #if PLATFORM(MAC)
@@ -103,6 +104,7 @@ protected:
     bool bindDisplayBufferBacking(std::unique_ptr<IOSurface> backing, void* pbuffer);
 
     ProcessIdentity m_resourceOwner;
+    DestinationColorSpace m_drawingBufferColorSpace;
 #if ENABLE(VIDEO)
     std::unique_ptr<GraphicsContextGLCVCocoa> m_cv;
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -228,6 +228,7 @@ RefPtr<GraphicsContextGLCocoa> GraphicsContextGLCocoa::create(GraphicsContextGLA
 GraphicsContextGLCocoa::GraphicsContextGLCocoa(GraphicsContextGLAttributes&& creationAttributes, ProcessIdentity&& resourceOwner)
     : GraphicsContextGLANGLE(WTFMove(creationAttributes))
     , m_resourceOwner(WTFMove(resourceOwner))
+    , m_drawingBufferColorSpace(DestinationColorSpace::SRGB())
 {
 }
 
@@ -578,10 +579,22 @@ bool GraphicsContextGLCocoa::reshapeDisplayBufferBacking()
     return allocateAndBindDisplayBufferBacking();
 }
 
+void GraphicsContextGLCocoa::setDrawingBufferColorSpace(const DestinationColorSpace& colorSpace)
+{
+    if (m_drawingBufferColorSpace != colorSpace) {
+        m_drawingBufferColorSpace = colorSpace;
+
+        if (!getInternalFramebufferSize().isEmpty() && !reshapeDisplayBufferBacking()) {
+            RELEASE_LOG(WebGL, "Fatal: Unable to allocate backing store of size %d x %d", getInternalFramebufferSize().width(), getInternalFramebufferSize().height());
+            forceContextLost();
+        }
+    }
+}
+
 bool GraphicsContextGLCocoa::allocateAndBindDisplayBufferBacking()
 {
     ASSERT(!getInternalFramebufferSize().isEmpty());
-    auto backing = IOSurface::create(nullptr, getInternalFramebufferSize(), DestinationColorSpace::SRGB());
+    auto backing = IOSurface::create(nullptr, getInternalFramebufferSize(), m_drawingBufferColorSpace);
     if (!backing)
         return false;
     if (m_resourceOwner)
@@ -757,7 +770,7 @@ void GraphicsContextGLCocoa::prepareForDisplay()
     m_displayBufferPbuffer = EGL_NO_SURFACE;
 
     bool hasNewBacking = false;
-    if (recycledBuffer.surface && recycledBuffer.surface->size() == getInternalFramebufferSize()) {
+    if (recycledBuffer.surface && recycledBuffer.surface->size() == getInternalFramebufferSize() && recycledBuffer.surface->colorSpace() == m_drawingBufferColorSpace) {
         hasNewBacking = bindDisplayBufferBacking(WTFMove(recycledBuffer.surface), recycledBuffer.handle);
         recycledBuffer.handle = nullptr;
     }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -307,6 +307,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void DrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t instanceCount, int32_t baseVertex, uint32_t baseInstance)
     void ProvokingVertexANGLE(uint32_t mode)
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
+    void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
     void PaintRenderingResultsToPixelBuffer() -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1397,6 +1397,11 @@
         m_context->getInternalformativ(target, internalformat, pname, params);
         completionHandler(IPC::ArrayReference<int32_t>(reinterpret_cast<int32_t*>(params.data()), params.size()));
     }
+    void setDrawingBufferColorSpace(WebCore::DestinationColorSpace&& arg0)
+    {
+        assertIsCurrent(workQueue());
+        m_context->setDrawingBufferColorSpace(arg0);
+    }
     void paintRenderingResultsToPixelBuffer(CompletionHandler<void(RefPtr<WebCore::PixelBuffer>&&)>&& completionHandler)
     {
         RefPtr<WebCore::PixelBuffer> returnValue = { };

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -334,6 +334,7 @@ public:
     void drawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLsizei count, GCGLenum type, GCGLintptr offset, GCGLsizei instanceCount, GCGLint baseVertex, GCGLuint baseInstance) final;
     void provokingVertexANGLE(GCGLenum mode) final;
     void getInternalformativ(GCGLenum target, GCGLenum internalformat, GCGLenum pname, GCGLSpan<GCGLint> params) final;
+    void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
     RefPtr<WebCore::PixelBuffer> paintRenderingResultsToPixelBuffer() final;
     // End of list used by generate-gpup-webgl script.
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -2863,10 +2863,12 @@ void RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceAN
 
 void RemoteGraphicsContextGLProxy::provokingVertexANGLE(GCGLenum mode)
 {
-    if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(mode));
-        if (!sendResult)
-            markContextLost();
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(mode));
+    if (!sendResult) {
+        markContextLost();
+        return;
     }
 }
 
@@ -2881,6 +2883,17 @@ void RemoteGraphicsContextGLProxy::getInternalformativ(GCGLenum target, GCGLenum
     }
     auto& [paramsReply] = sendResult.reply();
     memcpy(params.data(), paramsReply.data(), params.size() * sizeof(int32_t));
+}
+
+void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::DestinationColorSpace& arg0)
+{
+    if (isContextLost())
+        return;
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::SetDrawingBufferColorSpace(arg0));
+    if (!sendResult) {
+        markContextLost();
+        return;
+    }
 }
 
 RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer()


### PR DESCRIPTION
#### 0dfb608af54f0e352c7ba6879c72b1847886f585
<pre>
drawingBufferColorSpace support in WebGL canvas on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=247165">https://bugs.webkit.org/show_bug.cgi?id=247165</a>
&lt;rdar://101663516&gt;

Reviewed by Kimmo Kinnunen.

Add &apos;drawingBufferColorSpace&apos; attribute in canvas.getContext(&apos;webgl&apos; or &apos;webgl2&apos;).
The default value is &apos;srgb&apos;.
On macOS, the supported colorspaces are &apos;srgb&apos; and &apos;display-p3&apos;. Note that currently this only affects how the buffer is interpreted when presented on the screen.
On other platforms, the attribute will not even be present.

* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/256208@main">https://commits.webkit.org/256208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe11ad0941bf91f5a5f11b4e6a0e78a05c34e210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104494 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164757 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4122 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32218 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100415 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2979 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81581 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29963 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84438 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72850 "Found 1 new API test failure: /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38629 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18271 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36462 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19551 "Found 30 new test failures: editing/style/apply-style-join-child-text-nodes-crash.html, fast/events/wheelevent-in-frame.html, fast/frames/frame-limit.html, fast/loader/navigate-with-new-target-after-back-forward-navigation.html, http/tests/appcache/fail-on-update-2.html, http/tests/cookies/same-site/popup-same-site-post.html, http/tests/resourceLoadStatistics/third-party-cookie-blocking-ephemeral.html, http/wpt/cache-storage/cache-quota.any.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/IndexedDB/idb-explicit-commit.any.worker.html ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4291 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40386 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38784 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->