### PR TITLE
More SortedArrayMap clients can use the Packed types from that header for efficiency

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -34,7 +34,6 @@
 #include <utility>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
-#include <wtf/Span.h>
 #include <wtf/Vector.h>
 #include <wtf/WallTime.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -28,6 +28,7 @@
 #include <type_traits>
 #include <wtf/ASCIICType.h>
 #include <wtf/Forward.h>
+#include <wtf/Span.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
@@ -52,6 +53,7 @@ public:
     constexpr const char* characters() const { return m_characters; }
     const LChar* characters8() const { return bitwise_cast<const LChar*>(m_characters); }
     constexpr size_t length() const;
+    Span<const LChar> span8() const { return { characters8(), length() }; }
     size_t isEmpty() const { return !m_characters || !*m_characters; }
 
     constexpr char characterAt(unsigned index) const { return m_characters[index]; }

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -29,7 +29,6 @@
 
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
-#include <wtf/Span.h>
 #include <wtf/text/StringConcatenate.h>
 #include <wtf/text/StringView.h>
 

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -31,7 +31,6 @@
 #include <wtf/Expected.h>
 #include <wtf/MathExtras.h>
 #include <wtf/Packed.h>
-#include <wtf/Span.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 #include <wtf/text/ASCIIFastPath.h>

--- a/Source/WTF/wtf/text/StringSearch.h
+++ b/Source/WTF/wtf/text/StringSearch.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <limits>
-#include <wtf/Span.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringView.h>
 

--- a/Source/WebCore/html/EnterKeyHint.cpp
+++ b/Source/WebCore/html/EnterKeyHint.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 EnterKeyHint enterKeyHintForAttributeValue(StringView value)
 {
-    static constexpr std::pair<ComparableLettersLiteral, EnterKeyHint> mappings[] = {
+    static constexpr std::pair<PackedLettersLiteral<uint64_t>, EnterKeyHint> mappings[] = {
         { "done", EnterKeyHint::Done },
         { "enter", EnterKeyHint::Enter },
         { "go", EnterKeyHint::Go },

--- a/Source/WebCore/html/parser/HTMLTokenizer.h
+++ b/Source/WebCore/html/parser/HTMLTokenizer.h
@@ -160,7 +160,7 @@ private:
     void bufferASCIICharacter(UChar);
     void bufferCharacter(UChar);
     template<typename CharacterType> void bufferCharacters(Span<const CharacterType>);
-    void bufferCharacters(ASCIILiteral literal) { bufferCharacters(Span { literal.characters8(), literal.length() }); }
+    void bufferCharacters(ASCIILiteral literal) { bufferCharacters(literal.span8()); }
 
     bool emitAndResumeInDataState(SegmentedString&);
     bool emitAndReconsumeInDataState();

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -326,7 +326,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
         return false;
     // line starts with the substring "REGION" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
-    // (tab) characters expected other than these charecters it is invalid.
+    // (tab) characters expected other than these characters it is invalid.
     if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).isAllSpecialCharacters<isASpace>()) {
         m_currentRegion = VTTRegion::create(m_document);
         return true;
@@ -355,7 +355,7 @@ bool WebVTTParser::checkStyleSheet(StringView line)
         return false;
     // line starts with the substring "STYLE" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
-    // (tab) characters expected other than these charecters it is invalid.
+    // (tab) characters expected other than these characters it is invalid.
     if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASpace>())
         return true;
 

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -96,7 +96,7 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
     if (!(platformEvent->type() == PlatformEvent::RawKeyDown || platformEvent->type() == PlatformEvent::Char))
         return { };
 
-    static constexpr std::pair<ComparableASCIILiteral, KeyboardScrollingKey> mappings[] = {
+    static constexpr std::pair<PackedASCIILiteral<uint64_t>, KeyboardScrollingKey> mappings[] = {
         { "Down", KeyboardScrollingKey::DownArrow },
         { "Left", KeyboardScrollingKey::LeftArrow },
         { "PageDown", KeyboardScrollingKey::PageDown },

--- a/Source/WebCore/platform/graphics/HEVCUtilities.cpp
+++ b/Source/WebCore/platform/graphics/HEVCUtilities.cpp
@@ -290,7 +290,7 @@ std::optional<HEVCParameters> parseHEVCDecoderConfigurationRecord(FourCC codecCo
 
 static std::optional<DoViParameters::Codec> parseDoViCodecType(StringView string)
 {
-    static constexpr std::pair<PackedASCIILowerCodes<uint32_t>, DoViParameters::Codec> typesArray[] = {
+    static constexpr std::pair<PackedLettersLiteral<uint32_t>, DoViParameters::Codec> typesArray[] = {
         { "dva1", DoViParameters::Codec::AVC1 },
         { "dvav", DoViParameters::Codec::AVC3 },
         { "dvh1", DoViParameters::Codec::HVC1 },
@@ -303,7 +303,7 @@ static std::optional<DoViParameters::Codec> parseDoViCodecType(StringView string
 static std::optional<uint16_t> profileIDForAlphabeticDoViProfile(StringView profile)
 {
     // See Table 7 of "Dolby Vision Profiles and Levels Version 1.3.2"
-    static constexpr std::pair<PackedASCIILowerCodes<uint64_t>, uint16_t> profilesArray[] = {
+    static constexpr std::pair<PackedLettersLiteral<uint64_t>, uint16_t> profilesArray[] = {
         { "dvav.se", 9 },
         { "dvhe.dtb", 7 },
         { "dvhe.dtr", 4 },

--- a/Source/WebCore/platform/text/LocaleToScriptMapping.cpp
+++ b/Source/WebCore/platform/text/LocaleToScriptMapping.cpp
@@ -43,7 +43,7 @@ UScriptCode scriptNameToCode(StringView scriptName)
     // treated as a single script for assigning a per-script font in Settings. For example, "hira" is mapped to
     // USCRIPT_KATAKANA_OR_HIRAGANA instead of USCRIPT_HIRAGANA, since we want all Japanese scripts to be rendered
     // using the same font setting.
-    using ScriptName = PackedASCIILowerCodes<uint32_t>;
+    using ScriptName = PackedLettersLiteral<uint32_t>;
     static constexpr std::pair<ScriptName, UScriptCode> scriptNameCodeList[] = {
         { "arab", USCRIPT_ARABIC },
         { "armn", USCRIPT_ARMENIAN },

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -55,7 +55,7 @@ struct SVGPropertyTraits<ComponentTransferType> {
 
     static ComponentTransferType fromString(const String& value)
     {
-        static constexpr std::pair<ComparableASCIILiteral, ComponentTransferType> mappings[] = {
+        static constexpr std::pair<PackedASCIILiteral<uint64_t>, ComponentTransferType> mappings[] = {
             { "discrete", FECOMPONENTTRANSFER_TYPE_DISCRETE },
             { "gamma", FECOMPONENTTRANSFER_TYPE_GAMMA },
             { "identity", FECOMPONENTTRANSFER_TYPE_IDENTITY },

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -307,14 +307,6 @@ Value FunPosition::evaluate() const
     return Expression::evaluationContext().position;
 }
 
-// FIXME: Should StringBuilder offer this as a member function?
-static StringView toStringView(StringBuilder& builder)
-{
-    if (builder.is8Bit())
-        return { builder.characters8(), builder.length() };
-    return { builder.characters16(), builder.length() };
-}
-
 Value FunId::evaluate() const
 {
     Value a = argument(0).evaluate();
@@ -348,7 +340,7 @@ Value FunId::evaluate() const
 
         // If there are several nodes with the same id, id() should return the first one.
         // In WebKit, getElementById behaves so, too, although its behavior in this case is formally undefined.
-        Node* node = contextScope.getElementById(toStringView(idList).substring(startPos, endPos - startPos));
+        Node* node = contextScope.getElementById(StringView(idList).substring(startPos, endPos - startPos));
         if (node && resultSet.add(*node).isNewEntry)
             result.append(node);
         


### PR DESCRIPTION
#### becd8424226a4a29c34b9d66d37d9538f304086b
<pre>
More SortedArrayMap clients can use the Packed types from that header for efficiency
<a href="https://bugs.webkit.org/show_bug.cgi?id=246924">https://bugs.webkit.org/show_bug.cgi?id=246924</a>
rdar://problem/101478661

Reviewed by Yusuke Suzuki.

* Source/WTF/wtf/FileSystem.h: Removed include of Span.h; ASCIILiteral.h pulls it in.

* Source/WTF/wtf/text/ASCIILiteral.h: Added ASCIILiteral::span8.

* Source/WTF/wtf/text/Base64.h: Removed include of Span.h.
* Source/WTF/wtf/text/StringImpl.h: Ditto.
* Source/WTF/wtf/text/StringSearch.h: Ditto.

* Source/WebCore/html/EnterKeyHint.cpp:
(WebCore::enterKeyHintForAttributeValue): Use PackedLettersLiteral&lt;uint64_t&gt;
instead of ComparableLettersLiteral because the literals all have length &lt;= 8.

* Source/WebCore/html/parser/HTMLTokenizer.h:
(WebCore::HTMLTokenizer::bufferCharacters): Use ASCIILiteral::span8.

* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndCreateRegion): Fixed &quot;charecters&quot; typo.
(WebCore::WebVTTParser::checkStyleSheet): Ditto.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::keyboardScrollingKeyForKeyboardEvent): Use PackedASCIILiteral&lt;uint64_t&gt;
instead of ComparableASCIILiteral because the literals all have length &lt;= 8.

* Source/WebCore/platform/graphics/HEVCUtilities.cpp:
(WebCore::parseDoViCodecType): Use PackedLettersLiteral&lt;uint32_t&gt; instead of
PackedASCIILowerCodes&lt;uint32_t&gt; because all the characters are compatible with
the faster code path.
(WebCore::profileIDForAlphabeticDoViProfile): Ditto.
* Source/WebCore/platform/text/LocaleToScriptMapping.cpp:
(WebCore::scriptNameToCode): Ditto.

* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
(WebCore::SVGPropertyTraits&lt;ComponentTransferType&gt;::fromString): Use
PackedASCIILiteral&lt;uint64_t&gt; instead of ComparableASCIILiteral because the
literals all have length &lt;= 8.

* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::toStringView): Deleted.
(WebCore::XPath::FunId::evaluate const): Use the conversion built into StringView
instead of the toStringView function.

Canonical link: <a href="https://commits.webkit.org/256109@main">https://commits.webkit.org/256109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74c3f4e709dbd881c8a15ee8f690194ebdd91013

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103611 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163959 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/97970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3181 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31404 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99663 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99638 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2280 "Found 1 new test failure: fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80401 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29298 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72254 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37793 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17731 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80352 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/18995 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27683 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4212 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41565 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83006 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38226 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18745 "Passed tests") | 
<!--EWS-Status-Bubble-End-->