### PR TITLE
[WebXR] Use typed GL object helpers

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "GraphicsContextGL.h"
 #include "GraphicsTypesGL.h"
 #include "PlatformXR.h"
 #include "WebXRLayer.h"
@@ -72,15 +73,17 @@ private:
     Attributes m_attributes;
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
-    OwnedGLObject m_depthStencilBuffer;
-    OwnedGLObject m_stencilBuffer;
-    OwnedGLObject m_multisampleColorBuffer;
-    OwnedGLObject m_resolvedFBO;
+    GCGLOwnedRenderbuffer m_depthStencilBuffer;
+    GCGLOwnedRenderbuffer m_stencilBuffer;
+    GCGLOwnedRenderbuffer m_multisampleColorBuffer;
+    GCGLOwnedFramebuffer m_resolvedFBO;
     GCGLint m_sampleCount { 0 };
-    OwnedGLObject m_opaqueTexture;
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
+    GCGLOwnedTexture m_opaqueTexture;
     void* m_ioSurfaceTextureHandle { nullptr };
     bool m_ioSurfaceTextureHandleIsShared { false };
+#else
+    PlatformGLObject m_opaqueTexture;
 #endif
 #if USE(MTLSHAREDEVENT_FOR_XR_FRAME_COMPLETION)
     RetainPtr<id> m_completionEvent { nullptr };

--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -68,38 +68,6 @@ using GCGLContext = void*;
 typedef unsigned GLuint;
 #endif
 
-struct OwnedGLObject {
-    OwnedGLObject()
-        : OwnedGLObject(0)
-    { }
-    OwnedGLObject(PlatformGLObject object)
-        : m_object(object)
-    { }
-    OwnedGLObject(const OwnedGLObject&) = delete;
-    OwnedGLObject(OwnedGLObject&&) = delete;
-    ~OwnedGLObject()
-    {
-        ASSERT(!m_object, "Have you explicitly deleted this object? If so, call release().");
-    }
-
-    OwnedGLObject& operator=(const OwnedGLObject&) const = delete;
-    OwnedGLObject& operator=(OwnedGLObject&&) = delete;
-
-    operator PlatformGLObject() const { return m_object; }
-
-    [[nodiscard]] PlatformGLObject reset(PlatformGLObject newObject) {
-        std::swap(m_object, newObject);
-        return newObject;
-    }
-
-    [[nodiscard]] PlatformGLObject release() {
-        return reset(0);
-    }
-
-private:
-    PlatformGLObject m_object = 0;
-};
-
 inline constexpr size_t gcGLSpanDynamicExtent = std::numeric_limits<size_t>::max();
 
 template<typename T, size_t Extent = gcGLSpanDynamicExtent>


### PR DESCRIPTION
#### 31968b06266f78b64623bcfb667dfbd4063c101f
<pre>
[WebXR] Use typed GL object helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=246977">https://bugs.webkit.org/show_bug.cgi?id=246977</a>
rdar://101522082

Reviewed by Dean Jackson.

Replace generic OwnedGLObject with typed helpers that know how to create and
delete themselves. Since OpenGL object id&apos;s can be respecified, reset() is
replaced by ensure(), which ensures that an object id has been allocated.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
(WebCore::GCGLOwned::operator PlatformGLObject const):
(WebCore::GCGLOwned::~GCGLOwned):
* Source/WebCore/platform/graphics/GraphicsTypesGL.h:
(OwnedGLObject::OwnedGLObject): Deleted.
(OwnedGLObject::~OwnedGLObject): Deleted.
(OwnedGLObject::operator PlatformGLObject const): Deleted.
(OwnedGLObject::reset): Deleted.
(OwnedGLObject::release): Deleted.

Canonical link: <a href="https://commits.webkit.org/256347@main">https://commits.webkit.org/256347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41000837f0da678c6bbf665ac217db1a1104caa3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104954 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165220 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4647 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33365 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100836 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3393 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81958 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73312 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39188 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20050 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40845 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42697 "Found 1 new test failure: storage/indexeddb/crash-on-getdatabases.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2115 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39290 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->