### PR TITLE
SVG text in RTL mixes characters

### DIFF
--- a/LayoutTests/svg/text/bidi-dir-rtl-expected.txt
+++ b/LayoutTests/svg/text/bidi-dir-rtl-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Correctness of bidi reordering	
+

--- a/LayoutTests/svg/text/bidi-dir-rtl.html
+++ b/LayoutTests/svg/text/bidi-dir-rtl.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" style="width: 135px; height: 45px;">
+  <text y="16" x="70" direction="rtl" id="t">0 - blah(1)</text>
+</svg>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const text = document.getElementById('t');
+  const zero = text.getStartPositionOfChar(0);
+  const dash = text.getStartPositionOfChar(2);
+  const b = text.getStartPositionOfChar(4);
+  const open = text.getStartPositionOfChar(8);
+  const one = text.getStartPositionOfChar(9);
+  const close = text.getStartPositionOfChar(10);
+  let points = [zero, dash, b, open, one, close];
+  points.sort((a, b) => a.x - b.x);
+  // The order should be: b, (, 1, ), -, 0
+  assert_array_equals(points, [b, open, one, close, dash, zero]);
+}, 'Correctness of bidi reordering');
+</script>

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.cpp
@@ -260,21 +260,12 @@ static inline void swapItemsInLayoutAttributes(SVGTextLayoutAttributes* firstAtt
     SVGCharacterDataMap::iterator itLast = lastAttributes->characterDataMap().find(lastPosition + 1);
     bool firstPresent = itFirst != firstAttributes->characterDataMap().end();
     bool lastPresent = itLast != lastAttributes->characterDataMap().end();
-    if (!firstPresent && !lastPresent)
+    // We only want to perform the swap if both inline boxes are absolutely
+    // positioned.
+    if (!firstPresent || !lastPresent)
         return;
 
-    if (firstPresent && lastPresent) {
-        std::swap(itFirst->value, itLast->value);
-        return;
-    }
-
-    if (firstPresent && !lastPresent) {
-        lastAttributes->characterDataMap().set(lastPosition + 1, itFirst->value);
-        return;
-    }
-
-    // !firstPresent && lastPresent
-    firstAttributes->characterDataMap().set(firstPosition + 1, itLast->value);
+    std::swap(itFirst->value, itLast->value);
 }
 
 static inline void findFirstAndLastAttributesInVector(Vector<SVGTextLayoutAttributes*>& attributes, RenderSVGInlineText* firstContext, RenderSVGInlineText* lastContext,


### PR DESCRIPTION
<pre>
SVG text in RTL mixes characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=246888">https://bugs.webkit.org/show_bug.cgi?id=246888</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=167777">https://src.chromium.org/viewvc/blink?view=revision&revision=167777</a>

Only swap positions if both characters actually are absolute positioned

When re-ordering inline boxes within a "line", character-based absolute
positioning attributes are re-ordered to match. However, when attempting
to re-order/swap a inline box that does have a absolute positioning
attribute (and is of length 1) with one that doesn't, the positioning
attribute is copied rather than swapped - leading to additional chunks
being created and consequently additional adjustments being performed.
However, swapping is not needed/required in this case, since the attribute
is already in the correct (logical) position.
To mitigate this, only perform the attribute swap if both characters
(and consequently inline boxes) have attributes in the first place.

* Source/WebCore/rendering/svg/SVGRootInlineBox:
(SVGRootInlineBox::swapItemsInLayoutAttributes): Update to remove conditions about First and Last Positions
* LayoutTests/svg/text/bidi-dir-rtl.html: Added Test Case
* LayoutTests/svg/text/bidi-dir-rtl-expected.txt: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d99bef72a1f1f0dbd1da1f8ec57705d175427583

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103451 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163777 "Found 1 new test failure: svg/text/bidi-dir-rtl.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3026 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31250 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99461 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99477 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2159 "Found 1 new test failure: svg/text/bidi-dir-rtl.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80245 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29176 "Found 1 new test failure: svg/text/bidi-dir-rtl.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72131 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37645 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17615 "Found 1 new test failure: svg/text/bidi-dir-rtl.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35505 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18875 "Found 1 new test failure: svg/text/bidi-dir-rtl.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39384 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41451 "Found 1 new test failure: svg/text/bidi-dir-rtl.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38106 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->