### PR TITLE
Share libwpe gamepad code

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -82,6 +82,21 @@ list(APPEND WebCore_LIBRARIES
     WPE::libwpe
 )
 
+if (ENABLE_GAMEPAD)
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/platform/gamepad/libwpe"
+    )
+
+    list(APPEND WebCore_SOURCES
+        platform/gamepad/libwpe/GamepadLibWPE.cpp
+        platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+    )
+
+    list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/gamepad/libwpe/GamepadProviderLibWPE.h
+    )
+endif ()
+
 # Find the extras needed to copy for EGL besides the libraries
 set(EGL_EXTRAS)
 foreach (EGL_EXTRA_NAME ${EGL_EXTRA_NAMES})

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -143,7 +143,11 @@ if (USE_LIBGBM)
 endif ()
 
 if (ENABLE_GAMEPAD)
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/platform/gamepad/libwpe"
+    )
+
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
-        platform/gamepad/wpe/WPEGamepadProvider.h
+        platform/gamepad/libwpe/GamepadProviderLibWPE.h
     )
 endif ()

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -62,8 +62,8 @@ platform/UserAgentQuirks.cpp
 platform/adwaita/ScrollbarThemeAdwaita.cpp
 platform/adwaita/ThemeAdwaita.cpp
 
-platform/gamepad/wpe/WPEGamepad.cpp
-platform/gamepad/wpe/WPEGamepadProvider.cpp
+platform/gamepad/libwpe/GamepadLibWPE.cpp
+platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
 
 platform/generic/ScrollbarsControllerGeneric.cpp
 

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp
@@ -25,16 +25,16 @@
  */
 
 #include "config.h"
-#include "WPEGamepad.h"
+#include "GamepadLibWPE.h"
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && USE(LIBWPE)
 
-#include "WPEGamepadProvider.h"
+#include "GamepadProviderLibWPE.h"
 #include <wpe/wpe.h>
 
 namespace WebCore {
 
-WPEGamepad::WPEGamepad(struct wpe_gamepad_provider* provider, uintptr_t gamepadId, unsigned index)
+GamepadLibWPE::GamepadLibWPE(struct wpe_gamepad_provider* provider, uintptr_t gamepadId, unsigned index)
     : PlatformGamepad(index)
     , m_buttonValues(WPE_GAMEPAD_BUTTON_COUNT)
     , m_axisValues(WPE_GAMEPAD_AXIS_COUNT)
@@ -50,12 +50,12 @@ WPEGamepad::WPEGamepad(struct wpe_gamepad_provider* provider, uintptr_t gamepadI
     static const struct wpe_gamepad_client_interface s_client = {
         // button_event
         [](void* data, enum wpe_gamepad_button button, bool pressed) {
-            auto& self = *static_cast<WPEGamepad*>(data);
+            auto& self = *static_cast<GamepadLibWPE*>(data);
             self.buttonPressedOrReleased(static_cast<unsigned>(button), pressed);
         },
         // axis_event
         [](void* data, enum wpe_gamepad_axis axis, double value) {
-            auto& self = *static_cast<WPEGamepad*>(data);
+            auto& self = *static_cast<GamepadLibWPE*>(data);
             self.absoluteAxisChanged(static_cast<unsigned>(axis), value);
         },
         nullptr, nullptr, nullptr,
@@ -63,27 +63,27 @@ WPEGamepad::WPEGamepad(struct wpe_gamepad_provider* provider, uintptr_t gamepadI
     wpe_gamepad_set_client(m_gamepad.get(), &s_client, this);
 }
 
-WPEGamepad::~WPEGamepad()
+GamepadLibWPE::~GamepadLibWPE()
 {
     wpe_gamepad_set_client(m_gamepad.get(), nullptr, nullptr);
 }
 
-void WPEGamepad::buttonPressedOrReleased(unsigned button, bool pressed)
+void GamepadLibWPE::buttonPressedOrReleased(unsigned button, bool pressed)
 {
     m_lastUpdateTime = MonotonicTime::now();
     m_buttonValues[button].setValue(pressed ? 1.0 : 0.0);
 
-    WPEGamepadProvider::singleton().scheduleInputNotification(*this, pressed ? WPEGamepadProvider::ShouldMakeGamepadsVisible::Yes : WPEGamepadProvider::ShouldMakeGamepadsVisible::No);
+    GamepadProviderLibWPE::singleton().scheduleInputNotification(*this, pressed ? GamepadProviderLibWPE::ShouldMakeGamepadsVisible::Yes : GamepadProviderLibWPE::ShouldMakeGamepadsVisible::No);
 }
 
-void WPEGamepad::absoluteAxisChanged(unsigned axis, double value)
+void GamepadLibWPE::absoluteAxisChanged(unsigned axis, double value)
 {
     m_lastUpdateTime = MonotonicTime::now();
     m_axisValues[axis].setValue(value);
 
-    WPEGamepadProvider::singleton().scheduleInputNotification(*this, WPEGamepadProvider::ShouldMakeGamepadsVisible::No);
+    GamepadProviderLibWPE::singleton().scheduleInputNotification(*this, GamepadProviderLibWPE::ShouldMakeGamepadsVisible::No);
 }
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && USE(LIBWPE)

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && USE(LIBWPE)
 
 #include "PlatformGamepad.h"
 
@@ -35,10 +35,10 @@ struct wpe_gamepad_provider;
 
 namespace WebCore {
 
-class WPEGamepad final : public PlatformGamepad {
+class GamepadLibWPE final : public PlatformGamepad {
 public:
-    WPEGamepad(struct wpe_gamepad_provider*, uintptr_t, unsigned);
-    virtual ~WPEGamepad();
+    GamepadLibWPE(struct wpe_gamepad_provider*, uintptr_t, unsigned);
+    virtual ~GamepadLibWPE();
 
     const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
     const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
@@ -57,4 +57,4 @@ private:
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && USE(LIBWPE)

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && USE(LIBWPE)
 
 #include "GamepadProvider.h"
 #include <wtf/HashMap.h>
@@ -38,16 +38,16 @@ struct wpe_view_backend;
 
 namespace WebCore {
 
-class WPEGamepad;
+class GamepadLibWPE;
 
-class WPEGamepadProvider final : public GamepadProvider {
-    WTF_MAKE_NONCOPYABLE(WPEGamepadProvider);
-    friend class NeverDestroyed<WPEGamepadProvider>;
+class GamepadProviderLibWPE final : public GamepadProvider {
+    WTF_MAKE_NONCOPYABLE(GamepadProviderLibWPE);
+    friend class NeverDestroyed<GamepadProviderLibWPE>;
 
 public:
-    static WPEGamepadProvider& singleton();
+    static GamepadProviderLibWPE& singleton();
 
-    virtual ~WPEGamepadProvider();
+    virtual ~GamepadProviderLibWPE();
 
     void startMonitoringGamepads(GamepadProviderClient&) final;
     void stopMonitoringGamepads(GamepadProviderClient&) final;
@@ -55,32 +55,32 @@ public:
 
     enum class ShouldMakeGamepadsVisible : bool { No,
         Yes };
-    void scheduleInputNotification(WPEGamepad&, ShouldMakeGamepadsVisible);
+    void scheduleInputNotification(GamepadLibWPE&, ShouldMakeGamepadsVisible);
 
     struct wpe_view_backend* inputView();
 
 private:
-    WPEGamepadProvider();
+    GamepadProviderLibWPE();
 
     void gamepadConnected(unsigned);
     void gamepadDisconnected(unsigned);
-    std::unique_ptr<WPEGamepad> removeGamepadForId(unsigned);
+    std::unique_ptr<GamepadLibWPE> removeGamepadForId(unsigned);
 
     unsigned indexForNewlyConnectedDevice();
     void initialGamepadsConnectedTimerFired();
     void inputNotificationTimerFired();
 
     Vector<PlatformGamepad*> m_gamepadVector;
-    HashMap<unsigned, std::unique_ptr<WPEGamepad>> m_gamepadMap;
+    HashMap<unsigned, std::unique_ptr<GamepadLibWPE>> m_gamepadMap;
     bool m_initialGamepadsConnected { false };
 
     std::unique_ptr<struct wpe_gamepad_provider, void (*)(struct wpe_gamepad_provider*)> m_provider;
     struct wpe_gamepad* m_lastActiveGamepad { nullptr };
 
-    RunLoop::Timer<WPEGamepadProvider> m_initialGamepadsConnectedTimer;
-    RunLoop::Timer<WPEGamepadProvider> m_inputNotificationTimer;
+    RunLoop::Timer<GamepadProviderLibWPE> m_initialGamepadsConnectedTimer;
+    RunLoop::Timer<GamepadProviderLibWPE> m_inputNotificationTimer;
 };
 
 } // namespace WebCore
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && USE(LIBWPE)

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -151,6 +151,12 @@ list(APPEND WebKit_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/WebProcess/WebPage/libwpe"
 )
 
+if (ENABLE_GAMEPAD)
+    list(APPEND WebKit_SOURCES
+        UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
+    )
+endif ()
+
 if (USE_COORDINATED_GRAPHICS)
     list(APPEND WebKit_SOURCES
         Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -204,7 +204,7 @@ UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
 
 UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
 
-UIProcess/Gamepad/wpe/UIGamepadProviderWPE.cpp
+UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
 
 UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -40,7 +40,7 @@
 #include "WebProcessPool.h"
 #include <WebCore/CompositionUnderline.h>
 #if ENABLE(GAMEPAD)
-#include <WebCore/WPEGamepadProvider.h>
+#include <WebCore/GamepadProviderLibWPE.h>
 #endif
 #include <wpe/wpe.h>
 #include <wtf/NeverDestroyed.h>
@@ -466,7 +466,7 @@ WebKit::WebPageProxy* View::platformWebPageProxyForGamepadInput()
     if (views.isEmpty())
         return nullptr;
 
-    struct wpe_view_backend* viewBackend = WebCore::WPEGamepadProvider::singleton().inputView();
+    struct wpe_view_backend* viewBackend = WebCore::GamepadProviderLibWPE::singleton().inputView();
 
     size_t index = notFound;
 

--- a/Source/WebKit/UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp
@@ -26,11 +26,11 @@
 #include "config.h"
 #include "UIGamepadProvider.h"
 
-#if ENABLE(GAMEPAD)
+#if ENABLE(GAMEPAD) && USE(LIBWPE)
 
 #include "WPEView.h"
 
-#include <WebCore/WPEGamepadProvider.h>
+#include <WebCore/GamepadProviderLibWPE.h>
 
 using namespace WebCore;
 
@@ -41,7 +41,7 @@ void UIGamepadProvider::platformSetDefaultGamepadProvider()
     if (GamepadProvider::singleton().isMockGamepadProvider())
         return;
 
-    GamepadProvider::setSharedProvider(WPEGamepadProvider::singleton());
+    GamepadProvider::setSharedProvider(GamepadProviderLibWPE::singleton());
 }
 
 WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
@@ -58,4 +58,4 @@ void UIGamepadProvider::platformStartMonitoringInput()
 }
 }
 
-#endif // ENABLE(GAMEPAD)
+#endif // ENABLE(GAMEPAD) && USE(LIBWPE)


### PR DESCRIPTION
#### c1660e3ba241183a096c38ee11bc6b07f4f96676
<pre>
Share libwpe gamepad code
<a href="https://bugs.webkit.org/show_bug.cgi?id=246934">https://bugs.webkit.org/show_bug.cgi?id=246934</a>

Reviewed by Žan Doberšek and Adrian Perez de Castro.

In v1.14.0 libwpe added support for Gamepads. However when the code was
added to WebKit it was targeted specifically to the WPE port. All the
code is libwpe specific, not WPE specific so rename the code to fit
the convention where filenames and objects contain a LibWPE suffix and
the source code resides in a libwpe directory.

`WPEGamepad` -&gt; `GamepadLibWPE`
`WPEGamepadProvider` -&gt; `GamepadProviderLibWPE`

Additionally modify the PlayStation build to support `ENABLE_GAMEPAD`
using libwpe in the near future.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.cpp: Renamed from Source\WebCore\platform\gamepad\wpe\WPEGamepad.cpp.
* Source/WebCore/platform/gamepad/libwpe/GamepadLibWPE.h: Renamed from Source\WebCore\platform\gamepad\wpe\WPEGamepad.h.
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp: Renamed from Source\WebCore\platform\gamepad\wpe\WPEGamepadProvider.cpp.
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h: Renamed from Source\WebCore\platform\gamepad\wpe\WPEGamepadProvider.h.
* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
* Source/WebKit/UIProcess/Gamepad/libwpe/UIGamepadProviderLibWPE.cpp: Renamed from Source\WebKit\UIProcess\Gamepad\wpe\UIGamepadProviderWPE.cpp.

Canonical link: <a href="https://commits.webkit.org/255915@main">https://commits.webkit.org/255915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63d259b9b787e73f6d37f5853f46a3871ff6421

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103612 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163960 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3182 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31405 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99664 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2279 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80402 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29299 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83895 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72255 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37794 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18994 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4086 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41564 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38225 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->