### PR TITLE
[web-animations] web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation.html has one failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation-expected.txt
@@ -8,4 +8,5 @@ PASS In the idle state, the playback rate is applied immediately
 PASS In the paused state, the playback rate is applied immediately
 PASS Updating the playback rate on a finished animation maintains the current time
 PASS Updating the playback rate to zero on a finished animation maintains the current time
+PASS Updating the negative playback rate with the unresolved current time and a positive infinite associated effect end should not throw an exception
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation.html
@@ -138,5 +138,34 @@ promise_test(async t => {
 }, 'Updating the playback rate to zero on a finished animation maintains'
    + ' the current time');
 
+promise_test(async t => {
+  const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
+  await animation.ready;
+
+  // Get the animation in a state where it has an unresolved current time,
+  // a resolved start time (so it is not 'idle') and but no pending play task.
+  animation.timeline = null;
+  animation.startTime = 0;
+  assert_equals(animation.currentTime, null);
+  assert_equals(animation.playState, 'running');
+
+  // Make the effect end infinite.
+  animation.effect.updateTiming({ endDelay: 1e38 });
+
+  // Now we want to check that when we go to set a negative playback rate we
+  // don't end up throwing an InvalidStateError (which would happen if we ended
+  // up applying the auto-rewind behavior).
+  animation.updatePlaybackRate(-1);
+
+  // Furthermore, we should apply the playback rate immediately since the
+  // current time is unresolved.
+  assert_equals(animation.playbackRate, -1,
+    'We apply the pending playback rate immediately if the current time is ' +
+    'unresolved');
+  assert_false(animation.pending);
+}, 'Updating the negative playback rate with the unresolved current time and'
+   + ' a positive infinite associated effect end should not throw an'
+   + ' exception');
+
 </script>
 </body>


### PR DESCRIPTION
#### 74f098d0bcc007e37a80794c433acb83b942fbfd
<pre>
[web-animations] web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation.html has one failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=246850">https://bugs.webkit.org/show_bug.cgi?id=246850</a>

Reviewed by Dean Jackson.

Update our implementation of the &quot;play an animation&quot; [0] and &quot;seamlessly update the playback rate&quot; [1]
procedures to account for the spec changes made in <a href="https://github.com/w3c/csswg-drafts/pull/7148.">https://github.com/w3c/csswg-drafts/pull/7148.</a>

We also import the changes made to the matching WPT so that we have a new PASS results.

[0] <a href="https://drafts.csswg.org/web-animations-1/#play-an-animation">https://drafts.csswg.org/web-animations-1/#play-an-animation</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#seamlessly-update-the-playback-rate">https://drafts.csswg.org/web-animations-1/#seamlessly-update-the-playback-rate</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/seamlessly-updating-the-playback-rate-of-an-animation.html:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::updatePlaybackRate):
(WebCore::WebAnimation::play):
(WebCore::WebAnimation::runPendingPlayTask):

Canonical link: <a href="https://commits.webkit.org/255833@main">https://commits.webkit.org/255833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f0fbdabf9951de2475625ddf35a757798437129

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103366 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163686 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2932 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31173 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86061 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2085 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80161 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29112 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84009 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72064 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37566 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17576 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35415 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18836 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41384 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1895 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38067 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->