### PR TITLE
[GTK] Fix GIR build failure when cross compiling

### DIFF
--- a/Source/cmake/FindGI.cmake
+++ b/Source/cmake/FindGI.cmake
@@ -262,6 +262,7 @@ function(GI_INTROSPECT namespace nsversion header)
     foreach (dep IN LISTS opt_DEPENDENCIES)
         if (TARGET "gir-${dep}")
             get_property(dep_gir_path TARGET "gir-${dep}" PROPERTY GI_GIR_PATH)
+            get_property(dep_gir_lib TARGET "gir-${dep}" PROPERTY GI_GIR_LIBRARY)
             if (dep_gir_path)
                 list(APPEND scanner_flags "--include-uninstalled=${dep_gir_path}")
                 list(APPEND gir_deps "${dep_gir_path}")
@@ -270,6 +271,9 @@ function(GI_INTROSPECT namespace nsversion header)
                     "Target '${dep}' listed as a dependency but it has not "
                     "been previously configured with GI_INTROSPECT()"
                 )
+            endif ()
+            if (dep_gir_lib)
+                list(APPEND scanner_flags "--library=${dep_gir_lib}")
             endif ()
         elseif (dep MATCHES "^([a-zA-Z0-9._-]+):([a-z0-9._\\+-]+)$")
             list(APPEND scanner_flags
@@ -395,5 +399,6 @@ function(GI_INTROSPECT namespace nsversion header)
 
     # Record in targets to use later on e.g. with gi-docgen.
     set_property(TARGET "gir-${namespace}" PROPERTY GI_GIR_PATH "${gir_path}")
+    set_property(TARGET "gir-${namespace}" PROPERTY GI_GIR_LIBRARY "$<TARGET_FILE_BASE_NAME:${opt_TARGET}>")
     set_property(TARGET "gir-${namespace}" PROPERTY GI_PACKAGE "${opt_PACKAGE}-${nsversion}")
 endfunction()


### PR DESCRIPTION
#### a5345caf3944382860f3911dfcb8d359f1328d1a
<pre>
[GTK] Fix GIR build failure when cross compiling
<a href="https://bugs.webkit.org/show_bug.cgi?id=246907">https://bugs.webkit.org/show_bug.cgi?id=246907</a>

Reviewed by Michael Catanzaro.

* Source/cmake/FindGI.cmake

Canonical link: <a href="https://commits.webkit.org/255887@main">https://commits.webkit.org/255887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76976c278b94d6516cd057dfe32763f6b0c11649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103531 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3106 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31325 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99534 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2219 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80322 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29238 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84145 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72192 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37719 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17676 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80276 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18939 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4064 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39462 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82925 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38169 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18732 "Passed tests") | 
<!--EWS-Status-Bubble-End-->