### PR TITLE
[web-animations] support CSSNumberish? values for Animation.startTime and Animation.currentTime setters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-current-time-of-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-current-time-of-an-animation-expected.txt
@@ -2,9 +2,7 @@
 PASS Setting the current time of a pending animation to unresolved does not throw a TypeError
 PASS Setting the current time of a playing animation to unresolved throws a TypeError
 PASS Setting the current time of a paused animation to unresolved throws a TypeError
-FAIL Validate different value types that can be used to set current time assert_throws_dom: function "() => {
-    animation.currentTime = CSSNumericValue.parse("30%");
-  }" threw object "TypeError: The provided value is non-finite" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+PASS Validate different value types that can be used to set current time
 PASS Setting the current time of a pausing animation applies a pending playback rate
 PASS Setting the current time after the end with a positive playback rate
 PASS Setting a negative current time with a positive playback rate

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html
@@ -48,10 +48,10 @@ promise_test(async t => {
 promise_test(async t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
 
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("30%");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.currentTime = CSSNumericValue.parse("30deg");
   });
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt
@@ -1,7 +1,5 @@
 
-FAIL Validate different value types that can be used to set start time assert_throws_dom: function "() => {
-    animation.startTime = CSSNumericValue.parse("30%");
-  }" threw object "TypeError: The provided value is non-finite" that is not a DOMException NotSupportedError: property "code" is equal to undefined, expected 9
+PASS Validate different value types that can be used to set start time
 PASS Setting the start time of an animation without an active timeline
 PASS Setting an unresolved start time an animation without an active timeline does not clear the current time
 PASS Setting the start time clears the hold time

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html
@@ -16,10 +16,10 @@ promise_test(async t => {
     new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
                   null);
 
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("30%");
   });
-  assert_throws_dom('NotSupportedError', () => {
+  assert_throws_js(TypeError, () => {
     animation.startTime = CSSNumericValue.parse("30deg");
   });
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -178,7 +178,7 @@ void CSSAnimation::setBindingsEffect(RefPtr<AnimationEffect>&& newEffect)
     }
 }
 
-void CSSAnimation::setBindingsStartTime(std::optional<double> startTime)
+ExceptionOr<void> CSSAnimation::setBindingsStartTime(const std::optional<CSSNumberish>& startTime)
 {
     // https://drafts.csswg.org/css-animations-2/#animations
 
@@ -187,10 +187,14 @@ void CSSAnimation::setBindingsStartTime(std::optional<double> startTime)
     // change to the animation-play-state will no longer cause the CSSAnimation to be played or paused.
 
     auto previousPlayState = playState();
-    DeclarativeAnimation::setBindingsStartTime(startTime);
+    auto result = DeclarativeAnimation::setBindingsStartTime(startTime);
+    if (result.hasException())
+        return result.releaseException();
     auto currentPlayState = playState();
     if (currentPlayState != previousPlayState && (currentPlayState == PlayState::Paused || previousPlayState == PlayState::Paused))
         m_overriddenProperties.add(Property::PlayState);
+
+    return { };
 }
 
 ExceptionOr<void> CSSAnimation::bindingsReverse()

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -59,7 +59,7 @@ private:
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;
     void setBindingsEffect(RefPtr<AnimationEffect>&&) final;
-    void setBindingsStartTime(std::optional<double>) final;
+    ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberish>&) final;
     ExceptionOr<void> bindingsReverse() final;
 
     enum class Property : uint16_t {

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -28,6 +28,7 @@
 #include "ActiveDOMObject.h"
 #include "AnimationFrameRate.h"
 #include "AnimationFrameRatePreset.h"
+#include "CSSNumericValue.h"
 #include "EventTarget.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
@@ -109,11 +110,11 @@ public:
     ExceptionOr<void> commitStyles();
 
     virtual std::optional<double> bindingsStartTime() const;
-    virtual void setBindingsStartTime(std::optional<double>);
+    virtual ExceptionOr<void> setBindingsStartTime(const std::optional<CSSNumberish>&);
     std::optional<Seconds> startTime() const { return m_startTime; }
     void setStartTime(std::optional<Seconds>);
     virtual std::optional<double> bindingsCurrentTime() const;
-    virtual ExceptionOr<void> setBindingsCurrentTime(std::optional<double>);
+    virtual ExceptionOr<void> setBindingsCurrentTime(const std::optional<CSSNumberish>&);
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }
     virtual bool bindingsPending() const { return pending(); }
@@ -172,6 +173,7 @@ private:
     enum class AutoRewind : uint8_t { Yes, No };
     enum class TimeToRunPendingTask : uint8_t { NotScheduled, ASAP, WhenReady };
 
+    ExceptionOr<std::optional<Seconds>> validateCSSNumberishValue(const std::optional<CSSNumberish>&) const;
     void timingDidChange(DidSeek, SynchronouslyNotify, Silently = Silently::No);
     void updateFinishedState(DidSeek, SynchronouslyNotify);
     Seconds effectEndTime() const;

--- a/Source/WebCore/animation/WebAnimation.idl
+++ b/Source/WebCore/animation/WebAnimation.idl
@@ -38,6 +38,8 @@ enum AnimationReplaceState {
 
 typedef unsigned long FramesPerSecond;
 
+typedef (double or CSSNumericValue) CSSNumberish;
+
 [
     ActiveDOMObject,
     InterfaceName=Animation,
@@ -50,8 +52,8 @@ typedef unsigned long FramesPerSecond;
     attribute DOMString id;
     [ImplementedAs=bindingsEffect] attribute AnimationEffect? effect;
     [EnabledConditionallyReadWriteBySetting=WebAnimationsMutableTimelinesEnabled] attribute AnimationTimeline? timeline;
-    [ImplementedAs=bindingsStartTime] attribute double? startTime;
-    [ImplementedAs=bindingsCurrentTime] attribute double? currentTime;
+    [ImplementedAs=bindingsStartTime] attribute CSSNumberish? startTime;
+    [ImplementedAs=bindingsCurrentTime] attribute CSSNumberish? currentTime;
     attribute double playbackRate;
     [ImplementedAs=bindingsFrameRate, EnabledBySetting=WebAnimationsCustomFrameRateEnabled] attribute (FramesPerSecond or AnimationFrameRatePreset) frameRate;
     [ImplementedAs=bindingsPlayState] readonly attribute AnimationPlayState playState;


### PR DESCRIPTION
#### 4dc7e1ab89bb9ca1ec5863f324583758f933bba0
<pre>
[web-animations] support CSSNumberish? values for Animation.startTime and Animation.currentTime setters
<a href="https://bugs.webkit.org/show_bug.cgi?id=246876">https://bugs.webkit.org/show_bug.cgi?id=246876</a>

Reviewed by Chris Dumez.

Change the currentTime and startTime attributes of Animation to be CSSNumberish? instead of double?
per the latest Web Animations 2 draft (<a href="https://drafts.csswg.org/web-animations).">https://drafts.csswg.org/web-animations).</a>

Note that the WPT tests were incorrect in expecting a NotSupportedError exception instead of TypeError
when validating the numberish value as specified by <a href="https://drafts.csswg.org/web-animations/#validating-a-css-numberish-time.">https://drafts.csswg.org/web-animations/#validating-a-css-numberish-time.</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-current-time-of-an-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-current-time-of-an-animation.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/setting-the-start-time-of-an-animation.html:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::setBindingsStartTime):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::validateCSSNumberishValue const):
(WebCore::WebAnimation::setBindingsStartTime):
(WebCore::WebAnimation::setBindingsCurrentTime):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimation.idl:

Canonical link: <a href="https://commits.webkit.org/255870@main">https://commits.webkit.org/255870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47d2a78fdffe4649b858ed78c348adec73444936

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93852 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103484 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163817 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3060 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31279 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86171 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2181 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80275 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29201 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84107 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72154 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37675 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17638 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35539 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18900 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39418 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1911 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38130 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->