### PR TITLE
[web-animations] commitStyles() fails to commit a relative line-height value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt
@@ -8,7 +8,7 @@ PASS Commits values calculated mid-interval
 PASS Commits variable references as their computed values
 PASS Commits custom variables
 PASS Commits em units as pixel values
-FAIL Commits relative line-height assert_equals: line-height is committed as a relative value expected "1.5" but got "15px"
+PASS Commits relative line-height
 PASS Commits transforms
 FAIL Commits transforms as a transform list assert_equals: expected "translate(20px, 20px)" but got "matrix(1, 0, 0, 1, 20, 20)"
 FAIL Commits matrix-interpolated relative transforms assert_equals: Resolved transform is correct after commit. expected "matrix(2, 0, 0, 2, 100, 0)" but got "matrix(2, 0, 0, 2, 0, 0)"


### PR DESCRIPTION
#### 1610fc7268379c03a2abe302dd3982787de6ee0f
<pre>
[web-animations] commitStyles() fails to commit a relative line-height value
<a href="https://bugs.webkit.org/show_bug.cgi?id=246914">https://bugs.webkit.org/show_bug.cgi?id=246914</a>

Reviewed by Antti Koivisto.

When Animation.commitStyles() is called, we commit animated values to the target element&apos;s inline style. In the
case of &quot;line-height&quot; we must commit a relative value if one was specified, such that changing the font-size
after committing will adjust the line-height accordingly.

When extracting the value from commitStyles() where the &quot;valueType&quot; is set to &quot;Computed&quot;, such as when a
ComputedStyleExtractor is used in that method, we look for a relative &quot;line-height&quot; and return that value.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/Animation/commitStyles-expected.txt:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::optionalLineHeight):
(WebCore::lineHeight):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):

Canonical link: <a href="https://commits.webkit.org/255912@main">https://commits.webkit.org/255912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa2ab84ae867f9b32242c9b448a8c1ff493c737e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103624 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163972 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3193 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31417 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99676 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2291 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80413 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84217 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72271 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37805 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17742 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35675 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19006 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39549 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1921 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38237 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->