### PR TITLE
This ensures that the viewport anchor layer will be updated when updating compositing layers upon style change

### DIFF
--- a/LayoutTests/compositing/scrolling/fixed-style-with-rotation-expected.txt
+++ b/LayoutTests/compositing/scrolling/fixed-style-with-rotation-expected.txt
@@ -1,0 +1,1 @@
+The HTML page loads as expected

--- a/LayoutTests/compositing/scrolling/fixed-style-with-rotation.html
+++ b/LayoutTests/compositing/scrolling/fixed-style-with-rotation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    body {
+        rotate: y 1turn;
+    }
+</style>
+<body>
+    <p>The HTML page loads as expected</p>
+</body>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    onload = () => {
+        document.body.offsetTop;
+        document.body.style.position = 'fixed';
+        scrollBy(0, 0);
+    };
+</script>
+

--- a/LayoutTests/compositing/scrolling/sticky-style-with-rotation-expected.txt
+++ b/LayoutTests/compositing/scrolling/sticky-style-with-rotation-expected.txt
@@ -1,0 +1,1 @@
+The HTML page loads as expected

--- a/LayoutTests/compositing/scrolling/sticky-style-with-rotation.html
+++ b/LayoutTests/compositing/scrolling/sticky-style-with-rotation.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    body {
+        rotate: y 1turn;
+    }
+</style>
+<body>
+    <p>The HTML page loads as expected</p>
+</body>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    onload = () => {
+        document.body.offsetTop;
+        document.body.style.position = 'sticky';
+        scrollBy(0, 0);
+    };
+</script>
+

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1727,6 +1727,17 @@ void RenderLayerCompositor::layerStyleChanged(StyleDifference diff, RenderLayer&
                 }
             }
 
+            // This ensures that the viewport anchor layer will be updated when updating compositing layers upon style change
+            auto styleChangeAffectsAnchorLayer = [](const RenderStyle* oldStyle, const RenderStyle& newStyle) {
+                if (!oldStyle)
+                    return false;
+
+                return oldStyle->hasViewportConstrainedPosition() != newStyle.hasViewportConstrainedPosition();
+            };
+
+            if (styleChangeAffectsAnchorLayer(oldStyle, newStyle))
+                layer.setNeedsCompositingConfigurationUpdate();
+
             // These properties trigger compositing if some descendant is composited.
             if (oldStyle && styleChangeMayAffectIndirectCompositingReasons(*oldStyle, newStyle))
                 layer.setNeedsPostLayoutCompositingUpdate();


### PR DESCRIPTION
#### 67c0ccbbabbdad78541304fe936be3ef6bec10b9
<pre>
This ensures that the viewport anchor layer will be updated when updating compositing layers upon style change
<a href="https://bugs.webkit.org/show_bug.cgi?id=246890">https://bugs.webkit.org/show_bug.cgi?id=246890</a>
rdar://99568474

Reviewed by Simon Fraser.

* LayoutTests/compositing/scrolling/fixed-style-with-rotation.html: Added.
* LayoutTests/compositing/scrolling/sticky-style-with-rotation.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::layerStyleChanged):

Canonical link: <a href="https://commits.webkit.org/256025@main">https://commits.webkit.org/256025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d964e197e57977d76a58a7505fc067b61be66b90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103897 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164169 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3435 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31621 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99920 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2468 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80627 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29494 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84387 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38003 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17877 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4166 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41733 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38378 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->