### PR TITLE
File input value is not cloned by importNode()

### DIFF
--- a/LayoutTests/fast/forms/file/file-cloneNode-expected.txt
+++ b/LayoutTests/fast/forms/file/file-cloneNode-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Make sure that Node.cloneNode() works as expected for file input type.	
+

--- a/LayoutTests/fast/forms/file/file-cloneNode.html
+++ b/LayoutTests/fast/forms/file/file-cloneNode.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+function moveMouseToCenterOfElement(element) {
+    var centerX = element.offsetLeft + element.offsetWidth / 2;
+    var centerY = element.offsetTop + element.offsetHeight / 2;
+    eventSender.mouseMoveTo(centerX * devicePixelRatio, centerY * devicePixelRatio);
+}
+
+function dragFilesOntoInput(input, files) {
+    eventSender.beginDragWithFiles(files);
+    moveMouseToCenterOfElement(input);
+    eventSender.mouseUp();
+}
+
+function dragFilesOntoElement(element, files) {
+    eventSender.beginDragWithFiles(files);
+    var centerX = element.offsetLeft + element.offsetWidth / 2;
+    var centerY = element.offsetTop + element.offsetHeight / 2;
+    eventSender.mouseMoveTo(centerX, centerY);
+    eventSender.mouseUp();
+}
+</script>
+<form  method="GET">
+<input onchange="changeCount++;" type="file" id="file1">
+</form>
+<script>
+var changeCount;
+test(() => {
+  var file1 = document.getElementById('file1');
+  dragFilesOntoInput(file1, ['file-cloneNode.html']);
+  changeCount = 0;
+  var clone = file1.cloneNode(true);
+  assert_equals(file1.value, 'C:\\fakepath\\file-cloneNode.html');
+  assert_equals(clone.value, 'C:\\fakepath\\file-cloneNode.html');
+  // Test for crbug.com/388795.
+  assert_equals(changeCount, 0);
+
+  // Make sure two file input don't share their values.
+  document.body.appendChild(clone);
+  dragFilesOntoInput(file1, ['resources/file-drag-common.js']);
+  assert_equals(file1.value, 'C:\\fakepath\\file-drag-common.js');
+  assert_equals(clone.value, 'C:\\fakepath\\file-cloneNode.html');
+}, 'Make sure that Node.cloneNode() works as expected for file input type.');
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -564,6 +564,14 @@ String FileInputType::defaultToolTip() const
             names.append('\n');
     }
     return names.toString();
+}
+
+void FileInputType::copyNonAttributeProperties(const HTMLInputElement& source)
+{
+    ASSERT(m_fileList->isEmpty());
+    const FileList* sourceList = source.files();
+    for (unsigned i = 0; i < sourceList->length(); ++i)
+        m_fileList->append(sourceList->item(i)->clone());
 }
 
 

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2011-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -83,10 +83,11 @@ private:
     void disabledStateChanged() final;
     void attributeChanged(const QualifiedName&) final;
     String defaultToolTip() const final;
+    void copyNonAttributeProperties(const HTMLInputElement&) override;
 
     void filesChosen(const Vector<FileChooserFileInfo>&, const String& displayString = { }, Icon* = nullptr) final;
     void filesChosen(const Vector<String>& paths, const Vector<String>& replacementPaths = { });
-    void fileChoosingCancelled();
+    void fileChoosingCancelled() override;
 
     // FileIconLoaderClient implementation.
     void iconLoaded(RefPtr<Icon>&&) final;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2007 Samuel Weinig (sam@webkit.org)
  * Copyright (C) 2010-2021 Google Inc. All rights reserved.
@@ -1009,6 +1009,7 @@ void HTMLInputElement::copyNonAttributePropertiesFromElement(const Element& sour
     setChecked(sourceElement.m_isChecked);
     m_dirtyCheckednessFlag = sourceElement.m_dirtyCheckednessFlag;
     m_isIndeterminate = sourceElement.m_isIndeterminate;
+    m_inputType->copyNonAttributeProperties(sourceElement);
 
     HTMLTextFormControlElement::copyNonAttributePropertiesFromElement(source);
 
@@ -1421,7 +1422,7 @@ void HTMLInputElement::setShowAutoFillButton(AutoFillButtonType autoFillButtonTy
         cache->autofillTypeChanged(this);
 }
 
-FileList* HTMLInputElement::files()
+FileList* HTMLInputElement::files() const
 {
     if (auto* fileInputType = dynamicDowncast<FileInputType>(*m_inputType))
         return &fileInputType->files();

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -248,7 +248,7 @@ public:
     bool isAutoFillAvailable() const { return m_isAutoFillAvailable; }
     void setAutoFillAvailable(bool autoFillAvailable) { m_isAutoFillAvailable = autoFillAvailable; }
 
-    WEBCORE_EXPORT FileList* files();
+    WEBCORE_EXPORT FileList* files() const;
     WEBCORE_EXPORT void setFiles(RefPtr<FileList>&&, WasSetByJavaScript = WasSetByJavaScript::No);
     FileList* filesForBindings() { return files(); }
     void setFilesForBindings(RefPtr<FileList>&& fileList) { return setFiles(WTFMove(fileList), WasSetByJavaScript::Yes); }

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2007 Samuel Weinig (sam@webkit.org)
  * Copyright (C) 2009, 2010, 2011, 2012 Google Inc. All rights reserved.
@@ -998,6 +998,10 @@ std::optional<Decimal> InputType::findClosestTickMarkValue(const Decimal&)
 bool InputType::matchesIndeterminatePseudoClass() const
 {
     return false;
+}
+
+void InputType::copyNonAttributeProperties(const HTMLInputElement&)
+{
 }
 
 bool InputType::shouldAppearIndeterminate() const

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010-2021 Google Inc. All rights reserved.
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -366,6 +366,7 @@ public:
     virtual bool isFocusingWithDataListDropdown() const { return false; };
 #endif
     virtual void willUpdateCheckedness(bool /*nowChecked*/) { }
+    virtual void copyNonAttributeProperties(const HTMLInputElement&);
 
     // Parses the specified string for the type, and return
     // the Decimal value for the parsing result if the parsing


### PR DESCRIPTION
<pre>
File input value is not cloned by importNode()
<a href="https://bugs.webkit.org/show_bug.cgi?id=28123">https://bugs.webkit.org/show_bug.cgi?id=28123</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/69d0c9600bfd2afbc14047da931d4df1a67af4b9">https://chromium.googlesource.com/chromium/src.git/+/69d0c9600bfd2afbc14047da931d4df1a67af4b9</a>

This is to align Webkit with Blink / Chrome and Gecko / Firefox.

It is to allow file input values to be cloned on across to other iframe via importNode() and also fix and unexpected 'change' event from cloning of input file.

* Source/WebCore/html/FileInputType.cpp: (FileInputType::copyNonAttributesProperties): Added function
* Source/WebCore/html/FileInputType.h: Added "copyNonAttributeProperties" value
* Source/WebCore/html/HTMLInputElement.cpp: (HTMLInputElement::copyNonAttributePropertiesFromElement): Extend to add "m_inputType" pointer for "sourceElement" values (HTMLInputElement::files): changed to "const"
* Source/WebCore/html/HTMLInputElement.h: carry-forward 'const' change of function
* Source/WebCore/html/InputType.cpp:
(InputType::copyNonAttributesProperties): function with reference to "HTMLInputElement"
* Source/WebCore/html/InputType.h: carry-forward added function in "InputType.cpp"
* LayoutTests/fast/form/file/file-cloneNode.html: Added Test Case
* LayoutTests/fast/form/file/file-cloneNode-expected.txt: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9de960501b8c83501c6406af0296d693290e34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94175 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3364 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24704 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103797 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164127 "Hash ca9de960 for PR 5755 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98165 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3386 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31580 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86483 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99815 "Hash ca9de960 for PR 5755 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99833 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/3386 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80587 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/86483 "Hash ca9de960 for PR 5755 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/3386 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/24704 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/86483 "Hash ca9de960 for PR 5755 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37964 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/24704 "Hash ca9de960 for PR 5755 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35849 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/24704 "Hash ca9de960 for PR 5755 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39722 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/80587 "Hash ca9de960 for PR 5755 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41666 "Hash ca9de960 for PR 5755 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/24704 "Hash ca9de960 for PR 5755 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->