### PR TITLE
[WebCodecs] Implement pixel buffer conversion for video frames produced by libwebrtc VPX decoders

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Create ImageBitmap for a VideoFrame from VP9 decoder. assert_approx_equals: expected 50 +/- 10 but got 0
+PASS Create ImageBitmap for a VideoFrame from VP9 decoder.
 


### PR DESCRIPTION
#### 21c5196e6d48ea7f87c2083c5a3179195be3c905
<pre>
[WebCodecs] Implement pixel buffer conversion for video frames produced by libwebrtc VPX decoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=246998">https://bugs.webkit.org/show_bug.cgi?id=246998</a>
rdar://problem/101534191

Reviewed by Eric Carlson.

Our drawing path requires conversion to CVPixelBuffer right now.
Implement the conversion for now.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any-expected.txt:
* Source/WebCore/platform/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):

Canonical link: <a href="https://commits.webkit.org/255958@main">https://commits.webkit.org/255958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/608e5c25e48ed0a77fc5ee01ebc3f5e2474f2d2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103776 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164109 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3364 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31561 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99799 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2420 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80568 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29428 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84336 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72376 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37946 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35829 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19108 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4121 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39704 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38344 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->