### PR TITLE
[Cocoa] Potential channel count mismatch in CARingBuffer FetchABL

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -161,14 +161,17 @@ static void StoreABL(Vector<Byte*>& pointers, size_t destOffset, const AudioBuff
 static void FetchABL(AudioBufferList* list, size_t destOffset, Vector<Byte*>& pointers, size_t srcOffset, size_t nbytes, AudioStreamDescription::PCMFormat format, CARingBuffer::FetchMode mode)
 {
     ASSERT(list->mNumberBuffers == pointers.size());
-    AudioBuffer* dest = list->mBuffers;
-    for (auto& pointer : pointers) {
-        if (destOffset > dest->mDataByteSize)
+    auto bufferCount = std::min<size_t>(list->mNumberBuffers, pointers.size());
+    for (size_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {
+        auto& pointer = pointers[bufferIndex];
+        auto& dest = list->mBuffers[bufferIndex];
+
+        if (destOffset > dest.mDataByteSize)
             continue;
 
-        auto* destinationData = static_cast<Byte*>(dest->mData) + destOffset;
+        auto* destinationData = static_cast<Byte*>(dest.mData) + destOffset;
         auto* sourceData = pointer + srcOffset;
-        nbytes = std::min<size_t>(nbytes, dest->mDataByteSize - destOffset);
+        nbytes = std::min<size_t>(nbytes, dest.mDataByteSize - destOffset);
         if (mode == CARingBuffer::Copy)
             memcpy(destinationData, sourceData, nbytes);
         else {
@@ -200,7 +203,6 @@ static void FetchABL(AudioBufferList* list, size_t destOffset, Vector<Byte*>& po
                 break;
             }
         }
-        ++dest;
     }
 }
 


### PR DESCRIPTION
#### 013ff9c5d6163358e188b5778070bc1a756f9900
<pre>
[Cocoa] Potential channel count mismatch in CARingBuffer FetchABL
<a href="https://bugs.webkit.org/show_bug.cgi?id=246951">https://bugs.webkit.org/show_bug.cgi?id=246951</a>
rdar://100412139

Reviewed by Youenn Fablet.

In the case of a mismatch between the AudioFormatList&apos;s mNumberBuffers and the ring buffer&apos;s
m_pointers channel data, pick the minimum of the two to iterate over.

* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::FetchABL):

Canonical link: <a href="https://commits.webkit.org/255924@main">https://commits.webkit.org/255924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb93911e05fdfb55417e7929d74071bd7521f93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103656 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164006 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3226 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31449 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99706 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2316 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80445 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29337 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84242 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/83931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37837 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17763 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19027 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4094 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38259 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->