### PR TITLE
[WGSL] Turn AST::Attribute variants into data

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTAttribute.h
@@ -34,135 +34,45 @@
 
 namespace WGSL::AST {
 
-class Attribute : public ASTNode {
+struct BindingAttribute {
+    unsigned binding;
+};
+
+struct BuiltinAttribute {
+    StringView name;
+};
+
+struct GroupAttribute {
+    unsigned group;
+};
+
+struct LocationAttribute {
+    unsigned location;
+};
+
+enum struct StageAttribute : uint8_t {
+    Compute,
+    Fragment,
+    Vertex,
+};
+
+using AttributeBase = std::variant<BindingAttribute, BuiltinAttribute, GroupAttribute, LocationAttribute, StageAttribute>;
+
+class Attribute : public ASTNode, public AttributeBase {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    enum class Kind {
-        Group,
-        Binding,
-        Stage,
-        Location,
-        Builtin,
-    };
-
     using List = UniqueRefVector<Attribute, 2>;
 
-    Attribute(SourceSpan span)
+    template<class... Args>
+    Attribute(SourceSpan span, Args&&... args)
         : ASTNode(span)
+        , AttributeBase(std::forward<Args>(args)...)
     {
     }
 
-    virtual ~Attribute() { };
-
-    virtual Kind kind() const = 0;
-    bool isGroup() const { return kind() == Kind::Group; }
-    bool isBinding() const { return kind() == Kind::Binding; }
-    bool isStage() const { return kind() == Kind::Stage; }
-    bool isLocation() const { return kind() == Kind::Location; }
-    bool isBuiltin() const { return kind() == Kind::Builtin; }
-};
-
-class GroupAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    GroupAttribute(SourceSpan span, unsigned group)
-        : Attribute(span)
-        , m_value(group)
-    {
-    }
-
-    Kind kind() const override { return Kind::Group; }
-    unsigned group() const { return m_value; }
-
-private:
-    unsigned m_value;
-};
-
-class BindingAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    BindingAttribute(SourceSpan span, unsigned binding)
-        : Attribute(span)
-        , m_value(binding)
-    {
-    }
-
-    Kind kind() const override { return Kind::Binding; }
-    unsigned binding() const { return m_value; }
-
-private:
-    unsigned m_value;
-};
-
-class StageAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    enum class Stage : uint8_t {
-        Compute,
-        Vertex,
-        Fragment
-    };
-
-    StageAttribute(SourceSpan span, Stage stage)
-        : Attribute(span)
-        , m_stage(stage)
-    {
-    }
-
-    Kind kind() const override { return Kind::Stage; }
-    Stage stage() const { return m_stage; }
-
-private:
-    Stage m_stage;
-};
-
-class BuiltinAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    BuiltinAttribute(SourceSpan span, StringView name)
-        : Attribute(span)
-        , m_name(name)
-    {
-    }
-
-    Kind kind() const override { return Kind::Builtin; }
-    const StringView& name() const { return m_name; }
-
-private:
-    StringView m_name;
-};
-
-class LocationAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
-
-public:
-    LocationAttribute(SourceSpan span, unsigned value)
-        : Attribute(span)
-        , m_value(value)
-    {
-    }
-
-    Kind kind() const override { return Kind::Location; }
-    unsigned location() const { return m_value; }
-
-private:
-    unsigned m_value;
+    virtual ~Attribute() = default;
 };
 
 } // namespace WGSL::AST
 
-#define SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(ToValueTypeName, predicate) \
-SPECIALIZE_TYPE_TRAITS_BEGIN(WGSL::AST::ToValueTypeName) \
-    static bool isType(const WGSL::AST::Attribute& attr) { return attr.predicate; } \
-SPECIALIZE_TYPE_TRAITS_END()
-
-SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(GroupAttribute, isGroup())
-SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(BindingAttribute, isBinding())
-SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(StageAttribute, isStage())
-SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(LocationAttribute, isLocation())
-SPECIALIZE_TYPE_TRAITS_WGSL_ATTRIBUTE(BuiltinAttribute, isBuiltin())

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -31,11 +31,6 @@ class ShaderModule;
 class GlobalDirective;
 
 class Attribute;
-class BindingAttribute;
-class BuiltinAttribute;
-class GroupAttribute;
-class LocationAttribute;
-class StageAttribute;
 
 class Decl;
 class FunctionDecl;

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -93,39 +93,28 @@ void StringDumper::visit(GlobalDirective& directive)
 }
 
 // Attribute
-void StringDumper::visit(BindingAttribute& binding)
+void StringDumper::visit(Attribute& attribute)
 {
-    m_out.print("@binding(", binding.binding(), ")");
-}
+    WTF::switchOn(attribute,
+                  [&](BindingAttribute& attribute) { m_out.print("@binding(", attribute.binding, ")"); },
+                  [&](BuiltinAttribute& attribute) { m_out.print("@builtin(", attribute.name, ")"); },
+                  [&](GroupAttribute& attribute) { m_out.print("@group(", attribute.group, ")"); },
+                  [&](LocationAttribute& attribute) { m_out.print("@location(", attribute.location, ")"); },
+                  [&](StageAttribute& attribute) {
+        switch (attribute) {
+        case StageAttribute::Compute:
+            m_out.print("@compute");
+            break;
+        case StageAttribute::Fragment:
+            m_out.print("@fragment");
+            break;
+        case StageAttribute::Vertex:
+            m_out.print("@vertex");
+            break;
+        }
 
-void StringDumper::visit(BuiltinAttribute& builtin)
-{
-    m_out.print("@builtin(", builtin.name(), ")");
-}
+    });
 
-void StringDumper::visit(GroupAttribute& group)
-{
-    m_out.print("@group(", group.group(), ")");
-}
-
-void StringDumper::visit(LocationAttribute& location)
-{
-    m_out.print("@location(", location.location(), ")");
-}
-
-void StringDumper::visit(StageAttribute& stage)
-{
-    switch (stage.stage()) {
-    case StageAttribute::Stage::Compute:
-        m_out.print("@compute");
-        break;
-    case StageAttribute::Stage::Fragment:
-        m_out.print("@fragment");
-        break;
-    case StageAttribute::Stage::Vertex:
-        m_out.print("@vertex");
-        break;
-    }
 }
 
 // Declaration

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -44,11 +44,7 @@ public:
     void visit(GlobalDirective&) override;
 
     // Attribute
-    void visit(BindingAttribute&) override;
-    void visit(BuiltinAttribute&) override;
-    void visit(GroupAttribute&) override;
-    void visit(LocationAttribute&) override;
-    void visit(StageAttribute&) override;
+    void visit(Attribute&) override;
 
     // Declaration
     void visit(FunctionDecl&) override;

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -72,44 +72,7 @@ void Visitor::visit(GlobalDirective&)
 
 // Attribute
 
-void Visitor::visit(Attribute& attribute)
-{
-    switch (attribute.kind()) {
-    case Attribute::Kind::Binding:
-        checkErrorAndVisit(downcast<BindingAttribute>(attribute));
-        break;
-    case Attribute::Kind::Builtin:
-        checkErrorAndVisit(downcast<BuiltinAttribute>(attribute));
-        break;
-    case Attribute::Kind::Group:
-        checkErrorAndVisit(downcast<GroupAttribute>(attribute));
-        break;
-    case Attribute::Kind::Location:
-        checkErrorAndVisit(downcast<LocationAttribute>(attribute));
-        break;
-    case Attribute::Kind::Stage:
-        checkErrorAndVisit(downcast<StageAttribute>(attribute));
-        break;
-    }
-}
-
-void Visitor::visit(BindingAttribute&)
-{
-}
-
-void Visitor::visit(BuiltinAttribute&)
-{
-}
-
-void Visitor::visit(GroupAttribute&)
-{
-}
-
-void Visitor::visit(LocationAttribute&)
-{
-}
-
-void Visitor::visit(StageAttribute&)
+void Visitor::visit(Attribute&)
 {
 }
 

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -42,11 +42,6 @@ public:
 
     // Attribute
     virtual void visit(Attribute&);
-    virtual void visit(BindingAttribute&);
-    virtual void visit(BuiltinAttribute&);
-    virtual void visit(GroupAttribute&);
-    virtual void visit(LocationAttribute&);
-    virtual void visit(StageAttribute&);
 
     // Declaration
     virtual void visit(Decl&);

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -214,7 +214,7 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(GroupAttribute, id.m_literalValue);
+        RETURN_NODE_REF(Attribute, AST::GroupAttribute{ unsigned(id.m_literalValue) });
     }
 
     if (ident.m_ident == "binding"_s) {
@@ -222,7 +222,7 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(BindingAttribute, id.m_literalValue);
+        RETURN_NODE_REF(Attribute, AST::BindingAttribute { unsigned(id.m_literalValue) });
     }
 
     if (ident.m_ident == "location"_s) {
@@ -230,23 +230,23 @@ Expected<UniqueRef<AST::Attribute>, Error> Parser<Lexer>::parseAttribute()
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(LocationAttribute, id.m_literalValue);
+        RETURN_NODE_REF(Attribute, AST::LocationAttribute { unsigned(id.m_literalValue) });
     }
 
     if (ident.m_ident == "builtin"_s) {
         CONSUME_TYPE(ParenLeft);
         CONSUME_TYPE_NAMED(name, Identifier);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(BuiltinAttribute, name.m_ident);
+        RETURN_NODE_REF(Attribute, AST::BuiltinAttribute { name.m_ident });
     }
 
     // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes
-    if (ident.m_ident == "vertex"_s)
-        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Vertex);
     if (ident.m_ident == "compute"_s)
-        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Compute);
+        RETURN_NODE_REF(Attribute, AST::StageAttribute::Compute);
     if (ident.m_ident == "fragment"_s)
-        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Fragment);
+        RETURN_NODE_REF(Attribute, AST::StageAttribute::Fragment);
+    if (ident.m_ident == "vertex"_s)
+        RETURN_NODE_REF(Attribute, AST::StageAttribute::Vertex);
 
     FAIL("Unknown attribute. Supported attributes are 'group', 'binding', 'location', 'builtin', 'vertex', 'compute', 'fragment'."_s);
 }


### PR DESCRIPTION
#### d74d70b5fc5e690d2675836135eb5613e3286a9c
<pre>
[WGSL] Turn AST::Attribute variants into data
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebGPU/WGSL/AST/ASTAttribute.h:
(WGSL::AST::Attribute::Attribute):
(WGSL::AST::Attribute::~Attribute): Deleted.
(WGSL::AST::Attribute::isGroup const): Deleted.
(WGSL::AST::Attribute::isBinding const): Deleted.
(WGSL::AST::Attribute::isStage const): Deleted.
(WGSL::AST::Attribute::isLocation const): Deleted.
(WGSL::AST::Attribute::isBuiltin const): Deleted.
(): Deleted.
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74d70b5fc5e690d2675836135eb5613e3286a9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93835 "6 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3028 "Hash d74d70b5 for PR 5663 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103468 "Built successfully") | 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3044 "Hash d74d70b5 for PR 5663 does not build (failure)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86155 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99503 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/3044 "Hash d74d70b5 for PR 5663 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80259 "Hash d74d70b5 for PR 5663 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/3044 "Hash d74d70b5 for PR 5663 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/37659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35523 "Hash d74d70b5 for PR 5663 does not build (failure)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39402 "Hash d74d70b5 for PR 5663 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/80259 "Hash d74d70b5 for PR 5663 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41337 "Hash d74d70b5 for PR 5663 does not build (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->