### PR TITLE
[WPT] Remove some 3-second sleeps in test cases

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html
@@ -15,7 +15,6 @@
         const uid = token();
         const win = window.open(`./support/preload-csp-report.https.sub.html?uid=${uid}`);
         t.add_cleanup(() => win.close());
-        await wait(3000);
         const reports = await pollReports(endpoint, uid);
         const failures = reports.filter(r => r['csp-report']['blocked-uri'].endsWith('fail.png'));
         assert_equals(failures.length, 2);

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/cross-origin-report-no-credentials.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/cross-origin-report-no-credentials.https.sub.html
@@ -26,7 +26,6 @@
       });
 
       // Wait for report to be received.
-      await wait(3000);
       const reports = await pollReports(endpoint, id);
       checkReportExists(reports, 'csp-violation', location.href);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/cross-origin-reports-isolated.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/cross-origin-reports-isolated.https.sub.html
@@ -33,7 +33,6 @@
       });
 
       // Wait for 2 reports to be received.
-      await wait(3000);
       const reports = await pollReports(endpoint, id, 2);
       assert_equals(reports.length, 2);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/document-reporting-destroy-after-document-close.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/document-reporting-destroy-after-document-close.https.sub.html
@@ -21,14 +21,12 @@
       // Load a document that generates report into iframe. Server should return
       // Reporting-Endpoints header.
       const w = window.open(document_url, "test");
-      await wait(1000);
       let reports = await pollReports(endpoint, report_id);
       // Verify that reporting is configured on the document.
       assert_equals(reports.length, 1);
       // reload opened window. This time server will not return
       // Reporting-Endpoints header.
       w.location.reload();
-      await wait(1000);
       reports = await pollReports(endpoint, report_id);
       // Verify no reports are sent this time.
       assert_equals(reports.length, 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/reporting/same-origin-report-credentials.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/reporting/same-origin-report-credentials.https.sub.html
@@ -26,7 +26,6 @@
       });
 
       // Wait for report to be received.
-      await wait(3000);
       const reports = await pollReports(endpoint, id);
       checkReportExists(reports, 'csp-violation', location.href);
 


### PR DESCRIPTION
#### b726ba4505e482c617786dfc91fcda4407a804ee
<pre>
[WPT] Remove some 3-second sleeps in test cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=246887">https://bugs.webkit.org/show_bug.cgi?id=246887</a>
&lt;rdar://problem/101444494&gt;

Reviewed by Tim Nguyen.

Upstream WPT has a number of 3-second sleeps that don&apos;t seem to be needed (at least in WebKit). This slows down our CI system and makes life harder.

This patch removes those arbitrary sleeps to improve testing throughput.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html:
* LayoutTests/imported/w3c/web-platform-tests/reporting/cross-origin-report-no-credentials.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/reporting/cross-origin-reports-isolated.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/reporting/document-reporting-destroy-after-document-close.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/reporting/same-origin-report-credentials.https.sub.html:

Canonical link: <a href="https://commits.webkit.org/255885@main">https://commits.webkit.org/255885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/594627226dcc1cfac5ccfd7827cb18fcfc117313

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103449 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163774 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3023 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31248 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99459 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2153 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80243 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29174 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84079 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37643 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17614 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18874 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41448 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1917 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38105 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->