### PR TITLE
Migrate more WebCore argument coders to generated serialization format

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IndexedDB.h
+++ b/Source/WebCore/Modules/indexeddb/IndexedDB.h
@@ -98,7 +98,7 @@ enum class RequestType : uint8_t {
     Other,
 };
 
-enum class GetAllType : uint8_t {
+enum class GetAllType : bool {
     Keys,
     Values,
 };

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -43,7 +43,7 @@ class ThreadSafeDataBuffer;
 struct IDBKeyRangeData;
 
 namespace IndexedDB {
-enum class GetAllType : uint8_t;
+enum class GetAllType : bool;
 enum class IndexRecordType : bool;
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -45,7 +45,7 @@ class IDBValue;
 struct IDBKeyRangeData;
 
 namespace IndexedDB {
-enum class GetAllType : uint8_t;
+enum class GetAllType : bool;
 enum class IndexRecordType : bool;
 }
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 namespace IndexedDB {
-enum class GetAllType : uint8_t;
+enum class GetAllType : bool;
 }
 
 struct IDBGetAllRecordsData {

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -142,7 +142,7 @@ void MockContentFilter::maybeDetermineStatus(DecisionPoint decisionPoint)
     if (m_state != State::Filtering || decisionPoint != settings().decisionPoint())
         return;
 
-    LOG(ContentFiltering, "MockContentFilter stopped buffering with state %u at decision point %u.\n", m_state, decisionPoint);
+    LOG(ContentFiltering, "MockContentFilter stopped buffering with state %u at decision point %hhu.\n", m_state, decisionPoint);
 
     m_state = settings().decision() == Decision::Allow ? State::Allowed : State::Blocked;
     if (m_state != State::Blocked)

--- a/Source/WebCore/testing/MockContentFilterSettings.cpp
+++ b/Source/WebCore/testing/MockContentFilterSettings.cpp
@@ -38,6 +38,7 @@ namespace WebCore {
 
 MockContentFilterSettings& MockContentFilterSettings::singleton()
 {
+    MockContentFilter::ensureInstalled();
     static NeverDestroyed<MockContentFilterSettings> settings;
     return settings;
 }
@@ -50,7 +51,6 @@ void MockContentFilterSettings::reset()
 
 void MockContentFilterSettings::setEnabled(bool enabled)
 {
-    MockContentFilter::ensureInstalled();
     m_enabled = enabled;
     MockContentFilterManager::singleton().notifySettingsChanged(singleton());
 }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -473,6 +473,18 @@ std::optional<WTF::CreateUsingClass> ArgumentCoder<WTF::CreateUsingClass>::decod
 
 namespace WTF {
 
+template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t value)
+{
+    switch (static_cast<EnumWithoutNamespace>(value)) {
+    case EnumWithoutNamespace::Value1:
+    case EnumWithoutNamespace::Value2:
+    case EnumWithoutNamespace::Value3:
+        return true;
+    default:
+        return false;
+    }
+}
+
 #if ENABLE(UINT16_ENUM)
 template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t value)
 {

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -31,6 +31,7 @@
 #if ENABLE(BOOL_ENUM)
 namespace EnumNamespace { enum class BoolEnumType : bool; }
 #endif
+enum class EnumWithoutNamespace : uint8_t;
 #if ENABLE(UINT16_ENUM)
 namespace EnumNamespace { enum class EnumType : uint16_t; }
 #endif
@@ -112,6 +113,7 @@ template<> struct ArgumentCoder<WTF::CreateUsingClass> {
 
 namespace WTF {
 
+template<> bool isValidEnum<EnumWithoutNamespace, void>(uint8_t);
 #if ENABLE(UINT16_ENUM)
 template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t);
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -104,6 +104,11 @@ Vector<SerializedEnumInfo> allSerializedEnums()
             0, 1
         } },
 #endif
+        { "EnumWithoutNamespace"_s, sizeof(EnumWithoutNamespace), false, {
+            static_cast<uint64_t>(EnumWithoutNamespace::Value1),
+            static_cast<uint64_t>(EnumWithoutNamespace::Value2),
+            static_cast<uint64_t>(EnumWithoutNamespace::Value3),
+        } },
 #if ENABLE(UINT16_ENUM)
         { "EnumNamespace::EnumType"_s, sizeof(EnumNamespace::EnumType), false, {
             static_cast<uint64_t>(EnumNamespace::EnumType::FirstValue),

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -59,6 +59,12 @@ class WebCore::InheritanceGrandchild : WebCore::InheritsFrom {
 enum class EnumNamespace::BoolEnumType : bool
 #endif
 
+enum class EnumWithoutNamespace : uint8_t {
+    Value1,
+    Value2,
+    Value3
+}
+
 #if ENABLE(UINT16_ENUM)
 enum class EnumNamespace::EnumType : uint16_t {
     FirstValue,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1879,35 +1879,6 @@ bool ArgumentCoder<MediaPlaybackTargetContext>::decode(Decoder& decoder, MediaPl
 }
 #endif
 
-void ArgumentCoder<ExceptionDetails>::encode(IPC::Encoder& encoder, const ExceptionDetails& info)
-{
-    encoder << info.message;
-    encoder << info.lineNumber;
-    encoder << info.columnNumber;
-    encoder << info.type;
-    encoder << info.sourceURL;
-}
-
-bool ArgumentCoder<ExceptionDetails>::decode(IPC::Decoder& decoder, ExceptionDetails& result)
-{
-    if (!decoder.decode(result.message))
-        return false;
-
-    if (!decoder.decode(result.lineNumber))
-        return false;
-
-    if (!decoder.decode(result.columnNumber))
-        return false;
-
-    if (!decoder.decode(result.type))
-        return false;
-
-    if (!decoder.decode(result.sourceURL))
-        return false;
-
-    return true;
-}
-
 #if ENABLE(MEDIA_STREAM)
 void ArgumentCoder<MediaConstraints>::encode(Encoder& encoder, const WebCore::MediaConstraints& constraint)
 {
@@ -1927,35 +1898,6 @@ bool ArgumentCoder<MediaConstraints>::decode(Decoder& decoder, WebCore::MediaCon
         && decoder.decode(constraints.isValid);
 }
 #endif
-
-void ArgumentCoder<IDBKeyPath>::encode(Encoder& encoder, const IDBKeyPath& keyPath)
-{
-    bool isString = std::holds_alternative<String>(keyPath);
-    encoder << isString;
-    if (isString)
-        encoder << std::get<String>(keyPath);
-    else
-        encoder << std::get<Vector<String>>(keyPath);
-}
-
-bool ArgumentCoder<IDBKeyPath>::decode(Decoder& decoder, IDBKeyPath& keyPath)
-{
-    bool isString;
-    if (!decoder.decode(isString))
-        return false;
-    if (isString) {
-        String string;
-        if (!decoder.decode(string))
-            return false;
-        keyPath = string;
-    } else {
-        Vector<String> vector;
-        if (!decoder.decode(vector))
-            return false;
-        keyPath = vector;
-    }
-    return true;
-}
 
 #if ENABLE(SERVICE_WORKER)
 void ArgumentCoder<ServiceWorkerOrClientData>::encode(Encoder& encoder, const ServiceWorkerOrClientData& data)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -173,8 +173,6 @@ struct VelocityData;
 struct ViewportAttributes;
 struct WindowFeatures;
 
-using IDBKeyPath = std::variant<String, Vector<String>>;
-
 #if PLATFORM(COCOA)
 struct KeypressCommand;
 #endif
@@ -504,11 +502,6 @@ template<> struct ArgumentCoder<WebCore::RecentSearch> {
     static std::optional<WebCore::RecentSearch> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<WebCore::ExceptionDetails> {
-    static void encode(Encoder&, const WebCore::ExceptionDetails&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ExceptionDetails&);
-};
-
 #if ENABLE(APPLE_PAY)
 
 template<> struct ArgumentCoder<WebCore::Payment> {
@@ -563,11 +556,6 @@ template<> struct ArgumentCoder<WebCore::MediaConstraints> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::MediaConstraints&);
 };
 #endif
-
-template<> struct ArgumentCoder<WebCore::IDBKeyPath> {
-    static void encode(Encoder&, const WebCore::IDBKeyPath&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::IDBKeyPath&);
-};
 
 #if ENABLE(SERVICE_WORKER)
 
@@ -723,91 +711,6 @@ template<> struct ArgumentCoder<RefPtr<WebCore::ReportBody>> {
 
 namespace WTF {
 
-template<> struct EnumTraits<WebCore::RenderingMode> {
-    using values = EnumValues<
-        WebCore::RenderingMode,
-        WebCore::RenderingMode::Unaccelerated,
-        WebCore::RenderingMode::Accelerated
-    >;
-};
-
-template<> struct EnumTraits<WebCore::RenderingPurpose> {
-    using values = EnumValues<
-        WebCore::RenderingPurpose,
-        WebCore::RenderingPurpose::Unspecified,
-        WebCore::RenderingPurpose::Canvas,
-        WebCore::RenderingPurpose::DOM,
-        WebCore::RenderingPurpose::LayerBacking,
-        WebCore::RenderingPurpose::Snapshot,
-        WebCore::RenderingPurpose::ShareableSnapshot,
-        WebCore::RenderingPurpose::MediaPainting
-    >;
-};
-
-#if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
-template<> struct EnumTraits<WebCore::MockContentFilterSettings::DecisionPoint> {
-    using values = EnumValues<
-        WebCore::MockContentFilterSettings::DecisionPoint,
-        WebCore::MockContentFilterSettings::DecisionPoint::AfterWillSendRequest,
-        WebCore::MockContentFilterSettings::DecisionPoint::AfterRedirect,
-        WebCore::MockContentFilterSettings::DecisionPoint::AfterResponse,
-        WebCore::MockContentFilterSettings::DecisionPoint::AfterAddData,
-        WebCore::MockContentFilterSettings::DecisionPoint::AfterFinishedAddingData,
-        WebCore::MockContentFilterSettings::DecisionPoint::Never
-    >;
-};
-
-template<> struct EnumTraits<WebCore::MockContentFilterSettings::Decision> {
-    using values = EnumValues<
-        WebCore::MockContentFilterSettings::Decision,
-        WebCore::MockContentFilterSettings::Decision::Allow,
-        WebCore::MockContentFilterSettings::Decision::Block
-    >;
-};
-#endif
-
-template<> struct EnumTraits<WebCore::AutoplayEvent> {
-    using values = EnumValues<
-        WebCore::AutoplayEvent,
-        WebCore::AutoplayEvent::DidPreventMediaFromPlaying,
-        WebCore::AutoplayEvent::DidPlayMediaWithUserGesture,
-        WebCore::AutoplayEvent::DidAutoplayMediaPastThresholdWithoutUserInterference,
-        WebCore::AutoplayEvent::UserDidInterfereWithPlayback
-    >;
-};
-
-template<> struct EnumTraits<WebCore::InputMode> {
-    using values = EnumValues<
-        WebCore::InputMode,
-        WebCore::InputMode::Unspecified,
-        WebCore::InputMode::None,
-        WebCore::InputMode::Text,
-        WebCore::InputMode::Telephone,
-        WebCore::InputMode::Url,
-        WebCore::InputMode::Email,
-        WebCore::InputMode::Numeric,
-        WebCore::InputMode::Decimal,
-        WebCore::InputMode::Search
-    >;
-};
-
-template<> struct EnumTraits<WebCore::NotificationDirection> {
-    using values = EnumValues<
-        WebCore::NotificationDirection,
-        WebCore::NotificationDirection::Auto,
-        WebCore::NotificationDirection::Ltr,
-        WebCore::NotificationDirection::Rtl
-    >;
-};
-
-template<> struct EnumTraits<WebCore::IndexedDB::GetAllType> {
-    using values = EnumValues<
-        WebCore::IndexedDB::GetAllType,
-        WebCore::IndexedDB::GetAllType::Keys,
-        WebCore::IndexedDB::GetAllType::Values
-    >;
-};
-
 #if ENABLE(MEDIA_STREAM)
 template<> struct EnumTraits<WebCore::RealtimeMediaSource::Type> {
     using values = EnumValues<
@@ -817,23 +720,6 @@ template<> struct EnumTraits<WebCore::RealtimeMediaSource::Type> {
     >;
 };
 #endif
-
-template <> struct EnumTraits<WebCore::WorkerType> {
-    using values = EnumValues<
-        WebCore::WorkerType,
-        WebCore::WorkerType::Classic,
-        WebCore::WorkerType::Module
-    >;
-};
-
-template<> struct EnumTraits<WebCore::StoredCredentialsPolicy> {
-    using values = EnumValues<
-        WebCore::StoredCredentialsPolicy,
-        WebCore::StoredCredentialsPolicy::DoNotUse,
-        WebCore::StoredCredentialsPolicy::Use,
-        WebCore::StoredCredentialsPolicy::EphemeralStateless
-    >;
-};
 
 #if USE(CURL)
 template <> struct EnumTraits<WebCore::CurlProxySettings::Mode> {
@@ -845,15 +731,6 @@ template <> struct EnumTraits<WebCore::CurlProxySettings::Mode> {
     >;
 };
 #endif
-
-template<> struct EnumTraits<WTFLogChannelState> {
-    using values = EnumValues<
-    WTFLogChannelState,
-    WTFLogChannelState::Off,
-    WTFLogChannelState::On,
-    WTFLogChannelState::OnWithAccumulation
-    >;
-};
 
 #undef Always
 template<> struct EnumTraits<WTFLogLevel> {
@@ -888,11 +765,9 @@ template <> struct EnumTraits<WebCore::CDMInstance::HDCPStatus> {
     WebCore::CDMInstance::HDCPStatus::OutputDownscaled
     >;
 };
-
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
-
 template <> struct EnumTraits<WebCore::GraphicsContextGL::SimulatedEventForTesting> {
     using values = EnumValues<
     WebCore::GraphicsContextGL::SimulatedEventForTesting,
@@ -902,41 +777,5 @@ template <> struct EnumTraits<WebCore::GraphicsContextGL::SimulatedEventForTesti
     >;
 };
 #endif
-
-template<> struct EnumTraits<WebCore::ScrollSnapStrictness> {
-    using values = EnumValues<
-        WebCore::ScrollSnapStrictness,
-        WebCore::ScrollSnapStrictness::None,
-        WebCore::ScrollSnapStrictness::Proximity,
-        WebCore::ScrollSnapStrictness::Mandatory
-    >;
-};
-
-template<> struct EnumTraits<WebCore::LengthType> {
-    using values = EnumValues<
-        WebCore::LengthType,
-        WebCore::LengthType::Auto,
-        WebCore::LengthType::Relative,
-        WebCore::LengthType::Percent,
-        WebCore::LengthType::Fixed,
-        WebCore::LengthType::Intrinsic,
-        WebCore::LengthType::MinIntrinsic,
-        WebCore::LengthType::MinContent,
-        WebCore::LengthType::MaxContent,
-        WebCore::LengthType::FillAvailable,
-        WebCore::LengthType::FitContent,
-        WebCore::LengthType::Calculated,
-        WebCore::LengthType::Undefined
-    >;
-};
-
-template<> struct EnumTraits<WebCore::OverscrollBehavior> {
-    using values = EnumValues<
-        WebCore::OverscrollBehavior,
-        WebCore::OverscrollBehavior::Auto,
-        WebCore::OverscrollBehavior::Contain,
-        WebCore::OverscrollBehavior::None
-    >;
-};
 
 } // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1012,3 +1012,111 @@ struct WebCore::NavigationPreloadState {
     String headerValue;
 };
 #endif // ENABLE(SERVICE_WORKER)
+
+enum class WebCore::RenderingMode : bool
+
+enum class WebCore::RenderingPurpose : uint8_t {
+    Unspecified,
+    Canvas,
+    DOM,
+    LayerBacking,
+    Snapshot,
+    ShareableSnapshot,
+    MediaPainting
+};
+
+#if ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
+[LegacyPopulateFrom=EmptyConstructor] class WebCore::MockContentFilterSettings {
+    bool m_enabled;
+    WebCore::MockContentFilterSettings::DecisionPoint m_decisionPoint;
+    WebCore::MockContentFilterSettings::Decision m_decision;
+    WebCore::MockContentFilterSettings::Decision m_unblockRequestDecision;
+    String m_blockedString;
+    String m_modifiedRequestURL;
+}
+[Nested] enum class WebCore::MockContentFilterSettings::DecisionPoint : uint8_t {
+    AfterWillSendRequest,
+    AfterRedirect,
+    AfterResponse,
+    AfterAddData,
+    AfterFinishedAddingData,
+    Never
+};
+[Nested] enum class WebCore::MockContentFilterSettings::Decision : bool
+#endif
+
+enum class WebCore::AutoplayEvent : uint8_t {
+    DidPreventMediaFromPlaying,
+    DidPlayMediaWithUserGesture,
+    DidAutoplayMediaPastThresholdWithoutUserInterference,
+    UserDidInterfereWithPlayback
+};
+
+enum class WebCore::InputMode : uint8_t {
+    Unspecified,
+    None,
+    Text,
+    Telephone,
+    Url,
+    Email,
+    Numeric,
+    Decimal,
+    Search
+};
+
+enum class WebCore::NotificationDirection : uint8_t {
+    Auto,
+    Ltr,
+    Rtl
+};
+
+enum class WebCore::IndexedDB::GetAllType : bool
+
+enum class WebCore::WorkerType : bool
+
+enum class WebCore::StoredCredentialsPolicy : uint8_t {
+    DoNotUse,
+    Use,
+    EphemeralStateless
+};
+
+enum class WTFLogChannelState : uint8_t {
+    Off,
+    On,
+    OnWithAccumulation
+};
+
+enum class WebCore::ScrollSnapStrictness : uint8_t {
+    None,
+    Proximity,
+    Mandatory
+};
+
+enum class WebCore::LengthType : uint8_t {
+    Auto,
+    Relative,
+    Percent,
+    Fixed,
+    Intrinsic,
+    MinIntrinsic,
+    MinContent,
+    MaxContent,
+    FillAvailable,
+    FitContent,
+    Calculated,
+    Undefined
+};
+
+enum class WebCore::OverscrollBehavior : uint8_t {
+    Auto,
+    Contain,
+    None
+};
+
+struct WebCore::ExceptionDetails {
+    String message;
+    int lineNumber;
+    int columnNumber;
+    WebCore::ExceptionDetails::Type type;
+    String sourceURL;
+};


### PR DESCRIPTION
#### 52f26a2a696b9536dee799c640143cdaac808343
<pre>
Migrate more WebCore argument coders to generated serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=246965">https://bugs.webkit.org/show_bug.cgi?id=246965</a>
rdar://101516916

Reviewed by Tim Horton.

* Source/WebCore/Modules/indexeddb/IndexedDB.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/shared/IDBGetAllRecordsData.h:
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::maybeDetermineStatus):
* Source/WebCore/testing/MockContentFilterSettings.h:
(WebCore::MockContentFilterSettings::encode const): Deleted.
(WebCore::MockContentFilterSettings::decode): Deleted.
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedEnum.namespace_and_name):
(generate_header):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(WTF::void&gt;):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedEnums):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ExceptionDetails&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ExceptionDetails&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;IDBKeyPath&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;IDBKeyPath&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/256021@main">https://commits.webkit.org/256021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bac7d671038a7becd0ae121579421b9f4f92c783

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103971 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164245 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3523 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31688 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99980 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2524 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80698 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29559 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/97896 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84443 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38083 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19180 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4165 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38409 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->