### PR TITLE
[WinCairo] Unreviewed build fix after 255889@main

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -287,7 +287,7 @@ static bool shouldPaintBoundsRect(const IntRect& bounds, const Vector<IntRect, 1
 void DrawingAreaWC::sendUpdateNonAC()
 {
     if (m_dirtyRegion.isEmpty()) {
-        didUpdate();
+        displayDidRefresh();
         return;
     }
     IntRect bounds = m_dirtyRegion.bounds();
@@ -328,7 +328,7 @@ void DrawingAreaWC::sendUpdateNonAC()
             if (!weakThis)
                 return;
             if (stateID != m_backingStoreStateID) {
-                didUpdate();
+                displayDidRefresh();
                 return;
             }
 


### PR DESCRIPTION
#### b0d809850b743ede12a68aadd870de6603484daa
<pre>
[WinCairo] Unreviewed build fix after 255889@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=246897">https://bugs.webkit.org/show_bug.cgi?id=246897</a>

* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::sendUpdateNonAC): Renamed didUpdate to displayDidRefresh.

Canonical link: <a href="https://commits.webkit.org/255898@main">https://commits.webkit.org/255898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dce84f66be918d143c8157dc28d6a550c7e92de2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103587 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3159 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31382 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86276 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2262 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80377 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29277 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84188 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72233 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37771 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17712 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18977 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39514 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38207 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->