### PR TITLE
[GTK][WPE] AsyncScrolling: site bobbyhadz.com/blog/git-commit-skip-hooks is not scrollable

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
@@ -83,8 +83,7 @@ static bool collectDescendantLayersAtPoint(Vector<RefPtr<CompositionLayer>>& lay
     bool existsOnDescendent = false;
 
     parent->accessPending([&](const CompositionLayer::LayerState& state) {
-        if (FloatRect(FloatPoint(), state.size).contains(point))
-            existsOnLayer = !!state.scrollingNodeID;
+        existsOnLayer = !!state.scrollingNodeID && FloatRect({ }, state.size).contains(point) && state.eventRegion.contains(roundedIntPoint(point));
 
         for (auto child : state.children) {
             FloatPoint transformedPoint(point);

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPlatformLayer.h
@@ -136,6 +136,7 @@ public:
                     bool repaintCounterChanged : 1;
                     bool debugBorderChanged : 1;
                     bool scrollingNodeChanged : 1;
+                    bool eventRegionChanged : 1;
                 };
                 uint32_t value { 0 };
             };
@@ -204,6 +205,7 @@ public:
         } debugBorder;
 
         WebCore::ScrollingNodeID scrollingNodeID { 0 };
+        WebCore::EventRegion eventRegion;
     };
 
     template<typename T>
@@ -276,6 +278,9 @@ public:
 
         if (pending.delta.scrollingNodeChanged)
             staging.scrollingNodeID = pending.scrollingNodeID;
+
+        if (pending.delta.eventRegionChanged)
+            staging.eventRegion = pending.eventRegion;
 
         if (pending.delta.backingStoreChanged)
             staging.backingStore = pending.backingStore;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -248,6 +248,17 @@ void CoordinatedGraphicsLayer::removeFromParent()
     GraphicsLayer::removeFromParent();
 }
 
+void CoordinatedGraphicsLayer::setEventRegion(EventRegion&& eventRegion)
+{
+    if (eventRegion == m_eventRegion)
+        return;
+
+    GraphicsLayer::setEventRegion(WTFMove(eventRegion));
+    m_nicosia.delta.eventRegionChanged = true;
+
+    notifyFlushRequired();
+}
+
 #if ENABLE(SCROLLING_THREAD)
 void CoordinatedGraphicsLayer::setScrollingNodeID(ScrollingNodeID nodeID)
 {
@@ -1047,6 +1058,8 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
                 if (localDelta.scrollingNodeChanged)
                     state.scrollingNodeID = scrollingNodeID();
 #endif
+                if (localDelta.eventRegionChanged)
+                    state.eventRegion = eventRegion();
             });
         m_nicosia.performLayerSync = !!m_nicosia.delta.value;
         m_nicosia.delta = { };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -74,6 +74,7 @@ public:
     void addChildBelow(Ref<GraphicsLayer>&&, GraphicsLayer*) override;
     bool replaceChild(GraphicsLayer*, Ref<GraphicsLayer>&&) override;
     void removeFromParent() override;
+    void setEventRegion(EventRegion&&) override;
 #if ENABLE(SCROLLING_THREAD)
     void setScrollingNodeID(ScrollingNodeID) override;
 #endif


### PR DESCRIPTION
#### d911d7875a4949d3b3b5fd15246ea752882ff658
<pre>
[GTK][WPE] AsyncScrolling: site bobbyhadz.com/blog/git-commit-skip-hooks is not scrollable
<a href="https://bugs.webkit.org/show_bug.cgi?id=247004">https://bugs.webkit.org/show_bug.cgi?id=247004</a>

Reviewed by Žan Doberšek.

The problem is that ScrollingTreeNicosia::scrollingNodeForPoint() is
returning an overflow node containing the given point, but its event
region doesn&apos;t contain the point.

* Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp:
(WebCore::collectDescendantLayersAtPoint): Check also the event region contains the given point.
* Source/WebCore/platform/graphics/nicosia/NicosiaPlatformLayer.h: Add EventRegion.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::setEventRegion):
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:

Canonical link: <a href="https://commits.webkit.org/256004@main">https://commits.webkit.org/256004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e20860848ab0e2c2eb69b63573b00943ab7a459d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/24711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103808 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164139 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98174 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3396 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31591 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99829 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2450 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80599 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29453 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84361 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72401 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/37973 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19134 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4154 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39733 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41719 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/close/setInterval.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38365 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->