### PR TITLE
nullptr crash in WebCore::IDBTransaction::dispatchEvent

### DIFF
--- a/LayoutTests/storage/indexeddb/crash-on-getdatabases-expected.txt
+++ b/LayoutTests/storage/indexeddb/crash-on-getdatabases-expected.txt
@@ -1,0 +1,13 @@
+Test IndexedDB open request does not crash on indexedDB.databases().
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/crash-on-getdatabases.html
+++ b/LayoutTests/storage/indexeddb/crash-on-getdatabases.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/crash-on-getdatabases.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/resources/crash-on-getdatabases.js
+++ b/LayoutTests/storage/indexeddb/resources/crash-on-getdatabases.js
@@ -1,0 +1,23 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Test IndexedDB open request does not crash on indexedDB.databases().");
+
+indexedDBTest(testDoesNotCrash);
+async function testDoesNotCrash()
+{
+    document.documentElement.append(document.createElement('frameset'));
+    indexedDB.open('b', 1);
+    indexedDB.open('c', 1);
+    indexedDB.open('d', 1);
+    for (let i = 0; i < 100; i++) {
+        let idbOpenDBRequest = indexedDB.open('a', 1);
+        for (let x of await indexedDB.databases()) {}
+        let transaction = idbOpenDBRequest.transaction;
+        if (transaction)
+            transaction.oncomplete = () => location.hash = 'h';
+    }
+    finishJSTest();
+}

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -632,6 +632,11 @@ void IDBTransaction::dispatchEvent(Event& event)
     m_didDispatchAbortOrCommit = true;
 
     if (isVersionChange()) {
+        if (!m_openDBRequest) {
+            ASSERT(m_isStopped);
+            return;
+        }
+
         m_openDBRequest->versionChangeTransactionDidFinish();
 
         if (event.type() == eventNames().completeEvent) {


### PR DESCRIPTION
#### 4a1a50028375e15290414aa3f750adf95e9fe6ee
<pre>
nullptr crash in WebCore::IDBTransaction::dispatchEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=246706">https://bugs.webkit.org/show_bug.cgi?id=246706</a>
rdar://94637046

Reviewed by Sihui Liu.

We should check if m_openDBRequest is null in
IDBTransaction::dispatchEvent. The repro is flaky but does reproduce for
me ~1/3 of the time. I tried to reduce the test case but it either
stopped reproducing or reproduced significantly less frequently.

* LayoutTests/storage/indexeddb/crash-on-getdatabases-expected.txt: Added.
* LayoutTests/storage/indexeddb/crash-on-getdatabases.html: Added.
* LayoutTests/storage/indexeddb/resources/crash-on-getdatabases.js: Added.
(async testDoesNotCrash):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::dispatchEvent):

Canonical link: <a href="https://commits.webkit.org/256112@main">https://commits.webkit.org/256112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/567416ef995985f228e80b1b1428b2513d146162

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104247 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164519 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3848 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31973 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100210 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2767 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80990 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29792 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84692 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72687 "Found 1 new API test failure: /WebKitGTK/TestWebExtensions:/webkit/WebKitWebExtension/page-id (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38378 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36233 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40136 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41993 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/second-argument-undefined.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38571 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->