### PR TITLE
text-combine-upright text-shadow is not correctly positioned

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Reference: text-combine-upright: all with text-shadow</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="stylesheet" href="support/tcy.css">
+    <link rel="stylesheet" href="/fonts/ahem.css">
+    <style>
+    div {
+        text-shadow: 4px 10px 0px red;
+        font: 50px/1 Ahem;
+        writing-mode: vertical-rl;
+    }
+    </style>
+</head>
+<body>
+    <p>PASS if the text-shadow (red) is placed at the lower right of the text (black).</p>
+    <div>XX<span class="fake-tcy">X</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Reference: text-combine-upright: all with text-shadow</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="stylesheet" href="support/tcy.css">
+    <link rel="stylesheet" href="/fonts/ahem.css">
+    <style>
+    div {
+        text-shadow: 4px 10px 0px red;
+        font: 50px/1 Ahem;
+        writing-mode: vertical-rl;
+    }
+    </style>
+</head>
+<body>
+    <p>PASS if the text-shadow (red) is placed at the lower right of the text (black).</p>
+    <div>XX<span class="fake-tcy">X</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>text-combine-upright: all with text-shadow</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="stylesheet" href="support/tcy.css">
+    <link rel="stylesheet" href="/fonts/ahem.css">
+    <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#text-combine-layout" title="9.1.2. Layout Rules">
+    <link rel="match" href="text-combine-upright-shadow-ref.html">
+    <style>
+    div {
+        text-shadow: 4px 10px 0px red;
+        font: 50px/1 Ahem;
+        writing-mode: vertical-rl;
+    }
+    </style>
+</head>
+<body>
+    <p>PASS if the text-shadow (red) is placed at the lower right of the text (black).</p>
+    <div>XX<span class="tcy">X</span></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -143,7 +143,7 @@ void TextPainter::paintTextWithShadows(const ShadowData* shadow, const FilterOpe
     if (!opaque)
         m_context.setFillColor(Color::black);
     while (shadow) {
-        ShadowApplier shadowApplier(m_context, shadow, colorFilter, boxRect, lastShadowIterationShouldDrawText, opaque, m_textBoxIsHorizontal ? FontOrientation::Horizontal : FontOrientation::Vertical);
+        ShadowApplier shadowApplier(m_context, shadow, colorFilter, boxRect, lastShadowIterationShouldDrawText, opaque, (m_textBoxIsHorizontal || m_combinedText) ? FontOrientation::Horizontal : FontOrientation::Vertical);
         if (!shadowApplier.nothingToDraw())
             paintTextOrEmphasisMarks(font, textRun, emphasisMark, emphasisMarkOffset, textOrigin + shadowApplier.extraOffset(), startOffset, endOffset);
         shadow = shadow->next();


### PR DESCRIPTION
#### 0acf2457faa716438f87f4446a13b3da6a35be0f
<pre>
text-combine-upright text-shadow is not correctly positioned
<a href="https://bugs.webkit.org/show_bug.cgi?id=112655">https://bugs.webkit.org/show_bug.cgi?id=112655</a>
rdar://101467340

Reviewed by Simon Fraser and Darin Adler.

* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextWithShadows): Treat combined text as horizontal text when painting shadows.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-shadow.html: Added.

Canonical link: <a href="https://commits.webkit.org/255892@main">https://commits.webkit.org/255892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b76a4afea4b6bbbbba68b60a8c9f635557552bb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103543 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163881 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3118 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31338 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86233 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2230 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80334 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84156 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37731 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17683 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18946 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39474 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1918 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38176 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->