### PR TITLE
[web-animations] account for iterationComposite when blending

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
@@ -1,34 +1,34 @@
 
 PASS iteration composition of discrete type animation (align-content)
-FAIL iteration composition of <length> type animation assert_equals: Animated margin-left style at 0s of the third iteration expected "20px" but got "0px"
-FAIL iteration composition of <percentage> type animation assert_equals: Animated width style at 0s of the third iteration expected "100px" but got "0px"
-FAIL iteration composition of <color> type animation assert_equals: Animated color style at 0s of the third iteration expected "rgb(240, 240, 240)" but got "rgb(0, 0, 0)"
-FAIL iteration composition of <color> type animation that green component is decreasing assert_equals: Animated color style at 0s of the third iteration expected "rgb(120, 240, 120)" but got "rgb(0, 120, 0)"
-FAIL iteration composition of <number> type animation assert_equals: Animated flex-grow style at 0s of the third iteration expected "20" but got "0"
-FAIL iteration composition of <shape> type animation assert_equals: Animated clip style at 0s of the third iteration expected "rect(20px, 20px, 20px, 20px)" but got "rect(0px, 0px, 0px, 0px)"
-FAIL iteration composition of <calc()> value animation assert_equals: Animated calc width style at 0s of the third iteration expected "20px" but got "0px"
-FAIL iteration composition of <calc()> value animation that the values can'tbe reduced assert_equals: Animated calc width style at 0s of the third iteration expected "40px" but got "0px"
-FAIL iteration composition of opacity animation assert_equals: Animated opacity style at 0s of the third iteration expected "0.8" but got "0"
-FAIL iteration composition of box-shadow animation assert_equals: Animated box-shadow style at 0s of the third iteration expected "rgb(240, 240, 240) 20px 20px 20px 0px" but got "rgb(0, 0, 0) 0px 0px 0px 0px"
-FAIL iteration composition of filter blur animation assert_equals: Animated filter blur style at 0s of the third iteration expected "blur(20px)" but got "blur(0px)"
-FAIL iteration composition of filter brightness for different unit animation assert_equals: Animated filter brightness style at 0s of the third iteration expected "brightness(2.6)" but got "brightness(1)"
-PASS iteration composition of filter brightness animation
-FAIL iteration composition of filter drop-shadow animation assert_equals: Animated filter drop-shadow style at 0s of the third iteration expected "drop-shadow(rgb(240, 240, 240) 20px 20px 20px)" but got "drop-shadow(rgb(0, 0, 0) 0px 0px 0px)"
-FAIL iteration composition of same filter list animation assert_equals: Animated filter list at 0s of the third iteration expected "brightness(3) contrast(3)" but got "brightness(1) contrast(1)"
+PASS iteration composition of <length> type animation
+PASS iteration composition of <percentage> type animation
+PASS iteration composition of <color> type animation
+PASS iteration composition of <color> type animation that green component is decreasing
+PASS iteration composition of <number> type animation
+PASS iteration composition of <shape> type animation
+PASS iteration composition of <calc()> value animation
+PASS iteration composition of <calc()> value animation that the values can'tbe reduced
+FAIL iteration composition of opacity animation assert_equals: Animated opacity style at 50s of the third iteration expected "1" but got "0.9"
+PASS iteration composition of box-shadow animation
+PASS iteration composition of filter blur animation
+FAIL iteration composition of filter brightness for different unit animation assert_equals: Animated filter brightness style at 0s of the third iteration expected "brightness(2.6)" but got "brightness(4.6)"
+FAIL iteration composition of filter brightness animation assert_equals: Animated filter brightness style at 0s of the third iteration expected "brightness(0)" but got "brightness(2)"
+PASS iteration composition of filter drop-shadow animation
+FAIL iteration composition of same filter list animation assert_equals: Animated filter list at 0s of the third iteration expected "brightness(3) contrast(3)" but got "brightness(5) contrast(5)"
 FAIL iteration composition of discrete filter list because of mismatch of the order assert_equals: Animated filter list at 0s of the third iteration expected "brightness(1) contrast(1)" but got "contrast(2) brightness(2)"
 FAIL iteration composition of different length filter list animation assert_equals: Animated filter list at 50s of the first iteration expected "sepia(0.5) contrast(1.5)" but got "sepia(1) contrast(2)"
 PASS iteration composition of transform(rotate) animation
 PASS iteration composition of transform: [ scale(0), scale(1) ] animation
-FAIL iteration composition of transform: [ scale(1), scale(2) ] animation assert_approx_equals: expected matrix(3, 0, 0, 3, 0, 0) but got matrix(1, 0, 0, 1, 0, 0): Animated transform(scale) style at 0s of the third iteration expected 3 +/- 0.0001 but got 1
-FAIL iteration composition of transform: scale(2) animation assert_approx_equals: expected matrix(2, 0, 0, 2, 0, 0) but got matrix(0, 0, 0, 0, 0, 0): Animated transform(scale) style at 0s of the third iteration expected 2 +/- 0.0001 but got 0
-FAIL iteration composition of transform list animation assert_approx_equals: expected matrix(1, 0, 0, 1, 20, 0) but got matrix(1, 0, 0, 1, 0, 0): Animated transform list at 0s of the third iteration expected 20 +/- 0.0001 but got 0
-FAIL iteration composition of transform of matrix function assert_approx_equals: expected matrix(6, 0, 0, 6, 60, 0) but got matrix(2, 0, 0, 2, 0, 0): Animated transform of matrix function at 0s of the third iteration expected 6 +/- 0.0001 but got 2
-FAIL iteration composition of transform list animation whose order is mismatched assert_approx_equals: expected matrix(6, 0, 0, 6, 60, 0) but got matrix(2, 0, 0, 2, 0, 0): Animated transform list at 0s of the third iteration expected 6 +/- 0.0001 but got 2
-FAIL iteration composition of transform list animation whose order is mismatched because of missing functions assert_approx_equals: expected matrix(3, 0, 0, 3, 40, 0) but got matrix(1, 0, 0, 1, 0, 0): Animated transform list at 0s of the third iteration expected 3 +/- 0.0001 but got 1
-FAIL iteration composition of transform from none to translate assert_approx_equals: expected matrix(1, 0, 0, 1, 20, 0) but got matrix(1, 0, 0, 1, 0, 0): Animated transform list at 0s of the third iteration expected 20 +/- 0.0001 but got 0
-FAIL iteration composition of transform of matrix3d function assert_approx_equals: expected matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 130, 1) but got matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 30, 1): Animated transform of matrix3d function at 0s of the third iteration expected 130 +/- 0.0001 but got 30
-FAIL iteration composition of transform of rotate3d function assert_equals: dimension of the matrix: Animated transform of rotate3d function at 0s of the third iteration expected 16 but got 6
-FAIL iteration composition starts with non-zero value animation assert_equals: Animated margin-left style at 0s of the third iteration expected "50px" but got "10px"
-FAIL iteration composition with negative final value animation assert_equals: Animated margin-left style at 0s of the third iteration expected "-10px" but got "10px"
-FAIL duration changes with an iteration composition operation of accumulate assert_equals: Animated style at 50s of the third iteration expected "25px" but got "5px"
+PASS iteration composition of transform: [ scale(1), scale(2) ] animation
+PASS iteration composition of transform: scale(2) animation
+PASS iteration composition of transform list animation
+PASS iteration composition of transform of matrix function
+FAIL iteration composition of transform list animation whose order is mismatched assert_approx_equals: expected matrix(6.5, 0, 0, 6.5, 135, 0) but got matrix(6.5, 0, 0, 6.5, 75, 0): Animated transform list at 50s of the third iteration expected 135 +/- 0.0001 but got 75
+FAIL iteration composition of transform list animation whose order is mismatched because of missing functions assert_approx_equals: expected matrix(3.5, 0, 0, 3.5, 80, 0) but got matrix(3.5, 0, 0, 3.5, 50, 0): Animated transform list at 50s of the third iteration expected 80 +/- 0.0001 but got 50
+PASS iteration composition of transform from none to translate
+PASS iteration composition of transform of matrix3d function
+PASS iteration composition of transform of rotate3d function
+PASS iteration composition starts with non-zero value animation
+PASS iteration composition with negative final value animation
+FAIL duration changes with an iteration composition operation of accumulate assert_equals: Animated style at 25s of the first iteration expected "12.5px" but got "25px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/iterationComposite-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/iterationComposite-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL iterationComposite can be updated while an animation is in progress assert_equals: Animated style at 50s of the third iteration expected "25px" but got "5px"
+FAIL iterationComposite can be updated while an animation is in progress assert_equals: Animated style at 50s of the third iteration expected "5px" but got "25px"
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -215,7 +215,7 @@ private:
     void addPendingAcceleratedAction(AcceleratedAction);
     bool isCompletelyAccelerated() const { return m_acceleratedPropertiesState == AcceleratedProperties::All; }
     void updateAcceleratedActions();
-    void setAnimatedPropertiesInStyle(RenderStyle&, double);
+    void setAnimatedPropertiesInStyle(RenderStyle&, double iterationProgress, double currentIteration);
     TimingFunction* timingFunctionForKeyframeAtIndex(size_t) const;
     TimingFunction* timingFunctionForBlendingKeyframe(const KeyframeValue&) const;
     Ref<const Animation> backingAnimationForCompositedRenderer() const;


### PR DESCRIPTION
#### 85e288f3ba3e5ec763a6e16e00cde171ba1bdab3
<pre>
[web-animations] account for iterationComposite when blending
<a href="https://bugs.webkit.org/show_bug.cgi?id=246855">https://bugs.webkit.org/show_bug.cgi?id=246855</a>

Reviewed by Dean Jackson.

We now account for the iterationComposite property when blending. To do so, we need to also pass the
currentIteration from the computed timing down to KeyframeEffect::setAnimatedPropertiesInStyle().

A number of tests in web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation.html
still fail because we clip intermediate accumulated values in flight. This will need to be looked at
in future patches.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/iterationComposite-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::apply):
(WebCore::KeyframeEffect::getAnimatedStyle):
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
(WebCore::KeyframeEffect::applyPendingAcceleratedActions):
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/255834@main">https://commits.webkit.org/255834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cfff8432a669544fafe03c60600c56edfce9b4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103370 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163691 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2936 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31177 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86065 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2089 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80166 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84014 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72071 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37570 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17578 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18838 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41386 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1896 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38069 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->