### PR TITLE
[ITP Cleanup] Move ResourceLoadStatisticsEnabled out of DeprecatedGlobalSettings

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5429,7 +5429,7 @@ String Document::referrer()
 #if ENABLE(TRACKING_PREVENTION)
     if (!m_referrerOverride.isEmpty())
         return m_referrerOverride;
-    if (DeprecatedGlobalSettings::resourceLoadStatisticsEnabled() && frame()) {
+    if (m_settings->resourceLoadStatisticsEnabled() && frame()) {
         auto referrerStr = frame()->loader().referrer();
         if (!referrerStr.isEmpty()) {
             URL referrerURL { referrerStr };

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -185,6 +185,7 @@ std::unique_ptr<Page> createPageForSanitizingWebContent()
     auto pageConfiguration = pageConfigurationWithEmptyClients(PAL::SessionID::defaultSessionID());
     
     auto page = makeUnique<Page>(WTFMove(pageConfiguration));
+    page->settings().setResourceLoadStatisticsEnabled(true);
 #if ENABLE(VIDEO)
     page->settings().setMediaEnabled(false);
 #endif

--- a/Source/WebCore/page/DeprecatedGlobalSettings.cpp
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.cpp
@@ -181,11 +181,6 @@ void DeprecatedGlobalSettings::setLowPowerVideoAudioBufferSizeEnabled(bool flag)
     shared().m_lowPowerVideoAudioBufferSizeEnabled = flag;
 }
 
-void DeprecatedGlobalSettings::setResourceLoadStatisticsEnabled(bool flag)
-{
-    shared().m_resourceLoadStatisticsEnabledEnabled = flag;
-}
-
 #if PLATFORM(IOS_FAMILY)
 void DeprecatedGlobalSettings::setAudioSessionCategoryOverride(unsigned sessionCategory)
 {

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -57,9 +57,6 @@ public:
     static bool lowPowerVideoAudioBufferSizeEnabled() { return shared().m_lowPowerVideoAudioBufferSizeEnabled; }
     WEBCORE_EXPORT static void setLowPowerVideoAudioBufferSizeEnabled(bool);
 
-    static bool resourceLoadStatisticsEnabled() { return shared().m_resourceLoadStatisticsEnabledEnabled; }
-    WEBCORE_EXPORT static void setResourceLoadStatisticsEnabled(bool);
-
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT static void setAudioSessionCategoryOverride(unsigned);
     static unsigned audioSessionCategoryOverride();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -376,6 +376,8 @@ Page::Page(PageConfiguration&& pageConfiguration)
     pageCounter.increment();
 #endif
 
+    m_settings->setResourceLoadStatisticsEnabled(pageConfiguration.resourceLoadStatisticsEnabled);
+
     m_storageNamespaceProvider->setSessionStorageQuota(m_settings->sessionStorageQuota());
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -150,6 +150,7 @@ public:
     bool userScriptsShouldWaitUntilNotification { true };
     ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { ShouldRelaxThirdPartyCookieBlocking::No };
     bool httpsUpgradeEnabled { true };
+    bool resourceLoadStatisticsEnabled { false };
 
     UniqueRef<StorageProvider> storageProvider;
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1197,7 +1197,7 @@ Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(Completio
 
 Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& element, const PlatformMouseEvent& platformEvent, const AtomString& eventType, int detail, Element* relatedTarget, bool isParentProcessAFullWebBrowser, IsSyntheticClick isSyntheticClick) const
 {
-    if (!DeprecatedGlobalSettings::resourceLoadStatisticsEnabled() || !isParentProcessAFullWebBrowser)
+    if (!m_document || !m_document->settings().resourceLoadStatisticsEnabled() || !isParentProcessAFullWebBrowser)
         return Quirks::StorageAccessResult::ShouldNotCancelEvent;
 
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -423,6 +423,12 @@ PreventKeyboardDOMEventDispatch:
     WebCore:
       default: false
 
+ResourceLoadStatisticsEnabled:
+  type: bool
+  defaultValue:
+    WebCore:
+      default: false
+
 PrivateClickMeasurementFraudPreventionEnabled:
   type: bool
   defaultValue:

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -456,6 +456,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
         // SVGImage objects, but we're safe now, because SVGImage can only be
         // loaded by a top-level document.
         m_page = makeUnique<Page>(WTFMove(pageConfiguration));
+        m_page->settings().setResourceLoadStatisticsEnabled(true);
 #if ENABLE(VIDEO)
         m_page->settings().setMediaEnabled(false);
 #endif

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5205,9 +5205,9 @@ String Internals::resourceLoadStatisticsForURL(const DOMURL& url)
     return ResourceLoadObserver::shared().statisticsForURL(url.href());
 }
 
-void Internals::setResourceLoadStatisticsEnabled(bool enable)
+void Internals::setResourceLoadStatisticsEnabled(bool enabled)
 {
-    DeprecatedGlobalSettings::setResourceLoadStatisticsEnabled(enable);
+    contextDocument()->page()->settings().setResourceLoadStatisticsEnabled(enabled);
 }
 
 String Internals::composedTreeAsText(Node& node)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -147,7 +147,8 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
     assertIsCurrent(m_queue.get());
 
     callOnMainRunLoopAndWait([this, protectedThis = Ref { *this }, contextData = WTFMove(contextData).isolatedCopy(), workerData = WTFMove(workerData).isolatedCopy(), userAgent = WTFMove(userAgent).isolatedCopy(), workerThreadMode]() mutable {
-    auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
+        auto pageConfiguration = pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
+        pageConfiguration.resourceLoadStatisticsEnabled = WebProcess::singleton().resourceLoadStatisticsEnabled();
         pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroupID);
         pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
         pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -96,6 +96,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
     RELEASE_LOG(SharedWorker, "WebSharedWorkerContextManagerConnection::launchSharedWorker: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
     auto pageConfiguration = WebCore::pageConfigurationWithEmptyClients(WebProcess::singleton().sessionID());
 
+    pageConfiguration.resourceLoadStatisticsEnabled = WebProcess::singleton().resourceLoadStatisticsEnabled();
     pageConfiguration.databaseProvider = WebDatabaseProvider::getOrCreate(m_pageGroupID);
     pageConfiguration.socketProvider = WebSocketProvider::create(m_webPageProxyID);
     pageConfiguration.broadcastChannelRegistry = WebProcess::singleton().broadcastChannelRegistry();

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -56,7 +56,7 @@ WebCookieJar::WebCookieJar()
 #if ENABLE(TRACKING_PREVENTION)
 static bool shouldBlockCookies(WebFrame* frame, const URL& firstPartyForCookies, const URL& resourceURL, ShouldAskITP& shouldAskITPInNetworkProcess)
 {
-    if (!WebCore::DeprecatedGlobalSettings::resourceLoadStatisticsEnabled())
+    if (!WebProcess::singleton().resourceLoadStatisticsEnabled())
         return false;
 
     RegistrableDomain firstPartyDomain { firstPartyForCookies };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -687,6 +687,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.allowedNetworkHosts = parameters.allowedNetworkHosts;
     pageConfiguration.shouldRelaxThirdPartyCookieBlocking = parameters.shouldRelaxThirdPartyCookieBlocking;
     pageConfiguration.httpsUpgradeEnabled = parameters.httpsUpgradeEnabled;
+    pageConfiguration.resourceLoadStatisticsEnabled = WebProcess::singleton().resourceLoadStatisticsEnabled();
 
     if (!parameters.crossOriginAccessControlCheckEnabled)
         CrossOriginAccessControlCheckDisabler::singleton().setCrossOriginAccessControlCheckEnabled(false);
@@ -8333,6 +8334,11 @@ void WebPage::clearNotificationPermissionState()
     static_cast<WebNotificationClient&>(WebCore::NotificationController::from(m_page.get())->client()).clearNotificationPermissionState();
 }
 #endif
+
+void WebPage::setResourceLoadStatisticsEnabled(bool enabled)
+{
+    m_page->settings().setResourceLoadStatisticsEnabled(enabled);
+}
 
 void WebPage::generateTestReport(String&& message, String&& group)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1575,6 +1575,8 @@ public:
     void setInteractionRegionsEnabled(bool);
 #endif
 
+    void setResourceLoadStatisticsEnabled(bool);
+
     void generateTestReport(String&& message, String&& group);
 
 private:

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1665,13 +1665,17 @@ WeakPtr<StorageAreaMap> WebProcess::storageAreaMap(StorageAreaMapIdentifier iden
 
 void WebProcess::setResourceLoadStatisticsEnabled(bool enabled)
 {
-    if (WebCore::DeprecatedGlobalSettings::resourceLoadStatisticsEnabled() == enabled)
+    if (m_resourceLoadStatisticsEnabled == enabled)
         return;
-    WebCore::DeprecatedGlobalSettings::setResourceLoadStatisticsEnabled(enabled);
+
+    m_resourceLoadStatisticsEnabled = enabled;
+
 #if ENABLE(TRACKING_PREVENTION)
     if (enabled && !ResourceLoadObserver::sharedIfExists())
         WebCore::ResourceLoadObserver::setShared(*new WebResourceLoadObserver(m_sessionID && m_sessionID->isEphemeral() ? WebCore::ResourceLoadStatistics::IsEphemeral::Yes : WebCore::ResourceLoadStatistics::IsEphemeral::No));
 #endif
+    for (auto& page : m_pageMap.values())
+        page->setResourceLoadStatisticsEnabled(enabled);
 }
 
 void WebProcess::clearResourceLoadStatistics()

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -378,6 +378,8 @@ public:
     SpeechRecognitionRealtimeMediaSourceManager& ensureSpeechRecognitionRealtimeMediaSourceManager();
 #endif
 
+    bool resourceLoadStatisticsEnabled() const { return m_resourceLoadStatisticsEnabled; }
+
     bool isLockdownModeEnabled() const { return m_isLockdownModeEnabled; }
 
     void setHadMainFrameMainResourcePrivateRelayed() { m_hadMainFrameMainResourcePrivateRelayed = true; }
@@ -740,6 +742,7 @@ private:
     std::unique_ptr<SpeechRecognitionRealtimeMediaSourceManager> m_speechRecognitionRealtimeMediaSourceManager;
 #endif
     bool m_hadMainFrameMainResourcePrivateRelayed { false };
+    bool m_resourceLoadStatisticsEnabled { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -2970,7 +2970,7 @@ static bool needsSelfRetainWhileLoadingQuirk()
 #endif
 
     // FIXME: Is this relevent to WebKitLegacy? If not, we should remove it.
-    WebCore::DeprecatedGlobalSettings::setResourceLoadStatisticsEnabled([preferences resourceLoadStatisticsEnabled]);
+    settings.setResourceLoadStatisticsEnabled([preferences resourceLoadStatisticsEnabled]);
 
     // Application Cache Preferences are stored on the global cache storage manager, not in Settings.
     [WebApplicationCache setDefaultOriginQuota:[preferences applicationCacheDefaultOriginQuota]];


### PR DESCRIPTION
#### 5e85c7a437fee73ae2f02f875d3ff2fa5f748f54
<pre>
[ITP Cleanup] Move ResourceLoadStatisticsEnabled out of DeprecatedGlobalSettings
<a href="https://bugs.webkit.org/show_bug.cgi?id=246835">https://bugs.webkit.org/show_bug.cgi?id=246835</a>

Reviewed by NOBODY (OOPS!).

Refactor the `ResourceLoadStatisticsEnabled` feature flag, such that it&apos;s a regular boolean flag on
`WebCore::Setting` instead of a deprecated global setting.

(Work in progress)

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::referrer):
* Source/WebCore/page/DeprecatedGlobalSettings.cpp:
(WebCore::DeprecatedGlobalSettings::setResourceLoadStatisticsEnabled): Deleted.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::resourceLoadStatisticsEnabled): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::m_contentSecurityPolicyModeForExtension):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
* Source/WebCore/page/Settings.yaml:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setResourceLoadStatisticsEnabled):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::shouldBlockCookies):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::setResourceLoadStatisticsEnabled):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setResourceLoadStatisticsEnabled):
* Source/WebKit/WebProcess/WebProcess.h:
(WebKit::WebProcess::resourceLoadStatisticsEnabled const):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _preferencesChanged:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e85c7a437fee73ae2f02f875d3ff2fa5f748f54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103348 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163668 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2912 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31332 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99392 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2070 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80141 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29099 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/83994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72051 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37548 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17563 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35398 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18823 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41366 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38054 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->