### PR TITLE
LibWebRTCVPXVideoEncoder does not need to set the decoder codecType

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt
@@ -1,21 +1,3 @@
-CONSOLE MESSAGE: TypeError: Config is not valid
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
-CONSOLE MESSAGE: InvalidStateError: VideoDecoder is not configured
 
-Harness Error (FAIL), message = InvalidStateError: VideoDecoder is not configured
-
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
 

--- a/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp
@@ -84,15 +84,15 @@ void LibWebRTCVPXVideoEncoder::create(Type type, const VideoEncoder::Config& con
 {
     auto encoder = makeUniqueRef<LibWebRTCVPXVideoEncoder>(type, WTFMove(outputCallback), WTFMove(postTaskCallback));
     auto error = encoder->initialize(type, config);
-    vpxQueue().dispatch([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error, type]() mutable {
+    vpxQueue().dispatch([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error]() mutable {
         auto internalEncoder = encoder->m_internalEncoder;
-        internalEncoder->postTask([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error, type]() mutable {
+        internalEncoder->postTask([callback = WTFMove(callback), descriptionCallback = WTFMove(descriptionCallback), encoder = WTFMove(encoder), error]() mutable {
             if (error) {
                 callback(makeUnexpected(makeString("VPx encoding initialization failed with error ", error)));
                 return;
             }
             callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
-            descriptionCallback(VideoEncoder::ActiveConfiguration { type == Type::VP8 ? "vp8"_s : "vp9.00"_s, { }, { }, { }, { }, { } });
+            descriptionCallback({ });
         });
     });
 }


### PR DESCRIPTION
#### 09b196a141a8c1f13f244100c644a4f96680e429
<pre>
LibWebRTCVPXVideoEncoder does not need to set the decoder codecType
<a href="https://bugs.webkit.org/show_bug.cgi?id=247001">https://bugs.webkit.org/show_bug.cgi?id=247001</a>
rdar://problem/101539998

Reviewed by Eric Carlson.

Do not set the codec type for VPx, instead, reuse the one provided by the web application.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt:
* Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::create):

Canonical link: <a href="https://commits.webkit.org/256006@main">https://commits.webkit.org/256006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67ee4965089b5542cc4b4c089435c63df30121e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3497 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103987 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164261 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3540 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31704 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86654 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99990 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80714 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29580 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84459 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72475 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38099 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35977 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41812 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->