### PR TITLE
Add initial support for StylePropertyMap

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-typed-om-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-typed-om-expected.txt
@@ -1,26 +1,26 @@
 
 PASS CSS.cqw function
 PASS Reify value with cqw unit
-FAIL Set value with cqw unit (string) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', `10${unit}`)', 'element.attributeStyleMap.set' is undefined)
-FAIL Set value with cqw unit (CSS.cqw) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', func(10))', 'element.attributeStyleMap.set' is undefined)
+FAIL Set value with cqw unit (string) set() is not yet supported
+FAIL Set value with cqw unit (CSS.cqw) set() is not yet supported
 PASS CSS.cqh function
 PASS Reify value with cqh unit
-FAIL Set value with cqh unit (string) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', `10${unit}`)', 'element.attributeStyleMap.set' is undefined)
-FAIL Set value with cqh unit (CSS.cqh) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', func(10))', 'element.attributeStyleMap.set' is undefined)
+FAIL Set value with cqh unit (string) set() is not yet supported
+FAIL Set value with cqh unit (CSS.cqh) set() is not yet supported
 PASS CSS.cqi function
 PASS Reify value with cqi unit
-FAIL Set value with cqi unit (string) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', `10${unit}`)', 'element.attributeStyleMap.set' is undefined)
-FAIL Set value with cqi unit (CSS.cqi) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', func(10))', 'element.attributeStyleMap.set' is undefined)
+FAIL Set value with cqi unit (string) set() is not yet supported
+FAIL Set value with cqi unit (CSS.cqi) set() is not yet supported
 PASS CSS.cqb function
 PASS Reify value with cqb unit
-FAIL Set value with cqb unit (string) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', `10${unit}`)', 'element.attributeStyleMap.set' is undefined)
-FAIL Set value with cqb unit (CSS.cqb) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', func(10))', 'element.attributeStyleMap.set' is undefined)
+FAIL Set value with cqb unit (string) set() is not yet supported
+FAIL Set value with cqb unit (CSS.cqb) set() is not yet supported
 PASS CSS.cqmin function
 PASS Reify value with cqmin unit
-FAIL Set value with cqmin unit (string) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', `10${unit}`)', 'element.attributeStyleMap.set' is undefined)
-FAIL Set value with cqmin unit (CSS.cqmin) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', func(10))', 'element.attributeStyleMap.set' is undefined)
+FAIL Set value with cqmin unit (string) set() is not yet supported
+FAIL Set value with cqmin unit (CSS.cqmin) set() is not yet supported
 PASS CSS.cqmax function
 PASS Reify value with cqmax unit
-FAIL Set value with cqmax unit (string) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', `10${unit}`)', 'element.attributeStyleMap.set' is undefined)
-FAIL Set value with cqmax unit (CSS.cqmax) element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('top', func(10))', 'element.attributeStyleMap.set' is undefined)
+FAIL Set value with cqmax unit (string) set() is not yet supported
+FAIL Set value with cqmax unit (CSS.cqmax) set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -1,6 +1,479 @@
-CONSOLE MESSAGE: TypeError: target.attributeStyleMap.clear is not a function. (In 'target.attributeStyleMap.clear()', 'target.attributeStyleMap.clear' is undefined)
 
-Harness Error (FAIL), message = TypeError: target.attributeStyleMap.clear is not a function. (In 'target.attributeStyleMap.clear()', 'target.attributeStyleMap.clear' is undefined)
-
-FAIL Computed * is reified as CSSUnparsedValue target.attributeStyleMap.set is not a function. (In 'target.attributeStyleMap.set(name, 'as{}df')', 'target.attributeStyleMap.set' is undefined)
+FAIL Computed * is reified as CSSUnparsedValue set() is not yet supported
+FAIL Computed <angle> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
+FAIL Computed <color> is reified as CSSStyleValue The given initial value does not parse for the given syntax.
+FAIL Computed <custom-ident> is reified as CSSKeywordValue The given initial value does not parse for the given syntax.
+FAIL Computed <image> [url] is reified as CSSImageValue The given initial value does not parse for the given syntax.
+FAIL Computed <integer> is reified as CSSUnitValue assert_false: expected false got true
+FAIL Computed <length-percentage> [%] is reified as CSSUnitValue assert_false: expected false got true
+FAIL Computed <length-percentage> [px] is reified as CSSUnitValue assert_false: expected false got true
+FAIL Computed <length-percentage> [px + %] is reified as CSSMathSum The given initial value does not parse for the given syntax.
+FAIL Computed <length> is reified as CSSUnitValue assert_false: expected false got true
+FAIL Computed <number> is reified as CSSUnitValue assert_false: expected false got true
+FAIL Computed <percentage> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
+FAIL Computed <resolution> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
+FAIL Computed <time> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
+FAIL Computed <url> is reified as CSSStyleValue The given initial value does not parse for the given syntax.
+FAIL Computed ident is reified as CSSKeywordValue The given initial value does not parse for the given syntax.
+FAIL First computed value correctly reified in space-separated list assert_false: expected false got true
+FAIL First computed value correctly reified in comma-separated list assert_false: expected false got true
+FAIL All computed values correctly reified in space-separated list The given initial value does not parse for the given syntax.
+FAIL All computed values correctly reified in comma-separated list The given initial value does not parse for the given syntax.
+FAIL Specified * is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified * is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified foo is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified foo is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <angle> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <angle> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <color> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <color> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <custom-ident> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <custom-ident> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <image> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <image> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <integer> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified <integer> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified <length> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified <length> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified <number> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified <number> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified <percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <percentage> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <resolution> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <resolution> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-function> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <url> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <url> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <length>+ is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified <length>+ is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified <length># is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
+FAIL Specified <length># is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+FAIL Specified string "foo" accepted by set() for syntax * [attributeStyleMap] set() is not yet supported
+FAIL Specified string "foo" accepted by set() for syntax * [styleMap] set() is not yet supported
+FAIL Specified string "foo" accepted by set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "foo" accepted by set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10deg" accepted by set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10deg" accepted by set() for syntax <angle> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "green" accepted by set() for syntax <color> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "green" accepted by set() for syntax <color> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "foo" accepted by set() for syntax <custom-ident> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "foo" accepted by set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "url("a")" accepted by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "url("a")" accepted by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1" accepted by set() for syntax <integer> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "1" accepted by set() for syntax <integer> [styleMap] set() is not yet supported
+FAIL Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [styleMap] set() is not yet supported
+FAIL Specified string "10px" accepted by set() for syntax <length> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "10px" accepted by set() for syntax <length> [styleMap] set() is not yet supported
+FAIL Specified string "1" accepted by set() for syntax <number> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "1" accepted by set() for syntax <number> [styleMap] set() is not yet supported
+FAIL Specified string "10%" accepted by set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10%" accepted by set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10dpi" accepted by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10dpi" accepted by set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1s" accepted by set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1s" accepted by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "url("a")" accepted by set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "url("a")" accepted by set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px 11px" accepted by set() for syntax <length>+ [attributeStyleMap] set() is not yet supported
+FAIL Specified string "10px 11px" accepted by set() for syntax <length>+ [styleMap] set() is not yet supported
+FAIL Specified string "10px, 11px" accepted by set() for syntax <length># [attributeStyleMap] set() is not yet supported
+FAIL Specified string "10px, 11px" accepted by set() for syntax <length># [styleMap] set() is not yet supported
+FAIL Specified string "bar" accepted by set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "bar" accepted by set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px" accepted by set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px" accepted by set() for syntax <angle> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px" accepted by set() for syntax <color> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px" accepted by set() for syntax <color> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px" accepted by set() for syntax <custom-ident> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "10px" accepted by set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a" accepted by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a" accepted by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "float" accepted by set() for syntax <integer> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "float" accepted by set() for syntax <integer> [styleMap] set() is not yet supported
+FAIL Specified string "red" accepted by set() for syntax <length-percentage> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "red" accepted by set() for syntax <length-percentage> [styleMap] set() is not yet supported
+FAIL Specified string "red" accepted by set() for syntax <length> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "red" accepted by set() for syntax <length> [styleMap] set() is not yet supported
+FAIL Specified string "red" accepted by set() for syntax <number> [attributeStyleMap] set() is not yet supported
+FAIL Specified string "red" accepted by set() for syntax <number> [styleMap] set() is not yet supported
+FAIL Specified string "var(--x)" accepted by set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "var(--x)" accepted by set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "blue" accepted by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "blue" accepted by set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1meter" accepted by set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "1meter" accepted by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "foo(0)" accepted by set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "foo(0)" accepted by set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a" accepted by set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a" accepted by set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified string "a b" accepted by set() for syntax <length>+ [attributeStyleMap] set() is not yet supported
+FAIL Specified string "a b" accepted by set() for syntax <length>+ [styleMap] set() is not yet supported
+FAIL Specified string "a, b" accepted by set() for syntax <length># [attributeStyleMap] set() is not yet supported
+FAIL Specified string "a, b" accepted by set() for syntax <length># [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax * [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax * [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <angle> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <color> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <color> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <custom-ident> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <integer> [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <integer> [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length-percentage> [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length-percentage> [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length> [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length> [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <number> [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <number> [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <transform-function> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <transform-function> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnparsedValue is accepted via set() for syntax <length>+ [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length>+ [styleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length># [attributeStyleMap] set() is not yet supported
+FAIL CSSUnparsedValue is accepted via set() for syntax <length># [styleMap] set() is not yet supported
+FAIL CSSKeywordValue rejected by set() for syntax * [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSKeywordValue rejected by set() for syntax * [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSKeywordValue rejected by set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSKeywordValue rejected by set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <angle> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSKeywordValue rejected by set() for syntax <custom-ident> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSKeywordValue rejected by set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSImageValue rejected by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSImageValue rejected by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <integer> [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <integer> [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length-percentage> [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length-percentage> [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length> [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length> [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <number> [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <number> [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <resolution> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <time> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSTransformValue rejected by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL CSSTransformValue rejected by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
+FAIL CSSUnitValue rejected by set() for syntax <length>+ [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length>+ [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length># [attributeStyleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL CSSUnitValue rejected by set() for syntax <length># [styleMap] assert_throws_js: function "() => {
+        map.set(name, value);
+    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to * is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to * is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to foo+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to foo+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <angle>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <angle>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <color>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <color>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <custom-ident>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <custom-ident>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <image>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <image>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <integer>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <integer>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <length-percentage>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <length-percentage>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <length>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <length>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <number>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <number>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <percentage>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <percentage>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <resolution>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <resolution>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <time>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <time>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <transform-function>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <transform-function>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <url>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <url>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a string to <length># is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a string to <length># is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSKeywordValue to * is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSKeywordValue to * is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSKeywordValue to foo+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSKeywordValue to foo+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <angle>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <angle>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSKeywordValue to <custom-ident>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSKeywordValue to <custom-ident>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSImageValue to <image>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSImageValue to <image>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <integer>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <integer>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <length-percentage>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <length-percentage>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <length>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <length>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <number>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <number>+ is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <percentage>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <percentage>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <resolution>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <resolution>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <time>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <time>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
+FAIL Appending a CSSUnitValue to <length># is not allowed [attributeStyleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a CSSUnitValue to <length># is not allowed [styleMap] assert_throws_js: function "() => {
+        map.append(name, value);
+    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax *
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <angle> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <color> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <custom-ident> | <length> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <image> The given initial value does not parse for the given syntax.
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <integer>
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length-percentage> (10%)
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length-percentage> (10px)
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length-percentage> (calc(10px + 10%))
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <number>
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <percentage> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <resolution> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <time> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-function> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <transform-list> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <url> The given initial value does not parse for the given syntax.
+FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax thing1 | THING2 | <url> The given initial value does not parse for the given syntax.
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>+
+PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>#
+FAIL Direct CSSStyleValue may not be set [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Direct CSSStyleValue may not be set [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified * is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified * is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Specified foo is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified foo is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <angle> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <angle> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <color> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <color> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <custom-ident> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <custom-ident> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <image> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <image> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <integer> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified <integer> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Specified <length-percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified <length-percentage> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Specified <length> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified <length> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Specified <number> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified <number> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Specified <percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <percentage> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <resolution> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <resolution> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <time> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-function> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-function> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <url> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <url> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
+FAIL Specified <length>+ is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified <length>+ is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Specified <length># is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
+FAIL Specified <length># is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+FAIL Registered property with initial value show up on iteration of computedStyleMap assert_true: expected true got false
+FAIL Computed * is reified as CSSUnparsedValue by iterator set() is not yet supported
+FAIL Computed <angle> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <custom-ident> is reified as CSSKeywordValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <image> is reified as CSSImageValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <integer> is reified as CSSUnitValue by iterator set() is not yet supported
+FAIL Computed <length> is reified as CSSUnitValue by iterator set() is not yet supported
+FAIL Computed <number> is reified as CSSUnitValue by iterator set() is not yet supported
+FAIL Computed <percentage> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <resolution> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <time> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed none | thing | THING is reified as CSSKeywordValue by iterator The given initial value does not parse for the given syntax.
+FAIL Computed <angle> | <length> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt
@@ -1,5 +1,5 @@
-CONSOLE MESSAGE: TypeError: element.attributeStyleMap.clear is not a function. (In 'element.attributeStyleMap.clear()', 'element.attributeStyleMap.clear' is undefined)
+CONSOLE MESSAGE: NotSupportedError: set() is not yet supported
 
-Harness Error (FAIL), message = TypeError: element.attributeStyleMap.clear is not a function. (In 'element.attributeStyleMap.clear()', 'element.attributeStyleMap.clear' is undefined)
+Harness Error (FAIL), message = NotSupportedError: set() is not yet supported
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/declared-styleMap-accepts-inherit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/declared-styleMap-accepts-inherit-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Declared styleMap objects accept 'inherit' as a value element.attributeStyleMap.set is not a function. (In 'element.attributeStyleMap.set('width', new CSSKeywordValue('inherit'))', 'element.attributeStyleMap.set' is undefined)
+FAIL Declared styleMap objects accept 'inherit' as a value set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
@@ -53,26 +53,26 @@ PASS StylePropertyMap interface object name
 PASS StylePropertyMap interface: existence and properties of interface prototype object
 PASS StylePropertyMap interface: existence and properties of interface prototype object's "constructor" property
 PASS StylePropertyMap interface: existence and properties of interface prototype object's @@unscopables property
-FAIL StylePropertyMap interface: operation set(USVString, (CSSStyleValue or USVString)...) assert_own_property: interface prototype object missing non-static operation expected property "set" missing
-FAIL StylePropertyMap interface: operation append(USVString, (CSSStyleValue or USVString)...) assert_own_property: interface prototype object missing non-static operation expected property "append" missing
-FAIL StylePropertyMap interface: operation delete(USVString) assert_own_property: interface prototype object missing non-static operation expected property "delete" missing
-FAIL StylePropertyMap interface: operation clear() assert_own_property: interface prototype object missing non-static operation expected property "clear" missing
-FAIL StylePropertyMap must be primary interface of styleMap assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL Stringification of styleMap assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: styleMap must inherit property "set(USVString, (CSSStyleValue or USVString)...)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: calling set(USVString, (CSSStyleValue or USVString)...) on styleMap with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: styleMap must inherit property "append(USVString, (CSSStyleValue or USVString)...)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: calling append(USVString, (CSSStyleValue or USVString)...) on styleMap with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: styleMap must inherit property "delete(USVString)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: calling delete(USVString) on styleMap with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMap interface: styleMap must inherit property "clear()" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: styleMap must inherit property "get(USVString)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: calling get(USVString) on styleMap with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: styleMap must inherit property "getAll(USVString)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: calling getAll(USVString) on styleMap with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: styleMap must inherit property "has(USVString)" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: calling has(USVString) on styleMap with too few arguments must throw TypeError assert_equals: wrong typeof object expected "object" but got "undefined"
-FAIL StylePropertyMapReadOnly interface: styleMap must inherit property "size" with the proper type assert_equals: wrong typeof object expected "object" but got "undefined"
+PASS StylePropertyMap interface: operation set(USVString, (CSSStyleValue or USVString)...)
+PASS StylePropertyMap interface: operation append(USVString, (CSSStyleValue or USVString)...)
+PASS StylePropertyMap interface: operation delete(USVString)
+PASS StylePropertyMap interface: operation clear()
+PASS StylePropertyMap must be primary interface of styleMap
+PASS Stringification of styleMap
+PASS StylePropertyMap interface: styleMap must inherit property "set(USVString, (CSSStyleValue or USVString)...)" with the proper type
+PASS StylePropertyMap interface: calling set(USVString, (CSSStyleValue or USVString)...) on styleMap with too few arguments must throw TypeError
+PASS StylePropertyMap interface: styleMap must inherit property "append(USVString, (CSSStyleValue or USVString)...)" with the proper type
+PASS StylePropertyMap interface: calling append(USVString, (CSSStyleValue or USVString)...) on styleMap with too few arguments must throw TypeError
+PASS StylePropertyMap interface: styleMap must inherit property "delete(USVString)" with the proper type
+PASS StylePropertyMap interface: calling delete(USVString) on styleMap with too few arguments must throw TypeError
+PASS StylePropertyMap interface: styleMap must inherit property "clear()" with the proper type
+PASS StylePropertyMapReadOnly interface: styleMap must inherit property "get(USVString)" with the proper type
+PASS StylePropertyMapReadOnly interface: calling get(USVString) on styleMap with too few arguments must throw TypeError
+PASS StylePropertyMapReadOnly interface: styleMap must inherit property "getAll(USVString)" with the proper type
+PASS StylePropertyMapReadOnly interface: calling getAll(USVString) on styleMap with too few arguments must throw TypeError
+PASS StylePropertyMapReadOnly interface: styleMap must inherit property "has(USVString)" with the proper type
+PASS StylePropertyMapReadOnly interface: calling has(USVString) on styleMap with too few arguments must throw TypeError
+PASS StylePropertyMapReadOnly interface: styleMap must inherit property "size" with the proper type
 PASS CSSUnparsedValue interface: existence and properties of interface object
 PASS CSSUnparsedValue interface object length
 PASS CSSUnparsedValue interface object name
@@ -477,7 +477,7 @@ PASS CSSColor interface: existence and properties of interface prototype object'
 PASS CSSColor interface: attribute colorSpace
 FAIL CSSColor interface: attribute channels assert_true: The prototype object must have a property "channels" expected true got false
 PASS CSSColor interface: attribute alpha
-FAIL CSSStyleRule interface: attribute styleMap assert_true: The prototype object must have a property "styleMap" expected true got false
+PASS CSSStyleRule interface: attribute styleMap
 PASS CSS namespace: operation escape(CSSOMString)
 PASS CSS namespace: operation number(double)
 PASS CSS namespace: operation percent(double)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/set-var-reference-thcrash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/set-var-reference-thcrash-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Do not crash when referencing a variable with CSSVariableReferenceValue target.attributeStyleMap.set is not a function. (In 'target.attributeStyleMap.set('color', unparsed)', 'target.attributeStyleMap.set' is undefined)
+FAIL Do not crash when referencing a variable with CSSVariableReferenceValue set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssStyleValue-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssStyleValue-cssom-expected.txt
@@ -1,6 +1,6 @@
 
 PASS CSSStyleValue from specified CSSOM serializes correctly
 PASS CSSStyleValue from computed CSSOM serializes correctly
-FAIL Shorthand CSSStyleValue from inline CSSOM serializes correctly assert_equals: expected "blue" but got "initial"
+PASS Shorthand CSSStyleValue from inline CSSOM serializes correctly
 PASS Shorthand CSSStyleValue from computed CSSOM serializes correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/append.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/append.tentative-expected.txt
@@ -1,14 +1,32 @@
 
-PASS Calling StylePropertyMap.append with an unsupported property name throws TypeError
-PASS Calling StylePropertyMap.append with an null property name throws TypeError
-PASS Calling StylePropertyMap.append with a property that is not list valued throws TypeError
-PASS Calling StylePropertyMap.append with a shorthand property throws TypeError
-PASS Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError
-PASS Calling StylePropertyMap.append with an invalid String value throws TypeError
-PASS Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError
-PASS Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError
-PASS Calling StylePropertyMap.append with a var ref throws TypeError
-FAIL Appending a list-valued property with CSSStyleValue or String updates its values undefined is not an object (evaluating 'styleMap.append')
-FAIL Appending a list-valued property with list-valued string updates its values undefined is not an object (evaluating 'styleMap.append')
-FAIL StylePropertyMap.append is case-insensitive undefined is not an object (evaluating 'styleMap.append')
+FAIL Calling StylePropertyMap.append with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with an null property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a property that is not list valued throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a shorthand property throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with an invalid String value throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a var ref throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a list-valued property with CSSStyleValue or String updates its values append() is not yet supported
+FAIL Appending a list-valued property with list-valued string updates its values append() is not yet supported
+FAIL StylePropertyMap.append is case-insensitive append() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/clear-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Clearing an empty CSS rule is a no-op styleMap.clear is not a function. (In 'styleMap.clear()', 'styleMap.clear' is undefined)
-FAIL Can clear a CSS rule containing properties styleMap.clear is not a function. (In 'styleMap.clear()', 'styleMap.clear' is undefined)
-FAIL Declared StylePropertyMap.clear updates the CSS rule undefined is not an object (evaluating 'styleMap.clear')
+PASS Clearing an empty CSS rule is a no-op
+PASS Can clear a CSS rule containing properties
+PASS Declared StylePropertyMap.clear updates the CSS rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Declared StylePropertyMap only contains properties in the style rule undefined is not an object (evaluating 'styleMap.keys')
-FAIL Declared StylePropertyMap contains CSS property declarations in style rules undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap does not contain inline styles undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap contains custom property declarations undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap does not contain properties with invalid values undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap contains properties with their last valid value undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap is live undefined is not an object (evaluating 'styleMap.get')
+PASS Declared StylePropertyMap only contains properties in the style rule
+PASS Declared StylePropertyMap contains CSS property declarations in style rules
+PASS Declared StylePropertyMap does not contain inline styles
+FAIL Declared StylePropertyMap contains custom property declarations assert_equals: expected " auto" but got "auto"
+PASS Declared StylePropertyMap does not contain properties with invalid values
+PASS Declared StylePropertyMap contains properties with their last valid value
+FAIL Declared StylePropertyMap is live set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/delete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/delete-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Deleting a property not in the css rule is a no-op undefined is not an object (evaluating 'styleMap.delete')
-FAIL Deleting a property in the css rule removes it from the css rule undefined is not an object (evaluating 'styleMap.delete')
-FAIL Deleting a custom property in the css rule removes it from the css rule undefined is not an object (evaluating 'styleMap.delete')
-FAIL Deleting a list-valued property in the css rule removes it from the css rule undefined is not an object (evaluating 'styleMap.delete')
-FAIL Declared StylePropertyMap.delete is not case-sensitive undefined is not an object (evaluating 'styleMap.delete')
+PASS Deleting a property not in the css rule is a no-op
+PASS Deleting a property in the css rule removes it from the css rule
+PASS Deleting a custom property in the css rule removes it from the css rule
+PASS Deleting a list-valued property in the css rule removes it from the css rule
+PASS Declared StylePropertyMap.delete is not case-sensitive
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/delete-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/delete-shorthand-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Deleting a shorthand property not in the css rule is a no-op undefined is not an object (evaluating 'styleMap.delete')
-FAIL Deleting a shorthand property in the css rule removes both it and its longhands undefined is not an object (evaluating 'styleMap.delete')
-FAIL Deleting a longhand property in the css rule removes both it and its shorthand undefined is not an object (evaluating 'styleMap.delete')
+PASS Deleting a shorthand property not in the css rule is a no-op
+PASS Deleting a shorthand property in the css rule removes both it and its longhands
+PASS Deleting a longhand property in the css rule removes both it and its shorthand
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Getting a custom property not in the CSS rule returns null undefined is not an object (evaluating 'styleMap.get')
-FAIL Getting a valid property not in the CSS rule returns null undefined is not an object (evaluating 'styleMap.get')
-FAIL Getting a valid property from CSS rule returns the correct entry undefined is not an object (evaluating 'styleMap.get')
-FAIL Getting a valid custom property from CSS rule returns the correct entry undefined is not an object (evaluating 'styleMap.get')
-FAIL Getting a list-valued property from CSS rule returns only the first value undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap.get is not case-sensitive undefined is not an object (evaluating 'styleMap.get')
-FAIL Declared StylePropertyMap.get reflects changes in the CSS rule undefined is not an object (evaluating 'styleMap.get')
+PASS Getting a custom property not in the CSS rule returns null
+PASS Getting a valid property not in the CSS rule returns null
+PASS Getting a valid property from CSS rule returns the correct entry
+FAIL Getting a valid custom property from CSS rule returns the correct entry assert_equals: expected " auto" but got "auto"
+PASS Getting a list-valued property from CSS rule returns only the first value
+PASS Declared StylePropertyMap.get is not case-sensitive
+PASS Declared StylePropertyMap.get reflects changes in the CSS rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Getting a shorthand property set explicitly in css rule returns a base CSSStyleValue undefined is not an object (evaluating 'styleMap.get')
-FAIL Getting a shorthand property that is partially set in css rule returns null undefined is not an object (evaluating 'styleMap.get')
+PASS Getting a shorthand property set explicitly in css rule returns a base CSSStyleValue
+PASS Getting a shorthand property that is partially set in css rule returns null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/getAll-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/getAll-shorthand-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL StylePropertyMap.getAll() with a shorthand property set explicitly in css rule returns a base CSSStyleValue undefined is not an object (evaluating 'styleMap.getAll')
-FAIL StylePropertyMap.getAll() with a shorthand property that is partially in css rule returns empty list undefined is not an object (evaluating 'styleMap.getAll')
+PASS StylePropertyMap.getAll() with a shorthand property set explicitly in css rule returns a base CSSStyleValue
+PASS StylePropertyMap.getAll() with a shorthand property that is partially in css rule returns empty list
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Calling StylePropertyMap.getAll with an unsupported property throws a TypeError
-FAIL Calling StylePropertyMap.getAll with a property not in the property model returns an empty list undefined is not an object (evaluating 'styleMap.getAll')
-FAIL Calling StylePropertyMap.getAll with a custom property not in the property model returns an empty list undefined is not an object (evaluating 'styleMap.getAll')
-FAIL Calling StylePropertyMap.getAll with a valid property returns a single element list with the correct entry undefined is not an object (evaluating 'styleMap.getAll')
-FAIL StylePropertyMap.getAll is case-insensitive undefined is not an object (evaluating 'styleMap.getAll')
-FAIL Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry undefined is not an object (evaluating 'styleMap.getAll')
-FAIL Calling StylePropertyMap.getAll with a list-valued property returns all the values undefined is not an object (evaluating 'styleMap.getAll')
+PASS Calling StylePropertyMap.getAll with a property not in the property model returns an empty list
+PASS Calling StylePropertyMap.getAll with a custom property not in the property model returns an empty list
+PASS Calling StylePropertyMap.getAll with a valid property returns a single element list with the correct entry
+PASS StylePropertyMap.getAll is case-insensitive
+FAIL Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry assert_equals: expected " auto" but got "auto"
+PASS Calling StylePropertyMap.getAll with a list-valued property returns all the values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/has.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/has.tentative-expected.txt
@@ -1,11 +1,11 @@
 
 PASS Calling StylePropertyMap.has with an unsupported property throws a TypeError
-FAIL Calling StylePropertyMap.has with a property not in the property model returns false undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a custom property not in the property model returns false undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a valid property returns true undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a valid property in mixed case returns true undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a valid shorthand specified explicitly returns true undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a valid shorthand only partially specified returns false undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a valid custom property returns true undefined is not an object (evaluating 'styleMap.has')
-FAIL Calling StylePropertyMap.has with a valid list-valued property returns true undefined is not an object (evaluating 'styleMap.has')
+PASS Calling StylePropertyMap.has with a property not in the property model returns false
+PASS Calling StylePropertyMap.has with a custom property not in the property model returns false
+PASS Calling StylePropertyMap.has with a valid property returns true
+PASS Calling StylePropertyMap.has with a valid property in mixed case returns true
+PASS Calling StylePropertyMap.has with a valid shorthand specified explicitly returns true
+PASS Calling StylePropertyMap.has with a valid shorthand only partially specified returns false
+PASS Calling StylePropertyMap.has with a valid custom property returns true
+PASS Calling StylePropertyMap.has with a valid list-valued property returns true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/iterable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/iterable.tentative-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Iterating over an empty StylePropertyMap gives a zero-length array undefined is not an object (evaluating 'styleMap.entries')
-FAIL StylePropertyMap iterates properties in correct order undefined is not an object (evaluating 'styleMap.keys')
-FAIL StylePropertyMap iterator returns CSS properties with the correct CSSStyleValue undefined is not an object (evaluating 'styleMap.keys')
-FAIL StylePropertyMap iterator returns list-valued properties with the correct CSSStyleValue undefined is not an object (evaluating 'styleMap.keys')
-FAIL StylePropertyMap iterator returns custom properties with the correct CSSStyleValue undefined is not an object (evaluating 'styleMap.keys')
+PASS Iterating over an empty StylePropertyMap gives a zero-length array
+PASS StylePropertyMap iterates properties in correct order
+PASS StylePropertyMap iterator returns CSS properties with the correct CSSStyleValue
+PASS StylePropertyMap iterator returns list-valued properties with the correct CSSStyleValue
+FAIL StylePropertyMap iterator returns custom properties with the correct CSSStyleValue assert_equals: expected " A" but got "A"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set-shorthand-expected.txt
@@ -1,6 +1,10 @@
 
-PASS Setting a shorthand with an invalid CSSStyleValue on css rule throws TypeError
-PASS Setting a shorthand with an invalid String on css rule throws TypeError
-FAIL Setting a shorthand with a CSSStyleValue updates css rule undefined is not an object (evaluating 'styleMap.get')
-FAIL Setting a shorthand with a string updates css rule undefined is not an object (evaluating 'styleMap.set')
+FAIL Setting a shorthand with an invalid CSSStyleValue on css rule throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a shorthand with an invalid String on css rule throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a shorthand with a CSSStyleValue updates css rule set() is not yet supported
+FAIL Setting a shorthand with a string updates css rule set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set.tentative-expected.txt
@@ -1,16 +1,38 @@
 
-PASS Setting a StylePropertyMap with an unsupported property name throws TypeError
-PASS Setting a StylePropertyMap with an null property name throws TypeError
-PASS Setting a StylePropertyMap with a descriptor throws TypeError
-PASS Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError
-PASS Setting a StylePropertyMap with an invalid String throws TypeError
-PASS Setting a non list-valued property with multiple arguments throws TypeError
-PASS Setting a non list-valued property with list-valued string throws TypeError
-PASS Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError
-PASS Setting a list-valued property with a var ref() and other values throws TypeError
-FAIL Setting a property with CSSStyleValue or String updates its value undefined is not an object (evaluating 'styleMap.set')
-FAIL Setting a list-valued property with CSSStyleValue or String updates its values undefined is not an object (evaluating 'styleMap.set')
-FAIL Setting a list-valued property with a list-valued string updates its value undefined is not an object (evaluating 'styleMap.set')
-FAIL Setting a custom property with CSSStyleValue or String updates its value undefined is not an object (evaluating 'styleMap.set')
-FAIL StylePropertyMap.set is case-insensitive undefined is not an object (evaluating 'styleMap.set')
+FAIL Setting a StylePropertyMap with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with an null property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with a descriptor throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with an invalid String throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a non list-valued property with multiple arguments throws TypeError assert_throws_js: function "() => styleMap.set('width', CSS.px(10), CSS.px(10))" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a non list-valued property with list-valued string throws TypeError assert_throws_js: function "() => styleMap.set('width', '1s, 2s')" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError assert_throws_js: function "() => {
+    styleMap.set('transition-duration', '1s', new CSSUnparsedValue([]));
+  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a list-valued property with a var ref() and other values throws TypeError assert_throws_js: function "() => {
+    styleMap.set('transition-duration', '1s', 'var(--A)');
+  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a property with CSSStyleValue or String updates its value set() is not yet supported
+FAIL Setting a list-valued property with CSSStyleValue or String updates its values set() is not yet supported
+FAIL Setting a list-valued property with a list-valued string updates its value set() is not yet supported
+FAIL Setting a custom property with CSSStyleValue or String updates its value set() is not yet supported
+FAIL StylePropertyMap.set is case-insensitive set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt
@@ -1,14 +1,32 @@
 
-PASS Calling StylePropertyMap.append with an unsupported property name throws TypeError
-PASS Calling StylePropertyMap.append with an null property name throws TypeError
-PASS Calling StylePropertyMap.append with a property that is not list valued throws TypeError
-PASS Calling StylePropertyMap.append with a shorthand property throws TypeError
-PASS Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError
-PASS Calling StylePropertyMap.append with an invalid String value throws TypeError
-PASS Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError
-PASS Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError
-PASS Calling StylePropertyMap.append with a var ref throws TypeError
-FAIL Appending a list-valued property with CSSStyleValue or String updates its values styleMap.append is not a function. (In 'styleMap.append('transition-duration', CSS.s(1), '2s')', 'styleMap.append' is undefined)
-FAIL Appending a list-valued property with list-valued string updates its values styleMap.append is not a function. (In 'styleMap.append('transition-duration', '1s, 2s')', 'styleMap.append' is undefined)
-FAIL StylePropertyMap.append is case-insensitive styleMap.append is not a function. (In 'styleMap.append('tRaNsItIoN-dUrAtIoN', '1s', CSS.s(2))', 'styleMap.append' is undefined)
+FAIL Calling StylePropertyMap.append with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with an null property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a property that is not list valued throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a shorthand property throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with an invalid String value throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Calling StylePropertyMap.append with a var ref throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Appending a list-valued property with CSSStyleValue or String updates its values append() is not yet supported
+FAIL Appending a list-valued property with list-valued string updates its values append() is not yet supported
+FAIL StylePropertyMap.append is case-insensitive append() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/clear-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Clearing an empty inline style is a no-op styleMap.clear is not a function. (In 'styleMap.clear()', 'styleMap.clear' is undefined)
-FAIL Can clear an inline style containing properties styleMap.clear is not a function. (In 'styleMap.clear()', 'styleMap.clear' is undefined)
-FAIL Inline StylePropertyMap.clear updates the element inline style styleMap.clear is not a function. (In 'styleMap.clear()', 'styleMap.clear' is undefined)
+PASS Clearing an empty inline style is a no-op
+PASS Can clear an inline style containing properties
+PASS Inline StylePropertyMap.clear updates the element inline style
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/delete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/delete-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Deleting a property not in the inline style is a no-op styleMap.delete is not a function. (In 'styleMap.delete('width')', 'styleMap.delete' is undefined)
-FAIL Deleting a property in the inline style removes it from the inline style styleMap.delete is not a function. (In 'styleMap.delete('width')', 'styleMap.delete' is undefined)
-FAIL Deleting a custom property in the inline style removes it from the inline style styleMap.delete is not a function. (In 'styleMap.delete('--Foo')', 'styleMap.delete' is undefined)
-FAIL Deleting a list-valued property in the inline style removes it from the inline style styleMap.delete is not a function. (In 'styleMap.delete('transition-duration')', 'styleMap.delete' is undefined)
-FAIL Inline StylePropertyMap.delete is not case-sensitive styleMap.delete is not a function. (In 'styleMap.delete('wIdTh')', 'styleMap.delete' is undefined)
+PASS Deleting a property not in the inline style is a no-op
+PASS Deleting a property in the inline style removes it from the inline style
+PASS Deleting a custom property in the inline style removes it from the inline style
+PASS Deleting a list-valued property in the inline style removes it from the inline style
+PASS Inline StylePropertyMap.delete is not case-sensitive
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/delete-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/delete-shorthand-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Deleting a shorthand property not in the inline style is a no-op styleMap.delete is not a function. (In 'styleMap.delete('margin')', 'styleMap.delete' is undefined)
-FAIL Deleting a shorthand property in the inline style removes both it and its longhands styleMap.delete is not a function. (In 'styleMap.delete('margin')', 'styleMap.delete' is undefined)
-FAIL Deleting a longhand property in the inline style removes both it and its shorthand styleMap.delete is not a function. (In 'styleMap.delete('margin-top')', 'styleMap.delete' is undefined)
+PASS Deleting a shorthand property not in the inline style is a no-op
+PASS Deleting a shorthand property in the inline style removes both it and its longhands
+PASS Deleting a longhand property in the inline style removes both it and its shorthand
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-invalid-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Calling StylePropertyMap.get with an unsupported property throws a TypeError assert_throws_js: function "() => styleMap.get('lemon')" did not throw
+PASS Calling StylePropertyMap.get with an unsupported property throws a TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/get-shorthand-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Getting an shorthand property set explicitly in inline style returns a base CSSStyleValue assert_class_string: Shorthand value must be a base CSSStyleValue expected "[object CSSStyleValue]" but got "[object CSSUnitValue]"
-FAIL Getting a shorthand property that is partially set in inline style returns null assert_equals: Shorthand value must be null as it is not explicitly set expected null but got object "1px"
+PASS Getting an shorthand property set explicitly in inline style returns a base CSSStyleValue
+PASS Getting a shorthand property that is partially set in inline style returns null
 PASS Getting an attributeStyleMap shorthand property from an element without a style attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/getAll-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/getAll-shorthand-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL StylePropertyMap.getAll() with a shorthand property set explicitly in inline style returns a base CSSStyleValue assert_equals: Result must be a list with one item expected 1 but got 0
+PASS StylePropertyMap.getAll() with a shorthand property set explicitly in inline style returns a base CSSStyleValue
 PASS StylePropertyMap.getAll() with a shorthand property that is partially in inline style returns empty list
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative-expected.txt
@@ -1,9 +1,9 @@
 
-FAIL Calling StylePropertyMap.getAll with an unsupported property throws a TypeError assert_throws_js: function "() => styleMap.getAll('lemon')" did not throw
+PASS Calling StylePropertyMap.getAll with an unsupported property throws a TypeError
 PASS Calling StylePropertyMap.getAll with a property not in the property model returns an empty list
 PASS Calling StylePropertyMap.getAll with a custom property not in the property model returns an empty list
-FAIL Calling StylePropertyMap.getAll with a valid property returns a single element list with the correct entry assert_equals: expected 1 but got 0
-FAIL StylePropertyMap.getAll is case-insensitive assert_equals: expected 1 but got 0
-FAIL Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry assert_equals: expected 1 but got 0
-FAIL Calling StylePropertyMap.getAll with a list-valued property returns all the values assert_equals: expected 2 but got 0
+PASS Calling StylePropertyMap.getAll with a valid property returns a single element list with the correct entry
+PASS StylePropertyMap.getAll is case-insensitive
+FAIL Calling StylePropertyMap.getAll with a valid custom property returns a single element list with the correct entry assert_equals: expected " auto" but got "auto"
+PASS Calling StylePropertyMap.getAll with a list-valued property returns all the values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/has.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/has.tentative-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Calling StylePropertyMap.has with an unsupported property throws a TypeError assert_throws_js: function "() => styleMap.has('lemon')" did not throw
+PASS Calling StylePropertyMap.has with an unsupported property throws a TypeError
 PASS Calling StylePropertyMap.has with a property not in the property model returns false
 PASS Calling StylePropertyMap.has with a custom property not in the property model returns false
 PASS Calling StylePropertyMap.has with a valid property in mixed case returns false
-FAIL Calling StylePropertyMap.has with a valid property returns true assert_equals: expected true but got false
-FAIL Calling StylePropertyMap.has with a valid property in mixed case returns true assert_equals: expected true but got false
-FAIL Calling StylePropertyMap.has with a valid custom property returns true assert_equals: expected true but got false
-FAIL Calling StylePropertyMap.has with a valid list-valued property returns true assert_equals: expected true but got false
+PASS Calling StylePropertyMap.has with a valid property returns true
+PASS Calling StylePropertyMap.has with a valid property in mixed case returns true
+PASS Calling StylePropertyMap.has with a valid custom property returns true
+PASS Calling StylePropertyMap.has with a valid list-valued property returns true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/iterable.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/iterable.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Iterating over an empty StylePropertyMap gives a zero-length array
-FAIL StylePropertyMap iterates properties in inline style order assert_array_equals: lengths differ, expected array ["--A", "width", "--C", "transition-duration", "color", "--B"] length 6, got [] length 0
-FAIL StylePropertyMap iterator returns CSS properties with the correct CSSStyleValue assert_array_equals: lengths differ, expected array ["width", "height"] length 2, got [] length 0
-FAIL StylePropertyMap iterator returns list-valued properties with the correct CSSStyleValue assert_array_equals: lengths differ, expected array ["transition-duration"] length 1, got [] length 0
-FAIL StylePropertyMap iterator returns custom properties with the correct CSSStyleValue assert_array_equals: lengths differ, expected array ["--A", "--B", "--C"] length 3, got [] length 0
+PASS StylePropertyMap iterates properties in inline style order
+PASS StylePropertyMap iterator returns CSS properties with the correct CSSStyleValue
+PASS StylePropertyMap iterator returns list-valued properties with the correct CSSStyleValue
+FAIL StylePropertyMap iterator returns custom properties with the correct CSSStyleValue assert_equals: expected " A" but got "A"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set-shorthand-expected.txt
@@ -1,6 +1,10 @@
 
-PASS Setting a shorthand with an invalid CSSStyleValue on inline style throws TypeError
-PASS Setting a shorthand with an invalid String on inline style throws TypeError
-FAIL Setting a shorthand with a CSSStyleValue updates inline style styleMap.set is not a function. (In 'styleMap.set('margin', result)', 'styleMap.set' is undefined)
-FAIL Setting a shorthand with a string updates inline style styleMap.set is not a function. (In 'styleMap.set('margin', '1px 2px 3px 4px')', 'styleMap.set' is undefined)
+FAIL Setting a shorthand with an invalid CSSStyleValue on inline style throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a shorthand with an invalid String on inline style throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a shorthand with a CSSStyleValue updates inline style set() is not yet supported
+FAIL Setting a shorthand with a string updates inline style set() is not yet supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set.tentative-expected.txt
@@ -1,16 +1,38 @@
 
-PASS Setting a StylePropertyMap with an unsupported property name throws TypeError
-PASS Setting a StylePropertyMap with an null property name throws TypeError
-PASS Setting a StylePropertyMap with a descriptor throws TypeError
-PASS Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError
-PASS Setting a StylePropertyMap with an invalid String throws TypeError
-PASS Setting a non list-valued property with multiple arguments throws TypeError
-PASS Setting a non list-valued property with list-valued string throws TypeError
-PASS Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError
-PASS Setting a list-valued property with a var ref() and other values throws TypeError
-FAIL Setting a property with CSSStyleValue or String updates its value styleMap.set is not a function. (In 'styleMap.set('width', CSS.px(10))', 'styleMap.set' is undefined)
-FAIL Setting a list-valued property with CSSStyleValue or String updates its values styleMap.set is not a function. (In 'styleMap.set('transition-duration', CSS.s(1), '2s')', 'styleMap.set' is undefined)
-FAIL Setting a list-valued property with a list-valued string updates its value styleMap.set is not a function. (In 'styleMap.set('transition-duration', '1s, 2s')', 'styleMap.set' is undefined)
-FAIL Setting a custom property with CSSStyleValue or String updates its value styleMap.set is not a function. (In 'styleMap.set('--foo', new CSSUnparsedValue(['auto']))', 'styleMap.set' is undefined)
-FAIL StylePropertyMap.set is case-insensitive styleMap.set is not a function. (In 'styleMap.set('tRaNsItIoN-dUrAtIoN', '1s', CSS.s(2))', 'styleMap.set' is undefined)
+FAIL Setting a StylePropertyMap with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with an null property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with a descriptor throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a StylePropertyMap with an invalid String throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a non list-valued property with multiple arguments throws TypeError assert_throws_js: function "() => styleMap.set('width', CSS.px(10), CSS.px(10))" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a non list-valued property with list-valued string throws TypeError assert_throws_js: function "() => styleMap.set('width', '1s, 2s')" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError assert_throws_js: function "() => {
+    styleMap.set('transition-duration', '1s', new CSSUnparsedValue([]));
+  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a list-valued property with a var ref() and other values throws TypeError assert_throws_js: function "() => {
+    styleMap.set('transition-duration', '1s', 'var(--A)');
+  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL Setting a property with CSSStyleValue or String updates its value set() is not yet supported
+FAIL Setting a list-valued property with CSSStyleValue or String updates its values set() is not yet supported
+FAIL Setting a list-valued property with a list-valued string updates its value set() is not yet supported
+FAIL Setting a custom property with CSSStyleValue or String updates its value set() is not yet supported
+FAIL StylePropertyMap.set is case-insensitive set() is not yet supported
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class MediaKeySession;
+class ScriptExecutionContext;
 class SharedBuffer;
 
 class MediaKeyStatusMap : public RefCounted<MediaKeyStatusMap> {
@@ -66,7 +67,7 @@ public:
         Ref<MediaKeyStatusMap> m_map;
         size_t m_index { 0 };
     };
-    Iterator createIterator() { return Iterator(*this); }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator(*this); }
 
 private:
     MediaKeyStatusMap(const MediaKeySession&);

--- a/Source/WebCore/Modules/fetch/FetchHeaders.h
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.h
@@ -36,6 +36,8 @@
 
 namespace WebCore {
 
+class ScriptExecutionContext;
+
 class FetchHeaders : public RefCounted<FetchHeaders> {
 public:
     enum class Guard {
@@ -77,7 +79,7 @@ public:
         Vector<String> m_keys;
         size_t m_updateCounter { 0 };
     };
-    Iterator createIterator() { return Iterator { *this }; }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator { *this }; }
 
     void setInternalHeaders(HTTPHeaderMap&& headers) { m_headers = WTFMove(headers); }
     const HTTPHeaderMap& internalHeaders() const { return m_headers; }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -144,7 +144,7 @@ void FileSystemDirectoryHandle::getHandle(const String& name, CompletionHandler<
 
 using FileSystemDirectoryHandleIterator = FileSystemDirectoryHandle::Iterator;
 
-Ref<FileSystemDirectoryHandleIterator> FileSystemDirectoryHandle::createIterator()
+Ref<FileSystemDirectoryHandleIterator> FileSystemDirectoryHandle::createIterator(ScriptExecutionContext*)
 {
     return Iterator::create(*this);
 }

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h
@@ -74,7 +74,7 @@ public:
         bool m_isInitialized { false };
         bool m_isWaitingForResult { false };
     };
-    Ref<Iterator> createIterator();
+    Ref<Iterator> createIterator(ScriptExecutionContext*);
 
 private:
     FileSystemDirectoryHandle(ScriptExecutionContext&, String&&, FileSystemHandleIdentifier, Ref<FileSystemStorageConnection>&&);

--- a/Source/WebCore/Modules/webxr/WebXRHand.h
+++ b/Source/WebCore/Modules/webxr/WebXRHand.h
@@ -60,7 +60,7 @@ public:
         Ref<WebXRHand> m_hand;
         size_t m_index { 0 };
     };
-    Iterator createIterator() { return Iterator(*this); }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator(*this); }
 
     // For GC reachability.
     WebXRSession* session();

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -899,6 +899,8 @@ css/typedom/CSSStyleValueFactory.cpp
 css/typedom/CSSUnitValue.cpp
 css/typedom/CSSUnparsedValue.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp
+css/typedom/DeclaredStylePropertyMap.cpp
+css/typedom/StylePropertyMap.cpp
 css/typedom/color/CSSColor.cpp
 css/typedom/color/CSSHSL.cpp
 css/typedom/color/CSSHWB.cpp

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -106,7 +106,7 @@ public:
 protected:
     JSDOMAsyncIteratorBase(JSC::Structure* structure, JSWrapper& iteratedObject, IterationKind kind)
         : Base(structure, *iteratedObject.globalObject())
-        , m_iterator(iteratedObject.wrapped().createIterator())
+        , m_iterator(iteratedObject.wrapped().createIterator(iteratedObject.globalObject()->scriptExecutionContext()))
         , m_kind(kind)
     {
     }

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -107,7 +107,7 @@ public:
 protected:
     JSDOMIteratorBase(JSC::Structure* structure, JSWrapper& iteratedObject, IterationKind kind)
         : Base(structure, *iteratedObject.globalObject())
-        , m_iterator(iteratedObject.wrapped().createIterator())
+        , m_iterator(iteratedObject.wrapped().createIterator(iteratedObject.globalObject()->scriptExecutionContext()))
         , m_kind(kind)
     {
     }
@@ -210,7 +210,7 @@ template<typename JSIterator> JSC::JSValue iteratorForEach(JSC::JSGlobalObject& 
     if (callData.type == JSC::CallData::Type::None)
         return throwTypeError(&lexicalGlobalObject, scope, "Cannot call callback"_s);
 
-    auto iterator = thisObject.wrapped().createIterator();
+    auto iterator = thisObject.wrapped().createIterator(JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->scriptExecutionContext());
     while (auto value = iterator.next()) {
         JSC::MarkedArgumentBuffer arguments;
         appendForEachArguments<JSIterator>(lexicalGlobalObject, *thisObject.globalObject(), arguments, value);

--- a/Source/WebCore/css/CSSPendingSubstitutionValue.h
+++ b/Source/WebCore/css/CSSPendingSubstitutionValue.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CSSValue.h"
+#include "CSSVariableReferenceValue.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -24,6 +24,7 @@
 
 #include "CSSParser.h"
 #include "CSSStyleSheet.h"
+#include "DeclaredStylePropertyMap.h"
 #include "PropertySetCSSStyleDeclaration.h"
 #include "RuleSet.h"
 #include "StyleProperties.h"
@@ -43,6 +44,7 @@ static SelectorTextCache& selectorTextCache()
 CSSStyleRule::CSSStyleRule(StyleRule& styleRule, CSSStyleSheet* parent)
     : CSSRule(parent)
     , m_styleRule(styleRule)
+    , m_styleMap(DeclaredStylePropertyMap::create(*this))
 {
 }
 
@@ -62,6 +64,11 @@ CSSStyleDeclaration& CSSStyleRule::style()
     if (!m_propertiesCSSOMWrapper)
         m_propertiesCSSOMWrapper = StyleRuleCSSStyleDeclaration::create(m_styleRule->mutableProperties(), *this);
     return *m_propertiesCSSOMWrapper;
+}
+
+StylePropertyMap& CSSStyleRule::styleMap()
+{
+    return m_styleMap.get();
 }
 
 String CSSStyleRule::generateSelectorText() const

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -22,14 +22,17 @@
 #pragma once
 
 #include "CSSRule.h"
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class CSSStyleDeclaration;
+class DeclaredStylePropertyMap;
+class StylePropertyMap;
 class StyleRuleCSSStyleDeclaration;
 class StyleRule;
 
-class CSSStyleRule final : public CSSRule {
+class CSSStyleRule final : public CSSRule, public CanMakeWeakPtr<CSSStyleRule> {
 public:
     static Ref<CSSStyleRule> create(StyleRule& rule, CSSStyleSheet* sheet) { return adoptRef(*new CSSStyleRule(rule, sheet)); }
 
@@ -43,6 +46,8 @@ public:
     // FIXME: Not CSSOM. Remove.
     StyleRule& styleRule() const { return m_styleRule.get(); }
 
+    StylePropertyMap& styleMap();
+
 private:
     CSSStyleRule(StyleRule&, CSSStyleSheet*);
 
@@ -53,6 +58,7 @@ private:
     String generateSelectorText() const;
 
     Ref<StyleRule> m_styleRule;
+    Ref<DeclaredStylePropertyMap> m_styleMap;
     RefPtr<StyleRuleCSSStyleDeclaration> m_propertiesCSSOMWrapper;
 };
 

--- a/Source/WebCore/css/CSSStyleRule.idl
+++ b/Source/WebCore/css/CSSStyleRule.idl
@@ -23,4 +23,7 @@
 ] interface CSSStyleRule : CSSRule {
     attribute DOMString? selectorText;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
+
+    // https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects
+    [SameObject, EnabledBySetting=CSSTypedOMEnabled] readonly attribute StylePropertyMap styleMap;
 };

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -73,7 +73,7 @@ public:
         Ref<FontFaceSet> m_target;
         size_t m_index { 0 }; // FIXME: There needs to be a mechanism to handle when fonts are added or removed from the middle of the FontFaceSet.
     };
-    Iterator createIterator() { return Iterator(*this); }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator(*this); }
 
     using RefCounted::ref;
     using RefCounted::deref;

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -47,11 +47,11 @@ ComputedStylePropertyMapReadOnly::ComputedStylePropertyMapReadOnly(Element& elem
 {
 }
 
-ExceptionOr<RefPtr<CSSStyleValue>> ComputedStylePropertyMapReadOnly::get(const AtomString& property) const
+ExceptionOr<RefPtr<CSSStyleValue>> ComputedStylePropertyMapReadOnly::get(ScriptExecutionContext&, const AtomString& property) const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
     if (isCustomPropertyName(property))
-        return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property).get(), m_element->document(), m_element.ptr());
+        return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property).get(), m_element->document());
 
     auto propertyID = cssPropertyID(property);
     if (!propertyID || !isCSSPropertyExposed(propertyID, &m_element->document().settings()))
@@ -62,14 +62,14 @@ ExceptionOr<RefPtr<CSSStyleValue>> ComputedStylePropertyMapReadOnly::get(const A
         return CSSStyleValue::create(WTFMove(value), String(property)).ptr();
     }
 
-    return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed).get(), m_element->document(), m_element.ptr());
+    return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed).get(), m_element->document());
 }
 
-ExceptionOr<Vector<RefPtr<CSSStyleValue>>> ComputedStylePropertyMapReadOnly::getAll(const AtomString& property) const
+ExceptionOr<Vector<RefPtr<CSSStyleValue>>> ComputedStylePropertyMapReadOnly::getAll(ScriptExecutionContext&, const AtomString& property) const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
     if (isCustomPropertyName(property))
-        return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property).get(), m_element->document(), m_element.ptr());
+        return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property).get(), m_element->document());
 
     auto propertyID = cssPropertyID(property);
     if (!propertyID || !isCSSPropertyExposed(propertyID, &m_element->document().settings()))
@@ -80,13 +80,13 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> ComputedStylePropertyMapReadOnly::get
         return Vector<RefPtr<CSSStyleValue>> { CSSStyleValue::create(WTFMove(value), String(property)) };
     }
 
-    return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed).get(), m_element->document(), m_element.ptr());
+    return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed).get(), m_element->document());
 }
 
-ExceptionOr<bool> ComputedStylePropertyMapReadOnly::has(const AtomString& property) const
+ExceptionOr<bool> ComputedStylePropertyMapReadOnly::has(ScriptExecutionContext& context, const AtomString& property) const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
-    auto result = get(property);
+    auto result = get(context, property);
     if (result.hasException())
         return result.releaseException();
 
@@ -103,7 +103,7 @@ unsigned ComputedStylePropertyMapReadOnly::size() const
     return m_element->document().exposedComputedCSSPropertyIDs().size() + style->inheritedCustomProperties().size() + style->nonInheritedCustomProperties().size();
 }
 
-Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMapReadOnly::entries() const
+Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMapReadOnly::entries(ScriptExecutionContext*) const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#the-stylepropertymap
     Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> values;
@@ -118,12 +118,12 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     for (auto propertyID : exposedComputedCSSPropertyIDs) {
         auto key = getPropertyNameString(propertyID);
         auto value = ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        values.uncheckedAppend(makeKeyValuePair(WTFMove(key), StylePropertyMapReadOnly::reifyValueToVector(value.get(), m_element->document(), m_element.ptr())));
+        values.uncheckedAppend(makeKeyValuePair(WTFMove(key), StylePropertyMapReadOnly::reifyValueToVector(value.get(), m_element->document())));
     }
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         for (const auto& it : *map)
-            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.get(), m_element->document(), m_element.ptr())));
+            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.get(), m_element->document())));
     }
 
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h
@@ -37,11 +37,11 @@ public:
 private:
     explicit ComputedStylePropertyMapReadOnly(Element&);
 
-    ExceptionOr<RefPtr<CSSStyleValue>> get(const AtomString&) const final;
-    ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(const AtomString&) const final;
-    ExceptionOr<bool> has(const AtomString&) const final;
+    ExceptionOr<RefPtr<CSSStyleValue>> get(ScriptExecutionContext&, const AtomString&) const final;
+    ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const final;
+    ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const final;
     unsigned size() const final;
-    Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> entries() const final;
+    Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
 
     Ref<Element> m_element;
 };

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DeclaredStylePropertyMap.h"
+
+#include "CSSStyleRule.h"
+#include "CSSStyleSheet.h"
+#include "StyleProperties.h"
+#include "StyleRule.h"
+
+namespace WebCore {
+
+Ref<DeclaredStylePropertyMap> DeclaredStylePropertyMap::create(CSSStyleRule& ownerRule)
+{
+    return adoptRef(*new DeclaredStylePropertyMap(ownerRule));
+}
+
+DeclaredStylePropertyMap::DeclaredStylePropertyMap(CSSStyleRule& ownerRule)
+    : m_ownerRule(ownerRule)
+{
+}
+
+unsigned DeclaredStylePropertyMap::size() const
+{
+    if (auto* styleRule = this->styleRule())
+        return styleRule->properties().propertyCount();
+    return 0;
+}
+
+auto DeclaredStylePropertyMap::entries(ScriptExecutionContext* context) const -> Vector<StylePropertyMapEntry>
+{
+    if (!context)
+        return { };
+
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return { };
+
+    auto& document = downcast<Document>(*context);
+    Vector<StylePropertyMapEntry> result;
+    auto& declaredStyleSet = styleRule->properties();
+    result.reserveInitialCapacity(declaredStyleSet.propertyCount());
+    for (unsigned i = 0; i < declaredStyleSet.propertyCount(); ++i) {
+        auto propertyReference = declaredStyleSet.propertyAt(i);
+        result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(propertyReference.value(), document)));
+    }
+    return result;
+}
+
+CSSValue* DeclaredStylePropertyMap::propertyValue(CSSPropertyID propertyID) const
+{
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return nullptr;
+    return styleRule->properties().getPropertyCSSValue(propertyID).get();
+}
+
+CSSValue* DeclaredStylePropertyMap::customPropertyValue(const AtomString& propertyName) const
+{
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return nullptr;
+    return styleRule->properties().getCustomPropertyCSSValue(propertyName.string()).get();
+}
+
+void DeclaredStylePropertyMap::removeProperty(CSSPropertyID propertyID)
+{
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return;
+
+    CSSStyleSheet::RuleMutationScope mutationScope(m_ownerRule.get());
+    styleRule->mutableProperties().removeProperty(propertyID);
+}
+
+void DeclaredStylePropertyMap::removeCustomProperty(const AtomString& property)
+{
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return;
+
+    CSSStyleSheet::RuleMutationScope mutationScope(m_ownerRule.get());
+    styleRule->mutableProperties().removeCustomProperty(property.string());
+}
+
+StyleRule* DeclaredStylePropertyMap::styleRule() const
+{
+    return m_ownerRule ? &m_ownerRule->styleRule() : nullptr;
+}
+
+void DeclaredStylePropertyMap::clear()
+{
+    auto* styleRule = this->styleRule();
+    if (!styleRule)
+        return;
+
+    CSSStyleSheet::RuleMutationScope mutationScope(m_ownerRule.get());
+    styleRule->mutableProperties().clear();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePropertyMap.h"
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class CSSStyleRule;
+class StyleRule;
+
+// https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects
+class DeclaredStylePropertyMap final : public StylePropertyMap {
+public:
+    static Ref<DeclaredStylePropertyMap> create(CSSStyleRule&);
+
+    Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
+    unsigned size() const final;
+
+private:
+    explicit DeclaredStylePropertyMap(CSSStyleRule&);
+
+    StyleRule* styleRule() const;
+
+    void clear() final;
+    CSSValue* propertyValue(CSSPropertyID) const final;
+    CSSValue* customPropertyValue(const AtomString&) const final;
+    void removeProperty(CSSPropertyID) final;
+    void removeCustomProperty(const AtomString&) final;
+
+    WeakPtr<CSSStyleRule> m_ownerRule;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StylePropertyMap.h"
+
+#include "CSSPendingSubstitutionValue.h"
+#include "CSSPropertyNames.h"
+#include "CSSPropertyParser.h"
+#include "CSSStyleValue.h"
+#include "CSSStyleValueFactory.h"
+#include "CSSUnparsedValue.h"
+#include "CSSValueList.h"
+#include "CSSVariableData.h"
+#include "Document.h"
+#include "PaintWorkletGlobalScope.h"
+#include "StylePropertyShorthand.h"
+
+namespace WebCore {
+
+Document* StylePropertyMap::documentFromContext(ScriptExecutionContext& context)
+{
+    ASSERT(isMainThread());
+#if ENABLE(CSS_PAINTING_API)
+    if (auto* paintWorklet = dynamicDowncast<PaintWorkletGlobalScope>(context))
+        return paintWorklet->responsibleDocument();
+#endif
+    return &downcast<Document>(context);
+}
+
+RefPtr<CSSStyleValue> StylePropertyMap::shorthandPropertyValue(Document& document, CSSPropertyID propertyID) const
+{
+    auto shorthand = shorthandForProperty(propertyID);
+    Vector<Ref<CSSValue>> values;
+    for (auto& longhand : shorthand) {
+        RefPtr value = propertyValue(longhand);
+        if (!value)
+            return nullptr;
+        if (value->isImplicitInitialValue())
+            continue;
+        // VariableReference set from the shorthand.
+        if (is<CSSPendingSubstitutionValue>(*value))
+            return CSSUnparsedValue::create(downcast<CSSPendingSubstitutionValue>(*value).shorthandValue().data().tokenRange());
+        values.append(value.releaseNonNull());
+    }
+    if (values.isEmpty())
+        return nullptr;
+
+    if (values.size() == 1)
+        return reifyValue(values[0].ptr(), document);
+
+    auto valueList = CSSValueList::createSpaceSeparated();
+    for (auto& value : values)
+        valueList->append(WTFMove(value));
+    return CSSStyleValue::create(WTFMove(valueList));
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
+ExceptionOr<RefPtr<CSSStyleValue>> StylePropertyMap::get(ScriptExecutionContext& context, const AtomString& property) const
+{
+    auto* document = documentFromContext(context);
+    if (!document)
+        return nullptr;
+
+    if (isCustomPropertyName(property))
+        return reifyValue(customPropertyValue(property), *document);
+
+    auto propertyID = cssPropertyID(property);
+    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document->settings()))
+        return Exception { TypeError, makeString("Invalid property ", property) };
+
+    if (isShorthandCSSProperty(propertyID))
+        return shorthandPropertyValue(*document, propertyID);
+
+    return reifyValue(propertyValue(propertyID), *document);
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
+ExceptionOr<Vector<RefPtr<CSSStyleValue>>> StylePropertyMap::getAll(ScriptExecutionContext& context, const AtomString& property) const
+{
+    auto* document = documentFromContext(context);
+    if (!document)
+        return Vector<RefPtr<CSSStyleValue>> { };
+
+    if (isCustomPropertyName(property))
+        return reifyValueToVector(customPropertyValue(property), *document);
+
+    auto propertyID = cssPropertyID(property);
+    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document->settings()))
+        return Exception { TypeError, makeString("Invalid property ", property) };
+
+    if (isShorthandCSSProperty(propertyID)) {
+        if (RefPtr value = shorthandPropertyValue(*document, propertyID))
+            return Vector<RefPtr<CSSStyleValue>> { WTFMove(value) };
+        return Vector<RefPtr<CSSStyleValue>> { };
+    }
+
+    return reifyValueToVector(propertyValue(propertyID), *document);
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
+ExceptionOr<bool> StylePropertyMap::has(ScriptExecutionContext& context, const AtomString& property) const
+{
+    auto result = get(context, property);
+    if (result.hasException())
+        return result.releaseException();
+    return !!result.returnValue();
+}
+
+// https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-set
+ExceptionOr<void> StylePropertyMap::set(Document&, const AtomString&, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&&)
+{
+    return Exception { NotSupportedError, "set() is not yet supported"_s };
+}
+
+// https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-append
+ExceptionOr<void> StylePropertyMap::append(Document&, const AtomString&, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&&)
+{
+    return Exception { NotSupportedError, "append() is not yet supported"_s };
+}
+
+// https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-delete
+ExceptionOr<void> StylePropertyMap::remove(Document& document, const AtomString& property)
+{
+    if (isCustomPropertyName(property)) {
+        removeCustomProperty(property);
+        return { };
+    }
+
+    auto propertyID = cssPropertyID(property);
+    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document.settings()))
+        return Exception { TypeError, makeString("Invalid property ", property) };
+
+    removeProperty(propertyID);
+    return { };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMap.h
+++ b/Source/WebCore/css/typedom/StylePropertyMap.h
@@ -31,7 +31,27 @@ namespace WebCore {
 
 class StylePropertyMap : public StylePropertyMapReadOnly {
 public:
-    virtual void clearElement() = 0;
+    ExceptionOr<RefPtr<CSSStyleValue>> get(ScriptExecutionContext&, const AtomString& property) const final;
+    ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const final;
+    ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const final;
+
+    ExceptionOr<void> set(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
+    ExceptionOr<void> append(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
+    ExceptionOr<void> remove(Document&, const AtomString& property);
+    virtual void clear() = 0;
+
+    virtual void clearElement() { }
+
+protected:
+    static Document* documentFromContext(ScriptExecutionContext&);
+
+    virtual CSSValue* propertyValue(CSSPropertyID) const = 0;
+    virtual CSSValue* customPropertyValue(const AtomString&) const = 0;
+    virtual void removeProperty(CSSPropertyID) = 0;
+    virtual void removeCustomProperty(const AtomString&) = 0;
+
+private:
+    RefPtr<CSSStyleValue> shorthandPropertyValue(Document&, CSSPropertyID) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMap.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMap.idl
@@ -30,4 +30,8 @@
     SkipVTableValidation,
     JSGenerateToJSObject
 ] interface StylePropertyMap : StylePropertyMapReadOnly {
+    [CallWith=CurrentDocument] undefined set([AtomString] USVString property, (CSSStyleValue or USVString)... values);
+    [CallWith=CurrentDocument] undefined append([AtomString] USVString property, (CSSStyleValue or USVString)... values);
+    [ImplementedAs=remove, CallWith=CurrentDocument] undefined delete([AtomString] USVString property);
+    undefined clear();
 };

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp
@@ -33,6 +33,7 @@
 #include "CSSCustomPropertyValue.h"
 #include "CSSImageValue.h"
 #include "CSSPrimitiveValue.h"
+#include "CSSPropertyNames.h"
 #include "CSSStyleImageValue.h"
 #include "CSSStyleValueFactory.h"
 #include "CSSUnitValue.h"
@@ -42,7 +43,7 @@
 
 namespace WebCore {
 
-RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(CSSValue* value, Document& document, Element*)
+RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(CSSValue* value, Document& document)
 {
     if (!value)
         return nullptr;
@@ -50,40 +51,40 @@ RefPtr<CSSStyleValue> StylePropertyMapReadOnly::reifyValue(CSSValue* value, Docu
     return (result.hasException() ? nullptr : RefPtr<CSSStyleValue> { result.releaseReturnValue() });
 }
 
-RefPtr<CSSStyleValue> StylePropertyMapReadOnly::customPropertyValueOrDefault(const String& name, Document& document, CSSValue* inputValue, Element* element)
+RefPtr<CSSStyleValue> StylePropertyMapReadOnly::customPropertyValueOrDefault(const String& name, Document& document, CSSValue* inputValue)
 {
     if (!inputValue) {
         auto* registered = document.getCSSRegisteredCustomPropertySet().get(name);
 
         if (registered && registered->initialValue()) {
             auto value = registered->initialValueCopy();
-            return StylePropertyMapReadOnly::reifyValue(value.get(), document, element);
+            return StylePropertyMapReadOnly::reifyValue(value.get(), document);
         }
 
         return nullptr;
     }
 
-    return StylePropertyMapReadOnly::reifyValue(inputValue, document, element);
+    return StylePropertyMapReadOnly::reifyValue(inputValue, document);
 }
 
-Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(CSSValue* value, Document& document, Element* element)
+Vector<RefPtr<CSSStyleValue>> StylePropertyMapReadOnly::reifyValueToVector(CSSValue* value, Document& document)
 {
     if (!value)
         return { };
 
     if (!is<CSSValueList>(*value))
-        return { StylePropertyMapReadOnly::reifyValue(value, document, element) };
+        return { StylePropertyMapReadOnly::reifyValue(value, document) };
 
     auto valueList = downcast<CSSValueList>(value);
     Vector<RefPtr<CSSStyleValue>> result;
     result.reserveInitialCapacity(valueList->length());
     for (const auto& cssValue : *valueList)
-        result.uncheckedAppend(StylePropertyMapReadOnly::reifyValue(cssValue.ptr(), document, element));
+        result.uncheckedAppend(StylePropertyMapReadOnly::reifyValue(cssValue.ptr(), document));
     return result;
 }
 
-StylePropertyMapReadOnly::Iterator::Iterator(StylePropertyMapReadOnly& map)
-    : m_values(map.entries())
+StylePropertyMapReadOnly::Iterator::Iterator(StylePropertyMapReadOnly& map, ScriptExecutionContext* context)
+    : m_values(map.entries(context))
 {
 }
 

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -32,8 +32,10 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
 class Document;
 class Element;
+class ScriptExecutionContext;
 class StyledElement;
 
 class StylePropertyMapReadOnly : public RefCounted<StylePropertyMapReadOnly> {
@@ -41,27 +43,27 @@ public:
     using StylePropertyMapEntry = KeyValuePair<String, Vector<RefPtr<CSSStyleValue>>>;
     class Iterator {
     public:
-        explicit Iterator(StylePropertyMapReadOnly&);
+        explicit Iterator(StylePropertyMapReadOnly&, ScriptExecutionContext*);
         std::optional<StylePropertyMapEntry> next();
 
     private:
         Vector<StylePropertyMapEntry> m_values;
         size_t m_index { 0 };
     };
-    Iterator createIterator() { return Iterator(*this); }
+    Iterator createIterator(ScriptExecutionContext* context) { return Iterator(*this, context); }
 
     virtual ~StylePropertyMapReadOnly() = default;
-    virtual ExceptionOr<RefPtr<CSSStyleValue>> get(const AtomString& property) const = 0;
-    virtual ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(const AtomString&) const = 0;
-    virtual ExceptionOr<bool> has(const AtomString&) const = 0;
+    virtual ExceptionOr<RefPtr<CSSStyleValue>> get(ScriptExecutionContext&, const AtomString& property) const = 0;
+    virtual ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const = 0;
+    virtual ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const = 0;
     virtual unsigned size() const = 0;
 
-    static RefPtr<CSSStyleValue> reifyValue(CSSValue*, Document&, Element* = nullptr);
-    static RefPtr<CSSStyleValue> customPropertyValueOrDefault(const String& name, Document&, CSSValue*, Element* = nullptr);
-    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(CSSValue*, Document&, Element* = nullptr);
+    static RefPtr<CSSStyleValue> reifyValue(CSSValue*, Document&);
+    static RefPtr<CSSStyleValue> customPropertyValueOrDefault(const String& name, Document&, CSSValue*);
+    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(CSSValue*, Document&);
 
 protected:
-    virtual Vector<StylePropertyMapEntry> entries() const = 0;
+    virtual Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
@@ -32,9 +32,9 @@
 ] interface StylePropertyMapReadOnly {
     iterable<USVString, sequence<CSSStyleValue>>;
     // FIXME: should be (undefined or CSSStyleValue), not null
-    CSSStyleValue? get([AtomString] USVString property);
-    sequence<CSSStyleValue> getAll([AtomString] USVString property);
-    boolean has([AtomString] USVString property);
+    [CallWith=CurrentScriptExecutionContext] CSSStyleValue? get([AtomString] USVString property);
+    [CallWith=CurrentScriptExecutionContext] sequence<CSSStyleValue> getAll([AtomString] USVString property);
+    [CallWith=CurrentScriptExecutionContext] boolean has([AtomString] USVString property);
 
     readonly attribute unsigned long size;
 };

--- a/Source/WebCore/dom/NodeList.h
+++ b/Source/WebCore/dom/NodeList.h
@@ -50,7 +50,7 @@ public:
         size_t m_index { 0 };
         Ref<NodeList> m_list;
     };
-    Iterator createIterator() { return Iterator(*this); }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator(*this); }
 
     // Other methods (not part of DOM)
     virtual bool isLiveNodeList() const { return false; }

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -52,6 +52,7 @@ public:
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, double value, CSSUnitType, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, const String& value, bool important = false);
     bool removeInlineStyleProperty(CSSPropertyID);
+    bool removeInlineStyleCustomProperty(const AtomString&);
     void removeAllInlineStyleProperties();
 
     void synchronizeStyleAttributeInternal() const { const_cast<StyledElement*>(this)->synchronizeStyleAttributeInternalImpl(); }

--- a/Source/WebCore/html/DOMFormData.h
+++ b/Source/WebCore/html/DOMFormData.h
@@ -75,7 +75,7 @@ public:
         Ref<DOMFormData> m_target;
         size_t m_index { 0 };
     };
-    Iterator createIterator() { return Iterator { *this }; }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator { *this }; }
 
 private:
     explicit DOMFormData(const PAL::TextEncoding& = PAL::UTF8Encoding());

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -61,7 +61,7 @@ public:
         Ref<URLSearchParams> m_target;
         size_t m_index { 0 };
     };
-    Iterator createIterator() { return Iterator { *this }; }
+    Iterator createIterator(ScriptExecutionContext*) { return Iterator { *this }; }
 
 private:
     const Vector<KeyValuePair<String, String>>& pairs() const { return m_pairs; }


### PR DESCRIPTION
#### dcf5f3833e1e5ec71762095a6ce457638e96b8a9
<pre>
Add initial support for StylePropertyMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=246828">https://bugs.webkit.org/show_bug.cgi?id=246828</a>

Reviewed by Youenn Fablet.

Add initial support for StylePropertyMap:
- <a href="https://drafts.css-houdini.org/css-typed-om/#stylepropertymap">https://drafts.css-houdini.org/css-typed-om/#stylepropertymap</a>

This patch introduces the CSSStyleRule.styleMap property, which returns a declared StylePropertyMap:
- <a href="https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects">https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects</a>

For now, we have decent support for get() / has() / clear() / delete().
set() and append() and not yet supported and throw for now.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/declared-styleMap-accepts-inherit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/set-var-reference-thcrash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/append.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/clear-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/delete-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/delete-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/get-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/getAll-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/getAll.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/has.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/iterable.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/clear-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/delete-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/delete-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/getAll-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/getAll.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/has.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/iterable.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set.tentative-expected.txt:
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h:
(WebCore::MediaKeyStatusMap::createIterator):
* Source/WebCore/Modules/fetch/FetchHeaders.h:
(WebCore::FetchHeaders::createIterator):
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp:
(WebCore::FileSystemDirectoryHandle::createIterator):
* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.h:
* Source/WebCore/Modules/webxr/WebXRHand.h:
(WebCore::WebXRHand::createIterator):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMAsyncIterator.h:
(WebCore::JSDOMAsyncIteratorBase::JSDOMAsyncIteratorBase):
* Source/WebCore/bindings/js/JSDOMIterator.h:
(WebCore::JSDOMIteratorBase::JSDOMIteratorBase):
(WebCore::iteratorForEach):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::CSSStyleRule):
(WebCore::CSSStyleRule::styleMap):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleRule.idl:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::get const):
(WebCore::ComputedStylePropertyMapReadOnly::getAll const):
(WebCore::ComputedStylePropertyMapReadOnly::has const):
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp: Added.
(WebCore::DeclaredStylePropertyMap::create):
(WebCore::DeclaredStylePropertyMap::DeclaredStylePropertyMap):
(WebCore::DeclaredStylePropertyMap::size const):
(WebCore::DeclaredStylePropertyMap::entries const):
(WebCore::DeclaredStylePropertyMap::propertyValue const):
(WebCore::DeclaredStylePropertyMap::customPropertyValue const):
(WebCore::DeclaredStylePropertyMap::removeProperty):
(WebCore::DeclaredStylePropertyMap::removeCustomProperty):
(WebCore::DeclaredStylePropertyMap::styleRule const):
(WebCore::DeclaredStylePropertyMap::clear):
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.h: Copied from Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.h.
* Source/WebCore/css/typedom/StylePropertyMap.cpp: Added.
(WebCore::StylePropertyMap::get const):
(WebCore::StylePropertyMap::getAll const):
(WebCore::StylePropertyMap::has const):
(WebCore::StylePropertyMap::set):
(WebCore::StylePropertyMap::append):
(WebCore::StylePropertyMap::remove):
* Source/WebCore/css/typedom/StylePropertyMap.h:
(WebCore::StylePropertyMap::clearElement):
* Source/WebCore/css/typedom/StylePropertyMap.idl:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
(WebCore::StylePropertyMapReadOnly::reifyValue):
(WebCore::StylePropertyMapReadOnly::customPropertyValueOrDefault):
(WebCore::StylePropertyMapReadOnly::reifyValueToVector):
(WebCore::StylePropertyMapReadOnly::Iterator::Iterator):
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
(WebCore::StylePropertyMapReadOnly::createIterator):
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl:
* Source/WebCore/dom/NodeList.h:
(WebCore::NodeList::createIterator):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::removeInlineStyleProperty):
(WebCore::StyledElement::removeInlineStyleCustomProperty):
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/html/CustomPaintImage.cpp:
(WebCore::extractComputedProperty):
* Source/WebCore/html/DOMFormData.h:
(WebCore::DOMFormData::createIterator):
* Source/WebCore/html/URLSearchParams.h:
(WebCore::URLSearchParams::createIterator):

Canonical link: <a href="https://commits.webkit.org/255964@main">https://commits.webkit.org/255964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cef3793154d1e64e7b683bf77ce5af65072975ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103728 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164064 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3312 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31515 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99764 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2378 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80522 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84304 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72344 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37899 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17806 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19073 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41648 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1937 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38307 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->