### PR TITLE
Update AirPlay runtime logging

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -369,6 +369,7 @@ void WebMediaSessionManager::configurePlaybackTargetClients()
     size_t indexOfClientWillPlayToTarget = notFound;
     bool haveActiveRoute = m_playbackTarget && m_playbackTarget->hasActiveRoute();
 
+    ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, " haveActiveRoute = ", haveActiveRoute);
     for (size_t i = 0; i < m_clientState.size(); ++i) {
         auto& state = m_clientState[i];
 
@@ -394,8 +395,10 @@ void WebMediaSessionManager::configurePlaybackTargetClients()
     for (size_t i = 0; i < m_clientState.size(); ++i) {
         auto& state = m_clientState[i];
 
-        if (m_playbackTarget)
+        if (m_playbackTarget) {
+            ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, state.get(), " calling setPlaybackTarget");
             state->client.setPlaybackTarget(state->contextId, *m_playbackTarget.copyRef());
+        }
 
         if (i != indexOfClientWillPlayToTarget || !haveActiveRoute) {
             ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, state.get(), " calling setShouldPlayToPlaybackTarget(false)");

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -119,6 +119,16 @@ private:
     bool m_available { false };
 };
 
+String convertEnumerationToString(RemotePlayback::State);
+
+}
+
+namespace WTF {
+
+template<> struct LogArgument<WebCore::RemotePlayback::State> {
+    static String toString(WebCore::RemotePlayback::State state) { return convertEnumerationToString(state); }
+};
+
 }
 
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -223,9 +223,7 @@ private:
     bool m_shouldPlayToPlaybackTarget { false };
     mutable bool m_hasPlaybackTargets { false };
 #endif
-#if PLATFORM(IOS_FAMILY)
     bool m_hasPlaybackTargetAvailabilityListeners { false };
-#endif
 
     MonotonicTime m_mostRecentUserInteractionTime;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1245,7 +1245,7 @@ void MediaPlayerPrivateAVFoundationObjC::checkPlayability()
 
 void MediaPlayerPrivateAVFoundationObjC::beginLoadingMetadata()
 {
-    INFO_LOG(LOGIDENTIFIER);
+    ALWAYS_LOG(LOGIDENTIFIER);
 
     OSObjectPtr<dispatch_group_t> metadataLoadingGroup = adoptOSObject(dispatch_group_create());
     dispatch_group_enter(metadataLoadingGroup.get());
@@ -3149,7 +3149,7 @@ String MediaPlayerPrivateAVFoundationObjC::languageOfPrimaryAudioTrack() const
     ALLOW_DEPRECATED_DECLARATIONS_END
     if (currentlySelectedAudibleOption) {
         m_languageOfPrimaryAudioTrack = [[currentlySelectedAudibleOption locale] localeIdentifier];
-        INFO_LOG(LOGIDENTIFIER, "language of selected audible option ", m_languageOfPrimaryAudioTrack);
+        ALWAYS_LOG(LOGIDENTIFIER, "language of selected audible option ", m_languageOfPrimaryAudioTrack);
 
         return m_languageOfPrimaryAudioTrack;
     }
@@ -3159,14 +3159,14 @@ String MediaPlayerPrivateAVFoundationObjC::languageOfPrimaryAudioTrack() const
     NSArray *tracks = [m_avAsset tracksWithMediaType:AVMediaTypeAudio];
     if (!tracks || [tracks count] != 1) {
         m_languageOfPrimaryAudioTrack = emptyString();
-        INFO_LOG(LOGIDENTIFIER, tracks ? [tracks count] : 0, " audio tracks, returning empty");
+        ALWAYS_LOG(LOGIDENTIFIER, tracks ? [tracks count] : 0, " audio tracks, returning empty");
         return m_languageOfPrimaryAudioTrack;
     }
 
     AVAssetTrack *track = [tracks objectAtIndex:0];
     m_languageOfPrimaryAudioTrack = AVTrackPrivateAVFObjCImpl::languageForAVAssetTrack(track);
 
-    INFO_LOG(LOGIDENTIFIER, "single audio track has language \"", m_languageOfPrimaryAudioTrack, "\"");
+    ALWAYS_LOG(LOGIDENTIFIER, "single audio track has language \"", m_languageOfPrimaryAudioTrack, "\"");
 
     return m_languageOfPrimaryAudioTrack;
 }
@@ -3327,13 +3327,16 @@ bool MediaPlayerPrivateAVFoundationObjC::wirelessVideoPlaybackDisabled() const
 
 void MediaPlayerPrivateAVFoundationObjC::setWirelessVideoPlaybackDisabled(bool disabled)
 {
-    INFO_LOG(LOGIDENTIFIER, disabled);
-    m_allowsWirelessVideoPlayback = !disabled;
+    auto allows = !disabled;
+    if (m_allowsWirelessVideoPlayback != allows)
+        ALWAYS_LOG(LOGIDENTIFIER, disabled);
+
+    m_allowsWirelessVideoPlayback = allows;
     if (!m_avPlayer)
         return;
 
     setDelayCallbacks(true);
-    [m_avPlayer setAllowsExternalPlayback:!disabled];
+    [m_avPlayer setAllowsExternalPlayback:allows];
     setDelayCallbacks(false);
 }
 
@@ -3361,7 +3364,7 @@ void MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget(bool shou
     if (!m_playbackTarget)
         return;
 
-    INFO_LOG(LOGIDENTIFIER, shouldPlay);
+    ALWAYS_LOG(LOGIDENTIFIER, shouldPlay);
 
     if (m_playbackTarget->targetType() == MediaPlaybackTarget::TargetType::AVFoundation) {
         AVOutputContext *newContext = shouldPlay ? m_outputContext.get() : nil;


### PR DESCRIPTION
#### cbfb92b559687b5277cb5cd916421bb3a6c5d3c4
<pre>
Update AirPlay runtime logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=246859">https://bugs.webkit.org/show_bug.cgi?id=246859</a>
rdar://100004713

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionManager::configurePlaybackTargetClients):

* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
(WTF::LogArgument&lt;WebCore::RemotePlayback::State&gt;::toString):

* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::clientDataBufferingTimerFired):
(WebCore::MediaElementSession::addBehaviorRestriction):
(WebCore::MediaElementSession::removeBehaviorRestriction):
(WebCore::MediaElementSession::dataLoadingPermitted const):
(WebCore::MediaElementSession::fullscreenPermitted const):
(WebCore::MediaElementSession::pageAllowsDataLoading const):
(WebCore::MediaElementSession::pageAllowsPlaybackAfterResuming const):
(WebCore::MediaElementSession::wirelessVideoPlaybackDisabled const):
(WebCore::MediaElementSession::setWirelessVideoPlaybackDisabled):
(WebCore::MediaElementSession::setHasPlaybackTargetAvailabilityListeners):
(WebCore::MediaElementSession::externalOutputDeviceAvailableDidChange):
(WebCore::MediaElementSession::setShouldPlayToPlaybackTarget):
(WebCore::MediaElementSession::playbackTargetPickerWasDismissed):
(WebCore::MediaElementSession::mediaEngineUpdated):
* Source/WebCore/html/MediaElementSession.h:

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::beginLoadingMetadata):
(WebCore::MediaPlayerPrivateAVFoundationObjC::languageOfPrimaryAudioTrack const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setWirelessVideoPlaybackDisabled):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbfb92b559687b5277cb5cd916421bb3a6c5d3c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2944 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24353 "Hash cbfb92b5 for PR 5633 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103393 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163715 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2960 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31197 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99424 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2107 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80189 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29133 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84033 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/24353 "Hash cbfb92b5 for PR 5633 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37593 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/24353 "Hash cbfb92b5 for PR 5633 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35442 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/24353 "Hash cbfb92b5 for PR 5633 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41406 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41254 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/24353 "Hash cbfb92b5 for PR 5633 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->