### PR TITLE
Resync contain-intrinsic-size/contain-intrinsic-size-032.html from WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032-expected.txt
@@ -1,16 +1,16 @@
 
 
 FAIL .test 1 assert_equals:
-<select class="test ciw-none cih-none" data-expected-client-width="36" data-expected-client-height="18"></select>
-clientWidth expected 36 but got 34
+<select class="test ciw-none cih-none" data-expected-client-width="34" data-expected-client-height="16"></select>
+clientHeight expected 16 but got 12
 FAIL .test 2 assert_equals:
-<select class="test ciw-none cih-0" data-expected-client-width="36" data-expected-client-height="0"></select>
-clientWidth expected 36 but got 34
+<select class="test ciw-none cih-0" data-expected-client-width="34" data-expected-client-height="0"></select>
+clientHeight expected 0 but got 12
 FAIL .test 3 assert_equals:
-<select class="test ciw-none cih-100" data-expected-client-width="36" data-expected-client-height="100"></select>
-clientWidth expected 36 but got 34
+<select class="test ciw-none cih-100" data-expected-client-width="34" data-expected-client-height="100"></select>
+clientHeight expected 100 but got 12
 FAIL .test 4 assert_equals:
-<select class="test ciw-0 cih-none" data-expected-client-width="0" data-expected-client-height="18"></select>
+<select class="test ciw-0 cih-none" data-expected-client-width="0" data-expected-client-height="16"></select>
 clientWidth expected 0 but got 34
 FAIL .test 5 assert_equals:
 <select class="test ciw-0 cih-0" data-expected-client-width="0" data-expected-client-height="0"></select>
@@ -19,7 +19,7 @@ FAIL .test 6 assert_equals:
 <select class="test ciw-0 cih-100" data-expected-client-width="0" data-expected-client-height="100"></select>
 clientWidth expected 0 but got 34
 FAIL .test 7 assert_equals:
-<select class="test ciw-100 cih-none" data-expected-client-width="100" data-expected-client-height="18"></select>
+<select class="test ciw-100 cih-none" data-expected-client-width="100" data-expected-client-height="16"></select>
 clientWidth expected 100 but got 34
 FAIL .test 8 assert_equals:
 <select class="test ciw-100 cih-0" data-expected-client-width="100" data-expected-client-height="0"></select>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032.html
@@ -19,11 +19,11 @@
 }
 select {
   padding: 0;
+  border: solid;
+  margin: 5px;
 }
 .test {
   contain: size;
-  border: solid;
-  margin: 5px;
 }
 </style>
 


### PR DESCRIPTION
#### 12d37fe15c2150d912c9dd935612a9040b5ad1e9
<pre>
Resync contain-intrinsic-size/contain-intrinsic-size-032.html from WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=246944">https://bugs.webkit.org/show_bug.cgi?id=246944</a>

Reviewed by Rob Buis.

Border changes the appearance of &lt;select&gt; element, which makes contain-intrinsic-size-032.html not testable in WebKit.
Resync it to commit 1524b75b14c68d8 that both test cases and reference are with border.

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032.html:

Canonical link: <a href="https://commits.webkit.org/255920@main">https://commits.webkit.org/255920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc98542abbf0059f5d5d23cdcad8c02e9700910d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103645 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/163993 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3215 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31438 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86328 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99695 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2309 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80434 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29324 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84235 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72280 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37825 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17757 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35694 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4091 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39570 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41507 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38252 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->