### PR TITLE
Rename some functions related to display refresh

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -164,7 +164,7 @@ void DrawingAreaProxyCoordinatedGraphics::update(uint64_t backingStoreStateID, c
 #if !PLATFORM(WPE)
     incorporateUpdate(updateInfo);
 #endif
-    send(Messages::DrawingArea::DidUpdate());
+    send(Messages::DrawingArea::DisplayDidRefresh());
 }
 
 void DrawingAreaProxyCoordinatedGraphics::didUpdateBackingStoreState(uint64_t backingStoreStateID, const UpdateInfo& updateInfo, const LayerTreeContext& layerTreeContext)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -81,8 +81,8 @@ private:
     // Once we have other callbacks, it may make sense to have a before-commit/after-commit option.
     void dispatchAfterEnsuringDrawing(WTF::Function<void (CallbackBase::Error)>&&) final;
     
-    virtual void scheduleDisplayLink() { }
-    virtual void pauseDisplayLink() { }
+    virtual void scheduleDisplayRefreshCallbacks() { }
+    virtual void pauseDisplayRefreshCallbacks() { }
 
     float indicatorScale(WebCore::IntSize contentsSize) const;
     void updateDebugIndicator() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -171,7 +171,8 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(const RemoteLayerTreeTrans
 
     if (std::exchange(m_didUpdateMessageState, NeedsDidUpdate) == MissedCommit)
         didRefreshDisplay();
-    scheduleDisplayLink();
+
+    scheduleDisplayRefreshCallbacks();
 
     if (didUpdateEditorState)
         m_webPageProxy.dispatchDidUpdateEditorState();
@@ -322,7 +323,7 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()
 
     if (m_didUpdateMessageState != NeedsDidUpdate) {
         m_didUpdateMessageState = MissedCommit;
-        pauseDisplayLink();
+        pauseDisplayRefreshCallbacks();
         return;
     }
     
@@ -331,7 +332,7 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()
     // Waiting for CA to commit is insufficient, because the render server can still be
     // using our backing store. We can improve this by waiting for the render server to commit
     // if we find API to do so, but for now we will make extra buffers if need be.
-    send(Messages::DrawingArea::DidUpdate());
+    send(Messages::DrawingArea::DisplayDidRefresh());
 
     m_lastVisibleTransactionID = m_transactionIDForPendingCACommit;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -29,7 +29,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-OBJC_CLASS WKOneShotDisplayLinkHandler;
+OBJC_CLASS WKDisplayLinkHandler;
 
 namespace WebKit {
 
@@ -42,12 +42,12 @@ private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
 
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond) override;
-    void scheduleDisplayLink() override;
-    void pauseDisplayLink() override;
+    void scheduleDisplayRefreshCallbacks() override;
+    void pauseDisplayRefreshCallbacks() override;
 
-    WKOneShotDisplayLinkHandler *displayLinkHandler();
+    WKDisplayLinkHandler *displayLinkHandler();
 
-    RetainPtr<WKOneShotDisplayLinkHandler> m_displayLinkHandler;
+    RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -30,9 +30,7 @@
 
 #import "WebPageProxy.h"
 
-// FIXME: Mac will need something similar; we should figure out how to share this with DisplayRefreshMonitor without
-// breaking WebKit1 behavior or WebKit2-WebKit1 coexistence.
-@interface WKOneShotDisplayLinkHandler : NSObject {
+@interface WKDisplayLinkHandler : NSObject {
     WebKit::RemoteLayerTreeDrawingAreaProxy* _drawingAreaProxy;
     CADisplayLink *_displayLink;
 #if ENABLE(TIMER_DRIVEN_DISPLAY_REFRESH_FOR_TESTING)
@@ -49,7 +47,7 @@
 
 @end
 
-@implementation WKOneShotDisplayLinkHandler
+@implementation WKDisplayLinkHandler
 
 - (id)initWithDrawingAreaProxy:(WebKit::RemoteLayerTreeDrawingAreaProxy*)drawingAreaProxy
 {
@@ -166,10 +164,10 @@ DelegatedScrollingMode RemoteLayerTreeDrawingAreaProxyIOS::delegatedScrollingMod
     return DelegatedScrollingMode::DelegatedToNativeScrollView;
 }
 
-WKOneShotDisplayLinkHandler *RemoteLayerTreeDrawingAreaProxyIOS::displayLinkHandler()
+WKDisplayLinkHandler *RemoteLayerTreeDrawingAreaProxyIOS::displayLinkHandler()
 {
     if (!m_displayLinkHandler)
-        m_displayLinkHandler = adoptNS([[WKOneShotDisplayLinkHandler alloc] initWithDrawingAreaProxy:this]);
+        m_displayLinkHandler = adoptNS([[WKDisplayLinkHandler alloc] initWithDrawingAreaProxy:this]);
     return m_displayLinkHandler.get();
 }
 
@@ -178,12 +176,12 @@ void RemoteLayerTreeDrawingAreaProxyIOS::setPreferredFramesPerSecond(FramesPerSe
     [displayLinkHandler() setPreferredFramesPerSecond:preferredFramesPerSecond];
 }
 
-void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayLink()
+void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacks()
 {
     [displayLinkHandler() schedule];
 }
 
-void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayLink()
+void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks()
 {
     [displayLinkHandler() pause];
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -43,8 +43,8 @@ private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
     std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const override;
 
-    void scheduleDisplayLink() override;
-    void pauseDisplayLink() override;
+    void scheduleDisplayRefreshCallbacks() override;
+    void pauseDisplayRefreshCallbacks() override;
 
     void didChangeViewExposedRect() override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -52,7 +52,7 @@ std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxy
     return makeUnique<RemoteScrollingCoordinatorProxyMac>(m_webPageProxy);
 }
 
-void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink()
+void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks()
 {
     if (m_displayLinkTimer.isActive())
         return;
@@ -60,7 +60,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink()
     m_displayLinkTimer.startOneShot(displayLinkTimerInterval);
 }
 
-void RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayLink()
+void RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayRefreshCallbacks()
 {
     m_displayLinkTimer.stop();
 }

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -70,7 +70,7 @@ void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, const UpdateInfo& 
 {
     if (backingStoreStateID == m_currentBackingStoreStateID)
         incorporateUpdate(updateInfo);
-    send(Messages::DrawingArea::DidUpdate());
+    send(Messages::DrawingArea::DisplayDidRefresh());
 }
 
 void DrawingAreaProxyWC::enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -470,7 +470,7 @@ void DrawingAreaCoordinatedGraphics::targetRefreshRateDidChange(unsigned rate)
 #endif
 }
 
-void DrawingAreaCoordinatedGraphics::didUpdate()
+void DrawingAreaCoordinatedGraphics::displayDidRefresh()
 {
     // We might get didUpdate messages from the UI process even after we've
     // entered accelerated compositing mode. Ignore them.

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -83,7 +83,7 @@ private:
     // IPC message handlers.
     void updateBackingStoreState(uint64_t backingStoreStateID, bool respondImmediately, float deviceScaleFactor, const WebCore::IntSize&, const WebCore::IntSize& scrollOffset) override;
     void targetRefreshRateDidChange(unsigned rate) override;
-    void didUpdate() override;
+    void displayDidRefresh() override;
 
 #if PLATFORM(GTK)
     void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -178,7 +178,7 @@ private:
                                          const WebCore::IntSize& /*scrollOffset*/) { }
     virtual void targetRefreshRateDidChange(unsigned /*rate*/) { }
 #endif
-    virtual void didUpdate() { }
+    virtual void displayDidRefresh() { }
 
     // DisplayRefreshMonitorFactory.
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -26,7 +26,7 @@ messages -> DrawingArea NotRefCounted {
     TargetRefreshRateDidChange(unsigned rate)
 #endif
 
-    DidUpdate()
+    DisplayDidRefresh()
 
 #if PLATFORM(COCOA)
     // Used by TiledCoreAnimationDrawingArea.

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.h
@@ -32,6 +32,7 @@
 namespace WebKit {
 
 class RemoteLayerTreeDisplayRefreshMonitor : public WebCore::DisplayRefreshMonitor {
+friend class RemoteLayerTreeDrawingArea;
 public:
     static Ref<RemoteLayerTreeDisplayRefreshMonitor> create(WebCore::PlatformDisplayID displayID, RemoteLayerTreeDrawingArea& drawingArea)
     {
@@ -42,7 +43,6 @@ public:
 
     bool requestRefreshCallback() final;
 
-    void didUpdateLayers();
     void updateDrawingArea(RemoteLayerTreeDrawingArea&);
 
 private:
@@ -51,6 +51,8 @@ private:
     bool startNotificationMechanism() final { return true; }
     void stopNotificationMechanism() final { }
     std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() final;
+
+    void triggerDisplayDidRefresh();
 
     void adjustPreferredFramesPerSecond(WebCore::FramesPerSecond) final;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
@@ -79,7 +79,7 @@ bool RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback()
     return true;
 }
 
-void RemoteLayerTreeDisplayRefreshMonitor::didUpdateLayers()
+void RemoteLayerTreeDisplayRefreshMonitor::triggerDisplayDidRefresh()
 {
     {
         Locker locker { lock() };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -99,7 +99,7 @@ private:
     WebCore::FloatRect exposedContentRect() const override;
     void setExposedContentRect(const WebCore::FloatRect&) override;
 
-    void didUpdate() override;
+    void displayDidRefresh() override;
 
 #if PLATFORM(IOS_FAMILY)
     void setDeviceScaleFactor(float) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -401,7 +401,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     });
 }
 
-void RemoteLayerTreeDrawingArea::didUpdate()
+void RemoteLayerTreeDrawingArea::displayDidRefresh()
 {
     // FIXME: This should use a counted replacement for setLayerTreeStateIsFrozen, but
     // the callers of that function are not strictly paired.
@@ -421,7 +421,7 @@ void RemoteLayerTreeDrawingArea::didUpdate()
     ASSERT(!m_displayRefreshMonitorsToNotify);
     m_displayRefreshMonitorsToNotify = &monitorsToNotify;
     while (!monitorsToNotify.isEmpty())
-        monitorsToNotify.takeAny()->didUpdateLayers();
+        monitorsToNotify.takeAny()->triggerDisplayDidRefresh();
     m_displayRefreshMonitorsToNotify = nullptr;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -259,7 +259,7 @@ void DrawingAreaWC::sendUpdateAC()
                     send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, WTFMove(*updateInfo)));
                     return;
                 }
-                didUpdate();
+                displayDidRefresh();
             });
         });
     });
@@ -368,7 +368,7 @@ RefPtr<ImageBuffer> DrawingAreaWC::createImageBuffer(FloatSize size)
     return ImageBuffer::create<UnacceleratedImageBufferShareableBackend>(size, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, RenderingPurpose::DOM, nullptr);
 }
 
-void DrawingAreaWC::didUpdate()
+void DrawingAreaWC::displayDidRefresh()
 {
     m_waitDidUpdate = false;
     if (m_forceRepaintCompletionHandler) {

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -60,7 +60,7 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) override;
     void updatePreferences(const WebPreferencesStore&) override;
     bool shouldUseTiledBackingForFrameView(const WebCore::FrameView&) const override;
-    void didUpdate() override;
+    void displayDidRefresh() override;
     // GraphicsLayerWC::Observer
     void graphicsLayerAdded(GraphicsLayerWC&) override;
     void graphicsLayerRemoved(GraphicsLayerWC&) override;


### PR DESCRIPTION
#### 6ee1068d110acc9c299bf3e017a3ef192e4157a4
<pre>
Rename some functions related to display refresh
<a href="https://bugs.webkit.org/show_bug.cgi?id=246897">https://bugs.webkit.org/show_bug.cgi?id=246897</a>
rdar://101451193

Reviewed by Ryosuke Niwa.

DrawingArea::didUpdate() -&gt; DrawingArea::displayDidRefresh()
    This is the primary driver of web process &quot;displayDidRefresh&quot; in the RemoteLayerTree
    world; it was called DrawingArea::didUpdate() because, for a long commit, we did call it
    to indicate that the last one has completed. But it&apos;s more common behavior is the
    display refresh signal from the UI process.

RemoteLayerTreeDisplayRefreshMonitor::didUpdateLayers() -&gt; RemoteLayerTreeDisplayRefreshMonitor::triggerDisplayDidRefresh()
    Similar to above, this only meant &quot;did update layers&quot; in the &quot;missed commit&quot; scenario.
    Normally it just means &quot;trigger DisplayRefreshMonitor::displayDidRefresh&quot;.
    I made triggerDisplayDidRefresh() private to make it clear that the friended RemoteLayerTreeDrawingArea
    should be the only caller.

WKOneShotDisplayLinkHandler -&gt; WKDisplayLinkHandler
    It isn&apos;t one-shot.

RemoteLayerTreeDrawingAreaProxy::scheduleDisplayLink/pauseDisplayLink -&gt; RemoteLayerTreeDrawingAreaProxy::scheduleDisplayRefreshCallbacks/pauseDisplayRefreshCallbacks
    On macOS (which has additional needs for a display link in the UI process in addition to just
    notifying the web process) this doesn&apos;t directly correspond with starting/pausing a DisplayLink.

I did not attempt to unify displayDidRefresh/didRefreshDisplay, both of which we use.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::update):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxy::pauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxy::scheduleDisplayLink): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxy::pauseDisplayLink): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::displayLinkHandler):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks):
(-[WKOneShotDisplayLinkHandler initWithDrawingAreaProxy:]): Deleted.
(-[WKOneShotDisplayLinkHandler dealloc]): Deleted.
(-[WKOneShotDisplayLinkHandler setPreferredFramesPerSecond:]): Deleted.
(-[WKOneShotDisplayLinkHandler displayLinkFired:]): Deleted.
(-[WKOneShotDisplayLinkHandler timerFired]): Deleted.
(-[WKOneShotDisplayLinkHandler invalidate]): Deleted.
(-[WKOneShotDisplayLinkHandler schedule]): Deleted.
(-[WKOneShotDisplayLinkHandler pause]): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayLink): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayLink): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayLink): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::displayDidRefresh):
(WebKit::DrawingAreaCoordinatedGraphics::didUpdate): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::displayDidRefresh):
(WebKit::DrawingArea::didUpdate): Deleted.
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm:
(WebKit::RemoteLayerTreeDisplayRefreshMonitor::triggerDisplayDidRefresh):
(WebKit::RemoteLayerTreeDisplayRefreshMonitor::didUpdateLayers): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
(WebKit::RemoteLayerTreeDrawingArea::didUpdate): Deleted.

Canonical link: <a href="https://commits.webkit.org/255889@main">https://commits.webkit.org/255889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/289c80d40068dc71c7aae343bf49f44a9242e479

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103477 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3053 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31272 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86164 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99482 "Hash 289c80d4 for PR 5667 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2176 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80268 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29197 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84102 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72150 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37668 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18893 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39411 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41466 "Found 1 new test failure: http/wpt/service-workers/fetch-service-worker-preload.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38124 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->