### PR TITLE
[JSC] Add support for Atomics.waitAsync (ParkingLot Version WIP)

### DIFF
--- a/JSTests/stress/SharedArrayBuffer.js
+++ b/JSTests/stress/SharedArrayBuffer.js
@@ -85,6 +85,7 @@ for (bad of [void 0, null, false, true, 1, 0.5, Symbol(), {}, "hello", dv, u8ca,
 for (bad of [void 0, null, false, true, 1, 0.5, Symbol(), {}, "hello", dv, i8a, i16a, u8a, u8ca, u16a, u32a, f32a, f64a]) {
     shouldFail(() => Atomics.notify(bad, 0, 0), TypeError);
     shouldFail(() => Atomics.wait(bad, 0, 0), TypeError);
+    shouldFail(() => Atomics.waitAsync(bad, 0, 0), TypeError);
 }
 
 for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
@@ -101,6 +102,7 @@ for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
     }
     shouldFail(() => Atomics.notify(i32a, idx, 0), RangeError);
     shouldFail(() => Atomics.wait(i32a, idx, 0), RangeError);
+    shouldFail(() => Atomics.waitAsync(i32a, idx, 0), RangeError);
 }
 
 for (idx of ["hello"]) {
@@ -117,6 +119,7 @@ for (idx of ["hello"]) {
     }
     shouldSucceed(() => Atomics.notify(i32a, idx, 0));
     shouldSucceed(() => Atomics.wait(i32a, idx, 0, 1));
+    shouldSucceed(() => Atomics.waitAsync(i32a, idx, 0, 1));
 }
 
 function runAtomic(array, index, init, name, args, expectedResult, expectedOutcome)
@@ -146,9 +149,17 @@ i32a[0] = 0;
 var result = Atomics.wait(i32a, 0, 1);
 if (result != "not-equal")
     throw "Error: bad result from Atomics.wait: " + result;
+
+var result = Atomics.waitAsync(i32a, 0, 1);
+if (result.value != "not-equal")
+    throw "Error: bad result from Atomics.waitAsync: " + result;
+
 for (timeout of [0, 1, 10]) {
     var result = Atomics.wait(i32a, 0, 0, timeout);
     if (result != "timed-out")
         throw "Error: bad result from Atomics.wait: " + result;
 }
 
+var result = Atomics.waitAsync(i32a, 0, 0, 0);
+if (result.value != "timed-out")
+    throw "Error: bad result from Atomics.waitAsync: " + result;

--- a/JSTests/stress/bigint-atomics-fail.js
+++ b/JSTests/stress/bigint-atomics-fail.js
@@ -21,5 +21,9 @@ shouldThrow(() => {
 }, `TypeError: Typed array argument must be an Int32Array or BigInt64Array.`);
 
 shouldThrow(() => {
+    Atomics.waitAsync(u64a, 0, 0n);
+}, `TypeError: Typed array argument must be an Int32Array or BigInt64Array.`);
+
+shouldThrow(() => {
     Atomics.load(new Float64Array(8), 0);
 }, `TypeError: Typed array argument must be an Int8Array, Int16Array, Int32Array, Uint8Array, Uint16Array, Uint32Array, BigInt64Array, or BigUint64Array.`);

--- a/JSTests/stress/settimeout-starvation.js
+++ b/JSTests/stress/settimeout-starvation.js
@@ -1,0 +1,13 @@
+let promise = new Promise((resolve, _) => {
+    setTimeout(() => { resolve("timed-out") }, 1);
+});
+let outcome = null;
+
+(function wait() {
+    if (outcome === "timed-out") {
+        return;
+    }
+    setTimeout(wait, 0);
+})();
+
+promise.then(result => { outcome = result; });

--- a/JSTests/stress/shared-array-buffer-bigint.js
+++ b/JSTests/stress/shared-array-buffer-bigint.js
@@ -22,6 +22,7 @@ function shouldSucceed(f)
 for (bad of [bu64a]) {
     shouldFail(() => Atomics.notify(bad, 0, 0n), TypeError);
     shouldFail(() => Atomics.wait(bad, 0, 0n), TypeError);
+    shouldFail(() => Atomics.waitAsync(bad, 0, 0n), TypeError);
 }
 
 for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
@@ -38,6 +39,7 @@ for (idx of [-1, -1000000000000, 10000, 10000000000000]) {
     }
     shouldFail(() => Atomics.notify(bi64a, idx, 0n), RangeError);
     shouldFail(() => Atomics.wait(bi64a, idx, 0n), RangeError);
+    shouldFail(() => Atomics.waitAsync(bi64a, idx, 0n), RangeError);
 }
 
 for (idx of ["hello"]) {
@@ -54,6 +56,7 @@ for (idx of ["hello"]) {
     }
     shouldSucceed(() => Atomics.notify(bi64a, idx, 0));
     shouldSucceed(() => Atomics.wait(bi64a, idx, 0n, 1));
+    shouldSucceed(() => Atomics.waitAsync(bi64a, idx, 0n, 1));
 }
 
 function runAtomic(array, index, init, name, args, expectedResult, expectedOutcome)
@@ -83,8 +86,17 @@ bi64a[0] = 0n;
 var result = Atomics.wait(bi64a, 0, 1n);
 if (result != "not-equal")
     throw "Error: bad result from Atomics.wait: " + result;
+
+var result = Atomics.waitAsync(bi64a, 0, 1n);
+if (result.value != "not-equal")
+    throw "Error: bad result from Atomics.waitAsync: " + result;
+
 for (timeout of [0, 1, 10]) {
     var result = Atomics.wait(bi64a, 0, 0n, timeout);
     if (result != "timed-out")
         throw "Error: bad result from Atomics.wait: " + result;
 }
+
+var result = Atomics.waitAsync(bi64a, 0, 0n, 0);
+if (result.value != "timed-out")
+    throw "Error: bad result from Atomics.waitAsync: " + result;

--- a/JSTests/stress/waitasync-notify.js
+++ b/JSTests/stress/waitasync-notify.js
@@ -1,0 +1,75 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const READY_INDEX_A = 1;
+const READY_INDEX_B = 2;
+const NOTIFY_COUNT = 2;
+
+startWorker(`
+    $.agent.receiveBroadcast(async (sab) => {
+        var i32a = new Int32Array(sab);
+    
+        let p = Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, undefined).value;
+
+        Atomics.store(i32a, ${READY_INDEX_A}, 1);
+        Atomics.notify(i32a, ${READY_INDEX_A});
+
+        let res = await p;
+        if (res !== 'ok')
+            throw new Error("A resolve: " + res);
+
+        $.agent.report("done");
+    });
+`);
+
+startWorker(`
+    $.agent.receiveBroadcast(async (sab) => {
+        var i32a = new Int32Array(sab);
+    
+        let p = Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0, undefined).value;
+
+        Atomics.store(i32a, ${READY_INDEX_B}, 1);
+        Atomics.notify(i32a, ${READY_INDEX_B});
+
+        let res = await p;
+        if (res !== 'ok')
+            throw new Error("B resolve: " + res);
+
+        $.agent.report("done");
+    });
+`);
+
+startWorker(`
+    $.agent.receiveBroadcast((sab) => {
+        var i32a = new Int32Array(sab);
+    
+        Atomics.wait(i32a, ${READY_INDEX_A}, 0);
+        Atomics.wait(i32a, ${READY_INDEX_B}, 0);
+
+        let res = Atomics.notify(i32a, ${WAIT_INDEX}, ${NOTIFY_COUNT});
+        if (res !== 2)
+            throw new Error("C notified workers: " + res);
+
+        $.agent.report("done");
+    });
+`);
+
+$.agent.broadcast(sab);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else
+        print("report: " + report);
+}

--- a/JSTests/stress/waitasync-waiterlist.js
+++ b/JSTests/stress/waitasync-waiterlist.js
@@ -1,0 +1,70 @@
+var sab = new SharedArrayBuffer(3 * 4);
+var i32a = new Int32Array(sab);
+
+var numWorkers = 0;
+function startWorker(code) {
+    numWorkers++;
+    $.agent.start(code);
+}
+
+const WAIT_INDEX = 0;
+const WAITER_COUNT = 10;
+const ASYNC_WAITER_MULTIPLIER = 2;
+const ASYNC_WAITER_COUNT = WAITER_COUNT * ASYNC_WAITER_MULTIPLIER;
+const TOTAL_WAITER_COUNT = WAITER_COUNT + ASYNC_WAITER_COUNT;
+
+for (let i = 0; i < WAITER_COUNT; i++) {
+    startWorker(`
+        $.agent.receiveBroadcast((sab) => {
+            var i32a = new Int32Array(sab);
+
+            let result = Atomics.wait(i32a, ${WAIT_INDEX}, 0, undefined);
+            if (result !== 'ok')
+                throw new Error("Atomics.wait result: " + res);
+
+            $.agent.report("done");
+        });
+    `);
+
+    startWorker(`
+        $.agent.receiveBroadcast(async (sab) => {
+            var i32a = new Int32Array(sab);
+
+            let promises = [];
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                promises.push(Atomics.waitAsync(i32a, ${WAIT_INDEX}, 0).value);
+
+            function check(res) {
+                if (res !== 'ok')
+                    throw new Error("Atomics.waitAsync resolve: " + res);
+            }
+
+            for (let i = 0; i < ${ASYNC_WAITER_MULTIPLIER}; i++)
+                check(await promises[i]);
+
+            $.agent.report("done");
+        });
+    `);
+}
+
+$.agent.broadcast(sab);
+
+while (waiterListSize(i32a, WAIT_INDEX) != TOTAL_WAITER_COUNT);
+
+if (Atomics.notify(i32a, WAIT_INDEX, TOTAL_WAITER_COUNT + 10) != TOTAL_WAITER_COUNT)
+    throw new Error(`Atomics.notify should return ${TOTAL_WAITER_COUNT}.`);
+
+for (; ;) {
+    var report = waitForReport();
+    if (report == "done") {
+        if (!--numWorkers) {
+            print("All workers done!");
+            break;
+        }
+    } else
+        print("report: " + report);
+}
+
+if (waiterListSize(i32a, WAIT_INDEX) != 0)
+    throw new Error("The WaiterList should be empty.");

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -15,7 +15,6 @@ flags:
   json-modules: useImportAssertion
 skip:
   features:
-    - Atomics.waitAsync
     # https://bugs.webkit.org/show_bug.cgi?id=174931
     - regexp-lookbehind
     - regexp-v-flag

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-failure.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-failure.https.any.js
@@ -8,4 +8,8 @@ test(() => {
   assert_throws_js(TypeError, () => {
     Atomics.wait(ta, 0, 0, 10);
   });
+
+  assert_throws_js(TypeError, () => {
+    Atomics.waitAsync(ta, 0, 0, 10);
+  });
 }, `[[CanBlock]] in a ${self.constructor.name}`);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-success.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/integration-with-the-javascript-agent-formalism/requires-success.any.js
@@ -6,4 +6,6 @@ test(() => {
   const ta = new Int32Array(sab);
 
   assert_equals(Atomics.wait(ta, 0, 0, 10), "timed-out");
+
+  assert_equals(Atomics.waitAsync(ta, 0, 0, 0).value, "timed-out");
 }, `[[CanBlock]] in a ${self.constructor.name}`);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2156,6 +2156,7 @@
 		FEF5B430262A338B0016E776 /* ExceptionExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF5B42F262A338B0016E776 /* ExceptionExpectation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEF90A8D28AC135F00C14B84 /* APIIntegrityPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF90A8C28AC135C00C14B84 /* APIIntegrityPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEFD6FC61D5E7992008F2F0B /* JSStringInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -5850,6 +5851,8 @@
 		FEF90A8C28AC135C00C14B84 /* APIIntegrityPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIIntegrityPrivate.h; sourceTree = "<group>"; };
 		FEF90A8E28AC187A00C14B84 /* APIIntegrity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIIntegrity.cpp; sourceTree = "<group>"; };
 		FEFD6FC51D5E7970008F2F0B /* JSStringInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringInlines.h; sourceTree = "<group>"; };
+		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
+		FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaiterListManager.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -8449,6 +8452,8 @@
 				FE6F56DC1E64E92000D17801 /* VMTraps.cpp */,
 				FE6F56DD1E64E92000D17801 /* VMTraps.h */,
 				FEF5B42B2628CBC80016E776 /* VMTrapsInlines.h */,
+				FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */,
+				FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */,
 				FED94F2B171E3E2300BE77A4 /* Watchdog.cpp */,
 				FED94F2C171E3E2300BE77A4 /* Watchdog.h */,
 				BCE2FAFE26091782000A510F /* WeakGCHashTable.h */,
@@ -11335,6 +11340,7 @@
 				FEC5797323105B5100BCA83F /* VMInspectorInlines.h in Headers */,
 				FE6F56DE1E64EAD600D17801 /* VMTraps.h in Headers */,
 				FEF5B42C2628CBC80016E776 /* VMTrapsInlines.h in Headers */,
+				FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */,
 				52847ADC21FFB8690061A9DB /* WasmAirIRGenerator.h in Headers */,
 				53F40E931D5A4AB30099A1B6 /* WasmB3IRGenerator.h in Headers */,
 				53CA730A1EA533D80076049D /* WasmBBQPlan.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1075,6 +1075,7 @@ runtime/VM.cpp
 runtime/VMEntryScope.cpp
 runtime/VMTraps.cpp
 runtime/VarOffset.cpp
+runtime/WaiterListManager.cpp
 runtime/Watchdog.cpp
 runtime/WeakMapConstructor.cpp
 runtime/WeakMapImpl.cpp

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -24,6 +24,7 @@
 
 #include "APICast.h"
 #include "ArrayBuffer.h"
+#include "AtomicsObject.h"
 #include "BigIntConstructor.h"
 #include "BytecodeCacheError.h"
 #include "CatchScope.h"
@@ -383,6 +384,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionDollarAgentBroadcast);
 static JSC_DECLARE_HOST_FUNCTION(functionDollarAgentGetReport);
 static JSC_DECLARE_HOST_FUNCTION(functionDollarAgentLeaving);
 static JSC_DECLARE_HOST_FUNCTION(functionDollarAgentMonotonicNow);
+static JSC_DECLARE_HOST_FUNCTION(functionWaiterListSize);
 static JSC_DECLARE_HOST_FUNCTION(functionWaitForReport);
 static JSC_DECLARE_HOST_FUNCTION(functionHeapCapacity);
 static JSC_DECLARE_HOST_FUNCTION(functionFlashHeapAccess);
@@ -683,6 +685,8 @@ private:
         addFunction(vm, agent, "getReport"_s, functionDollarAgentGetReport, 0);
         addFunction(vm, agent, "leaving"_s, functionDollarAgentLeaving, 0);
         addFunction(vm, agent, "monotonicNow"_s, functionDollarAgentMonotonicNow, 0);
+
+        addFunction(vm, "waiterListSize"_s, functionWaiterListSize, 2);
 
         addFunction(vm, "waitForReport"_s, functionWaitForReport, 0);
 
@@ -2394,6 +2398,11 @@ JSC_DEFINE_HOST_FUNCTION(functionDollarAgentMonotonicNow, (JSGlobalObject*, Call
     return JSValue::encode(jsNumber(MonotonicTime::now().secondsSinceEpoch().milliseconds()));
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionWaiterListSize, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    return getWaiterListSize(globalObject, callFrame);
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionWaitForReport, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
@@ -2629,11 +2638,11 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout, (JSGlobalObject* globalObject, Call
         });
     };
 
+    // We need to add the dispatch callback to the run loop even the delay is 0 secs, otherwise 
+    // it will cause setTimeout starvation problem (see stress test settimeout-starvation.js).
     JSValue timeout = callFrame->argument(1);
-    if (timeout.isNumber() && timeout.asNumber())
-        RunLoop::current().dispatchAfter(Seconds::fromMilliseconds(timeout.asNumber()), WTFMove(dispatch));
-    else
-        dispatch();
+    Seconds delay = timeout.isNumber() ? Seconds::fromMilliseconds(timeout.asNumber()) : Seconds(0);
+    RunLoop::current().dispatchAfter(delay, WTFMove(dispatch));
 
     return JSValue::encode(jsUndefined());
 }

--- a/Source/JavaScriptCore/runtime/AtomicsObject.h
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.h
@@ -62,5 +62,7 @@ JSC_DECLARE_JIT_OPERATION(operationAtomicsStore, EncodedJSValue, (JSGlobalObject
 JSC_DECLARE_JIT_OPERATION(operationAtomicsSub, EncodedJSValue, (JSGlobalObject*, EncodedJSValue base, EncodedJSValue index, EncodedJSValue operand));
 JSC_DECLARE_JIT_OPERATION(operationAtomicsXor, EncodedJSValue, (JSGlobalObject*, EncodedJSValue base, EncodedJSValue index, EncodedJSValue operand));
 
+JS_EXPORT_PRIVATE EncodedJSValue getWaiterListSize(JSGlobalObject*, CallFrame*);
+
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -157,6 +157,7 @@ namespace JSC {
     macro(AtomicsOrIntrinsic) \
     macro(AtomicsStoreIntrinsic) \
     macro(AtomicsSubIntrinsic) \
+    macro(AtomicsWaitAsyncIntrinsic) \
     macro(AtomicsWaitIntrinsic) \
     macro(AtomicsXorIntrinsic) \
     macro(ParseIntIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -110,7 +110,6 @@ class JSModuleRecord;
 class JSPromise;
 class JSPromiseConstructor;
 class JSPromisePrototype;
-class JSSharedArrayBuffer;
 class JSSharedArrayBufferPrototype;
 class JSTypedArrayViewConstructor;
 class JSTypedArrayViewPrototype;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -553,6 +553,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object.") \
+    v(Bool, useWaitAsync, true, Normal, "Expose the waitAsync() methods on Atomics.") \
     v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec.") \
     v(Bool, useWebAssemblyTypedFunctionReferences, false, Normal, "Allow function types from the wasm typed function references spec.") \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
@@ -62,6 +62,11 @@ bool SimpleTypedArrayController::isAtomicsWaitAllowedOnCurrentThread()
     return m_allowAtomicsWait;
 }
 
+bool SimpleTypedArrayController::isAtomicsWaitAsyncAllowedOnCurrentThread()
+{
+    return m_allowAtomicsWaitAsync;
+}
+
 bool SimpleTypedArrayController::JSArrayBufferOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, const char** reason)
 {
     if (UNLIKELY(reason))

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.h
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.h
@@ -54,6 +54,7 @@ public:
     JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer*) final;
     void registerWrapper(JSGlobalObject*, ArrayBuffer*, JSArrayBuffer*) final;
     bool isAtomicsWaitAllowedOnCurrentThread() final;
+    bool isAtomicsWaitAsyncAllowedOnCurrentThread() final;
 
 private:
     class JSArrayBufferOwner final : public WeakHandleOwner {
@@ -64,6 +65,7 @@ private:
 
     JSArrayBufferOwner m_owner;
     bool m_allowAtomicsWait { false };
+    bool m_allowAtomicsWaitAsync { false };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -110,6 +110,7 @@
 #include "VMInlines.h"
 #include "VMInspector.h"
 #include "VariableEnvironment.h"
+#include "WaiterListManager.h"
 #include "WasmWorklist.h"
 #include "Watchdog.h"
 #include "WeakGCMapInlines.h"
@@ -405,6 +406,8 @@ VM::~VM()
 {
     Locker destructionLocker { s_destructionLock.read() };
     
+    WaiterListManager::singleton().unregister(this);
+
     Gigacage::removePrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);
     deferredWorkTimer->stopRunningTasks();
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,29 +20,23 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 #pragma once
 
-#include <wtf/RefCounted.h>
+#include "config.h"
+#include "WaiterListManager.h"
 
 namespace JSC {
 
-class ArrayBuffer;
-class CallFrame;
-class JSArrayBuffer;
-class JSGlobalObject;
-
-class TypedArrayController : public RefCounted<TypedArrayController> {
-public:
-    JS_EXPORT_PRIVATE TypedArrayController();
-    JS_EXPORT_PRIVATE virtual ~TypedArrayController();
-    
-    virtual JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer*) = 0;
-    virtual void registerWrapper(JSGlobalObject*, ArrayBuffer*, JSArrayBuffer*) = 0;
-    virtual bool isAtomicsWaitAllowedOnCurrentThread() = 0;
-    virtual bool isAtomicsWaitAsyncAllowedOnCurrentThread() = 0;
-};
+WaiterListManager& WaiterListManager::singleton()
+{
+    static LazyNeverDestroyed<WaiterListManager> manager;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        manager.construct();
+    });
+    return manager;
+}
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "JSGlobalObject.h"
+#include "JSPromise.h"
+#include "runtime/DeferredWorkTimer.h"
+#include <wtf/DataLog.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/ParkingLot.h>
+#include <wtf/RawPointer.h>
+
+namespace JSC {
+
+namespace WaiterListsManagerInternal {
+static constexpr bool verbose = false;
+}
+
+class WaiterListManager {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    static WaiterListManager& singleton();
+
+    void addWaiter(void* ptr, JSPromise* promise, Seconds timeout)
+    {
+        RELEASE_ASSERT(ptr && promise);
+        VM& vm = promise->globalObject()->vm();
+        vm.apiLock().lock();
+        auto ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, { });
+        vm.apiLock().unlock();
+
+        ParkingLot::parkAsync(ptr, ticket);
+
+        m_registeredVMs.add(&vm);
+        RunLoop::current().dispatchAfter(timeout, [ptr, ticket] {
+            WaiterListManager::singleton().timeout(ptr, ticket);
+        });
+
+        if (WaiterListsManagerInternal::verbose)
+            dataLogF("WaiterListManager added a new AsyncWaiter to a waiterList for ptr %p\n", ptr);
+    }
+
+    void timeout(void* ptr, DeferredWorkTimer::Ticket ticket)
+    {
+        RELEASE_ASSERT(ptr && ticket);
+        JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+        VM* vm = &promise->globalObject()->vm();
+        if (!m_registeredVMs.contains(vm))
+            return;
+
+        ParkingLot::unparkAsync(ptr, ticket, [this](void* data) {
+            bool isOKString = false;
+            notifyWaiterImpl(data, isOKString);
+        });
+    }
+
+    unsigned notifyWaiter(void* ptr, unsigned count)
+    {
+        RELEASE_ASSERT(ptr);
+        bool isAsyncMode = true;
+        unsigned notified = ParkingLot::unparkCount(ptr, count, [this](void* data) {
+            bool isOKString = true;
+            notifyWaiterImpl(data, isOKString);
+        }, isAsyncMode);
+        if (WaiterListsManagerInternal::verbose)
+            dataLogF("WaiterListManager notified waiters (count %d) for ptr %p\n", notified, ptr);
+        return notified;
+    }
+
+    void notifyWaiterImpl(void* data, const bool isOKString)
+    {
+        auto ticket = static_cast<DeferredWorkTimer::Ticket>(data);
+        VM* vm = &jsCast<JSPromise*>(ticket->target())->globalObject()->vm();
+        vm->deferredWorkTimer->scheduleWorkSoon(ticket, [isOKString](DeferredWorkTimer::Ticket ticket) {
+            JSPromise* promise = jsCast<JSPromise*>(ticket->target());
+            JSGlobalObject* globalObject = promise->globalObject();
+            VM& vm = promise->globalObject()->vm();
+            promise->resolve(globalObject, (isOKString ? vm.smallStrings.okString() : vm.smallStrings.timedOutString()));
+        });
+    }
+
+    void unregister(VM* vm)
+    {
+        m_registeredVMs.remove(vm);
+    }
+
+    size_t waiterListSize(void* ptr)
+    {
+        return ParkingLot::bucketSize(ptr);
+    }
+
+private:
+    struct RegisteredVMs {
+        WTF_MAKE_FAST_ALLOCATED;
+
+    public:
+        void add(VM* vm)
+        {
+            LockHolder locker(lock);
+            set.add(vm);
+            if (WaiterListsManagerInternal::verbose)
+                dataLogF("WaiterListManager registered vm %p\n", vm);
+        }
+
+        void remove(VM* vm)
+        {
+            LockHolder locker(lock);
+            set.remove(vm);
+            if (WaiterListsManagerInternal::verbose)
+                dataLogF("WaiterListManager unregistered vm %p\n", vm);
+        }
+
+        bool contains(VM* vm)
+        {
+            LockHolder locker(lock);
+            return set.contains(vm);
+        }
+
+        void dump(PrintStream& out) const
+        {
+            LockHolder locker(lock);
+            out.print("m_registeredVMs (size ", set.size(), "): ");
+            for (auto& vm : set)
+                out.print(RawPointer(vm), " ");
+        }
+
+    private:
+        mutable Lock lock;
+        HashSet<VM*> set;
+    };
+
+    RegisteredVMs m_registeredVMs;
+};
+
+} // namespace JSC

--- a/Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp
+++ b/Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp
@@ -56,6 +56,11 @@ bool WebCoreTypedArrayController::isAtomicsWaitAllowedOnCurrentThread()
     return m_allowAtomicsWait;
 }
 
+bool WebCoreTypedArrayController::isAtomicsWaitAsyncAllowedOnCurrentThread()
+{
+    return m_allowAtomicsWaitAsync;
+}
+
 bool WebCoreTypedArrayController::JSArrayBufferOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, const char** reason)
 {
     if (UNLIKELY(reason))

--- a/Source/WebCore/bindings/js/WebCoreTypedArrayController.h
+++ b/Source/WebCore/bindings/js/WebCoreTypedArrayController.h
@@ -42,6 +42,7 @@ public:
     JSC::JSArrayBuffer* toJS(JSC::JSGlobalObject*, JSC::JSGlobalObject*, JSC::ArrayBuffer*) override;
     void registerWrapper(JSC::JSGlobalObject*, ArrayBuffer*, JSC::JSArrayBuffer*) override;
     bool isAtomicsWaitAllowedOnCurrentThread() override;
+    bool isAtomicsWaitAsyncAllowedOnCurrentThread() override;
 
     JSC::WeakHandleOwner* wrapperOwner() { return &m_owner; }
 
@@ -54,6 +55,7 @@ private:
 
     JSArrayBufferOwner m_owner;
     bool m_allowAtomicsWait;
+    bool m_allowAtomicsWaitAsync;
 };
 
 } // namespace WebCore

--- a/WebKit.xcworkspace/contents.xcworkspacedata
+++ b/WebKit.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Source/JavaScriptCore/runtime/WaiterListManager.h">
+   </FileRef>
+   <FileRef
       location = "group:Configurations">
    </FileRef>
    <FileRef


### PR DESCRIPTION
#### c244558d61dc7726be0998e17944741f8fc02952
<pre>
[JSC] Add support for Atomics.waitAsync (ParkingLot Version WIP)
<a href="https://bugs.webkit.org/show_bug.cgi?id=241414">https://bugs.webkit.org/show_bug.cgi?id=241414</a>
rdar://94655073

Reviewed by NOBODY (OOPS!).

Atomics.waitAsync() waits asynchronously on a shared array buffer and
returns an object { async: bool, value: Promise }. Compare to Atomics.wait(),
waitAsync is non-blocking and usable on the main thread.

TC39 Spec: <a href="https://tc39.es/proposal-atomics-wait-async/">https://tc39.es/proposal-atomics-wait-async/</a>
TC39 Proposal: <a href="https://github.com/tc39/proposal-atomics-wait-async">https://github.com/tc39/proposal-atomics-wait-async</a>
MDN Web Doc: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync</a>

* JSTests/stress/settimeout-starvation.js: Added.
(let.promise.new.Promise):
(wait):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::atomicsWaitImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/Intrinsic.cpp:
(JSC::intrinsicName):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::JSArrayBufferView::hasArrayBuffer const):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp:
(JSC::SimpleTypedArrayController::isAtomicsWaitAsyncAllowedOnCurrentThread):
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.h:
* Source/JavaScriptCore/runtime/TypedArrayController.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::~VM):
* Source/JavaScriptCore/runtime/WaiterListsManager.h: Added.
(JSC::Waiter::Waiter):
(JSC::Waiter::isAsync const):
(JSC::Waiter::getVM const):
(JSC::Waiter::getPromise const):
(JSC::Waiter::getTicket const):
(JSC::Waiter::dump const):
(JSC::WaiterList::enqueue):
(JSC::WaiterList::dequeue):
(JSC::WaiterList::takeFirst):
(JSC::WaiterList::isEmpty):
(JSC::WaiterList::dump const):
(JSC::WaiterListsManager::singleton):
(JSC::WaiterListsManager::addWaiter):
(JSC::WaiterListsManager::notifyWaiter):
(JSC::WaiterListsManager::timeoutAsyncWaiter):
(JSC::WaiterListsManager::unregister):
(JSC::WaiterListsManager::dump const):
(JSC::WaiterListsManager::RegisteredVMs::add):
(JSC::WaiterListsManager::RegisteredVMs::remove):
(JSC::WaiterListsManager::RegisteredVMs::contains):
(JSC::WaiterListsManager::RegisteredVMs::dump const):
(JSC::WaiterListsManager::notifyWaiterImpl):
(JSC::WaiterListsManager::add):
(JSC::WaiterListsManager::find):
* Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp:
(WebCore::WebCoreTypedArrayController::isAtomicsWaitAsyncAllowedOnCurrentThread):
* Source/WebCore/bindings/js/WebCoreTypedArrayController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8524ae62cfba6f9d0d87dc7b88418af2df024db8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103556 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163894 "Hash 8524ae62 for PR 5683 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3130 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31350 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86244 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99626 "Hash 8524ae62 for PR 5683 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2239 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80346 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29256 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83861 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72212 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85173 "Found 1 new JSC stress test failure: stress/waitasync-waiterlist.js.dfg-eager-no-cjit-validate (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37742 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17692 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80300 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35609 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18955 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27677 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41524 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/82950 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38185 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18739 "Passed tests") | 
<!--EWS-Status-Bubble-End-->