### PR TITLE
Support async replies for stream connections.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1100,7 +1100,7 @@ def generate_message_handler(receiver):
         if message.reply_parameters is not None:
             delayed_or_async_messages.append(message)
 
-    if delayed_or_async_messages and not receiver.has_attribute(STREAM_ATTRIBUTE):
+    if delayed_or_async_messages:
         result.append('namespace Messages {\n\nnamespace %s {\n\n' % receiver.name)
 
         for message in delayed_or_async_messages:

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -150,6 +150,18 @@ public:
         sendToStream(WTFMove(message), renderingBackendIdentifier());
     }
 
+    template<typename T, typename U, typename C>
+    void sendToStreamWithAsyncReply(T&& message, ObjectIdentifier<U> identifier, C&& callback)
+    {
+        streamConnection().sendWithAsyncReply(WTFMove(message), identifier, Seconds::infinity(), WTFMove(callback));
+    }
+
+    template<typename T, typename C>
+    void sendToStreamWithAsyncReply(T&& message, C&& callback)
+    {
+        sendToStreamWithAsyncReply(WTFMove(message), renderingBackendIdentifier(), WTFMove(callback));
+    }
+
 private:
     explicit RemoteRenderingBackendProxy(WebPage&);
 


### PR DESCRIPTION
#### e18e89ba6de6a777a0e444e1291c7ad0e0198807
<pre>
Support async replies for stream connections.
<a href="https://bugs.webkit.org/show_bug.cgi?id=235965">https://bugs.webkit.org/show_bug.cgi?id=235965</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::sendWithAsyncReply):
* Source/WebKit/Scripts/webkit/messages.py:
(generate_message_handler):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::sendToStream):
(WebKit::RemoteRenderingBackendProxy::sendToStreamWithAsyncReply):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e18e89ba6de6a777a0e444e1291c7ad0e0198807

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103738 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3324 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31526 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99771 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2382 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80532 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29399 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/97704 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_receiver") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/83994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37910 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17813 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19081 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41664 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38315 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->