### PR TITLE
[WebXR] Catch undeleted GL objects with OwnedGLObject

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -72,12 +72,12 @@ private:
     Attributes m_attributes;
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
-    PlatformGLObject m_depthStencilBuffer { 0 };
-    PlatformGLObject m_stencilBuffer { 0 };
-    PlatformGLObject m_multisampleColorBuffer { 0 };
-    PlatformGLObject m_resolvedFBO { 0 };
+    OwnedGLObject m_depthStencilBuffer;
+    OwnedGLObject m_stencilBuffer;
+    OwnedGLObject m_multisampleColorBuffer;
+    OwnedGLObject m_resolvedFBO;
     GCGLint m_sampleCount { 0 };
-    PlatformGLObject m_opaqueTexture { 0 };
+    OwnedGLObject m_opaqueTexture;
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
     void* m_ioSurfaceTextureHandle { nullptr };
     bool m_ioSurfaceTextureHandleIsShared { false };

--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -68,6 +68,38 @@ using GCGLContext = void*;
 typedef unsigned GLuint;
 #endif
 
+struct OwnedGLObject {
+    OwnedGLObject()
+        : OwnedGLObject(0)
+    { }
+    OwnedGLObject(PlatformGLObject object)
+        : m_object(object)
+    { }
+    OwnedGLObject(const OwnedGLObject&) = delete;
+    OwnedGLObject(OwnedGLObject&&) = delete;
+    ~OwnedGLObject()
+    {
+        ASSERT(!m_object, "Have you explicitly deleted this object? If so, call release().");
+    }
+
+    OwnedGLObject& operator=(const OwnedGLObject&) const = delete;
+    OwnedGLObject& operator=(OwnedGLObject&&) = delete;
+
+    operator PlatformGLObject() const { return m_object; }
+
+    [[nodiscard]] PlatformGLObject reset(PlatformGLObject newObject) {
+        std::swap(m_object, newObject);
+        return newObject;
+    }
+
+    [[nodiscard]] PlatformGLObject release() {
+        return reset(0);
+    }
+
+private:
+    PlatformGLObject m_object = 0;
+};
+
 inline constexpr size_t gcGLSpanDynamicExtent = std::numeric_limits<size_t>::max();
 
 template<typename T, size_t Extent = gcGLSpanDynamicExtent>


### PR DESCRIPTION
#### 0a69bc3f00f0de42638cd745f3ccd1254c5014cc
<pre>
[WebXR] Catch undeleted GL objects with OwnedGLObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=246841">https://bugs.webkit.org/show_bug.cgi?id=246841</a>
rdar://101410305

Reviewed by Dean Jackson.

Use OwnedGLObject to ensure that OpenGL objects are correctly released
to avoid leaks. OwnedGLObject provides a reset/release interface similar
to std::unique_ptr. The results of reset() and release() are marked
[[nodiscard]] to signal the old value must be correctly handled. In
addition, release() must be called to disarm OwnedGLObject destructor
ASSERT.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
(WebCore::OwnedGLObject::OwnedGLObject):
(WebCore::OwnedGLObject::~OwnedGLObject):
(WebCore::OwnedGLObject::operator=):
(WebCore::OwnedGLObject::operator bool const):
(WebCore::OwnedGLObject::operator PlatformGLObject const):
(WebCore::OwnedGLObject::deleteObject):
(WebCore::OwnedGLObject::makeObject):

Canonical link: <a href="https://commits.webkit.org/255900@main">https://commits.webkit.org/255900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40e626c3c98529d2e0af5dc2c9704d4f65f06b32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103455 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163781 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3030 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31254 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99464 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2164 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80248 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29183 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72137 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37648 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17621 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35509 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18881 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4071 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39388 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41454 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/SharedWorkerGlobalScope/name/setting.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38112 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->