### PR TITLE
font-style: oblique must allow angles equal to 90deg or -90deg

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt
@@ -69,8 +69,8 @@ PASS font-style(invalid): 'italic' followed by angle: italic 20deg
 PASS font-style(invalid): Extra content after keyword: italic a
 PASS font-style(valid): 'oblique' followed by zero degrees: oblique 0deg
 FAIL font-style(valid): 'oblique' followed by default 20deg angle: oblique 20deg assert_equals: Unexpected resulting value. expected "oblique" but got "oblique 20deg"
-FAIL font-style(valid): 'oblique' followed by maxumum 90 degree angle: oblique 90deg assert_not_equals: Valid value should be accepted. got disallowed value ""
-FAIL font-style(valid): 'oblique' followed by minimum -90 degree angle: oblique -90deg assert_not_equals: Valid value should be accepted. got disallowed value ""
+PASS font-style(valid): 'oblique' followed by maxumum 90 degree angle: oblique 90deg
+PASS font-style(valid): 'oblique' followed by minimum -90 degree angle: oblique -90deg
 FAIL font-style(valid): 'oblique' followed by calc with out of range value (should be clamped): oblique calc(91deg) assert_not_equals: Valid value should be accepted. got disallowed value ""
 FAIL font-style(valid): 'oblique' followed by calc with out of range value (should be clamped): oblique calc(-91deg) assert_not_equals: Valid value should be accepted. got disallowed value ""
 FAIL font-style(valid): 'oblique' followed by  angle in radians: oblique 0rad assert_equals: Unexpected resulting value. expected "oblique 0deg" but got "oblique 0rad"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-parse-numeric-stretch-style-weight-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-parse-numeric-stretch-style-weight-expected.txt
@@ -16,8 +16,8 @@ PASS Valid value normal for font property style used for styling.
 PASS Valid value italic for font property style used for styling.
 PASS Valid value oblique for font property style used for styling.
 PASS Valid value oblique 50deg for font property style used for styling.
-FAIL Valid value oblique -90deg for font property style used for styling. assert_true: expected true got false
-FAIL Valid value oblique 90deg for font property style used for styling. assert_true: expected true got false
+PASS Valid value oblique -90deg for font property style used for styling.
+PASS Valid value oblique 90deg for font property style used for styling.
 FAIL Valid value oblique calc(90deg + 20deg) for font property style used for styling. assert_true: expected true got false
 PASS Valid value oblique calc(30deg + 20deg) for font property style used for styling.
 PASS Invalid value 100 400 for font property weight used for styling.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-style-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-style-parsing-expected.txt
@@ -11,8 +11,8 @@ PASS Font-style (supports): 'oblique' followed by positive angle in turns is val
 PASS Font-style (supports): 'oblique' followed by number with invalid unit type is in valid
 PASS Font-style (supports): 'oblique' followed by negative angle is valid
 PASS Font-style (supports): 'oblique' followed by fractional angle is valid
-FAIL Font-style (supports): 'oblique' followed by maxumum 90 degree angle is valid assert_equals: Font-style supports: 'oblique' followed by maxumum 90 degree angle is valid expected true but got false
-FAIL Font-style (supports): 'oblique' followed by minimum -90 degree angle is valid assert_equals: Font-style supports: 'oblique' followed by minimum -90 degree angle is valid expected true but got false
+PASS Font-style (supports): 'oblique' followed by maxumum 90 degree angle is valid
+PASS Font-style (supports): 'oblique' followed by minimum -90 degree angle is valid
 PASS Font-style (supports): 'oblique' followed by positive out of range angle is in invalid
 PASS Font-style (supports): 'oblique' followed by negative out of range angle is in invalid
 PASS Font-style (supports): 'oblique' followed by unit-less value is invalid
@@ -35,8 +35,8 @@ PASS Font-style (computed): 'oblique' followed by positive angle in gradians is 
 PASS Font-style (computed): 'oblique' followed by positive angle in turns is valid
 PASS Font-style (computed): 'oblique' followed by negative angle is valid
 PASS Font-style (computed): 'oblique' followed by fractional angle is valid
-FAIL Font-style (computed): 'oblique' followed by maxumum 90 degree angle is valid assert_equals: Font-style computed style: 'oblique' followed by maxumum 90 degree angle is valid expected "oblique 90deg" but got "normal"
-FAIL Font-style (computed): 'oblique' followed by minimum -90 degree angle is valid assert_equals: Font-style computed style: 'oblique' followed by minimum -90 degree angle is valid expected "oblique -90deg" but got "normal"
+PASS Font-style (computed): 'oblique' followed by maxumum 90 degree angle is valid
+PASS Font-style (computed): 'oblique' followed by minimum -90 degree angle is valid
 PASS Font-style (computed): 'oblique' followed by positive angle is valid
 PASS Font-style (computed): 'oblique' followed by calc is valid
 FAIL Font-style (computed): 'oblique' followed by calc is valid even if it must be clamped (no computation) assert_equals: Font-style computed style: 'oblique' followed by calc is valid even if it must be clamped (no computation) expected "oblique -90deg" but got "normal"

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -246,7 +246,7 @@ template<CSSValueID... names> RefPtr<CSSPrimitiveValue> consumeIdentWorkerSafe(C
 
 inline bool isFontStyleAngleInRange(double angleInDegrees)
 {
-    return angleInDegrees > -90 && angleInDegrees < 90;
+    return angleInDegrees >= -90 && angleInDegrees <= 90;
 }
 
 inline bool isSystemFontShorthand(CSSValueID valueID)


### PR DESCRIPTION
#### 817e48d200576ca3a12a2c5928825725ffec05cd
<pre>
font-style: oblique must allow angles equal to 90deg or -90deg
<a href="https://bugs.webkit.org/show_bug.cgi?id=246901">https://bugs.webkit.org/show_bug.cgi?id=246901</a>
rdar://101461149

Reviewed by Alan Bujtas and Darin Adler.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-parse-numeric-stretch-style-weight-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/font-style-parsing-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
(WebCore::CSSPropertyParserHelpers::isFontStyleAngleInRange):

Canonical link: <a href="https://commits.webkit.org/255875@main">https://commits.webkit.org/255875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45060faf65d37ade11c00034b692129fd3335d5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103501 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163835 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3077 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99506 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99535 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80293 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29221 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84122 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72173 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37691 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17653 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35555 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18916 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39434 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1913 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38146 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->