### PR TITLE
Update fuzziness in fast/ for accelerated drawing

### DIFF
--- a/LayoutTests/fast/backgrounds/background-opaque-clipped-gradients.html
+++ b/LayoutTests/fast/backgrounds/background-opaque-clipped-gradients.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=7500-8000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=7200-8000" />
 <style type="text/css" media="screen">
     #div1 {
         width: 100px;

--- a/LayoutTests/fast/backgrounds/generated-bck-image-with-small-relative-size.html
+++ b/LayoutTests/fast/backgrounds/generated-bck-image-with-small-relative-size.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=750-850" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=750-1400" />
 <style>
 div {
     background: linear-gradient(green, green);

--- a/LayoutTests/fast/backgrounds/hidpi-background-image-contain-cover-scale-needs-more-precision.html
+++ b/LayoutTests/fast/backgrounds/hidpi-background-image-contain-cover-scale-needs-more-precision.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-33;totalPixels=7800-9500" />
+<meta name="fuzzy" content="maxDifference=0-33;totalPixels=5800-9500" />
 <title>This tests that background image tile's dimension is computed correctly for the contain case.</title>
 <style>
   div {

--- a/LayoutTests/fast/backgrounds/scaled-gradient-background.html
+++ b/LayoutTests/fast/backgrounds/scaled-gradient-background.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=14900-15300" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=14500-15300" />
     <style>
     .box {
         position: absolute;

--- a/LayoutTests/fast/borders/border-image-fill-inline-no-border.html
+++ b/LayoutTests/fast/borders/border-image-fill-inline-no-border.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta name="fuzzy" content="maxDifference=0-26; totalPixels=0-281" />
   <style> 
     td {
       padding: 10px;

--- a/LayoutTests/fast/borders/border-image-repeat-stretch.html
+++ b/LayoutTests/fast/borders/border-image-repeat-stretch.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1260" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2760" />
 <style>
   div {
     border: 30px solid transparent;

--- a/LayoutTests/fast/borders/border-painting-correctness-dashed.html
+++ b/LayoutTests/fast/borders/border-painting-correctness-dashed.html
@@ -1,6 +1,7 @@
 <DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-4808" />
 <title>This tests that dashed borders look ok.</title>
 <style>
   div {

--- a/LayoutTests/fast/borders/border-painting-correctness-dotted.html
+++ b/LayoutTests/fast/borders/border-painting-correctness-dotted.html
@@ -1,6 +1,7 @@
 <DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-15225" />
 <title>This tests that dotted borders look ok.</title>
 <style>
   div {

--- a/LayoutTests/fast/borders/hidpi-double-border-with-border-radius-always-produce-solid-line.html
+++ b/LayoutTests/fast/borders/hidpi-double-border-with-border-radius-always-produce-solid-line.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-73; totalPixels=0-10" />
 <title>This tests if double borders with radius paint doubles instead of solid single borders.</title>
 <style>
   .outer {

--- a/LayoutTests/fast/borders/outline-border-radius-simple.html
+++ b/LayoutTests/fast/borders/outline-border-radius-simple.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=24-68; totalPixels=319-573" />
+<meta name="fuzzy" content="maxDifference=24-68; totalPixels=319-673" />
 <style>
 div {
   display: inline-block;

--- a/LayoutTests/fast/box-shadow/box-shadow-with-zero-radius.html
+++ b/LayoutTests/fast/box-shadow/box-shadow-with-zero-radius.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-64; totalPixels=0-626" />
 <style type="text/css">
 .greenSquare-shadow {
     position: absolute;

--- a/LayoutTests/fast/box-shadow/inset-box-shadow.html
+++ b/LayoutTests/fast/box-shadow/inset-box-shadow.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-46;totalPixels=0-110" />
+<meta name="fuzzy" content="maxDifference=0-56;totalPixels=0-210" />
 <style>
     div {
         position: absolute;

--- a/LayoutTests/fast/css/text-decorations-on-first-line-and-containing-block.html
+++ b/LayoutTests/fast/css/text-decorations-on-first-line-and-containing-block.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=59-64; totalPixels=4-10" />
+<meta name="fuzzy" content="maxDifference=40-74; totalPixels=4-15" />
 <html>
 <head>
 <style>

--- a/LayoutTests/fast/filter-image/clipped-filter.html
+++ b/LayoutTests/fast/filter-image/clipped-filter.html
@@ -2,6 +2,7 @@
 
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-5" />
     <style>
         .circle {
             width: 300px;

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-placeholder-color.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-placeholder-color.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-415" />
 <style>
 
 #black-on-white input {

--- a/LayoutTests/fast/gradients/conic-center-outside-box.html
+++ b/LayoutTests/fast/gradients/conic-center-outside-box.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=1040-2500" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=940-2500" />
     <style>
         #grad {
             height: 50px;

--- a/LayoutTests/fast/gradients/radial-two-hints.html
+++ b/LayoutTests/fast/gradients/radial-two-hints.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=1800-1900" />
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=1500-1900" />
     <style>
     	div {
     		position: absolute;

--- a/LayoutTests/fast/images/async-image-background-image-repeated.html
+++ b/LayoutTests/fast/images/async-image-background-image-repeated.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=28600-29000" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=28300-29000" />
 <style>
     .box {
         height: 50px;

--- a/LayoutTests/fast/images/exif-orientation-background-image-repeat.html
+++ b/LayoutTests/fast/images/exif-orientation-background-image-repeat.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-89;totalPixels=20700-20900" />
-<style>
+<meta name="fuzzy" content="maxDifference=0-200; totalPixels=0-10000" /><style>
     div.container {
         display: inline-block;
         margin-right: 20px; 

--- a/LayoutTests/fast/images/hidpi-image-position-on-device-pixels-with-border-radius.html
+++ b/LayoutTests/fast/images/hidpi-image-position-on-device-pixels-with-border-radius.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-1" />
 <style>
 div {
   width: 200.25px;

--- a/LayoutTests/fast/images/image-map-outline-with-paint-root-offset.html
+++ b/LayoutTests/fast/images/image-map-outline-with-paint-root-offset.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-432" />
 <title>This tests that we paint area outline properly when the paintroot is shifted.</title>
 <style>
 .paintroot {

--- a/LayoutTests/fast/images/sprite-sheet-image-draw.html
+++ b/LayoutTests/fast/images/sprite-sheet-image-draw.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=14400-14600" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=14200-14600" />
 <style>
     .box {
         width: 200px;

--- a/LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html
+++ b/LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-32" />
 <title>This tests that parent clipping is applied properly when border-radius is present.</title>
 <style>
   .container {

--- a/LayoutTests/fast/layers/wrong-clipping-semi-transparent-compositing-layer-on-subpixel-position.html
+++ b/LayoutTests/fast/layers/wrong-clipping-semi-transparent-compositing-layer-on-subpixel-position.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-6600" />
 <title>This tests that semi-transparent layers with compositing parent on subpixel position get clipped properly. Non-retina test only.</title>
 <style>
   div {

--- a/LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html
+++ b/LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5" />
 <title>This tests that paginated lines are painting properly when lines visually overflow.</title>
 <style>
 html {

--- a/LayoutTests/fast/repaint/gradients-em-stops-repaint.html
+++ b/LayoutTests/fast/repaint/gradients-em-stops-repaint.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-
 <html>
 <head>
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-24837" />
   <style type="text/css" media="screen">
     .box {
       display: inline-block;

--- a/LayoutTests/fast/table/table-border-radius.html
+++ b/LayoutTests/fast/table/table-border-radius.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-17; totalPixels=0-140"/>
+<meta name="fuzzy" content="maxDifference=0-37; totalPixels=0-170"/>
 <style>
     table {
         width: 300px;

--- a/LayoutTests/fast/text/empty-shadow.html
+++ b/LayoutTests/fast/text/empty-shadow.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-5" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-21" />
 <p>This tests that text drawn with text-shadows of radius 0 and (0, 0) offset are not drawn.</p>
 <p>In the following tests, the actual text is green while the shadows are blue.</p>
 

--- a/LayoutTests/fast/text/frequent-text.html
+++ b/LayoutTests/fast/text/frequent-text.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="fuzzy" content="maxDifference=0-70; totalPixels=0-382" />
 </head>
 <body>
 <div id="target">Hello 👋 <span id="inside"></span> World!</div>

--- a/LayoutTests/fast/text/initial-advance-selected-text.html
+++ b/LayoutTests/fast/text/initial-advance-selected-text.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-10" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-30" />
 <style>
     div {
         font-size: 200px;

--- a/LayoutTests/fast/transforms/skew-x-135deg-with-gradient.html
+++ b/LayoutTests/fast/transforms/skew-x-135deg-with-gradient.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=5280-5300" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=4980-5600" />
 <style>
 #content {
   margin:100px;

--- a/LayoutTests/fast/transforms/skew-y-135deg-with-gradient.html
+++ b/LayoutTests/fast/transforms/skew-y-135deg-with-gradient.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1;totalPixels=4500-4825" />
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=2900-4825" />
 <style>
 #content {
   margin:100px;


### PR DESCRIPTION
#### 22276a499a287dd1e40ba4e583aa0e9b20cbd197
<pre>
Update fuzziness in fast/ for accelerated drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=246837">https://bugs.webkit.org/show_bug.cgi?id=246837</a>
rdar://101449704

Reviewed by Simon Fraser.

Update fuzziness in fast/ for when accelerated drawing is enabled by default.

* LayoutTests/fast/backgrounds/background-opaque-clipped-gradients.html:
* LayoutTests/fast/backgrounds/generated-bck-image-with-small-relative-size.html:
* LayoutTests/fast/backgrounds/hidpi-background-image-contain-cover-scale-needs-more-precision.html:
* LayoutTests/fast/backgrounds/scaled-gradient-background.html:
* LayoutTests/fast/borders/border-image-fill-inline-no-border.html:
* LayoutTests/fast/borders/border-image-repeat-stretch.html:
* LayoutTests/fast/borders/border-painting-correctness-dashed.html:
* LayoutTests/fast/borders/border-painting-correctness-dotted.html:
* LayoutTests/fast/borders/hidpi-double-border-with-border-radius-always-produce-solid-line.html:
* LayoutTests/fast/borders/outline-border-radius-simple.html:
* LayoutTests/fast/box-shadow/box-shadow-with-zero-radius.html:
* LayoutTests/fast/box-shadow/inset-box-shadow.html:
* LayoutTests/fast/css/text-decorations-on-first-line-and-containing-block.html:
* LayoutTests/fast/filter-image/clipped-filter.html:
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-placeholder-color.html:
* LayoutTests/fast/gradients/conic-center-outside-box.html:
* LayoutTests/fast/gradients/radial-two-hints.html:
* LayoutTests/fast/images/async-image-background-image-repeated.html:
* LayoutTests/fast/images/exif-orientation-background-image-repeat.html:
* LayoutTests/fast/images/hidpi-image-position-on-device-pixels-with-border-radius.html:
* LayoutTests/fast/images/image-map-outline-with-paint-root-offset.html:
* LayoutTests/fast/images/sprite-sheet-image-draw.html:
* LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html:
* LayoutTests/fast/layers/wrong-clipping-semi-transparent-compositing-layer-on-subpixel-position.html:
* LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html:
* LayoutTests/fast/repaint/gradients-em-stops-repaint.html:
* LayoutTests/fast/table/table-border-radius.html:
* LayoutTests/fast/text/empty-shadow.html:
* LayoutTests/fast/text/frequent-text.html:
* LayoutTests/fast/text/initial-advance-selected-text.html:
* LayoutTests/fast/transforms/skew-x-135deg-with-gradient.html:
* LayoutTests/fast/transforms/skew-y-135deg-with-gradient.html:

Canonical link: <a href="https://commits.webkit.org/255974@main">https://commits.webkit.org/255974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/196eee65392258bd899026b8f2e22ad32c6a2327

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3409 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/24974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/3436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99873 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/3436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/80629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/3436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/24974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38005 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/24974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35889 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/24974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/80629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1943 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41710 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/24974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->