### PR TITLE
[iOS] Add a warning banner upon entering element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)invalidate;
 - (void)showUI;
 - (void)hideUI;
+- (void)showBanner;
+- (void)hideBanner;
 - (void)videoControlsManagerDidChange;
 - (void)setAnimatingViewAlpha:(CGFloat)alpha;
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -103,6 +103,27 @@ private:
 }
 @end
 
+#pragma mark - _WKInsetLabel
+
+@interface _WKInsetLabel : UILabel
+@property (assign, nonatomic) UIEdgeInsets edgeInsets;
+@end
+
+@implementation _WKInsetLabel
+- (void)drawTextInRect:(CGRect)rect
+{
+    [super drawTextInRect:UIEdgeInsetsInsetRect(rect, self.edgeInsets)];
+}
+
+- (CGSize)intrinsicContentSize
+{
+    auto intrinsicSize = [super intrinsicContentSize];
+    intrinsicSize.width += self.edgeInsets.left + self.edgeInsets.right;
+    intrinsicSize.height += self.edgeInsets.top + self.edgeInsets.bottom;
+    return intrinsicSize;
+}
+@end
+
 #pragma mark - WKFullScreenViewController
 
 @interface WKFullScreenViewController () <UIGestureRecognizerDelegate, UIToolbarDelegate>
@@ -116,11 +137,14 @@ private:
     RetainPtr<UILongPressGestureRecognizer> _touchGestureRecognizer;
     RetainPtr<UIView> _animatingView;
     RetainPtr<UIStackView> _stackView;
+    RetainPtr<UIStackView> _banner;
+    RetainPtr<_WKInsetLabel> _bannerLabel;
     RetainPtr<_WKExtrinsicButton> _cancelButton;
     RetainPtr<_WKExtrinsicButton> _pipButton;
     RetainPtr<UIButton> _locationButton;
     RetainPtr<UILayoutGuide> _topGuide;
     RetainPtr<NSLayoutConstraint> _topConstraint;
+    String _location;
     WebKit::FullscreenTouchSecheuristic _secheuristic;
     WKFullScreenViewControllerPlaybackSessionModelClient _playbackClient;
     CGFloat _nonZeroStatusBarHeight;
@@ -165,6 +189,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _valid = NO;
 
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideUI) object:nil];
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     _playbackClient.setParent(nullptr);
     _playbackClient.setInterface(nullptr);
@@ -175,7 +200,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self invalidate];
 
     [_target release];
-    [_location release];
 
     [super dealloc];
 }
@@ -242,6 +266,33 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return;
 
         [_stackView setHidden:YES];
+    }];
+}
+
+- (void)showBanner
+{
+    ASSERT(_valid);
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
+
+    [UIView animateWithDuration:showHideAnimationDuration animations:^{
+        [_banner setHidden:NO];
+        [_banner setAlpha:1];
+    }];
+
+    [self performSelector:@selector(hideBanner) withObject:nil afterDelay:autoHideDelay];
+}
+
+- (void)hideBanner
+{
+    ASSERT(_valid);
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
+    [UIView animateWithDuration:showHideAnimationDuration animations:^{
+        [_banner setAlpha:0];
+    } completion:^(BOOL finished) {
+        if (!finished)
+            return;
+
+        [_banner setHidden:YES];
     }];
 }
 
@@ -350,6 +401,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [self showUI];
 }
 
+- (NSString *)location
+{
+    return _location;
+}
+
+- (void)setLocation:(NSString *)location
+{
+    _location = location;
+
+    [_bannerLabel setText:[NSString stringWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]];
+}
+
 #pragma mark - UIViewController Overrides
 
 - (void)loadView
@@ -427,9 +490,24 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [stackView addArrangedSubview:_pipButton.get() applyingMaterialStyle:AVBackgroundViewMaterialStylePrimary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
         _stackView = WTFMove(stackView);
     }
-    
+
     [_stackView setTranslatesAutoresizingMaskIntoConstraints:NO];
-    [_animatingView addSubview:_stackView.get()];    
+    [_animatingView addSubview:_stackView.get()];
+
+    _bannerLabel = adoptNS([[_WKInsetLabel alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
+    [_bannerLabel setEdgeInsets:UIEdgeInsetsMake(16, 16, 16, 16)];
+    [_bannerLabel setBackgroundColor:[UIColor clearColor]];
+    [_bannerLabel setNumberOfLines:0];
+    [_bannerLabel setLineBreakMode:NSLineBreakByWordWrapping];
+    [_bannerLabel setTextAlignment:NSTextAlignmentCenter];
+    [_bannerLabel setText:[NSString stringWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]];
+
+    auto banner = adoptNS([[WKFullscreenStackView alloc] init]);
+    [banner addArrangedSubview:_bannerLabel.get() applyingMaterialStyle:AVBackgroundViewMaterialStyleSecondary tintEffectStyle:AVBackgroundViewTintEffectStyleSecondary];
+    _banner = WTFMove(banner);
+    [_banner setTranslatesAutoresizingMaskIntoConstraints:NO];
+
+    [_animatingView addSubview:_banner.get()];
 
     UILayoutGuide *safeArea = self.view.safeAreaLayoutGuide;
     UILayoutGuide *margins = self.view.layoutMarginsGuide;
@@ -446,12 +524,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [NSLayoutConstraint activateConstraints:@[
         _topConstraint.get(),
         stackViewToTopGuideConstraint,
+        [[_banner centerYAnchor] constraintEqualToAnchor:margins.centerYAnchor],
+        [[_banner centerXAnchor] constraintEqualToAnchor:margins.centerXAnchor],
+        [[_banner widthAnchor] constraintEqualToAnchor:margins.widthAnchor],
         [[_stackView leadingAnchor] constraintEqualToAnchor:margins.leadingAnchor],
     ]];
 
     [_stackView setAlpha:0];
     [_stackView setHidden:YES];
     [self videoControlsManagerDidChange];
+
+    [_banner setAlpha:0];
+    [_banner setHidden:YES];
 
     _touchGestureRecognizer = adoptNS([[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(_touchDetected:)]);
     [_touchGestureRecognizer setCancelsTouchesInView:NO];

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -498,6 +498,8 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
 
     self._webView = webView;
 
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:[UIApplication sharedApplication]];
+
     return self;
 }
 
@@ -733,6 +735,8 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
             manager->didEnterFullScreen();
             manager->setAnimatingFullScreen(false);
             page->setSuppressVisibilityUpdates(false);
+
+            [_fullscreenViewController showBanner];
 
 #if HAVE(UIKIT_WEBKIT_INTERNALS)
             configureViewForEnteringFullscreen(_fullscreenViewController.get().view, kAnimationDuration, [_window frame].size);
@@ -1295,6 +1299,11 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
     [_interactiveDismissTransitionCoordinator updateInteractiveTransition:progress withScale:scale andTranslation:CGSizeMake(translation.x, translation.y)];
 }
 #endif // ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
+
+- (void)_applicationDidBecomeActive:(NSNotification*)notification
+{
+    [_fullscreenViewController showBanner];
+}
 
 @end
 


### PR DESCRIPTION
#### 3c1ac0d1fc163cdbcebc60329bef12353a00208c
<pre>
[iOS] Add a warning banner upon entering element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=246872">https://bugs.webkit.org/show_bug.cgi?id=246872</a>
rdar://101435275

Reviewed by Eric Carlson.

Add a warning banner to the element fullscreen implementation which appears after the fullscreen animation
completes, disappears shortly afterwards, and re-appears after a background fullscreen webview is foregrounded.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[_WKInsetLabel drawTextInRect:]):
(-[_WKInsetLabel intrinsicContentSize]):
(-[WKFullScreenViewController invalidate]):
(-[WKFullScreenViewController dealloc]):
(-[WKFullScreenViewController showBanner]):
(-[WKFullScreenViewController hideBanner]):
(-[WKFullScreenViewController location]):
(-[WKFullScreenViewController setLocation:]):
(-[WKFullScreenViewController loadView]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController initWithWebView:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _applicationDidBecomeActive:]):

Canonical link: <a href="https://commits.webkit.org/255921@main">https://commits.webkit.org/255921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d888b6928734302166a74d8564cabdcae50a0e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103440 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3011 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31240 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99451 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2149 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80234 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29180 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37635 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17612 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35492 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18872 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4089 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41444 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38103 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->