### PR TITLE
Add WebCodecsVideoFrame initial support for serialisation and transfer

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-serialization-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-serialization-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Verify closing frames does not propagate accross contexts with Worker.postMessage.
+PASS Verify transferring frames closes them with Worker.postMessage.
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-serialization.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-serialization.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+var defaultInit = {
+  timestamp : 100,
+  duration : 33,
+}
+
+function createDefaultVideoFrame() {
+  const init = {
+    format: 'I420',
+    timestamp: 1234,
+    codedWidth: 4,
+    codedHeight: 2,
+    timestamp: defaultInit.timestamp,
+    duration: defaultInit.duration
+  };
+  const data = new Uint8Array([
+    1, 2, 3, 4, 5, 6, 7, 8,  // y
+    1, 2,                    // u
+    1, 2,                    // v
+  ]);
+  return new VideoFrame(data, init);
+}
+
+async function createWorker(script)
+{
+  script += "self.postMessage('ready');";
+  const blob = new Blob([script], { type: 'text/javascript' });
+  const url = URL.createObjectURL(blob);
+  const worker = new Worker(URL.createObjectURL(blob));
+  await new Promise(resolve => worker.onmessage = () => {
+      resolve();
+  });
+  URL.revokeObjectURL(url);
+  return worker;
+}
+
+promise_test(async t => {
+  let localFrame = createDefaultVideoFrame();
+
+  const worker = await createWorker(`
+    self.onmessage = (event) => {
+      let externalFrame = event.data;
+      externalFrame.close();
+      self.postMessage("Done");
+    }
+  `);
+
+  const promise = new Promise(resolve => worker.onmessage = resolve);  
+  worker.postMessage(localFrame);
+  await promise;
+
+  assert_equals(localFrame.timestamp, defaultInit.timestamp);
+  localFrame.close();
+}, 'Verify closing frames does not propagate accross contexts with Worker.postMessage.');
+
+promise_test(async t => {
+  let localFrame = createDefaultVideoFrame();
+
+  const worker = await createWorker(`
+    self.onmessage = (event) => {
+      let externalFrame = event.data;
+      self.postMessage(externalFrame.timestamp);
+      externalFrame.close();
+    }
+  `);
+
+  const promise = new Promise(resolve => worker.onmessage = event => resolve(event.data));  
+  worker.postMessage(localFrame);
+
+  assert_equals(await promise, defaultInit.timestamp);
+  localFrame.close();
+}, 'Verify transferring frames closes them with Worker.postMessage.');
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any-expected.txt
@@ -2,7 +2,7 @@
 PASS Test we can clone a VideoFrame.
 PASS Verify closing a frame doesn't affect its clones.
 PASS Verify cloning a closed frame throws.
-FAIL Verify closing frames does not propagate accross contexts. The object can not be cloned.
-FAIL Verify transferring frames closes them. The object can not be cloned.
+PASS Verify closing frames does not propagate accross contexts.
+PASS Verify transferring frames closes them.
 PASS Verify posting closed frames throws.
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -249,6 +249,7 @@ imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html [ Pass ]
 imported/w3c/web-platform-tests/web-animations/timing-model/animations/update-playback-rate-zero.html [ Pass ]
 
 # Tests need rebasing
+http/wpt/webcodecs [ Skip ]
 imported/w3c/web-platform-tests/webcodecs [ Skip ]
 
 # Tests that timeout on Apple platforms.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -42,6 +42,7 @@ webkit.org/b/235072 imported/w3c/web-platform-tests/video-rvfc/request-video-fra
 
 webkit.org/b/244736 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback.html [ Pass Failure ]
 
+http/wpt/webcodecs [ Skip ]
 imported/w3c/web-platform-tests/webcodecs [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -414,6 +414,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webcodecs/WebCodecsEncodedVideoChunk.h
     Modules/webcodecs/WebCodecsEncodedVideoChunkData.h
     Modules/webcodecs/WebCodecsEncodedVideoChunkType.h
+    Modules/webcodecs/WebCodecsVideoFrame.h
+    Modules/webcodecs/WebCodecsVideoFrameData.h
 
     Modules/webdatabase/DatabaseDetails.h
     Modules/webdatabase/DatabaseManager.h

--- a/Source/WebCore/Modules/webcodecs/VideoColorSpace.h
+++ b/Source/WebCore/Modules/webcodecs/VideoColorSpace.h
@@ -57,6 +57,8 @@ public:
     const std::optional<bool>& fullRange() const { return m_state.fullRange; }
     void setfFullRange(std::optional<bool>&& fullRange) { m_state.fullRange = WTFMove(fullRange); }
 
+    VideoColorSpaceInit state() const { return m_state; }
+
 private:
     VideoColorSpace() = default;
     VideoColorSpace(const VideoColorSpaceInit& init)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
@@ -275,15 +275,15 @@ void initializeVisibleRectAndDisplaySize(WebCodecsVideoFrame& frame, const WebCo
 }
 
 // https://w3c.github.io/webcodecs/#videoframe-pick-color-space
-Ref<VideoColorSpace> videoFramePickColorSpace(const std::optional<VideoColorSpaceInit>& overrideColorSpace, VideoPixelFormat format)
+VideoColorSpaceInit videoFramePickColorSpace(const std::optional<VideoColorSpaceInit>& overrideColorSpace, VideoPixelFormat format)
 {
     if (overrideColorSpace)
-        return VideoColorSpace::create(*overrideColorSpace);
+        return *overrideColorSpace;
 
     if (isRGBVideoPixelFormat(format))
-        return VideoColorSpace::create({ PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Rgb, true });
+        return { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Rgb, true };
 
-    return VideoColorSpace::create({ PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false });
+    return { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Bt709, PlatformVideoMatrixCoefficients::Bt709, false };
 }
 
 // https://w3c.github.io/webcodecs/#validate-videoframeinit

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h
@@ -51,7 +51,7 @@ ExceptionOr<CombinedPlaneLayout> parseVideoFrameCopyToOptions(const WebCodecsVid
 
 void initializeVisibleRectAndDisplaySize(WebCodecsVideoFrame&, const WebCodecsVideoFrame::Init&, const DOMRectInit&, size_t defaultDisplayWidth, size_t defaultDisplayHeight);
 
-Ref<VideoColorSpace> videoFramePickColorSpace(const std::optional<VideoColorSpaceInit>&, VideoPixelFormat);
+VideoColorSpaceInit videoFramePickColorSpace(const std::optional<VideoColorSpaceInit>&, VideoPixelFormat);
 
 bool validateVideoFrameInit(const WebCodecsVideoFrame::Init&, size_t codedWidth, size_t codedHeight, VideoPixelFormat);
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameData.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "VideoColorSpaceInit.h"
+#include "VideoFrame.h"
+#include "VideoPixelFormat.h"
+
+namespace WebCore {
+
+struct WebCodecsVideoFrameData {
+    RefPtr<VideoFrame> internalFrame;
+    std::optional<VideoPixelFormat> format;
+    size_t codedWidth { 0 };
+    size_t codedHeight { 0 };
+    size_t displayWidth { 0 };
+    size_t displayHeight { 0 };
+    size_t visibleWidth { 0 };
+    size_t visibleHeight { 0 };
+    size_t visibleLeft { 0 };
+    size_t visibleTop { 0 };
+    std::optional<uint64_t> duration { 0 };
+    int64_t timestamp { 0 };
+    VideoColorSpaceInit colorSpace;
+};
+
+}
+
+#endif

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -39,6 +39,7 @@
 
 #if ENABLE(WEB_CODECS)
 #include "WebCodecsEncodedVideoChunk.h"
+#include "WebCodecsVideoFrame.h"
 #endif
 
 typedef const struct OpaqueJSContext* JSContextRef;
@@ -61,10 +62,6 @@ class MessagePort;
 class ImageBitmapBacking;
 class FragmentedSharedBuffer;
 enum class SerializationReturnCode;
-#if ENABLE(WEB_CODECS)
-class WebCodecsEncodedVideoChunk;
-class WebCodecsEncodedVideoChunkStorage;
-#endif
 
 enum class SerializationErrorMode { NonThrowing, Throwing };
 enum class SerializationContext { Default, WorkerPostMessage, WindowPostMessage };
@@ -127,6 +124,7 @@ private:
 #endif
 #if ENABLE(WEB_CODECS)
         , Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& = { }
+        , Vector<WebCodecsVideoFrameData>&& = { }
 #endif
         );
 
@@ -143,6 +141,7 @@ private:
 #endif
 #if ENABLE(WEB_CODECS)
         , Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>>&& = { }
+        , Vector<WebCodecsVideoFrameData>&& = { }
 #endif
         );
 
@@ -164,6 +163,7 @@ private:
 #endif
 #if ENABLE(WEB_CODECS)
     Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> m_serializedVideoChunks;
+    Vector<WebCodecsVideoFrameData> m_serializedVideoFrames;
 #endif
     Vector<URLKeepingBlobAlive> m_blobHandles;
     size_t m_memoryCost { 0 };
@@ -195,6 +195,8 @@ void SerializedScriptValue::encode(Encoder& encoder) const
     encoder << static_cast<uint64_t>(m_serializedVideoChunks.size());
     for (const auto &videoChunk : m_serializedVideoChunks)
         encoder << videoChunk->data();
+
+    // FIXME: encode video frames
 #endif
 }
 
@@ -265,6 +267,8 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::decode(Decoder& decoder)
             return nullptr;
         serializedVideoChunks.append(WebCodecsEncodedVideoChunkStorage::create(WTFMove(*videoChunkData)));
     }
+    // FIXME: decode video frames
+    Vector<WebCodecsVideoFrameData> serializedVideoFrames;
 #endif
 
     return adoptRef(*new SerializedScriptValue(WTFMove(data), WTFMove(arrayBufferContentsArray)
@@ -273,6 +277,9 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::decode(Decoder& decoder)
 #endif
 #if ENABLE(WEB_CODECS)
         , WTFMove(serializedVideoChunks)
+#endif
+#if ENABLE(WEB_CODECS)
+        , WTFMove(serializedVideoFrames)
 #endif
         ));
 }


### PR DESCRIPTION
#### e813fe5c61f40e29f9f9d28a465224f05ae088ae
<pre>
Add WebCodecsVideoFrame initial support for serialisation and transfer
<a href="https://bugs.webkit.org/show_bug.cgi?id=246854">https://bugs.webkit.org/show_bug.cgi?id=246854</a>
rdar://problem/101425176

Reviewed by Eric Carlson.

Introduce WebCodecsVideoFrameData which contains the necessary data to rebuild an equivalent WebCodecs video frame.
Add support for serialization of video frames. This works for postMessaging to workers and for same-process MessageChannel but not cross process MessageChannel since encode/decode is not yet supported.

Covered by Worker specific added test.
Skipped new test in glib and wk1.

* LayoutTests/http/wpt/webcodecs/videoFrame-serialization-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-serialization.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webcodecs/VideoColorSpace.h:
(WebCore::VideoColorSpace::state const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::WebCodecsVideoFrame):
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
(WebCore::WebCodecsVideoFrame::initializeFrameWithResourceAndSize):
(WebCore::WebCodecsVideoFrame::allocationSize):
(WebCore::WebCodecsVideoFrame::copyTo):
(WebCore::WebCodecsVideoFrame::clone):
(WebCore::WebCodecsVideoFrame::close):
(WebCore::WebCodecsVideoFrame::codedRect const):
(WebCore::WebCodecsVideoFrame::visibleRect const):
(WebCore::WebCodecsVideoFrame::setDisplaySize):
(WebCore::WebCodecsVideoFrame::setVisibleRect):
(WebCore::WebCodecsVideoFrame::colorSpace const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::format const):
(WebCore::WebCodecsVideoFrame::codedWidth const):
(WebCore::WebCodecsVideoFrame::codedHeight const):
(WebCore::WebCodecsVideoFrame::displayWidth const):
(WebCore::WebCodecsVideoFrame::displayHeight const):
(WebCore::WebCodecsVideoFrame::duration const):
(WebCore::WebCodecsVideoFrame::timestamp const):
(WebCore::WebCodecsVideoFrame::internalFrame const):
(WebCore::WebCodecsVideoFrame::shoudlDiscardAlpha const):
(WebCore::WebCodecsVideoFrame::data const):
(WebCore::WebCodecsVideoFrame::colorSpace const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp:
(WebCore::videoFramePickColorSpace):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameAlgorithms.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameData.h: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serialize):
(WebCore::CloneSerializer::CloneSerializer):
(WebCore::CloneSerializer::dumpWebCodecsVideoFrame):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::deserialize):
(WebCore::CloneDeserializer::readWebCodecsVideoFrame):
(WebCore::CloneDeserializer::readTerminal):
(WebCore::SerializedScriptValue::SerializedScriptValue):
(WebCore::SerializedScriptValue::computeMemoryCost const):
(WebCore::SerializedScriptValue::create):
(WebCore::SerializedScriptValue::deserialize):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::encode const):
(WebCore::SerializedScriptValue::decode):

Canonical link: <a href="https://commits.webkit.org/255949@main">https://commits.webkit.org/255949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97fff850cdefccf861e7917ab9860de34f607254

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94159 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3349 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103781 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3369 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31564 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86466 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99818 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80571 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37949 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35833 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4110 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39707 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41650 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->