### PR TITLE
[GTK][WPE] AsyncScrolling: notify scrolling tree about display refresh through ThreadedCompositor client

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
@@ -29,9 +29,7 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #include "CompositingRunLoop.h"
-#include "EventDispatcher.h"
 #include "ThreadedDisplayRefreshMonitor.h"
-#include "WebProcess.h"
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/SetForScope.h>
@@ -259,11 +257,11 @@ void ThreadedCompositor::sceneUpdateFinished()
     Locker stateLocker { m_compositingRunLoop->stateLock() };
 
     // Schedule the DisplayRefreshMonitor callback, if necessary.
-    if (shouldDispatchDisplayRefreshCallback)
+    if (shouldDispatchDisplayRefreshCallback) {
         m_displayRefreshMonitor->dispatchDisplayRefreshCallback();
-
-    // Always notify the ScrollingTrees to make sure scrolling does not depend on the main thread.
-    WebProcess::singleton().eventDispatcher().notifyScrollingTreesDisplayWasRefreshed(m_displayRefreshMonitor->displayID());
+        // Notify the ScrollingTree to make sure scrolling does not depend on the main thread.
+        m_client.displayDidRefresh(m_displayRefreshMonitor->displayID());
+    }
 
     // Mark the scene update as completed.
     m_compositingRunLoop->updateCompleted(stateLocker);

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -56,6 +56,7 @@ public:
         virtual void resize(const WebCore::IntSize&) = 0;
         virtual void willRenderFrame() = 0;
         virtual void didRenderFrame() = 0;
+        virtual void displayDidRefresh(WebCore::PlatformDisplayID) = 0;
     };
 
     static Ref<ThreadedCompositor> create(Client&, ThreadedDisplayRefreshMonitor::Client&, WebCore::PlatformDisplayID, const WebCore::IntSize&, float scaleFactor, WebCore::TextureMapper::PaintFlags);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -34,12 +34,14 @@
 #include "DrawingArea.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include <WebCore/AsyncScrollingCoordinator.h>
 #include <WebCore/Chrome.h>
 #include <WebCore/Frame.h>
 #include <WebCore/FrameView.h>
 #include <WebCore/PageOverlayController.h>
 #include <WebCore/RenderLayerBacking.h>
 #include <WebCore/RenderView.h>
+#include <WebCore/ThreadedScrollingTree.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -416,6 +418,18 @@ void LayerTreeHost::willRenderFrame()
 void LayerTreeHost::didRenderFrame()
 {
     m_surface->didRenderFrame();
+}
+
+void LayerTreeHost::displayDidRefresh(PlatformDisplayID displayID)
+{
+#if ENABLE(ASYNC_SCROLLING)
+    if (auto* scrollingCoordinator = m_webPage.scrollingCoordinator()) {
+        if (auto* scrollingTree = downcast<AsyncScrollingCoordinator>(*scrollingCoordinator).scrollingTree())
+            downcast<ThreadedScrollingTree>(*scrollingTree).displayDidRefresh(displayID);
+    }
+#else
+    UNUSED_PARAM(displayID);
+#endif
 }
 
 void LayerTreeHost::requestDisplayRefreshMonitorUpdate()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -124,6 +124,7 @@ private:
     void resize(const WebCore::IntSize&) override;
     void willRenderFrame() override;
     void didRenderFrame() override;
+    void displayDidRefresh(WebCore::PlatformDisplayID) override;
 
     // ThreadedDisplayRefreshMonitor::Client
     void requestDisplayRefreshMonitorUpdate() override;


### PR DESCRIPTION
#### 8bc5773a96b51ca47acf38542daf32434ea2832e
<pre>
[GTK][WPE] AsyncScrolling: notify scrolling tree about display refresh through ThreadedCompositor client
<a href="https://bugs.webkit.org/show_bug.cgi?id=246940">https://bugs.webkit.org/show_bug.cgi?id=246940</a>

Reviewed by Žan Doberšek.

The threaded compositor is already attached to a WebPage so we can
notify the associated scrolling tree directly instead of iterating all
scrolling trees in the process. Also accessing the WebProcess and
EventDipatcher from ThreadedCompositor was a layering violation.

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::sceneUpdateFinished):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::displayDidRefresh):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:

Canonical link: <a href="https://commits.webkit.org/255913@main">https://commits.webkit.org/255913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85384fc5a1aa6ac9043d105bee49069da371ee44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103631 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3200 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31424 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99681 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2298 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80420 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29313 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84224 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72269 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37812 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19009 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4085 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39556 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38240 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->