### PR TITLE
Enable DEVELOPER_MODE_FATAL_WARNINGS by default

### DIFF
--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -87,7 +87,7 @@ macro(WEBKIT_ADD_TARGET_CXX_FLAGS _target)
 endmacro()
 
 
-option(DEVELOPER_MODE_FATAL_WARNINGS "Build with warnings as errors if DEVELOPER_MODE is also enabled" OFF)
+option(DEVELOPER_MODE_FATAL_WARNINGS "Build with warnings as errors if DEVELOPER_MODE is also enabled" ON)
 if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)
     if (MSVC)
         set(FATAL_WARNINGS_FLAG /WX)


### PR DESCRIPTION
#### 07a028007570a50ae18e6db0c5abfceb6875f0a0
<pre>
Enable DEVELOPER_MODE_FATAL_WARNINGS by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=246871">https://bugs.webkit.org/show_bug.cgi?id=246871</a>

Reviewed by NOBODY (OOPS!).

* Source/cmake/WebKitCompilerFlags.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07a028007570a50ae18e6db0c5abfceb6875f0a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103653 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3221 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31445 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99704 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2314 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80441 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29329 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84240 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72285 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85269 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37832 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17762 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80392 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19026 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27687 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41596 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83048 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38258 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18749 "Passed tests") | 
<!--EWS-Status-Bubble-End-->