### PR TITLE
Support appending to CSSUnparsedValue via its indexed setter

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssUnparsedValue-indexed-getter-setter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssUnparsedValue-indexed-getter-setter-expected.txt
@@ -2,7 +2,7 @@
 PASS Getting invalid index in CSSUnparsedValue returns undefined
 PASS Can update fragment in CSSUnparsedValue to a String
 PASS Can update fragment in CSSUnparsedValue to a CSSVariableReference
-FAIL Setting one past the last fragment in a CSSUnparsedValue to a String appends the new fragment Index 0 exceeds index range for unparsed segments.
-FAIL Setting one past the last fragment in a CSSUnparsedValue to a CSSVariableReferenceValue appends the new fragment Index 1 exceeds index range for unparsed segments.
+PASS Setting one past the last fragment in a CSSUnparsedValue to a String appends the new fragment
+PASS Setting one past the last fragment in a CSSUnparsedValue to a CSSVariableReferenceValue appends the new fragment
 PASS Setting out of range index in CSSUnparsedValue throws RangeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssUnparsedValue-length-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssUnparsedValue-length-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Length of CSSUnparsedValue with no fragments is zero
 PASS Length of CSSUnparsedValue with multiple fragments is the number of fragments
-FAIL Length of CSSUnparsedValue updates when fragments are appended Index 1 exceeds index range for unparsed segments.
+PASS Length of CSSUnparsedValue updates when fragments are appended
 PASS Length of CSSUnparsedValue does not change when fragments are modified
 

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -137,9 +137,12 @@ ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::item(size_t index)
 
 ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::setItem(size_t index, CSSUnparsedSegment&& val)
 {
-    if (index >= m_segments.size())
+    if (index > m_segments.size())
         return Exception { RangeError, makeString("Index ", index, " exceeds index range for unparsed segments.") };
-    m_segments[index] = WTFMove(val);
+    if (index == m_segments.size())
+        m_segments.append(WTFMove(val));
+    else
+        m_segments[index] = WTFMove(val);
     return CSSUnparsedSegment { m_segments[index] };
 }
 


### PR DESCRIPTION
#### 4b8121fb48a10e98bfb9f66473b388c2312868db
<pre>
Support appending to CSSUnparsedValue via its indexed setter
<a href="https://bugs.webkit.org/show_bug.cgi?id=246889">https://bugs.webkit.org/show_bug.cgi?id=246889</a>

Reviewed by Antoine Quint.

Support appending to CSSUnparsedValue via its indexed setter.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssUnparsedValue-indexed-getter-setter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssUnparsedValue-length-expected.txt:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::setItem):

Canonical link: <a href="https://commits.webkit.org/255877@main">https://commits.webkit.org/255877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bd92da06082983a8f92e8e5430fbd01252884e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103452 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163778 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3027 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31251 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99462 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2160 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80246 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29185 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84086 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72139 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37646 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35506 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18878 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41452 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1915 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38109 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->