### PR TITLE
[GTK][WPE] Async Scrolling: Slow scrolling and CSS animations on a static page

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp
@@ -42,17 +42,6 @@ ScrollingTreeScrollingNodeDelegateNicosia::ScrollingTreeScrollingNodeDelegateNic
 
 ScrollingTreeScrollingNodeDelegateNicosia::~ScrollingTreeScrollingNodeDelegateNicosia() = default;
 
-std::unique_ptr<Nicosia::SceneIntegration::UpdateScope> ScrollingTreeScrollingNodeDelegateNicosia::createUpdateScope()
-{
-    auto* scrollLayer = static_cast<Nicosia::PlatformLayer*>(scrollingNode().scrollContainerLayer());
-    if (is<ScrollingTreeFrameScrollingNode>(scrollingNode()))
-        scrollLayer = static_cast<Nicosia::PlatformLayer*>(scrollingNode().scrolledContentsLayer());
-
-    ASSERT(scrollLayer);
-    auto& compositionLayer = downcast<Nicosia::CompositionLayer>(*scrollLayer);
-    return compositionLayer.createUpdateScope();
-}
-
 void ScrollingTreeScrollingNodeDelegateNicosia::updateVisibleLengths()
 {
     m_scrollController.contentsSizeChanged();
@@ -65,12 +54,6 @@ bool ScrollingTreeScrollingNodeDelegateNicosia::handleWheelEvent(const PlatformW
     updateUserScrollInProgressForEvent(wheelEvent);
 
     return m_scrollController.handleWheelEvent(wheelEvent);
-}
-
-void ScrollingTreeScrollingNodeDelegateNicosia::immediateScrollBy(const FloatSize& delta, ScrollClamping clamping)
-{
-    auto updateScope = createUpdateScope();
-    ThreadedScrollingTreeScrollingNodeDelegate::immediateScrollBy(delta, clamping);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.h
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.h
@@ -40,14 +40,11 @@ public:
     explicit ScrollingTreeScrollingNodeDelegateNicosia(ScrollingTreeScrollingNode&, bool scrollAnimatorEnabled);
     virtual ~ScrollingTreeScrollingNodeDelegateNicosia();
 
-    std::unique_ptr<Nicosia::SceneIntegration::UpdateScope> createUpdateScope();
     void updateVisibleLengths();
     bool handleWheelEvent(const PlatformWheelEvent&);
 
 private:
     // ScrollingEffectsControllerClient.
-    void immediateScrollBy(const FloatSize&, ScrollClamping = ScrollClamping::Clamped) final;
-
     bool scrollAnimationEnabled() const final { return m_scrollAnimatorEnabled; }
 
     bool m_scrollAnimatorEnabled { false };


### PR DESCRIPTION
#### 1bf61e6bec1893edfa64c595eea49793fa53fccb
<pre>
[GTK][WPE] Async Scrolling: Slow scrolling and CSS animations on a static page
<a href="https://bugs.webkit.org/show_bug.cgi?id=221738">https://bugs.webkit.org/show_bug.cgi?id=221738</a>

Reviewed by Žan Doberšek.

Do not schedule a threaded compositor update from the scrolling thread
on every scroll. We were doing that to avoid blocking scrolling when
main thread is blocked, but it doesn&apos;t currently work and it&apos;s breaking
some sites using fixed backgrounds.

* Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.cpp:
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::createUpdateScope): Deleted.
(WebCore::ScrollingTreeScrollingNodeDelegateNicosia::immediateScrollBy): Deleted.
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeScrollingNodeDelegateNicosia.h:

Canonical link: <a href="https://commits.webkit.org/255959@main">https://commits.webkit.org/255959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6896e4b1681718adb06541e43e6d07f1a10fb473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103796 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164126 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3385 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31579 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99814 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99832 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80586 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29447 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37963 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35848 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39721 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38358 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->