### PR TITLE
Implement input validation for CSSRGB constructor and setters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssRGB-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssRGB-expected.txt
@@ -1,50 +1,50 @@
 
-FAIL Constructing a CSSRGB with an angle CSSUnitValue for the color channels throws a TypeError. assert_throws_js: function "() => new CSSRGB(color, 0, 0)" did not throw
-FAIL Constructing a CSSRGB with a CSSMathValue that doesn"t match <number> for the color channels throws a TypeError. assert_throws_js: function "() => new CSSRGB(color, 0, 0)" did not throw
-FAIL Constructing a CSSRGB with undefined for the color channels throws a TypeError. assert_throws_js: function "() => new CSSRGB(color, 0, 0)" did not throw
-FAIL Constructing a CSSRGB with a CSS math calculation for the color channels throws a TypeError. assert_throws_js: function "() => new CSSRGB(color, 0, 0)" did not throw
-FAIL Constructing a CSSRGB with a CSS number for the alpha channels throws a TypeError. assert_throws_js: function "() => new CSSRGB(0, 0, 0, CSS.number(1))" did not throw
-FAIL Updating CSSRGB. r to an angle CSSUnitValue throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. r to a CSSMathValue that doesn"t match <number> throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. r to undefined throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. r to a CSS math calculation throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. g to an angle CSSUnitValue throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. g to a CSSMathValue that doesn"t match <number> throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. g to undefined throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. g to a CSS math calculation throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. b to an angle CSSUnitValue throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. b to a CSSMathValue that doesn"t match <number> throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. b to undefined throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. b to a CSS math calculation throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. alpha to an angle CSSUnitValue throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. alpha to a CSSMathValue that doesn"t match <number> throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. alpha to undefined throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating CSSRGB. alpha to a CSS math calculation throws a TypeError. assert_throws_js: function "() => result[attr] = value" did not throw
-FAIL Updating the alpha channel to a CSS number throws a TypeError. assert_throws_js: function "() => result.alpha = CSS.number(1)" did not throw
-FAIL CSSRGB can be constructed from three numbers and will get an alpha of 100%. assert_equals: expected "CSSUnitValue" but got "Number"
-FAIL CSSRGB can be constructed from four numbers. assert_equals: expected "CSSUnitValue" but got "Number"
-FAIL CSSRGB.r can be updated with a number with the resulting value being a percentage. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Constructing a CSSRGB with an angle CSSUnitValue for the color channels throws a SyntaxError.
+PASS Constructing a CSSRGB with a CSSMathValue that doesn"t match <number> for the color channels throws a SyntaxError.
+FAIL Constructing a CSSRGB with undefined for the color channels throws a SyntaxError. assert_throws_dom: function "() => new CSSRGB(color, 0, 0)" did not throw
+FAIL Constructing a CSSRGB with a CSS math calculation for the color channels throws a SyntaxError. assert_throws_dom: function "() => new CSSRGB(color, 0, 0)" did not throw
+PASS Constructing a CSSRGB with a CSS number for the alpha channels throws a SyntaxError.
+PASS Updating CSSRGB. r to an angle CSSUnitValue throws a SyntaxError.
+PASS Updating CSSRGB. r to a CSSMathValue that doesn"t match <number> throws a SyntaxError.
+FAIL Updating CSSRGB. r to undefined throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+FAIL Updating CSSRGB. r to a CSS math calculation throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+PASS Updating CSSRGB. g to an angle CSSUnitValue throws a SyntaxError.
+PASS Updating CSSRGB. g to a CSSMathValue that doesn"t match <number> throws a SyntaxError.
+FAIL Updating CSSRGB. g to undefined throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+FAIL Updating CSSRGB. g to a CSS math calculation throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+PASS Updating CSSRGB. b to an angle CSSUnitValue throws a SyntaxError.
+PASS Updating CSSRGB. b to a CSSMathValue that doesn"t match <number> throws a SyntaxError.
+FAIL Updating CSSRGB. b to undefined throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+FAIL Updating CSSRGB. b to a CSS math calculation throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+PASS Updating CSSRGB. alpha to an angle CSSUnitValue throws a SyntaxError.
+PASS Updating CSSRGB. alpha to a CSSMathValue that doesn"t match <number> throws a SyntaxError.
+FAIL Updating CSSRGB. alpha to undefined throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+FAIL Updating CSSRGB. alpha to a CSS math calculation throws a SyntaxError. assert_throws_dom: function "() => result[attr] = color" did not throw
+PASS Updating the alpha channel to a CSS number throws a SyntaxError.
+PASS CSSRGB can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSRGB can be constructed from four numbers.
+PASS CSSRGB.r can be updated with a number with the resulting value being a percentage.
 PASS CSSRGB.r can be updated with a CSS number.
 PASS CSSRGB.r can be updated with CSS percent.
 PASS CSSRGB.r can be updated with CSS math sum.
 PASS CSSRGB.r can be updated with CSS math product.
 PASS CSSRGB.r can be updated with CSS math max.
 PASS CSSRGB.r can be updated with CSS math min.
-FAIL CSSRGB.g can be updated with a number with the resulting value being a percentage. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS CSSRGB.g can be updated with a number with the resulting value being a percentage.
 PASS CSSRGB.g can be updated with a CSS number.
 PASS CSSRGB.g can be updated with CSS percent.
 PASS CSSRGB.g can be updated with CSS math sum.
 PASS CSSRGB.g can be updated with CSS math product.
 PASS CSSRGB.g can be updated with CSS math max.
 PASS CSSRGB.g can be updated with CSS math min.
-FAIL CSSRGB.b can be updated with a number with the resulting value being a percentage. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS CSSRGB.b can be updated with a number with the resulting value being a percentage.
 PASS CSSRGB.b can be updated with a CSS number.
 PASS CSSRGB.b can be updated with CSS percent.
 PASS CSSRGB.b can be updated with CSS math sum.
 PASS CSSRGB.b can be updated with CSS math product.
 PASS CSSRGB.b can be updated with CSS math max.
 PASS CSSRGB.b can be updated with CSS math min.
-FAIL CSSRGB.alpha can be updated with a number with the resulting value being a percentage. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS CSSRGB.alpha can be updated with a number with the resulting value being a percentage.
 PASS CSSRGB.alpha can be updated with CSS percent.
 PASS CSSRGB.alpha can be updated with CSS math sum.
 PASS CSSRGB.alpha can be updated with CSS math product.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssRGB.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssRGB.html
@@ -28,34 +28,34 @@ const gValidColorTestCases = [
 
 for (const {color, desc, skipAlpha} of gInvalidColorTestCases) {
   test(() => {
-    assert_throws_js(TypeError, () => new CSSRGB(color, 0, 0));
-    assert_throws_js(TypeError, () => new CSSRGB(0, color, 0));
-    assert_throws_js(TypeError, () => new CSSRGB(0, 0, color));
-    assert_throws_js(TypeError, () => new CSSRGB(color, 0, 0, 0));
-    assert_throws_js(TypeError, () => new CSSRGB(0, color, 0, 0));
-    assert_throws_js(TypeError, () => new CSSRGB(0, 0, color, 0));
-    if (!skipAlpha) assert_throws_js(TypeError, () => new CSSRGB(0, 0, 0, color));
-  }, `Constructing a CSSRGB with ${desc} for the color channels throws a TypeError.`);
+    assert_throws_dom("SyntaxError", () => new CSSRGB(color, 0, 0));
+    assert_throws_dom("SyntaxError", () => new CSSRGB(0, color, 0));
+    assert_throws_dom("SyntaxError", () => new CSSRGB(0, 0, color));
+    assert_throws_dom("SyntaxError", () => new CSSRGB(color, 0, 0, 0));
+    assert_throws_dom("SyntaxError", () => new CSSRGB(0, color, 0, 0));
+    assert_throws_dom("SyntaxError", () => new CSSRGB(0, 0, color, 0));
+    if (!skipAlpha) assert_throws_dom("SyntaxError", () => new CSSRGB(0, 0, 0, color));
+  }, `Constructing a CSSRGB with ${desc} for the color channels throws a SyntaxError.`);
 }
 
 test(() => {
-  assert_throws_js(TypeError, () => new CSSRGB(0, 0, 0, CSS.number(1)));
-}, `Constructing a CSSRGB with a CSS number for the alpha channels throws a TypeError.`);
+  assert_throws_dom("SyntaxError", () => new CSSRGB(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSRGB with a CSS number for the alpha channels throws a SyntaxError.`);
 
 for (const attr of ['r', 'g', 'b', 'alpha']) {
-  for (const {value, desc} of gInvalidColorTestCases) {
+  for (const {color, desc} of gInvalidColorTestCases) {
     test(() => {
       const result = new CSSRGB(0, 0, 0, 0);
-      assert_throws_js(TypeError, () => result[attr] = value);
+      assert_throws_dom("SyntaxError", () => result[attr] = color);
       assert_style_value_equals(result[attr], CSS.percent(0));
-    }, `Updating CSSRGB. ${attr} to ${desc} throws a TypeError.`);
+    }, `Updating CSSRGB. ${attr} to ${desc} throws a SyntaxError.`);
   }
 }
 
 test(() => {
   const result = new CSSRGB(0, 0, 0);
-  assert_throws_js(TypeError, () => result.alpha = CSS.number(1));
-}, "Updating the alpha channel to a CSS number throws a TypeError.");
+  assert_throws_dom("SyntaxError", () => result.alpha = CSS.number(1));
+}, "Updating the alpha channel to a CSS number throws a SyntaxError.");
 
 test(() => {
   const result = new CSSRGB(0.5, CSS.number(73), CSS.percent(91));

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -903,6 +903,7 @@ css/typedom/DeclaredStylePropertyMap.cpp
 css/typedom/MainThreadStylePropertyMapReadOnly.cpp
 css/typedom/StylePropertyMap.cpp
 css/typedom/color/CSSColor.cpp
+css/typedom/color/CSSColorValue.cpp
 css/typedom/color/CSSHSL.cpp
 css/typedom/color/CSSHWB.cpp
 css/typedom/color/CSSLCH.cpp

--- a/Source/WebCore/css/typedom/color/CSSColorValue.cpp
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSColorValue.h"
+
+#include "CSSKeywordValue.h"
+#include "CSSUnitValue.h"
+#include "CSSUnits.h"
+#include "ExceptionOr.h"
+
+namespace WebCore {
+
+RefPtr<CSSKeywordValue> CSSColorValue::colorSpace()
+{
+    // FIXME: implement this.
+    return nullptr;
+}
+
+RefPtr<CSSColorValue> CSSColorValue::to(CSSKeywordish)
+{
+    // FIXME: implement this.
+    return nullptr;
+}
+
+std::variant<RefPtr<CSSColorValue>, RefPtr<CSSStyleValue>> CSSColorValue::parse(const String&)
+{
+    // FIXME: implement this.
+    return RefPtr<CSSColorValue> { nullptr };
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-csscolorpercent
+ExceptionOr<RectifiedCSSColorPercent> CSSColorValue::rectifyCSSColorPercent(CSSColorPercent&& colorPercent)
+{
+    return switchOn(WTFMove(colorPercent), [](double value) -> ExceptionOr<RectifiedCSSColorPercent> {
+        return { RefPtr<CSSNumericValue> { CSSUnitValue::create(value * 100, CSSUnitType::CSS_PERCENTAGE) } };
+    }, [](RefPtr<CSSNumericValue>&& numericValue) -> ExceptionOr<RectifiedCSSColorPercent> {
+        if (numericValue->type().matches<CSSNumericBaseType::Percent>())
+            return { WTFMove(numericValue) };
+        return Exception { SyntaxError, "Invalid CSSColorPercent"_s };
+    }, [](String&& string) -> ExceptionOr<RectifiedCSSColorPercent> {
+        return { RefPtr<CSSKeywordValue> { CSSKeywordValue::rectifyKeywordish(WTFMove(string)) } };
+    }, [](RefPtr<CSSKeywordValue>&& keywordValue) -> ExceptionOr<RectifiedCSSColorPercent> {
+        if (equalIgnoringASCIICase(keywordValue->value(), "none"_s))
+            return { WTFMove(keywordValue) };
+        return Exception { SyntaxError, "Invalid CSSColorPercent"_s };
+    });
+}
+
+CSSColorPercent CSSColorValue::toCSSColorPercent(const RectifiedCSSColorPercent& component)
+{
+    return switchOn(component, [](const RefPtr<CSSKeywordValue>& keywordValue) -> CSSColorPercent {
+        return keywordValue;
+    }, [](const RefPtr<CSSNumericValue>& numericValue) -> CSSColorPercent {
+        return numericValue;
+    });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSColorValue.h
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.h
@@ -32,17 +32,21 @@
 namespace WebCore {
 
 class CSSKeywordValue;
+
 using CSSKeywordish = std::variant<String, RefPtr<CSSKeywordValue>>;
 using CSSColorPercent = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+using RectifiedCSSColorPercent = std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;
 using CSSColorNumber = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
 using CSSColorAngle = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
 
 class CSSColorValue : public CSSStyleValue {
 public:
-    // FIXME: Implement these.
-    RefPtr<CSSKeywordValue> colorSpace() { return nullptr; }
-    RefPtr<CSSColorValue> to(CSSKeywordish) { return nullptr; }
-    static std::variant<RefPtr<CSSColorValue>, RefPtr<CSSStyleValue>> parse(String) { return RefPtr<CSSColorValue> { nullptr }; }
+    RefPtr<CSSKeywordValue> colorSpace();
+    RefPtr<CSSColorValue> to(CSSKeywordish);
+    static std::variant<RefPtr<CSSColorValue>, RefPtr<CSSStyleValue>> parse(const String&);
+
+    static ExceptionOr<RectifiedCSSColorPercent> rectifyCSSColorPercent(CSSColorPercent&&);
+    static CSSColorPercent toCSSColorPercent(const RectifiedCSSColorPercent&);
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSRGB.cpp
+++ b/Source/WebCore/css/typedom/color/CSSRGB.cpp
@@ -26,18 +26,121 @@
 #include "config.h"
 #include "CSSRGB.h"
 
+#include "CSSUnitValue.h"
+#include "CSSUnits.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSRGB);
 
-CSSRGB::CSSRGB(CSSColorRGBComp red, CSSColorRGBComp green, CSSColorRGBComp blue, CSSColorPercent alpha)
+static CSSColorRGBComp toCSSColorRGBComp(const RectifiedCSSColorRGBComp& component)
+{
+    return switchOn(component, [](const RefPtr<CSSKeywordValue>& keywordValue) -> CSSColorRGBComp {
+        return keywordValue;
+    }, [](const RefPtr<CSSNumericValue>& numericValue) -> CSSColorRGBComp {
+        return numericValue;
+    });
+}
+
+ExceptionOr<Ref<CSSRGB>> CSSRGB::create(CSSColorRGBComp&& red, CSSColorRGBComp&& green, CSSColorRGBComp&& blue, CSSColorPercent&& alpha)
+{
+    auto rectifiedRed = rectifyCSSColorRGBComp(WTFMove(red));
+    if (rectifiedRed.hasException())
+        return rectifiedRed.releaseException();
+    auto rectifiedGreen = rectifyCSSColorRGBComp(WTFMove(green));
+    if (rectifiedGreen.hasException())
+        return rectifiedGreen.releaseException();
+    auto rectifiedBlue = rectifyCSSColorRGBComp(WTFMove(blue));
+    if (rectifiedBlue.hasException())
+        return rectifiedBlue.releaseException();
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+
+    return adoptRef(*new CSSRGB(rectifiedRed.releaseReturnValue(), rectifiedGreen.releaseReturnValue(), rectifiedBlue.releaseReturnValue(), rectifiedAlpha.releaseReturnValue()));
+}
+
+CSSRGB::CSSRGB(RectifiedCSSColorRGBComp&& red, RectifiedCSSColorRGBComp&& green, RectifiedCSSColorRGBComp&& blue, RectifiedCSSColorPercent&& alpha)
     : m_red(WTFMove(red))
     , m_green(WTFMove(green))
     , m_blue(WTFMove(blue))
     , m_alpha(WTFMove(alpha))
 {
+}
+
+CSSColorRGBComp CSSRGB::r() const
+{
+    return toCSSColorRGBComp(m_red);
+}
+
+ExceptionOr<void> CSSRGB::setR(CSSColorRGBComp&& red)
+{
+    auto rectifiedRed = rectifyCSSColorRGBComp(WTFMove(red));
+    if (rectifiedRed.hasException())
+        return rectifiedRed.releaseException();
+    m_red = rectifiedRed.releaseReturnValue();
+    return { };
+}
+
+CSSColorRGBComp CSSRGB::g() const
+{
+    return toCSSColorRGBComp(m_green);
+}
+
+ExceptionOr<void> CSSRGB::setG(CSSColorRGBComp&& green)
+{
+    auto rectifiedGreen = rectifyCSSColorRGBComp(WTFMove(green));
+    if (rectifiedGreen.hasException())
+        return rectifiedGreen.releaseException();
+    m_green = rectifiedGreen.releaseReturnValue();
+    return { };
+}
+
+CSSColorRGBComp CSSRGB::b() const
+{
+    return toCSSColorRGBComp(m_blue);
+}
+
+ExceptionOr<void> CSSRGB::setB(CSSColorRGBComp&& blue)
+{
+    auto rectifiedBlue = rectifyCSSColorRGBComp(WTFMove(blue));
+    if (rectifiedBlue.hasException())
+        return rectifiedBlue.releaseException();
+    m_blue = rectifiedBlue.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSRGB::alpha() const
+{
+    return toCSSColorPercent(m_alpha);
+}
+
+ExceptionOr<void> CSSRGB::setAlpha(CSSColorPercent&& alpha)
+{
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    m_alpha = rectifiedAlpha.releaseReturnValue();
+    return { };
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-csscolorrgbcomp
+ExceptionOr<RectifiedCSSColorRGBComp> CSSRGB::rectifyCSSColorRGBComp(CSSColorRGBComp&& component)
+{
+    return switchOn(WTFMove(component), [](double value) -> ExceptionOr<RectifiedCSSColorRGBComp> {
+        return { RefPtr<CSSNumericValue> { CSSUnitValue::create(value * 100, CSSUnitType::CSS_PERCENTAGE) } };
+    }, [](RefPtr<CSSNumericValue>&& numericValue) -> ExceptionOr<RectifiedCSSColorRGBComp> {
+        if (numericValue->type().matchesNumber() || numericValue->type().matches<CSSNumericBaseType::Percent>())
+            return { WTFMove(numericValue) };
+        return Exception { SyntaxError, "Invalid CSSColorRGBComp"_s };
+    }, [](String&& string) -> ExceptionOr<RectifiedCSSColorRGBComp> {
+        return { RefPtr<CSSKeywordValue> { CSSKeywordValue::rectifyKeywordish(WTFMove(string)) } };
+    }, [](RefPtr<CSSKeywordValue>&& keywordValue) -> ExceptionOr<RectifiedCSSColorRGBComp> {
+        if (equalIgnoringASCIICase(keywordValue->value(), "none"_s))
+            return { WTFMove(keywordValue) };
+        return Exception { SyntaxError, "Invalid CSSColorRGBComp"_s };
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSRGB.h
+++ b/Source/WebCore/css/typedom/color/CSSRGB.h
@@ -26,32 +26,36 @@
 #pragma once
 
 #include "CSSColorValue.h"
+#include "ExceptionOr.h"
 
 namespace WebCore {
 
 using CSSColorRGBComp = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+using RectifiedCSSColorRGBComp = std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;
 
 class CSSRGB : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSRGB);
 public:
-    template<typename... Args> static Ref<CSSRGB> create(Args&&... args) { return adoptRef(*new CSSRGB(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSRGB>> create(CSSColorRGBComp&&, CSSColorRGBComp&&, CSSColorRGBComp&&, CSSColorPercent&&);
 
-    const CSSColorRGBComp& r() const { return m_red; }
-    void setR(CSSColorRGBComp red) { m_red = WTFMove(red); }
-    const CSSColorRGBComp& g() const { return m_green; }
-    void setG(CSSColorRGBComp green) { m_green = WTFMove(green); }
-    const CSSColorRGBComp& b() const { return m_blue; }
-    void setB(CSSColorRGBComp blue) { m_blue = WTFMove(blue); }
-    const CSSColorPercent& alpha() const { return m_alpha; }
-    void setAlpha(CSSColorPercent alpha) { m_alpha = WTFMove(alpha); }
+    CSSColorRGBComp r() const;
+    ExceptionOr<void> setR(CSSColorRGBComp&&);
+    CSSColorRGBComp g() const;
+    ExceptionOr<void> setG(CSSColorRGBComp&&);
+    CSSColorRGBComp b() const;
+    ExceptionOr<void> setB(CSSColorRGBComp&&);
+    CSSColorPercent alpha() const;
+    ExceptionOr<void> setAlpha(CSSColorPercent&&);
+
+    static ExceptionOr<RectifiedCSSColorRGBComp> rectifyCSSColorRGBComp(CSSColorRGBComp&&);
 
 private:
-    CSSRGB(CSSColorRGBComp, CSSColorRGBComp, CSSColorRGBComp, CSSColorPercent);
+    CSSRGB(RectifiedCSSColorRGBComp&&, RectifiedCSSColorRGBComp&&, RectifiedCSSColorRGBComp&&, RectifiedCSSColorPercent&&);
 
-    CSSColorRGBComp m_red;
-    CSSColorRGBComp m_green;
-    CSSColorRGBComp m_blue;
-    CSSColorPercent m_alpha;
+    RectifiedCSSColorRGBComp m_red;
+    RectifiedCSSColorRGBComp m_green;
+    RectifiedCSSColorRGBComp m_blue;
+    RectifiedCSSColorPercent m_alpha;
 };
     
 } // namespace WebCore


### PR DESCRIPTION
#### c4f1f9c6e5d1a6085ded4dfbc458a965024ed8a4
<pre>
Implement input validation for CSSRGB constructor and setters
<a href="https://bugs.webkit.org/show_bug.cgi?id=246972">https://bugs.webkit.org/show_bug.cgi?id=246972</a>

Reviewed by Antti Koivisto.

Implement input validation for CSSRGB constructor and setters:
- <a href="https://drafts.css-houdini.org/css-typed-om-1/#dom-cssrgb-cssrgb-r-g-b-optional-alpha">https://drafts.css-houdini.org/css-typed-om-1/#dom-cssrgb-cssrgb-r-g-b-optional-alpha</a>
- <a href="https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-csscolorrgbcomp">https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-csscolorrgbcomp</a>
- <a href="https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-csscolorpercent">https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-csscolorpercent</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssRGB-expected.txt:

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssRGB.html:
Made some fixes to the test, which I will export to WPT:
- Expect a Syntax error instead of a TypeError, as per the specification.
- The loop for iterating over invalid test cases for the setters was wrong. As a result, the setters kept
  getting called with the string &quot;undefined&quot; instead of the actual test value.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/typedom/color/CSSColorValue.cpp: Added.
(WebCore::CSSColorValue::colorSpace):
(WebCore::CSSColorValue::to):
(WebCore::CSSColorValue::parse):
(WebCore::CSSColorValue::rectifyCSSColorPercent):
(WebCore::CSSColorValue::toCSSColorPercent):
* Source/WebCore/css/typedom/color/CSSColorValue.h:
(WebCore::CSSColorValue::colorSpace): Deleted.
(WebCore::CSSColorValue::to): Deleted.
(WebCore::CSSColorValue::parse): Deleted.
* Source/WebCore/css/typedom/color/CSSRGB.cpp:
(WebCore::toCSSColorRGBComp):
(WebCore::CSSRGB::create):
(WebCore::CSSRGB::CSSRGB):
(WebCore::CSSRGB::r const):
(WebCore::CSSRGB::setR):
(WebCore::CSSRGB::g const):
(WebCore::CSSRGB::setG):
(WebCore::CSSRGB::b const):
(WebCore::CSSRGB::setB):
(WebCore::CSSRGB::alpha const):
(WebCore::CSSRGB::setAlpha):
(WebCore::CSSRGB::rectifyCSSColorRGBComp):
* Source/WebCore/css/typedom/color/CSSRGB.h:
(WebCore::CSSRGB::create): Deleted.
(WebCore::CSSRGB::r const): Deleted.
(WebCore::CSSRGB::setR): Deleted.
(WebCore::CSSRGB::g const): Deleted.
(WebCore::CSSRGB::setG): Deleted.
(WebCore::CSSRGB::b const): Deleted.
(WebCore::CSSRGB::setB): Deleted.
(WebCore::CSSRGB::alpha const): Deleted.
(WebCore::CSSRGB::setAlpha): Deleted.

Canonical link: <a href="https://commits.webkit.org/256024@main">https://commits.webkit.org/256024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a767698b3dd38e1752d61bcb6291fe100155b66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103715 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164055 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3297 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31502 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99755 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2370 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80509 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29378 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84296 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83978 "Found 37 new API test failures: TestWebKitAPI.PDFHUD.MainResourcePDF, TestWebKitAPI.WKWebViewCloseAllMediaPresentations.ElementFullscreen, TestWebKitAPI.WebKit.MediaBufferingPolicy, TestWebKitAPI.WebKit.AutoplayOnVisibilityChange, TestWebKitAPI.WebKit.QuotaDelegate, TestWebKitAPI.CloseWebViewAfterEnterFullscreen.VideoFullscreen, TestWebKitAPI.VideoControlsManager.VideoControlsManagerMultipleVideosSwitchControlledVideoWhenScrolling, TestWebKitAPI.WKNavigation.AutomaticVisibleViewReloadAfterWebProcessCrash, TestWebKitAPI.CloseWebViewAfterEnterFullscreen.ElementFullscreen, TestWebKitAPI.WebKit.GeolocationPermission ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72330 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37888 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17801 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35769 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19068 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41641 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1969 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38301 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->