### PR TITLE
[WebCodecs] Update WPT validateBlackDots to test 4 pixels instead of just one

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js
@@ -67,9 +67,18 @@ function validateBlackDots(frame, count) {
     let x = i * step + dot_size / 2;
     let y = step * (x / width + 1) + dot_size / 2;
     x %= width;
-    let rgba = ctx.getImageData(x, y, 1, 1).data;
+
+    if (x)
+      x = x -1;
+    if (y)
+      y = y -1;
+
+    let rgba = ctx.getImageData(x, y, 2, 2).data;
     const tolerance = 40;
-    if (rgba[0] > tolerance || rgba[1] > tolerance || rgba[2] > tolerance) {
+    if ((rgba[0] > tolerance || rgba[1] > tolerance || rgba[2] > tolerance)
+      && (rgba[4] > tolerance || rgba[5] > tolerance || rgba[6] > tolerance)
+      && (rgba[8] > tolerance || rgba[9] > tolerance || rgba[10] > tolerance)
+      && (rgba[12] > tolerance || rgba[13] > tolerance || rgba[14] > tolerance)) {
       // The dot is too bright to be a black dot.
       return false;
     }


### PR DESCRIPTION
#### 19e96c9ddbe9b2896ca93b2b8effc8d976f33042
<pre>
[WebCodecs] Update WPT validateBlackDots to test 4 pixels instead of just one
<a href="https://bugs.webkit.org/show_bug.cgi?id=247003">https://bugs.webkit.org/show_bug.cgi?id=247003</a>
rdar://problem/101540548

Reviewed by Eric Carlson.

When validating black dots, check 4 pixels next to each other instead of 1 to limit the aliasing potential issues.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-utils.js:
(validateBlackDots):

Canonical link: <a href="https://commits.webkit.org/256017@main">https://commits.webkit.org/256017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34170893f233c7e5a617eb6a00389ca91049802f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3525 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104014 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164288 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3572 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31731 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86684 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2563 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80742 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29605 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84484 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72496 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38126 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36003 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4160 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39890 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41840 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->