### PR TITLE
Allow calc() with combined percentages and lengths for line-height

### DIFF
--- a/LayoutTests/css3/calc/line-height-expected.txt
+++ b/LayoutTests/css3/calc/line-height-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS getComputedStyle(document.getElementById("calc-percent"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
-FAIL getComputedStyle(document.getElementById("calc-percent-pixels"), null).lineHeight should be 32px. Was normal.
+PASS getComputedStyle(document.getElementById("calc-percent-pixels"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/calc-with-percent-and-number-in-line-height-crash-expected.txt
+++ b/LayoutTests/fast/css/calc-with-percent-and-number-in-line-height-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if it does not crash in debug.

--- a/LayoutTests/fast/css/calc-with-percent-and-number-in-line-height-crash.html
+++ b/LayoutTests/fast/css/calc-with-percent-and-number-in-line-height-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+* {
+    line-height: calc(100% + 30);
+}
+</style>
+<p>PASS if it does not crash in debug.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>

--- a/LayoutTests/fast/css/line-height-1-expected.html
+++ b/LayoutTests/fast/css/line-height-1-expected.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<style>
+div {
+ width:100px;
+ height:600px;
+ margin:5px 0 0 5px;
+ font-size: 30px;
+ float:left;
+}
+div#one {
+ line-height: 300%;
+}
+div#two {
+ line-height: 100px;
+}
+div#three {
+ line-height: 110px;
+}
+div#four {
+ line-height: 20px;
+}
+div#five {
+ line-height: 12px;
+}
+div#six {
+ line-height: 12px;
+}
+div#seven {
+ line-height: 12px;
+}
+div#eight {
+ line-height: 12px;
+}
+div#nine {
+ line-height: 12px;
+}
+div#nine {
+ line-height: 12px;
+}
+div#ten {
+ line-height: 12px;
+}
+div#div-11 {
+ line-height: 15px;
+}
+div#div-12 {
+ line-height: 195px;
+}
+</style>
+<div id="one">line height is 300%</div>
+<div id="two">line height is 100px</div>
+<div id="three">line height is 50px</div>
+<div id="four">line height is 10px * 2</div>
+<div id="five">line height is 50% - 3px</div>
+<div id="six">line height is 25% - 3px + 25%</div>
+<div id="seven">line height is 25% - 3px + 12.5% * 2</div>
+<div id="eight">line height is 25% - 3px + 12.5%*2</div>
+<div id="nine">line height is 25% - 3px + 2*12.5%</div>
+<div id="ten">line height is 25% - 3px + 2 * 12.5%</div>
+<div id="div-11">line height is 30% + 20%</div>
+<div id="div-12">line height is 3 * 2 + 3 / 6</div>
+</html>

--- a/LayoutTests/fast/css/line-height-1.html
+++ b/LayoutTests/fast/css/line-height-1.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<style>
+div {
+ width:100px;
+ height:600px;
+ margin:5px 0 0 5px;
+ font-size: 30px;
+ float:left;
+}
+div#one {
+ line-height: calc(300%);
+}
+div#two {
+ line-height: calc(100px);
+}
+div#three {
+ line-height: calc(20px + 300%);
+}
+div#four {
+ line-height: calc(10px * 2);
+}
+div#five {
+ line-height: calc(50% - 3px);
+}
+div#six {
+ line-height: calc(25% - 3px + 25%);
+}
+div#seven {
+ line-height: calc(25% - 3px + 12.5% * 2);
+}
+div#eight {
+ line-height: calc(25% - 3px + 12.5%*2);
+}
+div#nine {
+ line-height: calc(25% - 3px + 2 * 12.5%);
+}
+div#nine {
+ line-height: calc(25% - 3px + 2*12.5%);
+}
+div#ten {
+ line-height: calc(25% - 3px + 2 * 12.5%);
+}
+div#div-11 {
+ line-height: calc(30% + 20%);
+}
+div#div-12 {
+ line-height: calc(3 * 2 + 3 / 6);
+}
+</style>
+<div id="one">line height is 300%</div>
+<div id="two">line height is 100px</div>
+<div id="three">line height is 50px</div>
+<div id="four">line height is 10px * 2</div>
+<div id="five">line height is 50% - 3px</div>
+<div id="six">line height is 25% - 3px + 25%</div>
+<div id="seven">line height is 25% - 3px + 12.5% * 2</div>
+<div id="eight">line height is 25% - 3px + 12.5%*2</div>
+<div id="nine">line height is 25% - 3px + 2*12.5%</div>
+<div id="ten">line height is 25% - 3px + 2 * 12.5%</div>
+<div id="div-11">line height is 30% + 20%</div>
+<div id="div-12">line height is 3 * 2 + 3 / 6</div>
+</html>

--- a/LayoutTests/fast/css/line-height-2-expected.html
+++ b/LayoutTests/fast/css/line-height-2-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><meta charset=utf-8>
+<style>
+.a1, .a2, .a3, .a4, .a5, .a6 { float: left; }
+.a1 { line-height: 2; }
+.a2 { line-height: 6; }
+.a3 { line-height: 6px; }
+.a4 { line-height: 6; }
+.a5 { line-height: 6; }
+.a6 { line-height: 6; }
+.a7 { line-height: 0; }
+</style>
+<p class="a1">abc<br>def</p>
+<p class="a2">abc<br>def</p>
+<p class="a3">abc<br>def</p>
+<p class="a4">abc<br>def</p>
+<p class="a5">abc<br>def</p>
+<p class="a6">abc<br>def</p>
+<p class="a7">abc<br>def</p>

--- a/LayoutTests/fast/css/line-height-2.html
+++ b/LayoutTests/fast/css/line-height-2.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><meta charset=utf-8>
+<style>
+.a1, .a2, .a3, .a4, .a5, .a6 { float: left; }
+.a1 { line-height: calc(1*2); }
+.a2 { line-height: calc(1*2*3); }
+.a3 { line-height: calc(1*2*3*1px); }
+.a4 { line-height: calc((1*2)*3); }
+.a5 { line-height: calc(1*(2*3)); }
+.a6 { line-height: calc((1*2*3)); }
+.a7 { line-height: calc(-1); }
+</style>
+<p class="a1">abc<br>def</p>
+<p class="a2">abc<br>def</p>
+<p class="a3">abc<br>def</p>
+<p class="a4">abc<br>def</p>
+<p class="a5">abc<br>def</p>
+<p class="a6">abc<br>def</p>
+<p class="a7">abc<br>def</p>

--- a/LayoutTests/fast/css/line-height-basics-expected.txt
+++ b/LayoutTests/fast/css/line-height-basics-expected.txt
@@ -1,0 +1,15 @@
+Tests that CSS3 calc() can be used for the line-height property
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(document.getElementById("calc-percent"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
+PASS getComputedStyle(document.getElementById("calc-percent-pixels"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
+PASS getComputedStyle(document.getElementById("calc-percent-ems"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
+PASS getComputedStyle(document.getElementById("calc-percent"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
+PASS getComputedStyle(document.getElementById("calc-percent-pixels"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
+PASS getComputedStyle(document.getElementById("calc-percent-ems"), null).lineHeight is getComputedStyle(document.getElementById("control"), null).lineHeight
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/line-height-basics.html
+++ b/LayoutTests/fast/css/line-height-basics.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<style>
+    span { font-size: 16px; }
+    #control { line-height: 200%; }
+    #calc-percent { line-height: calc(100% * 2); }
+    #calc-percent-pixels { line-height: calc(100% + 16px); }
+    #calc-percent-ems { line-height: calc(100% + 1em); }
+</style>
+<div id="test-container">
+    <span id="control">The line height of these lines should be identical</span><hr/>
+    <span id="calc-percent">The line height of these lines should be identical</span><hr/>
+    <span id="calc-percent-pixels">The line height of these lines should be identical</span><hr/>
+    <span id="calc-percent-ems">The line height of these lines should be identical</span><hr/>
+</div>
+<script>
+    description("Tests that CSS3 calc() can be used for the line-height property");
+
+    shouldEvaluateTo('getComputedStyle(document.getElementById("calc-percent"), null).lineHeight', 'getComputedStyle(document.getElementById("control"), null).lineHeight');
+    shouldEvaluateTo('getComputedStyle(document.getElementById("calc-percent-pixels"), null).lineHeight', 'getComputedStyle(document.getElementById("control"), null).lineHeight');
+    shouldEvaluateTo('getComputedStyle(document.getElementById("calc-percent-ems"), null).lineHeight', 'getComputedStyle(document.getElementById("control"), null).lineHeight');
+
+    document.body.style.zoom = 1.75;
+
+    shouldEvaluateTo('getComputedStyle(document.getElementById("calc-percent"), null).lineHeight', 'getComputedStyle(document.getElementById("control"), null).lineHeight');
+    shouldEvaluateTo('getComputedStyle(document.getElementById("calc-percent-pixels"), null).lineHeight', 'getComputedStyle(document.getElementById("control"), null).lineHeight');
+    shouldEvaluateTo('getComputedStyle(document.getElementById("calc-percent-ems"), null).lineHeight', 'getComputedStyle(document.getElementById("control"), null).lineHeight');
+
+    if (window.testRunner) {
+        var testContainer = document.getElementById("test-container");
+        if (testContainer)
+            document.body.removeChild(testContainer);
+    }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-computed-expected.txt
@@ -8,310 +8,310 @@ PASS status-bar should be a supported system font.
 PASS Property font value 'xx-small serif'
 PASS Property font value 'normal medium/normal sans-serif'
 PASS Property font value 'normal normal xx-large/1.2 cursive'
-FAIL Property font value 'normal normal normal larger/calc(120% + 1.2em) fantasy' assert_equals: expected "48px / normal fantasy" but got "48px fantasy"
+PASS Property font value 'normal normal normal larger/calc(120% + 1.2em) fantasy'
 PASS Property font value 'normal normal normal normal smaller monospace'
 PASS Property font value 'normal normal normal italic 10px/normal Menu'
 PASS Property font value 'normal normal normal small-caps 20%/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'normal normal normal bold calc(30% - 40px)/calc(120% + 1.2em) serif' assert_equals: expected "700 0px / normal serif" but got "700 0px serif"
+PASS Property font value 'normal normal normal bold calc(30% - 40px)/calc(120% + 1.2em) serif'
 PASS Property font value 'normal normal normal ultra-condensed xx-small sans-serif'
 PASS Property font value 'normal normal italic medium/normal cursive'
 PASS Property font value 'normal normal italic normal xx-large/1.2 fantasy'
-FAIL Property font value 'normal normal italic small-caps larger/calc(120% + 1.2em) monospace' assert_equals: expected "italic small-caps 48px / normal monospace" but got "italic small-caps 48px monospace"
+PASS Property font value 'normal normal italic small-caps larger/calc(120% + 1.2em) monospace'
 PASS Property font value 'normal normal italic bolder smaller Menu'
 PASS Property font value 'normal normal italic extra-condensed 10px/normal "Non-Generic Example Family Name"'
 PASS Property font value 'normal normal small-caps 20%/1.2 serif'
-FAIL Property font value 'normal normal small-caps normal calc(30% - 40px)/calc(120% + 1.2em) sans-serif' assert_equals: expected "small-caps 0px / normal sans-serif" but got "small-caps 0px sans-serif"
+PASS Property font value 'normal normal small-caps normal calc(30% - 40px)/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'normal normal small-caps italic xx-small cursive'
 PASS Property font value 'normal normal small-caps lighter medium/normal fantasy'
 PASS Property font value 'normal normal small-caps condensed xx-large/1.2 monospace'
-FAIL Property font value 'normal normal 100 larger/calc(120% + 1.2em) Menu' assert_equals: expected "100 48px / normal Menu" but got "100 48px Menu"
+PASS Property font value 'normal normal 100 larger/calc(120% + 1.2em) Menu'
 PASS Property font value 'normal normal 900 normal smaller "Non-Generic Example Family Name"'
 PASS Property font value 'normal normal bold italic 10px/normal serif'
 PASS Property font value 'normal normal bolder small-caps 20%/1.2 sans-serif'
-FAIL Property font value 'normal normal lighter semi-condensed calc(30% - 40px)/calc(120% + 1.2em) cursive' assert_equals: expected "700 semi-condensed 0px / normal cursive" but got "700 semi-condensed 0px cursive"
+PASS Property font value 'normal normal lighter semi-condensed calc(30% - 40px)/calc(120% + 1.2em) cursive'
 PASS Property font value 'normal normal semi-expanded xx-small fantasy'
 PASS Property font value 'normal normal expanded normal medium/normal monospace'
 PASS Property font value 'normal normal extra-expanded italic xx-large/1.2 Menu'
-FAIL Property font value 'normal normal ultra-expanded small-caps larger/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "small-caps ultra-expanded 48px / normal \"Non-Generic Example Family Name\"" but got "small-caps ultra-expanded 48px \"Non-Generic Example Family Name\""
+PASS Property font value 'normal normal ultra-expanded small-caps larger/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'normal normal ultra-condensed 100 smaller serif'
 PASS Property font value 'normal italic 10px/normal sans-serif'
 PASS Property font value 'normal italic normal 20%/1.2 cursive'
-FAIL Property font value 'normal italic normal normal calc(30% - 40px)/calc(120% + 1.2em) fantasy' assert_equals: expected "italic 0px / normal fantasy" but got "italic 0px fantasy"
+PASS Property font value 'normal italic normal normal calc(30% - 40px)/calc(120% + 1.2em) fantasy'
 PASS Property font value 'normal italic normal small-caps xx-small monospace'
 PASS Property font value 'normal italic normal 900 medium/normal Menu'
 PASS Property font value 'normal italic normal extra-condensed xx-large/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'normal italic small-caps larger/calc(120% + 1.2em) serif' assert_equals: expected "italic small-caps 48px / normal serif" but got "italic small-caps 48px serif"
+PASS Property font value 'normal italic small-caps larger/calc(120% + 1.2em) serif'
 PASS Property font value 'normal italic small-caps normal smaller sans-serif'
 PASS Property font value 'normal italic small-caps bold 10px/normal cursive'
 PASS Property font value 'normal italic small-caps condensed 20%/1.2 fantasy'
-FAIL Property font value 'normal italic bolder calc(30% - 40px)/calc(120% + 1.2em) monospace' assert_equals: expected "italic 900 0px / normal monospace" but got "italic 900 0px monospace"
+PASS Property font value 'normal italic bolder calc(30% - 40px)/calc(120% + 1.2em) monospace'
 PASS Property font value 'normal italic lighter normal xx-small Menu'
 PASS Property font value 'normal italic 100 small-caps medium/normal "Non-Generic Example Family Name"'
 PASS Property font value 'normal italic 900 semi-condensed xx-large/1.2 serif'
-FAIL Property font value 'normal italic semi-expanded larger/calc(120% + 1.2em) sans-serif' assert_equals: expected "italic semi-expanded 48px / normal sans-serif" but got "italic semi-expanded 48px sans-serif"
+PASS Property font value 'normal italic semi-expanded larger/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'normal italic expanded normal smaller cursive'
 PASS Property font value 'normal italic extra-expanded small-caps 10px/normal fantasy'
 PASS Property font value 'normal italic ultra-expanded bold 20%/1.2 monospace'
-FAIL Property font value 'normal small-caps calc(30% - 40px)/calc(120% + 1.2em) Menu' assert_equals: expected "small-caps 0px / normal Menu" but got "small-caps 0px Menu"
+PASS Property font value 'normal small-caps calc(30% - 40px)/calc(120% + 1.2em) Menu'
 PASS Property font value 'normal small-caps normal xx-small "Non-Generic Example Family Name"'
 PASS Property font value 'normal small-caps normal normal medium/normal serif'
 PASS Property font value 'normal small-caps normal italic xx-large/1.2 sans-serif'
-FAIL Property font value 'normal small-caps normal bolder larger/calc(120% + 1.2em) cursive' assert_equals: expected "small-caps 900 48px / normal cursive" but got "small-caps 900 48px cursive"
+PASS Property font value 'normal small-caps normal bolder larger/calc(120% + 1.2em) cursive'
 PASS Property font value 'normal small-caps normal ultra-condensed smaller fantasy'
 PASS Property font value 'normal small-caps italic 10px/normal monospace'
 PASS Property font value 'normal small-caps italic normal 20%/1.2 Menu'
-FAIL Property font value 'normal small-caps italic lighter calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "italic small-caps 700 0px / normal \"Non-Generic Example Family Name\"" but got "italic small-caps 700 0px \"Non-Generic Example Family Name\""
+PASS Property font value 'normal small-caps italic lighter calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'normal small-caps italic extra-condensed xx-small serif'
 PASS Property font value 'normal small-caps 100 medium/normal sans-serif'
 PASS Property font value 'normal small-caps 900 normal xx-large/1.2 cursive'
-FAIL Property font value 'normal small-caps bold italic larger/calc(120% + 1.2em) fantasy' assert_equals: expected "italic small-caps 700 48px / normal fantasy" but got "italic small-caps 700 48px fantasy"
+PASS Property font value 'normal small-caps bold italic larger/calc(120% + 1.2em) fantasy'
 PASS Property font value 'normal small-caps bolder condensed smaller monospace'
 PASS Property font value 'normal small-caps semi-condensed 10px/normal Menu'
 PASS Property font value 'normal small-caps semi-expanded normal 20%/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'normal small-caps expanded italic calc(30% - 40px)/calc(120% + 1.2em) serif' assert_equals: expected "italic small-caps expanded 0px / normal serif" but got "italic small-caps expanded 0px serif"
+PASS Property font value 'normal small-caps expanded italic calc(30% - 40px)/calc(120% + 1.2em) serif'
 PASS Property font value 'normal small-caps extra-expanded lighter xx-small sans-serif'
 PASS Property font value 'normal 100 medium/normal cursive'
 PASS Property font value 'normal 900 normal xx-large/1.2 fantasy'
-FAIL Property font value 'normal bold normal normal larger/calc(120% + 1.2em) monospace' assert_equals: expected "700 48px / normal monospace" but got "700 48px monospace"
+PASS Property font value 'normal bold normal normal larger/calc(120% + 1.2em) monospace'
 PASS Property font value 'normal bolder normal italic smaller Menu'
 PASS Property font value 'normal lighter normal small-caps 10px/normal "Non-Generic Example Family Name"'
 PASS Property font value 'normal 100 normal ultra-expanded 20%/1.2 serif'
-FAIL Property font value 'normal 900 italic calc(30% - 40px)/calc(120% + 1.2em) sans-serif' assert_equals: expected "italic 900 0px / normal sans-serif" but got "italic 900 0px sans-serif"
+PASS Property font value 'normal 900 italic calc(30% - 40px)/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'normal bold italic normal xx-small cursive'
 PASS Property font value 'normal bolder italic small-caps medium/normal fantasy'
 PASS Property font value 'normal lighter italic ultra-condensed xx-large/1.2 monospace'
-FAIL Property font value 'normal 100 small-caps larger/calc(120% + 1.2em) Menu' assert_equals: expected "small-caps 100 48px / normal Menu" but got "small-caps 100 48px Menu"
+PASS Property font value 'normal 100 small-caps larger/calc(120% + 1.2em) Menu'
 PASS Property font value 'normal 900 small-caps normal smaller "Non-Generic Example Family Name"'
 PASS Property font value 'normal bold small-caps italic 10px/normal serif'
 PASS Property font value 'normal bolder small-caps extra-condensed 20%/1.2 sans-serif'
-FAIL Property font value 'normal lighter condensed calc(30% - 40px)/calc(120% + 1.2em) cursive' assert_equals: expected "700 condensed 0px / normal cursive" but got "700 condensed 0px cursive"
+PASS Property font value 'normal lighter condensed calc(30% - 40px)/calc(120% + 1.2em) cursive'
 PASS Property font value 'normal 100 semi-condensed normal xx-small fantasy'
 PASS Property font value 'normal 900 semi-expanded italic medium/normal monospace'
 PASS Property font value 'normal bold expanded small-caps xx-large/1.2 Menu'
-FAIL Property font value 'normal extra-expanded larger/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "extra-expanded 48px / normal \"Non-Generic Example Family Name\"" but got "extra-expanded 48px \"Non-Generic Example Family Name\""
+PASS Property font value 'normal extra-expanded larger/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'normal ultra-expanded normal smaller serif'
 PASS Property font value 'normal ultra-condensed normal normal 10px/normal sans-serif'
 PASS Property font value 'normal extra-condensed normal italic 20%/1.2 cursive'
-FAIL Property font value 'normal condensed normal small-caps calc(30% - 40px)/calc(120% + 1.2em) fantasy' assert_equals: expected "small-caps condensed 0px / normal fantasy" but got "small-caps condensed 0px fantasy"
+PASS Property font value 'normal condensed normal small-caps calc(30% - 40px)/calc(120% + 1.2em) fantasy'
 PASS Property font value 'normal semi-condensed normal bolder xx-small monospace'
 PASS Property font value 'normal semi-expanded italic medium/normal Menu'
 PASS Property font value 'normal expanded italic normal xx-large/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'normal extra-expanded italic small-caps larger/calc(120% + 1.2em) serif' assert_equals: expected "italic small-caps extra-expanded 48px / normal serif" but got "italic small-caps extra-expanded 48px serif"
+PASS Property font value 'normal extra-expanded italic small-caps larger/calc(120% + 1.2em) serif'
 PASS Property font value 'normal ultra-expanded italic lighter smaller sans-serif'
 PASS Property font value 'normal ultra-condensed small-caps 10px/normal cursive'
 PASS Property font value 'normal extra-condensed small-caps normal 20%/1.2 fantasy'
-FAIL Property font value 'normal condensed small-caps italic calc(30% - 40px)/calc(120% + 1.2em) monospace' assert_equals: expected "italic small-caps condensed 0px / normal monospace" but got "italic small-caps condensed 0px monospace"
+PASS Property font value 'normal condensed small-caps italic calc(30% - 40px)/calc(120% + 1.2em) monospace'
 PASS Property font value 'normal semi-condensed small-caps 100 xx-small Menu'
 PASS Property font value 'normal semi-expanded 900 medium/normal "Non-Generic Example Family Name"'
 PASS Property font value 'normal expanded bold normal xx-large/1.2 serif'
-FAIL Property font value 'normal extra-expanded bolder italic larger/calc(120% + 1.2em) sans-serif' assert_equals: expected "italic 900 extra-expanded 48px / normal sans-serif" but got "italic 900 extra-expanded 48px sans-serif"
+PASS Property font value 'normal extra-expanded bolder italic larger/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'normal ultra-expanded lighter small-caps smaller cursive'
 PASS Property font value 'italic 10px/normal fantasy'
 PASS Property font value 'italic normal 20%/1.2 monospace'
-FAIL Property font value 'italic normal normal calc(30% - 40px)/calc(120% + 1.2em) Menu' assert_equals: expected "italic 0px / normal Menu" but got "italic 0px Menu"
+PASS Property font value 'italic normal normal calc(30% - 40px)/calc(120% + 1.2em) Menu'
 PASS Property font value 'italic normal normal normal xx-small "Non-Generic Example Family Name"'
 PASS Property font value 'italic normal normal small-caps medium/normal serif'
 PASS Property font value 'italic normal normal 100 xx-large/1.2 sans-serif'
-FAIL Property font value 'italic normal normal ultra-condensed larger/calc(120% + 1.2em) cursive' assert_equals: expected "italic ultra-condensed 48px / normal cursive" but got "italic ultra-condensed 48px cursive"
+PASS Property font value 'italic normal normal ultra-condensed larger/calc(120% + 1.2em) cursive'
 PASS Property font value 'italic normal small-caps smaller fantasy'
 PASS Property font value 'italic normal small-caps normal 10px/normal monospace'
 PASS Property font value 'italic normal small-caps 900 20%/1.2 Menu'
-FAIL Property font value 'italic normal small-caps extra-condensed calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "italic small-caps extra-condensed 0px / normal \"Non-Generic Example Family Name\"" but got "italic small-caps extra-condensed 0px \"Non-Generic Example Family Name\""
+PASS Property font value 'italic normal small-caps extra-condensed calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'italic normal bold xx-small serif'
 PASS Property font value 'italic normal bolder normal medium/normal sans-serif'
 PASS Property font value 'italic normal lighter small-caps xx-large/1.2 cursive'
-FAIL Property font value 'italic normal 100 condensed larger/calc(120% + 1.2em) fantasy' assert_equals: expected "italic 100 condensed 48px / normal fantasy" but got "italic 100 condensed 48px fantasy"
+PASS Property font value 'italic normal 100 condensed larger/calc(120% + 1.2em) fantasy'
 PASS Property font value 'italic normal semi-condensed smaller monospace'
 PASS Property font value 'italic normal semi-expanded normal 10px/normal Menu'
 PASS Property font value 'italic normal expanded small-caps 20%/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'italic normal extra-expanded 900 calc(30% - 40px)/calc(120% + 1.2em) serif' assert_equals: expected "italic 900 extra-expanded 0px / normal serif" but got "italic 900 extra-expanded 0px serif"
+PASS Property font value 'italic normal extra-expanded 900 calc(30% - 40px)/calc(120% + 1.2em) serif'
 PASS Property font value 'italic small-caps xx-small sans-serif'
 PASS Property font value 'italic small-caps normal medium/normal cursive'
 PASS Property font value 'italic small-caps normal normal xx-large/1.2 fantasy'
-FAIL Property font value 'italic small-caps normal bold larger/calc(120% + 1.2em) monospace' assert_equals: expected "italic small-caps 700 48px / normal monospace" but got "italic small-caps 700 48px monospace"
+PASS Property font value 'italic small-caps normal bold larger/calc(120% + 1.2em) monospace'
 PASS Property font value 'italic small-caps normal ultra-expanded smaller Menu'
 PASS Property font value 'italic small-caps bolder 10px/normal "Non-Generic Example Family Name"'
 PASS Property font value 'italic small-caps lighter normal 20%/1.2 serif'
-FAIL Property font value 'italic small-caps 100 ultra-condensed calc(30% - 40px)/calc(120% + 1.2em) sans-serif' assert_equals: expected "italic small-caps 100 ultra-condensed 0px / normal sans-serif" but got "italic small-caps 100 ultra-condensed 0px sans-serif"
+PASS Property font value 'italic small-caps 100 ultra-condensed calc(30% - 40px)/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'italic small-caps extra-condensed xx-small cursive'
 PASS Property font value 'italic small-caps condensed normal medium/normal fantasy'
 PASS Property font value 'italic small-caps semi-condensed 900 xx-large/1.2 monospace'
-FAIL Property font value 'italic bold larger/calc(120% + 1.2em) Menu' assert_equals: expected "italic 700 48px / normal Menu" but got "italic 700 48px Menu"
+PASS Property font value 'italic bold larger/calc(120% + 1.2em) Menu'
 PASS Property font value 'italic bolder normal smaller "Non-Generic Example Family Name"'
 PASS Property font value 'italic lighter normal normal 10px/normal serif'
 PASS Property font value 'italic 100 normal small-caps 20%/1.2 sans-serif'
-FAIL Property font value 'italic 900 normal semi-expanded calc(30% - 40px)/calc(120% + 1.2em) cursive' assert_equals: expected "italic 900 semi-expanded 0px / normal cursive" but got "italic 900 semi-expanded 0px cursive"
+PASS Property font value 'italic 900 normal semi-expanded calc(30% - 40px)/calc(120% + 1.2em) cursive'
 PASS Property font value 'italic bold small-caps xx-small fantasy'
 PASS Property font value 'italic bolder small-caps normal medium/normal monospace'
 PASS Property font value 'italic lighter small-caps expanded xx-large/1.2 Menu'
-FAIL Property font value 'italic 100 extra-expanded larger/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "italic 100 extra-expanded 48px / normal \"Non-Generic Example Family Name\"" but got "italic 100 extra-expanded 48px \"Non-Generic Example Family Name\""
+PASS Property font value 'italic 100 extra-expanded larger/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'italic 900 ultra-expanded normal smaller serif'
 PASS Property font value 'italic bold ultra-condensed small-caps 10px/normal sans-serif'
 PASS Property font value 'italic extra-condensed 20%/1.2 cursive'
-FAIL Property font value 'italic condensed normal calc(30% - 40px)/calc(120% + 1.2em) fantasy' assert_equals: expected "italic condensed 0px / normal fantasy" but got "italic condensed 0px fantasy"
+PASS Property font value 'italic condensed normal calc(30% - 40px)/calc(120% + 1.2em) fantasy'
 PASS Property font value 'italic semi-condensed normal normal xx-small monospace'
 PASS Property font value 'italic semi-expanded normal small-caps medium/normal Menu'
 PASS Property font value 'italic expanded normal bolder xx-large/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'italic extra-expanded small-caps larger/calc(120% + 1.2em) serif' assert_equals: expected "italic small-caps extra-expanded 48px / normal serif" but got "italic small-caps extra-expanded 48px serif"
+PASS Property font value 'italic extra-expanded small-caps larger/calc(120% + 1.2em) serif'
 PASS Property font value 'italic ultra-expanded small-caps normal smaller sans-serif'
 PASS Property font value 'italic ultra-condensed small-caps lighter 10px/normal cursive'
 PASS Property font value 'italic extra-condensed 100 20%/1.2 fantasy'
-FAIL Property font value 'italic condensed 900 normal calc(30% - 40px)/calc(120% + 1.2em) monospace' assert_equals: expected "italic 900 condensed 0px / normal monospace" but got "italic 900 condensed 0px monospace"
+PASS Property font value 'italic condensed 900 normal calc(30% - 40px)/calc(120% + 1.2em) monospace'
 PASS Property font value 'italic semi-condensed bold small-caps xx-small Menu'
 PASS Property font value 'small-caps medium/normal "Non-Generic Example Family Name"'
 PASS Property font value 'small-caps normal xx-large/1.2 serif'
-FAIL Property font value 'small-caps normal normal larger/calc(120% + 1.2em) sans-serif' assert_equals: expected "small-caps 48px / normal sans-serif" but got "small-caps 48px sans-serif"
+PASS Property font value 'small-caps normal normal larger/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'small-caps normal normal normal smaller cursive'
 PASS Property font value 'small-caps normal normal italic 10px/normal fantasy'
 PASS Property font value 'small-caps normal normal bolder 20%/1.2 monospace'
-FAIL Property font value 'small-caps normal normal semi-expanded calc(30% - 40px)/calc(120% + 1.2em) Menu' assert_equals: expected "small-caps semi-expanded 0px / normal Menu" but got "small-caps semi-expanded 0px Menu"
+PASS Property font value 'small-caps normal normal semi-expanded calc(30% - 40px)/calc(120% + 1.2em) Menu'
 PASS Property font value 'small-caps normal italic xx-small "Non-Generic Example Family Name"'
 PASS Property font value 'small-caps normal italic normal medium/normal serif'
 PASS Property font value 'small-caps normal italic lighter xx-large/1.2 sans-serif'
-FAIL Property font value 'small-caps normal italic expanded larger/calc(120% + 1.2em) cursive' assert_equals: expected "italic small-caps expanded 48px / normal cursive" but got "italic small-caps expanded 48px cursive"
+PASS Property font value 'small-caps normal italic expanded larger/calc(120% + 1.2em) cursive'
 PASS Property font value 'small-caps normal 100 smaller fantasy'
 PASS Property font value 'small-caps normal 900 normal 10px/normal monospace'
 PASS Property font value 'small-caps normal bold italic 20%/1.2 Menu'
-FAIL Property font value 'small-caps normal bolder extra-expanded calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "small-caps 900 extra-expanded 0px / normal \"Non-Generic Example Family Name\"" but got "small-caps 900 extra-expanded 0px \"Non-Generic Example Family Name\""
+PASS Property font value 'small-caps normal bolder extra-expanded calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'small-caps normal ultra-expanded xx-small serif'
 PASS Property font value 'small-caps normal ultra-condensed normal medium/normal sans-serif'
 PASS Property font value 'small-caps normal extra-condensed italic xx-large/1.2 cursive'
-FAIL Property font value 'small-caps normal condensed lighter larger/calc(120% + 1.2em) fantasy' assert_equals: expected "small-caps 700 condensed 48px / normal fantasy" but got "small-caps 700 condensed 48px fantasy"
+PASS Property font value 'small-caps normal condensed lighter larger/calc(120% + 1.2em) fantasy'
 PASS Property font value 'small-caps italic smaller monospace'
 PASS Property font value 'small-caps italic normal 10px/normal Menu'
 PASS Property font value 'small-caps italic normal normal 20%/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'small-caps italic normal 100 calc(30% - 40px)/calc(120% + 1.2em) serif' assert_equals: expected "italic small-caps 100 0px / normal serif" but got "italic small-caps 100 0px serif"
+PASS Property font value 'small-caps italic normal 100 calc(30% - 40px)/calc(120% + 1.2em) serif'
 PASS Property font value 'small-caps italic normal semi-condensed xx-small sans-serif'
 PASS Property font value 'small-caps italic 900 medium/normal cursive'
 PASS Property font value 'small-caps italic bold normal xx-large/1.2 fantasy'
-FAIL Property font value 'small-caps italic bolder semi-expanded larger/calc(120% + 1.2em) monospace' assert_equals: expected "italic small-caps 900 semi-expanded 48px / normal monospace" but got "italic small-caps 900 semi-expanded 48px monospace"
+PASS Property font value 'small-caps italic bolder semi-expanded larger/calc(120% + 1.2em) monospace'
 PASS Property font value 'small-caps italic expanded smaller Menu'
 PASS Property font value 'small-caps italic extra-expanded normal 10px/normal "Non-Generic Example Family Name"'
 PASS Property font value 'small-caps italic ultra-expanded lighter 20%/1.2 serif'
-FAIL Property font value 'small-caps 100 calc(30% - 40px)/calc(120% + 1.2em) sans-serif' assert_equals: expected "small-caps 100 0px / normal sans-serif" but got "small-caps 100 0px sans-serif"
+PASS Property font value 'small-caps 100 calc(30% - 40px)/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'small-caps 900 normal xx-small cursive'
 PASS Property font value 'small-caps bold normal normal medium/normal fantasy'
 PASS Property font value 'small-caps bolder normal italic xx-large/1.2 monospace'
-FAIL Property font value 'small-caps lighter normal ultra-condensed larger/calc(120% + 1.2em) Menu' assert_equals: expected "small-caps 700 ultra-condensed 48px / normal Menu" but got "small-caps 700 ultra-condensed 48px Menu"
+PASS Property font value 'small-caps lighter normal ultra-condensed larger/calc(120% + 1.2em) Menu'
 PASS Property font value 'small-caps 100 italic smaller "Non-Generic Example Family Name"'
 PASS Property font value 'small-caps 900 italic normal 10px/normal serif'
 PASS Property font value 'small-caps bold italic extra-condensed 20%/1.2 sans-serif'
-FAIL Property font value 'small-caps bolder condensed calc(30% - 40px)/calc(120% + 1.2em) cursive' assert_equals: expected "small-caps 900 condensed 0px / normal cursive" but got "small-caps 900 condensed 0px cursive"
+PASS Property font value 'small-caps bolder condensed calc(30% - 40px)/calc(120% + 1.2em) cursive'
 PASS Property font value 'small-caps lighter semi-condensed normal xx-small fantasy'
 PASS Property font value 'small-caps 100 semi-expanded italic medium/normal monospace'
 PASS Property font value 'small-caps expanded xx-large/1.2 Menu'
-FAIL Property font value 'small-caps extra-expanded normal larger/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "small-caps extra-expanded 48px / normal \"Non-Generic Example Family Name\"" but got "small-caps extra-expanded 48px \"Non-Generic Example Family Name\""
+PASS Property font value 'small-caps extra-expanded normal larger/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'small-caps ultra-expanded normal normal smaller serif'
 PASS Property font value 'small-caps ultra-condensed normal italic 10px/normal sans-serif'
 PASS Property font value 'small-caps extra-condensed normal 900 20%/1.2 cursive'
-FAIL Property font value 'small-caps condensed italic calc(30% - 40px)/calc(120% + 1.2em) fantasy' assert_equals: expected "italic small-caps condensed 0px / normal fantasy" but got "italic small-caps condensed 0px fantasy"
+PASS Property font value 'small-caps condensed italic calc(30% - 40px)/calc(120% + 1.2em) fantasy'
 PASS Property font value 'small-caps semi-condensed italic normal xx-small monospace'
 PASS Property font value 'small-caps semi-expanded italic bold medium/normal Menu'
 PASS Property font value 'small-caps expanded bolder xx-large/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'small-caps extra-expanded lighter normal larger/calc(120% + 1.2em) serif' assert_equals: expected "small-caps 700 extra-expanded 48px / normal serif" but got "small-caps 700 extra-expanded 48px serif"
+PASS Property font value 'small-caps extra-expanded lighter normal larger/calc(120% + 1.2em) serif'
 PASS Property font value 'small-caps ultra-expanded 100 italic smaller sans-serif'
 PASS Property font value '900 10px/normal cursive'
 PASS Property font value 'bold normal 20%/1.2 fantasy'
-FAIL Property font value 'bolder normal normal calc(30% - 40px)/calc(120% + 1.2em) monospace' assert_equals: expected "900 0px / normal monospace" but got "900 0px monospace"
+PASS Property font value 'bolder normal normal calc(30% - 40px)/calc(120% + 1.2em) monospace'
 PASS Property font value 'lighter normal normal normal xx-small Menu'
 PASS Property font value '100 normal normal italic medium/normal "Non-Generic Example Family Name"'
 PASS Property font value '900 normal normal small-caps xx-large/1.2 serif'
-FAIL Property font value 'bold normal normal ultra-condensed larger/calc(120% + 1.2em) sans-serif' assert_equals: expected "700 ultra-condensed 48px / normal sans-serif" but got "700 ultra-condensed 48px sans-serif"
+PASS Property font value 'bold normal normal ultra-condensed larger/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'bolder normal italic smaller cursive'
 PASS Property font value 'lighter normal italic normal 10px/normal fantasy'
 PASS Property font value '100 normal italic small-caps 20%/1.2 monospace'
-FAIL Property font value '900 normal italic extra-condensed calc(30% - 40px)/calc(120% + 1.2em) Menu' assert_equals: expected "italic 900 extra-condensed 0px / normal Menu" but got "italic 900 extra-condensed 0px Menu"
+PASS Property font value '900 normal italic extra-condensed calc(30% - 40px)/calc(120% + 1.2em) Menu'
 PASS Property font value 'bold normal small-caps xx-small "Non-Generic Example Family Name"'
 PASS Property font value 'bolder normal small-caps normal medium/normal serif'
 PASS Property font value 'lighter normal small-caps italic xx-large/1.2 sans-serif'
-FAIL Property font value '100 normal small-caps condensed larger/calc(120% + 1.2em) cursive' assert_equals: expected "small-caps 100 condensed 48px / normal cursive" but got "small-caps 100 condensed 48px cursive"
+PASS Property font value '100 normal small-caps condensed larger/calc(120% + 1.2em) cursive'
 PASS Property font value '900 normal semi-condensed smaller fantasy'
 PASS Property font value 'bold normal semi-expanded normal 10px/normal monospace'
 PASS Property font value 'bolder normal expanded italic 20%/1.2 Menu'
-FAIL Property font value 'lighter normal extra-expanded small-caps calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "small-caps 700 extra-expanded 0px / normal \"Non-Generic Example Family Name\"" but got "small-caps 700 extra-expanded 0px \"Non-Generic Example Family Name\""
+PASS Property font value 'lighter normal extra-expanded small-caps calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value '100 italic xx-small serif'
 PASS Property font value '900 italic normal medium/normal sans-serif'
 PASS Property font value 'bold italic normal normal xx-large/1.2 cursive'
-FAIL Property font value 'bolder italic normal small-caps larger/calc(120% + 1.2em) fantasy' assert_equals: expected "italic small-caps 900 48px / normal fantasy" but got "italic small-caps 900 48px fantasy"
+PASS Property font value 'bolder italic normal small-caps larger/calc(120% + 1.2em) fantasy'
 PASS Property font value 'lighter italic normal ultra-expanded smaller monospace'
 PASS Property font value '100 italic small-caps 10px/normal Menu'
 PASS Property font value '900 italic small-caps normal 20%/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'bold italic small-caps ultra-condensed calc(30% - 40px)/calc(120% + 1.2em) serif' assert_equals: expected "italic small-caps 700 ultra-condensed 0px / normal serif" but got "italic small-caps 700 ultra-condensed 0px serif"
+PASS Property font value 'bold italic small-caps ultra-condensed calc(30% - 40px)/calc(120% + 1.2em) serif'
 PASS Property font value 'bolder italic extra-condensed xx-small sans-serif'
 PASS Property font value 'lighter italic condensed normal medium/normal cursive'
 PASS Property font value '100 italic semi-condensed small-caps xx-large/1.2 fantasy'
-FAIL Property font value '900 small-caps larger/calc(120% + 1.2em) monospace' assert_equals: expected "small-caps 900 48px / normal monospace" but got "small-caps 900 48px monospace"
+PASS Property font value '900 small-caps larger/calc(120% + 1.2em) monospace'
 PASS Property font value 'bold small-caps normal smaller Menu'
 PASS Property font value 'bolder small-caps normal normal 10px/normal "Non-Generic Example Family Name"'
 PASS Property font value 'lighter small-caps normal italic 20%/1.2 serif'
-FAIL Property font value '100 small-caps normal semi-expanded calc(30% - 40px)/calc(120% + 1.2em) sans-serif' assert_equals: expected "small-caps 100 semi-expanded 0px / normal sans-serif" but got "small-caps 100 semi-expanded 0px sans-serif"
+PASS Property font value '100 small-caps normal semi-expanded calc(30% - 40px)/calc(120% + 1.2em) sans-serif'
 PASS Property font value '900 small-caps italic xx-small cursive'
 PASS Property font value 'bold small-caps italic normal medium/normal fantasy'
 PASS Property font value 'bolder small-caps italic expanded xx-large/1.2 monospace'
-FAIL Property font value 'lighter small-caps extra-expanded larger/calc(120% + 1.2em) Menu' assert_equals: expected "small-caps 700 extra-expanded 48px / normal Menu" but got "small-caps 700 extra-expanded 48px Menu"
+PASS Property font value 'lighter small-caps extra-expanded larger/calc(120% + 1.2em) Menu'
 PASS Property font value '100 small-caps ultra-expanded normal smaller "Non-Generic Example Family Name"'
 PASS Property font value '900 small-caps ultra-condensed italic 10px/normal serif'
 PASS Property font value 'bold extra-condensed 20%/1.2 sans-serif'
-FAIL Property font value 'bolder condensed normal calc(30% - 40px)/calc(120% + 1.2em) cursive' assert_equals: expected "900 condensed 0px / normal cursive" but got "900 condensed 0px cursive"
+PASS Property font value 'bolder condensed normal calc(30% - 40px)/calc(120% + 1.2em) cursive'
 PASS Property font value 'lighter semi-condensed normal normal xx-small fantasy'
 PASS Property font value '100 semi-expanded normal italic medium/normal monospace'
 PASS Property font value '900 expanded normal small-caps xx-large/1.2 Menu'
-FAIL Property font value 'bold extra-expanded italic larger/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "italic 700 extra-expanded 48px / normal \"Non-Generic Example Family Name\"" but got "italic 700 extra-expanded 48px \"Non-Generic Example Family Name\""
+PASS Property font value 'bold extra-expanded italic larger/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'bolder ultra-expanded italic normal smaller serif'
 PASS Property font value 'lighter ultra-condensed italic small-caps 10px/normal sans-serif'
 PASS Property font value '100 extra-condensed small-caps 20%/1.2 cursive'
-FAIL Property font value '900 condensed small-caps normal calc(30% - 40px)/calc(120% + 1.2em) fantasy' assert_equals: expected "small-caps 900 condensed 0px / normal fantasy" but got "small-caps 900 condensed 0px fantasy"
+PASS Property font value '900 condensed small-caps normal calc(30% - 40px)/calc(120% + 1.2em) fantasy'
 PASS Property font value 'bold semi-condensed small-caps italic xx-small monospace'
 PASS Property font value 'semi-expanded medium/normal Menu'
 PASS Property font value 'expanded normal xx-large/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'extra-expanded normal normal larger/calc(120% + 1.2em) serif' assert_equals: expected "extra-expanded 48px / normal serif" but got "extra-expanded 48px serif"
+PASS Property font value 'extra-expanded normal normal larger/calc(120% + 1.2em) serif'
 PASS Property font value 'ultra-expanded normal normal normal smaller sans-serif'
 PASS Property font value 'ultra-condensed normal normal italic 10px/normal cursive'
 PASS Property font value 'extra-condensed normal normal small-caps 20%/1.2 fantasy'
-FAIL Property font value 'condensed normal normal bolder calc(30% - 40px)/calc(120% + 1.2em) monospace' assert_equals: expected "900 condensed 0px / normal monospace" but got "900 condensed 0px monospace"
+PASS Property font value 'condensed normal normal bolder calc(30% - 40px)/calc(120% + 1.2em) monospace'
 PASS Property font value 'semi-condensed normal italic xx-small Menu'
 PASS Property font value 'semi-expanded normal italic normal medium/normal "Non-Generic Example Family Name"'
 PASS Property font value 'expanded normal italic small-caps xx-large/1.2 serif'
-FAIL Property font value 'extra-expanded normal italic lighter larger/calc(120% + 1.2em) sans-serif' assert_equals: expected "italic 700 extra-expanded 48px / normal sans-serif" but got "italic 700 extra-expanded 48px sans-serif"
+PASS Property font value 'extra-expanded normal italic lighter larger/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'ultra-expanded normal small-caps smaller cursive'
 PASS Property font value 'ultra-condensed normal small-caps normal 10px/normal fantasy'
 PASS Property font value 'extra-condensed normal small-caps italic 20%/1.2 monospace'
-FAIL Property font value 'condensed normal small-caps 100 calc(30% - 40px)/calc(120% + 1.2em) Menu' assert_equals: expected "small-caps 100 condensed 0px / normal Menu" but got "small-caps 100 condensed 0px Menu"
+PASS Property font value 'condensed normal small-caps 100 calc(30% - 40px)/calc(120% + 1.2em) Menu'
 PASS Property font value 'semi-condensed normal 900 xx-small "Non-Generic Example Family Name"'
 PASS Property font value 'semi-expanded normal bold normal medium/normal serif'
 PASS Property font value 'expanded normal bolder italic xx-large/1.2 sans-serif'
-FAIL Property font value 'extra-expanded normal lighter small-caps larger/calc(120% + 1.2em) cursive' assert_equals: expected "small-caps 700 extra-expanded 48px / normal cursive" but got "small-caps 700 extra-expanded 48px cursive"
+PASS Property font value 'extra-expanded normal lighter small-caps larger/calc(120% + 1.2em) cursive'
 PASS Property font value 'ultra-expanded italic smaller fantasy'
 PASS Property font value 'ultra-condensed italic normal 10px/normal monospace'
 PASS Property font value 'extra-condensed italic normal normal 20%/1.2 Menu'
-FAIL Property font value 'condensed italic normal small-caps calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "italic small-caps condensed 0px / normal \"Non-Generic Example Family Name\"" but got "italic small-caps condensed 0px \"Non-Generic Example Family Name\""
+PASS Property font value 'condensed italic normal small-caps calc(30% - 40px)/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'semi-condensed italic normal 100 xx-small serif'
 PASS Property font value 'semi-expanded italic small-caps medium/normal sans-serif'
 PASS Property font value 'expanded italic small-caps normal xx-large/1.2 cursive'
-FAIL Property font value 'extra-expanded italic small-caps 900 larger/calc(120% + 1.2em) fantasy' assert_equals: expected "italic small-caps 900 extra-expanded 48px / normal fantasy" but got "italic small-caps 900 extra-expanded 48px fantasy"
+PASS Property font value 'extra-expanded italic small-caps 900 larger/calc(120% + 1.2em) fantasy'
 PASS Property font value 'ultra-expanded italic bold smaller monospace'
 PASS Property font value 'ultra-condensed italic bolder normal 10px/normal Menu'
 PASS Property font value 'extra-condensed italic lighter small-caps 20%/1.2 "Non-Generic Example Family Name"'
-FAIL Property font value 'condensed small-caps calc(30% - 40px)/calc(120% + 1.2em) serif' assert_equals: expected "small-caps condensed 0px / normal serif" but got "small-caps condensed 0px serif"
+PASS Property font value 'condensed small-caps calc(30% - 40px)/calc(120% + 1.2em) serif'
 PASS Property font value 'semi-condensed small-caps normal xx-small sans-serif'
 PASS Property font value 'semi-expanded small-caps normal normal medium/normal cursive'
 PASS Property font value 'expanded small-caps normal italic xx-large/1.2 fantasy'
-FAIL Property font value 'extra-expanded small-caps normal 100 larger/calc(120% + 1.2em) monospace' assert_equals: expected "small-caps 100 extra-expanded 48px / normal monospace" but got "small-caps 100 extra-expanded 48px monospace"
+PASS Property font value 'extra-expanded small-caps normal 100 larger/calc(120% + 1.2em) monospace'
 PASS Property font value 'ultra-expanded small-caps italic smaller Menu'
 PASS Property font value 'ultra-condensed small-caps italic normal 10px/normal "Non-Generic Example Family Name"'
 PASS Property font value 'extra-condensed small-caps italic 900 20%/1.2 serif'
-FAIL Property font value 'condensed small-caps bold calc(30% - 40px)/calc(120% + 1.2em) sans-serif' assert_equals: expected "small-caps 700 condensed 0px / normal sans-serif" but got "small-caps 700 condensed 0px sans-serif"
+PASS Property font value 'condensed small-caps bold calc(30% - 40px)/calc(120% + 1.2em) sans-serif'
 PASS Property font value 'semi-condensed small-caps bolder normal xx-small cursive'
 PASS Property font value 'semi-expanded small-caps lighter italic medium/normal fantasy'
 PASS Property font value 'expanded 100 xx-large/1.2 monospace'
-FAIL Property font value 'extra-expanded 900 normal larger/calc(120% + 1.2em) Menu' assert_equals: expected "900 extra-expanded 48px / normal Menu" but got "900 extra-expanded 48px Menu"
+PASS Property font value 'extra-expanded 900 normal larger/calc(120% + 1.2em) Menu'
 PASS Property font value 'ultra-expanded bold normal normal smaller "Non-Generic Example Family Name"'
 PASS Property font value 'ultra-condensed bolder normal italic 10px/normal serif'
 PASS Property font value 'extra-condensed lighter normal small-caps 20%/1.2 sans-serif'
-FAIL Property font value 'condensed 100 italic calc(30% - 40px)/calc(120% + 1.2em) cursive' assert_equals: expected "italic 100 condensed 0px / normal cursive" but got "italic 100 condensed 0px cursive"
+PASS Property font value 'condensed 100 italic calc(30% - 40px)/calc(120% + 1.2em) cursive'
 PASS Property font value 'semi-condensed 900 italic normal xx-small fantasy'
 PASS Property font value 'semi-expanded bold italic small-caps medium/normal monospace'
 PASS Property font value 'expanded bolder small-caps xx-large/1.2 Menu'
-FAIL Property font value 'extra-expanded lighter small-caps normal larger/calc(120% + 1.2em) "Non-Generic Example Family Name"' assert_equals: expected "small-caps 700 extra-expanded 48px / normal \"Non-Generic Example Family Name\"" but got "small-caps 700 extra-expanded 48px \"Non-Generic Example Family Name\""
+PASS Property font value 'extra-expanded lighter small-caps normal larger/calc(120% + 1.2em) "Non-Generic Example Family Name"'
 PASS Property font value 'ultra-expanded 100 small-caps italic smaller serif'
 


### PR DESCRIPTION
#### 2946bb7fba02b40105f29744a1600ec192b59a78
<pre>
Allow calc() with combined percentages and lengths for line-height
<a href="https://bugs.webkit.org/show_bug.cgi?id=247007">https://bugs.webkit.org/show_bug.cgi?id=247007</a>
rdar://problem/101546260

Reviewed by Tim Nguyen and Sam Weinig.

* LayoutTests/css3/calc/line-height-expected.txt: Expect PASS.

* LayoutTests/fast/css/calc-with-percent-and-number-in-line-height-crash-expected.txt: Added.
* LayoutTests/fast/css/calc-with-percent-and-number-in-line-height-crash.html: Added.
Adopted this test from Chromium.

* LayoutTests/fast/css/line-height-1-expected.html: Added.
* LayoutTests/fast/css/line-height-1.html: Added.
* LayoutTests/fast/css/line-height-2-expected.html: Added.
* LayoutTests/fast/css/line-height-2.html: Added.
Adopted these tests from Mozilla.

* LayoutTests/fast/css/line-height-basics-expected.txt: Added.
* LayoutTests/fast/css/line-height-basics.html: Added.
Adopted this test from Chromium.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-computed-expected.txt:
Expected many more PASS.

* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLineHeight): Allow percentage combined with length.

Canonical link: <a href="https://commits.webkit.org/256095@main">https://commits.webkit.org/256095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a42ecfed98d266e66cbd26f6f0718866d2a15a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104109 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164384 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3684 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31841 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100097 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2644 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80846 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29674 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72568 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38231 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36098 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19243 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4208 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41878 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38472 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->