### PR TITLE
Release assert while scrolling subframes under reentrant calls to updateAppearanceAfterLayout()

### DIFF
--- a/LayoutTests/editing/resources/selection-scrolling-in-multiple-nested-subframes-iframe.html
+++ b/LayoutTests/editing/resources/selection-scrolling-in-multiple-nested-subframes-iframe.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html, div[contenteditable] {
+    width: 100%;
+    background-color: lavender;
+    margin: 0;
+}
+
+iframe {
+    width: 100px;
+    height: 100px;
+}
+
+.fixed {
+    width: 10px;
+    height: 10px;
+    position: fixed;
+    background: red;
+    bottom: 0;
+    right: 0;
+}
+</style>
+</head>
+<body>
+<div>
+    <iframe srcdoc="<body contenteditable style='height: 100%; background: lightgreen;'>1. Change selection using arrow keys.</body>"></iframe>
+    <iframe srcdoc="<body contenteditable style='height: 100%; background: lightgreen;'>2. Change selection using arrow keys.</body>"></iframe>
+    <p>3. Scroll this iframe to the very bottom.</p>
+</div>
+<div class="fixed"></div>
+<p style="position: absolute; top: 400px;">4. Click the button labeled 'Click me'.</p>
+<script>
+function handleClick() {
+    [...document.querySelectorAll("iframe")].map(frame => frame.contentDocument.body.innerHTML = "")
+}
+
+function scrollDown() {
+    scrollTo(0, 400);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/selection/selection-scrolling-in-multiple-nested-subframes-expected.txt
+++ b/LayoutTests/editing/selection/selection-scrolling-in-multiple-nested-subframes-expected.txt
@@ -1,0 +1,1 @@
+PASS: Did not crash

--- a/LayoutTests/editing/selection/selection-scrolling-in-multiple-nested-subframes.html
+++ b/LayoutTests/editing/selection/selection-scrolling-in-multiple-nested-subframes.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+iframe {
+    height: 160px;
+}
+</style>
+</head>
+<body>
+<iframe src="../resources/selection-scrolling-in-multiple-nested-subframes-iframe.html"></iframe>
+<div><button>Click me</button></div>
+<p>This test verifies that we don't crash when selection scrolling triggers recursive scrolling in subframes. To run the test manually, follow the steps above and verify that we do not crash.</p>
+<script>
+let button = document.querySelector("button");
+button.addEventListener("click", () => {
+    document.body.style.overflowY = "hidden";
+    document.querySelector("iframe").contentWindow.handleClick();
+    document.body.offsetHeight;
+});
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    await UIHelper.activateAt(50, 50);
+    await UIHelper.keyDown("leftArrow");
+    await UIHelper.renderingUpdate();
+
+    await UIHelper.activateAt(150, 50);
+    await UIHelper.keyDown("leftArrow");
+    await UIHelper.renderingUpdate();
+
+    document.querySelector("iframe").contentWindow.scrollDown();
+    await UIHelper.activateElement(button);
+
+    document.write("PASS: Did not crash");
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -3693,7 +3693,12 @@ void FrameView::performPostLayoutTasks()
     // FIXME: We should not run any JavaScript code in this function.
     LOG(Layout, "FrameView %p performPostLayoutTasks", this);
     updateHasReachedSignificantRenderedTextThreshold();
-    frame().selection().updateAppearanceAfterLayout();
+
+    if (auto& selection = frame().selection(); selection.isFocusedAndActive()) {
+        // FIXME (247041): We should be able to remove this appearance update altogether,
+        // and instead defer updates until the next rendering update.
+        selection.updateAppearanceAfterLayout();
+    }
 
     flushPostLayoutTasksQueue();
 


### PR DESCRIPTION
#### dd872d60f50136a1283804ae5e957a8c039e1c96
<pre>
Release assert while scrolling subframes under reentrant calls to updateAppearanceAfterLayout()
<a href="https://bugs.webkit.org/show_bug.cgi?id=246978">https://bugs.webkit.org/show_bug.cgi?id=246978</a>
rdar://97896551

Reviewed by Simon Fraser.

It&apos;s currently possible to induce a release assertion when attempting to update layout underneath
`RenderWidget::updateWidgetPosition()`, by revealing the selection inside of a nested subframe that
contains viewport-constrained elements. The new test case below contains the steps required to set
up this assertion:

-   Load a page that contains a subframe (`s_0`), which in turn contains two or more child frames
    (`s_1`, `s_2`). `s_1` and `s_2` contain editable content, and `s_0` contains a fixed-position
    element.

-   Focus each of `s_1` and `s_2`, and use the keyboard to change the selection. This causes both
    frames&apos; `FrameSelection`s to be in a state where `m_selectionRevealMode` is set to `Reveal`.

-   Scroll `s_0` down to the bottom (see (3) below for more information), and then click the button
    to trigger an event handler that runs the rest of the test.

1.  On click, in `s_1` and `s_2`, we clear the contents of the body, which schedules selection
    revealing as post-layout tasks.

2.  Next, we force a sync layout update by invoking `document.body.offsetHeight;` in the main frame,
    which triggers all the following events in the test.

3.  As a post-layout task, since `s_0` contains a fixed-position element, we invoke
    `FrameView::updateWidgetPositions()`, which triggers a subsequent layout in each of the
    subframes.

4.  In this nested layout pass, we then fire off the additional post-layout tasks scheduled by `s_1`
    and `s_2`, which both attempt to reveal the selection synchronously, one after another.

5.  The selection scrolling causes us to establish a `ScriptDisallowedScope` inside of
    `FrameView::scrollRectToVisibleInChildView`, while attempting scrolling the child frame `s_1` to
    reveal the selection.

6.  This nested `RenderWidget::updateWidgetPosition()` triggers another nested layout pass. Note
    that this, in theory, already reveals the bug — though in practice, we don&apos;t crash yet because
    `s_1`&apos;s layout is already up to date. After layout, we fire off the other queued post-layout
    task to reveal the selection, this time for `s_2`.

7.  We then attempt to reveal the selection again, this time for `s_2`. However, due to the fact
    that this is now all happening inside a `ScriptDisallowedScope` established in (5), we now
    crash.

To fix this, we take advantage of some of the prior work done in `commits.webkit.org/250836@main` to
remove a synchronous post-layout call to `updateAppearanceAfterLayout()` in the case where the
selection is not focused and active. Since we now update the selection appearance in the next
rendering update anyways, this simply defers work that would&apos;ve otherwise been done as a post-layout
task to the next rendering update instead. Note that we still update eagerly here in the case where
the selection is active, since accessibility notifications still rely on the fact that intermediate
AX notifications are dispatched for selection changes that happen during text editing (see:
accessibility/mac/selection-value-changes-for-aria-textbox.html).

In the future, we could probably queue the accessibility notifications above as well, and eliminate
the post-layout selection appearance update altogether.

Test: editing/selection/selection-scrolling-in-multiple-nested-subframes.html

* LayoutTests/editing/resources/selection-scrolling-in-multiple-nested-subframes-iframe.html: Added.
* LayoutTests/editing/selection/selection-scrolling-in-multiple-nested-subframes-expected.txt: Added.
* LayoutTests/editing/selection/selection-scrolling-in-multiple-nested-subframes.html: Added.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::performPostLayoutTasks):

Canonical link: <a href="https://commits.webkit.org/255998@main">https://commits.webkit.org/255998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40752baba8d65de8a2e6a952e91e870d7b21e8df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3469 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/26754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103959 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3510 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99961 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80687 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/26754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38071 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/26754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35949 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/26754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4150 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39835 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41784 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/26754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->