### PR TITLE
[Live Range Selection] Fix some tests that throw exception

### DIFF
--- a/LayoutTests/editing/deleting/delete-contenteditable-crash.html
+++ b/LayoutTests/editing/deleting/delete-contenteditable-crash.html
@@ -8,7 +8,7 @@ function runTest()
     if (window.testRunner)
         testRunner.dumpAsText();
 
-    getSelection().setBaseAndExtent(span, 0, span, 2);
+    getSelection().setBaseAndExtent(span, 0, span, 1);
     document.execCommand("delete", false);
     document.write("Test passes if no crashes with asan.")
 }

--- a/LayoutTests/editing/inserting/edit-style-and-insert-image.html
+++ b/LayoutTests/editing/inserting/edit-style-and-insert-image.html
@@ -6,7 +6,7 @@
 <script>
 if (window.testRunner)
     testRunner.dumpAsText();
-getSelection().setPosition(document.querySelector('input'), 1);
+getSelection().setPosition(document.querySelector('blockquote'), 1);
 document.documentElement.style = 'content: url();'
 document.execCommand('InsertImage');
 </script>

--- a/LayoutTests/editing/selection/move-selection-backwards-at-end-of-table-by-sentence-granularity.html
+++ b/LayoutTests/editing/selection/move-selection-backwards-at-end-of-table-by-sentence-granularity.html
@@ -21,7 +21,7 @@ table, th, td {
 Markup.description('This tests moving the selection backwards at the end of a table by sentence granularity. The caret should move to the beginning of the table.');
 
 editor.focus();
-getSelection().setPosition(target, 5);
+getSelection().setPosition(target, 1);
 getSelection().modify('move', 'left', 'sentence');
 
 Markup.dump(editor);


### PR DESCRIPTION
#### a17cd4123b5aa723067c4c3ba81d3ddd35b9eea9
<pre>
[Live Range Selection] Fix some tests that throw exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=246839">https://bugs.webkit.org/show_bug.cgi?id=246839</a>

Reviewed by Wenson Hsieh.

Use correct offsets in these tests so that selection API won&apos;t throw exceptions when enabling live range selection.

* LayoutTests/editing/deleting/delete-contenteditable-crash.html:
* LayoutTests/editing/inserting/edit-style-and-insert-image.html:
* LayoutTests/editing/selection/move-selection-backwards-at-end-of-table-by-sentence-granularity.html:

Canonical link: <a href="https://commits.webkit.org/255860@main">https://commits.webkit.org/255860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/988687ee0bb84377558a6573861cf020338950df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103316 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163641 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2876 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31137 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99377 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2049 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80111 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29073 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72025 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37523 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17549 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18809 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41349 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1904 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38040 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->