### PR TITLE
Update idlharness-shadowrealm.js.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resources/idlharness-shadowrealm.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/idlharness-shadowrealm.js
@@ -21,11 +21,6 @@ function fetch_text(url) {
  *      dependency (i.e. have already been seen).
  */
 function idl_test_shadowrealm(srcs, deps) {
-    const script_urls = [
-        "/resources/testharness.js",
-        "/resources/WebIDLParser.js",
-        "/resources/idlharness.js",
-    ];
     promise_setup(async t => {
         const realm = new ShadowRealm();
         // https://github.com/web-platform-tests/wpt/issues/31996
@@ -38,44 +33,29 @@ function idl_test_shadowrealm(srcs, deps) {
                 isShadowRealm: function() { return true; },
             }; undefined;
         `);
-
-        const ss = await Promise.all(script_urls.map(url => fetch_text(url)));
-        for (const s of ss) {
-            realm.evaluate(s);
-        }
         const specs = await Promise.all(srcs.concat(deps).map(spec => {
             return fetch_text("/interfaces/" + spec + ".idl");
         }));
         const idls = JSON.stringify(specs);
-
-        const results = JSON.parse(await new Promise(
-          realm.evaluate(`(resolve,reject) => {
-              const idls = ${idls};
-              add_completion_callback(function (tests, harness_status, asserts_run) {
-                resolve(JSON.stringify(tests));
-              });
-
-              // Without the wrapping test, testharness.js will think it's done after it has run
-              // the first idlharness test.
-              test(() => {
-                  const idl_array = new IdlArray();
-                  for (let i = 0; i < ${srcs.length}; i++) {
-                      idl_array.add_idls(idls[i]);
-                  }
-                  for (let i = ${srcs.length}; i < ${srcs.length + deps.length}; i++) {
-                      idl_array.add_dependency_idls(idls[i]);
-                  }
-                  idl_array.test();
-              }, "setup");
-          }`)
-        ));
-
-        // We ran the tests in the ShadowRealm and gathered the results. Now treat them as if
-        // we'd run them directly here, so we can see them.
-        for (const {name, status, message} of results) {
-            // TODO: make this an API in testharness.js - needs RFC?
-            promise_test(t => {t.set_status(status, message); t.phase = t.phases.HAS_RESULT; t.done()}, name);
-        }
-    }, "outer setup");
+        await new Promise(
+            realm.evaluate(`(resolve,reject) => {
+                (async () => {
+                    await import("/resources/testharness.js");
+                    await import("/resources/WebIDLParser.js");
+                    await import("/resources/idlharness.js");
+                    const idls = ${idls};
+                    const idl_array = new IdlArray();
+                    for (let i = 0; i < ${srcs.length}; i++) {
+                        idl_array.add_idls(idls[i]);
+                    }
+                    for (let i = ${srcs.length}; i < ${srcs.length + deps.length}; i++) {
+                        idl_array.add_dependency_idls(idls[i]);
+                    }
+                    idl_array.test();
+                })().then(resolve, (e) => reject(e.toString()));
+            }`)
+        );
+        await fetch_tests_from_shadow_realm(realm);
+    });
 }
 // vim: set expandtab shiftwidth=4 tabstop=4 foldmarker=@{,@} foldmethod=marker:


### PR DESCRIPTION
# Pull Request Template

## File a Bug

All changes should be associated with a bug. The WebKit project is currently using [Bugzilla](https://bugs.webkit.org) as our bug tracker. Note that multiple changes may be associated with a single bug.

## Provided Tooling

The WebKit Project strongly recommends contributors use [`Tools/Scripts/git-webkit`](https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/git-webkit) to generate pull requests. See [Setup](https://github.com/WebKit/WebKit/wiki/Contributing#setup) and [Contributing Code](https://github.com/WebKit/WebKit/wiki/Contributing#contributing-code) for how to do this.

## Template

If a contributor wishes to file a pull request manually, the template is below. Manually-filed pull requests should contain their commit message as the pull request description, and their commit message should be formatted like the template below.

Additionally, the pull request should be mentioned on [Bugzilla](https://bugs.webkit.org), labels applied to the pull request matching the component and version of the [Bugzilla](https://bugs.webkit.org) associated with the pull request and the pull request assigned to its author.

<pre>
< bug title >
<a href="https://bugs.webkit.org/enter_bug.cgi">https://bugs.webkit.org/show_bug.cgi?id=#####</a>

Reviewed by NOBODY (OOPS!).

* path/changed.ext:
(function):
(class.function):

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aa651d8a38767275d0f7638474d9ea9cb8fedd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103760 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164094 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3349 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31548 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86446 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80554 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29416 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37933 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35816 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39691 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41632 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/38332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->