### PR TITLE
Simplify FEComponentTransfer coding

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -58,8 +58,8 @@ using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, Com
 
 class FEComponentTransfer : public FilterEffect {
 public:
-    WEBCORE_EXPORT static Ref<FEComponentTransfer> create(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc);
-    static Ref<FEComponentTransfer> create(ComponentTransferFunctions&&);
+    static Ref<FEComponentTransfer> create(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc);
+    WEBCORE_EXPORT static Ref<FEComponentTransfer> create(ComponentTransferFunctions&&);
 
     ComponentTransferFunction redFunction() const { return m_functions[ComponentTransferChannel::Red]; }
     ComponentTransferFunction greenFunction() const { return m_functions[ComponentTransferChannel::Green]; }
@@ -146,36 +146,18 @@ std::optional<ComponentTransferFunction> ComponentTransferFunction::decode(Decod
 template<class Encoder>
 void FEComponentTransfer::encode(Encoder& encoder) const
 {
-    encoder << m_functions[ComponentTransferChannel::Red];
-    encoder << m_functions[ComponentTransferChannel::Green];
-    encoder << m_functions[ComponentTransferChannel::Blue];
-    encoder << m_functions[ComponentTransferChannel::Alpha];
+    encoder << m_functions;
 }
 
 template<class Decoder>
 std::optional<Ref<FEComponentTransfer>> FEComponentTransfer::decode(Decoder& decoder)
 {
-    std::optional<ComponentTransferFunction> redFunction;
-    decoder >> redFunction;
-    if (!redFunction)
+    std::optional<ComponentTransferFunctions> functions;
+    decoder >> functions;
+    if (!functions)
         return std::nullopt;
 
-    std::optional<ComponentTransferFunction> greenFunction;
-    decoder >> greenFunction;
-    if (!greenFunction)
-        return std::nullopt;
-
-    std::optional<ComponentTransferFunction> blueFunction;
-    decoder >> blueFunction;
-    if (!blueFunction)
-        return std::nullopt;
-
-    std::optional<ComponentTransferFunction> alphaFunction;
-    decoder >> alphaFunction;
-    if (!alphaFunction)
-        return std::nullopt;
-
-    return FEComponentTransfer::create(*redFunction, *greenFunction, *blueFunction, *alphaFunction);
+    return FEComponentTransfer::create(WTFMove(*functions));
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 355426c15db9b7f3fec2a3a35a743cdb5b1fc0d3
<pre>
Simplify FEComponentTransfer coding
<a href="https://bugs.webkit.org/show_bug.cgi?id=246908">https://bugs.webkit.org/show_bug.cgi?id=246908</a>
&lt;rdar://problem/101464975&gt;

Reviewed by Said Abou-Hallawa.

* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
(WebCore::FEComponentTransfer::encode const):
(WebCore::FEComponentTransfer::decode):

Canonical link: <a href="https://commits.webkit.org/255906@main">https://commits.webkit.org/255906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7e73b0313d6be383d753fac10a39615625d8d9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103605 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163953 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3176 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31399 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99657 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2275 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80395 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84201 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37787 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17725 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35657 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39531 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38220 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->