### PR TITLE
REGRESSION(254947@main): [GTK] GBM dependency breaks build

### DIFF
--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -387,14 +387,15 @@ if (USE_OPENGL_OR_ES)
 
     if (ENABLE_WEBGL)
         # ANGLE-backed WebGL depends on DMABuf support, which at the moment is leveraged
-        # through libgbm and libdrm dependencies. USE_LIBGBM and USE_TEXTURE_MAPPER_DMABUF
-        # also have to be defined in that case.
-
-        find_package(GBM REQUIRED)
-        find_package(LibDRM REQUIRED)
-
-        SET_AND_EXPOSE_TO_BUILD(USE_LIBGBM TRUE)
-        SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER_DMABUF TRUE)
+        # through libgbm and libdrm dependencies. When libgbm is found to be available,
+        # make libdrm a requirement and define the USE_LIBGBM and USE_TEXTURE_MAPPER_DMABUF
+        # macros. When not available, ANGLE will be used in slower software-rasterization mode.
+        find_package(GBM)
+        if (GBM_FOUND)
+            find_package(LibDRM REQUIRED)
+            SET_AND_EXPOSE_TO_BUILD(USE_LIBGBM TRUE)
+            SET_AND_EXPOSE_TO_BUILD(USE_TEXTURE_MAPPER_DMABUF TRUE)
+        endif ()
     endif ()
 endif ()
 


### PR DESCRIPTION
#### bf82e38ba2dda606ff415c152a26ef098396cbd2
<pre>
REGRESSION(254947@main): [GTK] GBM dependency breaks build
<a href="https://bugs.webkit.org/show_bug.cgi?id=246812">https://bugs.webkit.org/show_bug.cgi?id=246812</a>

Reviewed by Carlos Garcia Campos.

* Source/cmake/OptionsGTK.cmake: Make ligbm and libdrm soft dependencies,
detecting the former before requiring the latter. When found, the DMA-BUF-based
ANGLE backing will be used through defining the two relevant macros. When not
found, software-backed ANGLE backing will be used to keep WebGL operational.

Canonical link: <a href="https://commits.webkit.org/255909@main">https://commits.webkit.org/255909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0b624018d9f9bdb239ae6a03b798ddec44bcdc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103618 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3188 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31411 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86305 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99670 "Hash a0b62401 for PR 5698 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2288 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80408 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29304 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84214 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72260 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85234 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37800 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17737 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80359 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19001 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83013 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38232 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18748 "Passed tests") | 
<!--EWS-Status-Bubble-End-->