### PR TITLE
HTMLFieldSetElement shouldn't be allowed as an interaction region

### DIFF
--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -33,6 +33,7 @@
 #include "FrameView.h"
 #include "GeometryUtilities.h"
 #include "HTMLAnchorElement.h"
+#include "HTMLFieldSetElement.h"
 #include "HTMLFormControlElement.h"
 #include "HitTestResult.h"
 #include "Page.h"
@@ -95,7 +96,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         return std::nullopt;
 
     auto cursor = cursorTypeForElement(*element);
-    if (cursor != CursorType::Pointer && !is<HTMLFormControlElement>(element))
+    if (cursor != CursorType::Pointer && (!is<HTMLFormControlElement>(element) || is<HTMLFieldSetElement>(element)))
         return std::nullopt;
 
     bool isInlineNonBlock = renderer.isInline() && !renderer.isReplacedOrInlineBlock();


### PR DESCRIPTION
#### 72744d330830c65cd3bf7e92638efd2d91d33772
<pre>
HTMLFieldSetElement shouldn&apos;t be allowed as an interaction region
<a href="https://bugs.webkit.org/show_bug.cgi?id=246879">https://bugs.webkit.org/show_bug.cgi?id=246879</a>
&lt;rdar://100420346&gt;

Reviewed by Tim Horton.

HTMLFieldSetElement shouldn&apos;t be allowed as an interaction region.

It is not interactable, rather the elements it contains are interactable.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):

Canonical link: <a href="https://commits.webkit.org/255933@main">https://commits.webkit.org/255933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ba3a19ef72880adf54160b9730c9e7280a87ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/2980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103426 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163748 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/2996 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31227 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99440 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2133 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80220 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29165 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37622 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17602 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35477 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18862 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4099 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41432 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38093 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->