### PR TITLE
[web-animations] commitStyles() should update layout prior to committing animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
@@ -11,7 +11,7 @@ PASS Commits em units as pixel values
 FAIL Commits relative line-height assert_equals: line-height is committed as a relative value expected "1.5" but got "15px"
 PASS Commits transforms
 FAIL Commits transforms as a transform list assert_equals: expected "translate(20px, 20px)" but got "matrix(1, 0, 0, 1, 20, 20)"
-FAIL Commits matrix-interpolated relative transforms assert_equals: Resolved transform is correct after commit. expected "matrix(2, 0, 0, 2, 100, 0)" but got "matrix(2, 0, 0, 2, 0, 0)"
+PASS Commits matrix-interpolated relative transforms
 PASS Commits "none" transform
 PASS Commits the intermediate value of an animation in the middle of stack
 PASS Commit composites on top of the underlying value

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1515,7 +1515,9 @@ ExceptionOr<void> WebAnimation::commitStyles()
     auto& styledElement = downcast<StyledElement>(*target);
 
     // 2.2 If, after applying any pending style changes, target is not being rendered, throw an "InvalidStateError" DOMException and abort these steps.
-    styledElement.document().updateStyleIfNeeded();
+    // Note that while the spec says to "apply pending style changes", we update the layout as well because layout may not
+    // have happened yet and we must make sure that any value that is layout-dependent can be resolved.
+    styledElement.document().updateLayoutIgnorePendingStylesheets();
     auto* renderer = styledElement.renderer();
     if (!renderer)
         return Exception { InvalidStateError };


### PR DESCRIPTION
#### 242a47777034864316ae429ee72503b524557367
<pre>
[web-animations] commitStyles() should update layout prior to committing animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=246913">https://bugs.webkit.org/show_bug.cgi?id=246913</a>

Reviewed by NOBODY (OOPS!).

We were failing one subtest in web-animations/interfaces/Animation/commitStyles.html due to the test
running an animation that is layout-dependent (using a percentage in a transform) prior to any layout
being performed by the time commitStyles() was called and animations were resolved.

Instead of calling udpateStyleIfNeeded() as a preliminary step in commitStyles(), we now
call updateLayout() to ensure any layout-dependent animation yields a correct computed value.

Note that we use the computed value for `commitStyles()` and not the used value per the Web Animations
spec: https://w3c.github.io/csswg-drafts/web-animations-1/#commit-computed-styles.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/242a47777034864316ae429ee72503b524557367

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103558 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163896 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3132 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31352 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99627 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2241 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80348 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29258 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72214 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37744 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17694 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35611 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18957 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41526 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38187 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->