### PR TITLE
CSSPerspective.toMatrix() should throw if its length is not compatible with 'px' unit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-relative-units-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-relative-units-expected.txt
@@ -1,6 +1,4 @@
 
 PASS CSSTranslate.toMatrix() containing relative units throws TypeError
-FAIL CSSPerspective.toMatrix() containing relative units throws TypeError assert_throws_js: function "() => {
-    return new CSSPerspective(new CSSUnitValue(1, 'em')).toMatrix();
-  }" did not throw
+PASS CSSPerspective.toMatrix() containing relative units throws TypeError
 

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -148,8 +148,12 @@ ExceptionOr<Ref<DOMMatrix>> CSSPerspective::toMatrix()
     if (!is<CSSUnitValue>(length))
         return Exception { TypeError };
 
+    auto valuePx = downcast<CSSUnitValue>(*length).convertTo(CSSUnitType::CSS_PX);
+    if (!valuePx)
+        return Exception { TypeError, "Length unit is not compatible with 'px'"_s };
+
     TransformationMatrix matrix { };
-    matrix.applyPerspective(downcast<CSSUnitValue>(*length).value());
+    matrix.applyPerspective(valuePx->value());
 
     return { DOMMatrix::create(WTFMove(matrix), DOMMatrixReadOnly::Is2D::No) };
 }


### PR DESCRIPTION
#### 02ba20dc48a2ce34a4429aa705e444497298c723
<pre>
CSSPerspective.toMatrix() should throw if its length is not compatible with &apos;px&apos; unit
<a href="https://bugs.webkit.org/show_bug.cgi?id=246891">https://bugs.webkit.org/show_bug.cgi?id=246891</a>

Reviewed by Antoine Quint.

CSSPerspective.toMatrix() should throw a TypeError if its length is not compatible with &apos;px&apos; unit:
- <a href="https://drafts.css-houdini.org/css-typed-om-1/#dom-csstransformcomponent-tomatrix">https://drafts.css-houdini.org/css-typed-om-1/#dom-csstransformcomponent-tomatrix</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssTransformComponent-toMatrix-relative-units-expected.txt:
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
(WebCore::CSSPerspective::toMatrix):

Canonical link: <a href="https://commits.webkit.org/255876@main">https://commits.webkit.org/255876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93f9165ea536f6c1e6d2cca10080409322e5d871

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103456 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163785 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3031 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31255 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99465 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2162 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80249 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29181 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84088 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72135 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37649 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18879 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41453 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1914 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38110 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->