### PR TITLE
Move frame tree insertion to AbstractFrame constructor

### DIFF
--- a/Source/WebCore/page/AbstractFrame.cpp
+++ b/Source/WebCore/page/AbstractFrame.cpp
@@ -33,12 +33,14 @@
 
 namespace WebCore {
 
-AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement)
+AbstractFrame::AbstractFrame(Page& page, FrameIdentifier frameID, AbstractFrame* parent)
     : m_page(page)
     , m_frameID(frameID)
-    , m_treeNode(*this, ownerElement ? ownerElement->document().frame() : nullptr)
+    , m_treeNode(*this, parent)
     , m_windowProxy(WindowProxy::create(*this))
 {
+    if (parent)
+        parent->tree().appendChild(*this);
 }
 
 AbstractFrame::~AbstractFrame()

--- a/Source/WebCore/page/AbstractFrame.h
+++ b/Source/WebCore/page/AbstractFrame.h
@@ -43,8 +43,8 @@ class AbstractFrame : public ThreadSafeRefCounted<AbstractFrame, WTF::Destructio
 public:
     virtual ~AbstractFrame();
 
-    virtual bool isLocalFrame() const = 0;
-    virtual bool isRemoteFrame() const = 0;
+    enum class FrameType : bool { Local, Remote };
+    virtual FrameType frameType() const = 0;
 
     WindowProxy& windowProxy() { return m_windowProxy; }
     const WindowProxy& windowProxy() const { return m_windowProxy; }
@@ -55,7 +55,7 @@ public:
     WEBCORE_EXPORT void detachFromPage();
 
 protected:
-    AbstractFrame(Page&, FrameIdentifier, HTMLFrameOwnerElement*);
+    AbstractFrame(Page&, FrameIdentifier, AbstractFrame* parent);
     void resetWindowProxy();
 
 private:

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -151,7 +151,7 @@ static inline float parentTextZoomFactor(Frame* frame)
 }
 
 Frame::Frame(Page& page, HTMLFrameOwnerElement* ownerElement, UniqueRef<FrameLoaderClient>&& frameLoaderClient)
-    : AbstractFrame(page, FrameIdentifier::generate(), ownerElement)
+    : AbstractFrame(page, FrameIdentifier::generate(), ownerElement ? ownerElement->document().frame() : nullptr)
     , m_mainFrame(ownerElement ? page.mainFrame() : *this)
     , m_settings(&page.settings())
     , m_loader(makeUniqueRef<FrameLoader>(*this, WTFMove(frameLoaderClient)))

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -305,8 +305,7 @@ private:
 
     void dropChildren();
 
-    bool isLocalFrame() const final { return true; }
-    bool isRemoteFrame() const final { return false; }
+    FrameType frameType() const final { return FrameType::Local; }
 
     AbstractDOMWindow* virtualWindow() const final;
 
@@ -388,5 +387,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Frame&);
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Frame)
-    static bool isType(const WebCore::AbstractFrame& frame) { return frame.isLocalFrame(); }
+static bool isType(const WebCore::AbstractFrame& frame) { return frame.frameType() == WebCore::AbstractFrame::FrameType::Local; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -30,9 +30,8 @@
 
 namespace WebCore {
 
-RemoteFrame::RemoteFrame(Page& page, FrameIdentifier frameID, GlobalFrameIdentifier&& frameIdentifier)
-    : AbstractFrame(page, frameID, nullptr)
-    , m_identifier(WTFMove(frameIdentifier))
+RemoteFrame::RemoteFrame(Page& page, FrameIdentifier frameID, AbstractFrame* parent)
+    : AbstractFrame(page, frameID, parent)
 {
 }
 
@@ -41,6 +40,16 @@ RemoteFrame::~RemoteFrame() = default;
 AbstractDOMWindow* RemoteFrame::virtualWindow() const
 {
     return window();
+}
+
+void RemoteFrame::setWindow(RemoteDOMWindow* window)
+{
+    m_window = WeakPtr { window };
+}
+
+RemoteDOMWindow* RemoteFrame::window() const
+{
+    return m_window.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -26,45 +26,36 @@
 #pragma once
 
 #include "AbstractFrame.h"
-#include "GlobalFrameIdentifier.h"
-#include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
 class RemoteDOMWindow;
+class WeakPtrImplWithEventTargetData;
 
-// FIXME: Don't instantiate any of these until the unsafe reinterpret_cast's are removed from FrameTree.h
-// and FrameTree::m_thisFrame is an AbstractFrame&. Otherwise we will have some invalid pointer use.
 class RemoteFrame final : public AbstractFrame {
 public:
-    static Ref<RemoteFrame> create(Page& page, FrameIdentifier frameID, GlobalFrameIdentifier&& frameIdentifier)
+    static Ref<RemoteFrame> create(Page& page, FrameIdentifier frameID, AbstractFrame* parent)
     {
-        return adoptRef(*new RemoteFrame(page, frameID, WTFMove(frameIdentifier)));
+        return adoptRef(*new RemoteFrame(page, frameID, parent));
     }
     ~RemoteFrame();
 
-    const GlobalFrameIdentifier& identifier() const { return m_identifier; }
-
-    void setWindow(RemoteDOMWindow* window) { m_window = window; }
-    RemoteDOMWindow* window() const { return m_window; }
+    void setWindow(RemoteDOMWindow*);
+    RemoteDOMWindow* window() const;
 
     void setOpener(AbstractFrame* opener) { m_opener = opener; }
     AbstractFrame* opener() const { return m_opener.get(); }
 
 private:
-    WEBCORE_EXPORT explicit RemoteFrame(Page&, FrameIdentifier, GlobalFrameIdentifier&&);
+    WEBCORE_EXPORT explicit RemoteFrame(Page&, FrameIdentifier, AbstractFrame* parent);
 
-    bool isRemoteFrame() const final { return true; }
-    bool isLocalFrame() const final { return false; }
+    FrameType frameType() const final { return FrameType::Remote; }
 
     AbstractDOMWindow* virtualWindow() const final;
 
-    GlobalFrameIdentifier m_identifier;
-
-    // FIXME: This should not be a raw pointer.
-    RemoteDOMWindow* m_window { nullptr };
+    WeakPtr<RemoteDOMWindow, WeakPtrImplWithEventTargetData> m_window;
 
     RefPtr<AbstractFrame> m_opener;
 };
@@ -72,5 +63,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::RemoteFrame)
-    static bool isType(const WebCore::AbstractFrame& frame) { return frame.isRemoteFrame(); }
+static bool isType(const WebCore::AbstractFrame& frame) { return frame.frameType() == WebCore::AbstractFrame::FrameType::Remote; }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -132,7 +132,6 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
 
     coreFrame->tree().setName(frameName);
     ASSERT(ownerElement.document().frame());
-    ownerElement.document().frame()->tree().appendChild(coreFrame.get());
     coreFrame->init();
 
     return frame;

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -306,10 +306,6 @@ WebView *getWebView(WebFrame *webFrame)
     frame->_private->coreFrame = coreFrame.ptr();
 
     coreFrame.get().tree().setName(name);
-    if (ownerElement) {
-        ASSERT(ownerElement->document().frame());
-        ownerElement->document().frame()->tree().appendChild(coreFrame.get());
-    }
 
     coreFrame.get().init();
 

--- a/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -951,7 +951,6 @@ RefPtr<Frame> WebFrameLoaderClient::createFrame(const AtomString& name, HTMLFram
     RefPtr<Frame> childFrame = webFrame->createSubframeWithOwnerElement(m_webFrame->webView(), coreFrame->page(), &ownerElement);
 
     childFrame->tree().setName(name);
-    coreFrame->tree().appendChild(*childFrame);
     childFrame->init();
 
     return childFrame;


### PR DESCRIPTION
#### 38bea4b994b275f9f462ca1bff37bc4128d9d948
<pre>
Move frame tree insertion to AbstractFrame constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=246903">https://bugs.webkit.org/show_bug.cgi?id=246903</a>

Reviewed by Tim Horton.

* Source/WebCore/page/AbstractFrame.cpp:
(WebCore::AbstractFrame::AbstractFrame):
* Source/WebCore/page/AbstractFrame.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::Frame):
* Source/WebCore/page/Frame.h:
(isType):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::RemoteFrame):
(WebCore::RemoteFrame::setWindow):
* Source/WebCore/page/RemoteFrame.h:
(isType):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame _createFrameWithPage:frameName:frameView:ownerElement:]):
* Source/WebKitLegacy/win/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebFrameLoaderClient::createFrame):

Canonical link: <a href="https://commits.webkit.org/255930@main">https://commits.webkit.org/255930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adee8e3b02ef4a889cf4fc4ca2cbbb61ed01412c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103524 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163860 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3099 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31319 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99528 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2218 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80316 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29236 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72190 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37713 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18934 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41505 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1927 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38164 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->