### PR TITLE
Enable ShadowRealm JS tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6087,12 +6087,6 @@ imported/w3c/web-platform-tests/performance-timeline/idlharness-shadowrealm.wind
 imported/w3c/web-platform-tests/streams/idlharness-shadowrealm.window.html [ Pass Failure ]
 imported/w3c/web-platform-tests/url/idlharness-shadowrealm.window.html [ Pass Failure ]
 imported/w3c/web-platform-tests/user-timing/idlharness-shadowrealm.window.html [ Pass Failure ]
-js/ShadowRealm-evaluate.html [ Pass Failure ]
-js/ShadowRealm-globalThis.html [ Pass Failure ]
-js/ShadowRealm-iframe-detach.html [ Pass Failure ]
-js/ShadowRealm-iframe-sandboxed.html [ Pass Failure ]
-js/ShadowRealm-importValue.html [ Pass Failure ]
-js/ShadowRealm-worker.html [ Pass Failure ]
 
 # Failing since their import.
 imported/w3c/web-platform-tests/css/css-typed-om/rotate-by-added-angle.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 6667286895fcd5471ebc352495d865852dc98d55
<pre>
Enable ShadowRealm JS tests
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

* LayoutTests/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6667286895fcd5471ebc352495d865852dc98d55

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/93998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103633 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163979 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3202 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31426 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86317 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99683 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99659 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2299 "Found 2 new test failures: js/ShadowRealm-evaluate.html, js/ShadowRealm-globalThis.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80422 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29317 "Found 1 new test failure: js/ShadowRealm-evaluate.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72273 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37814 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35683 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19012 "Found 2 new test failures: js/ShadowRealm-evaluate.html, js/ShadowRealm-globalThis.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39558 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41583 "Found 2 new test failures: js/ShadowRealm-evaluate.html, js/ShadowRealm-globalThis.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38243 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->