### PR TITLE
font shorthand should reject out-of-range angles in for font-style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-shorthand-expected.txt
@@ -10,8 +10,8 @@ PASS Font shorthand: Font weight specified as calc(), value greater than 1000
 PASS Font shorthand: 'oblique' with positive angle
 PASS Font shorthand: 'oblique' with negative angle
 PASS Font shorthand: 'oblique' without slant angle
-FAIL Font shorthand: 'oblique' with positive angle, value out of range assert_equals: Font shorthand: 'oblique' with positive angle, value out of range expected false but got true
-FAIL Font shorthand: 'oblique' with negative angle, value out of range assert_equals: Font shorthand: 'oblique' with negative angle, value out of range expected false but got true
+PASS Font shorthand: 'oblique' with positive angle, value out of range
+PASS Font shorthand: 'oblique' with negative angle, value out of range
 PASS Font shorthand: 'oblique' followed by valid small weight
 PASS Font shorthand: 'oblique' followed by valid large weight
 PASS Font shorthand: 'oblique' with positive angle followed by valid weight

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -200,7 +200,6 @@ std::optional<CSSValueID> consumeFontVariantCSS21Raw(CSSParserTokenRange&);
 std::optional<CSSValueID> consumeFontWeightKeywordValueRaw(CSSParserTokenRange&);
 std::optional<FontWeightRaw> consumeFontWeightRaw(CSSParserTokenRange&);
 std::optional<CSSValueID> consumeFontStretchKeywordValueRaw(CSSParserTokenRange&);
-std::optional<CSSValueID> consumeFontStyleKeywordValueRaw(CSSParserTokenRange&);
 std::optional<FontStyleRaw> consumeFontStyleRaw(CSSParserTokenRange&, CSSParserMode);
 AtomString concatenateFamilyName(CSSParserTokenRange&);
 AtomString consumeFamilyNameRaw(CSSParserTokenRange&);


### PR DESCRIPTION
#### 773a9ae47bff35f76ce9ea77c3ab34f7a68f4e6b
<pre>
font shorthand should reject out-of-range angles in for font-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=246572">https://bugs.webkit.org/show_bug.cgi?id=246572</a>
rdar://problem/101437235

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-shorthand-expected.txt:
Expect some more PASS.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontStyleKeywordValueRaw): Deleted.
Not helpful to have this in a separate function.
(WebCore::CSSPropertyParserHelpers::consumeFontStyleRaw): Fixed case where we would
consume the keyword and angle if the angle failed to parse or if the angle parsed
but was out of the allowed numeric range. This required a rollback to the position
before the keyword. Also restructured the function so it&apos;s easier to read.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h: Removed consumeFontStyleKeywordValueRaw.

Canonical link: <a href="https://commits.webkit.org/255871@main">https://commits.webkit.org/255871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01e64a017930e9a114c3210b219a1ea99c6e70dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103461 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163789 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3037 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31257 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99467 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2166 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80252 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29182 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84092 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72136 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37652 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17620 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18880 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4053 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41456 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38111 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->