### PR TITLE
When table cell have inline children which change writing-mode, the cell overflows its contents

### DIFF
--- a/LayoutTests/fast/writing-mode/table-vertical-child-width-expected.html
+++ b/LayoutTests/fast/writing-mode/table-vertical-child-width-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html><head>
+    <meta charset="UTF-8">
+<style>
+    .middle { vertical-align: middle; }
+</style>
+</head><body>
+The table should not overflow its contents, and 1st table and 2nd table look same.
+<table border="1">
+    <tr><td><div class="middle" style="writing-mode: vertical-rl; width: 100px; background-color: red;">vertical text</div>
+</table>
+<table border="1">
+    <tr><td><div style="writing-mode: vertical-rl; width: 100px; background-color: red;">vertical text</div>
+</table>
+</body></html>

--- a/LayoutTests/fast/writing-mode/table-vertical-child-width.html
+++ b/LayoutTests/fast/writing-mode/table-vertical-child-width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html><head>
+<meta charset="UTF-8">
+<meta name="fuzzy" content="maxDifference=8-244; totalPixels=24-378" />
+<style>
+    .middle { vertical-align: middle; }
+</style>
+</head><body>
+The table should not overflow its contents, and 1st table and 2nd table look same.
+<table border="1">
+    <tr><td><span class="middle" style="writing-mode: vertical-rl; width: 100px; background-color: red;">vertical text</span>
+</table>
+<table border="1">
+    <tr><td><div style="writing-mode: vertical-rl; width: 100px; background-color: red;">vertical text</div>
+</table>
+</body></html>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
- * Copyright (C) 2003-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -4224,7 +4224,14 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
                 // Case (2). Inline replaced elements and floats.
                 // Terminate the current line as far as minwidth is concerned.
                 LayoutUnit childMinPreferredLogicalWidth, childMaxPreferredLogicalWidth;
-                computeChildPreferredLogicalWidths(*child, childMinPreferredLogicalWidth, childMaxPreferredLogicalWidth);
+                if (is<RenderBox>(*child) && child->isHorizontalWritingMode() != isHorizontalWritingMode()) {
+                    auto& box = downcast<RenderBox>(*child);
+                    auto extent = box.computeLogicalHeight(box.borderAndPaddingLogicalHeight(), 0).m_extent;
+                    childMinPreferredLogicalWidth = extent;
+                    childMaxPreferredLogicalWidth = extent;
+                } else
+                    computeChildPreferredLogicalWidths(*child, childMinPreferredLogicalWidth, childMaxPreferredLogicalWidth);
+
                 childMin += childMinPreferredLogicalWidth.ceilToFloat();
                 childMax += childMaxPreferredLogicalWidth.ceilToFloat();
 


### PR DESCRIPTION
#### 29a59ed73e09bf27feb6bd3e78345d52e7517ad6
<pre>
When table cell have inline children which change writing-mode, the cell overflows its contents

When table cell have inline children which change writing-mode, the cell overflows its contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=112897">https://bugs.webkit.org/show_bug.cgi?id=112897</a>

Reviewed by Alan Bujtas.

Inspired from - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=163239

When writing-mode is changed at block element, Blink thinks the logical
height as preferred logical width. This is done at
RenderBlockFlow::computeBlockPreferredLogicalWidths(). However,
RenderBlockFlow::computeInlinePreferredLogicalWidths() doesn&apos;t check
writing-mode, and just uses child&apos;s preferred logical width as preferred
logical width. If the height of a child is bigger than its preferred
width, this make the width of table cell narrower than its child.

We should check writing-mode of inline block. If the writing-mode is
changed, we must use child&apos;s logical height as preferred logical width.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::computeInlinePreferredLogicalWidths): Add logic for accounting for writing mode
* LayoutTests/fast/writing-mode/table-vertical-child-width.html: Added Test Case
* LayoutTests/fast/writing-mode/table-vertical-child-width-expected.html: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/255919@main">https://commits.webkit.org/255919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80d6609f28cb7416fbf45b728f0ed3f2473742c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103639 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163986 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3208 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31432 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99689 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2306 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80428 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29322 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84232 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72278 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37820 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17753 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35688 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19017 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4088 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39564 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38248 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->