### PR TITLE
REGRESSION (r145541): Incorrect local to device transformation when the SVG is rendered into a separate composited layer

### DIFF
--- a/LayoutTests/svg/custom/filter-css-transform-resolution-expected.html
+++ b/LayoutTests/svg/custom/filter-css-transform-resolution-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+  <!-- Test for http://crbug.com/345441 - the circle edge should not be blurry -->
+  <div id="div">
+    <svg width="300" height="300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <defs>
+        <filter x="0" y="0" width="100%" height="100%" id="filter">
+          <feOffset/>
+        </filter>
+      </defs>
+      <circle cx="100" cy="100" r="100" fill="green" filter="url(#filter)"/>
+    </svg>
+  </div>
+</body>
+</html>

--- a/LayoutTests/svg/custom/filter-css-transform-resolution.html
+++ b/LayoutTests/svg/custom/filter-css-transform-resolution.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="../../fast/repaint/resources/text-based-repaint.js" type="text/javascript"></script>
+  <script>
+      function repaintTest() {
+      document.getElementById('div').style.transform = '';
+    }
+  </script>
+</head>
+<body onload="runRepaintTest();">
+  <!-- Test for http://crbug.com/345441 - the circle edge should not be blurry -->
+  <div id="div" style="transform: rotate3d(1, 0, 0, 85deg); -webkit-transform-origin: 100px 100px 0px;">
+    <svg width="300" height="300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <defs>
+        <filter x="0" y="0" width="100%" height="100%" id="filter">
+          <feOffset/>
+        </filter>
+      </defs>
+      <circle cx="100" cy="100" r="100" fill="green" filter="url(#filter)"/>
+    </svg>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -200,7 +200,6 @@ AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinat
 {
     AffineTransform absoluteTransform = currentContentTransformation();
 
-    float deviceScaleFactor = renderer.document().deviceScaleFactor();
     // Walk up the render tree, accumulating SVG transforms.
     const RenderObject* ancestor = &renderer;
     while (ancestor) {
@@ -213,17 +212,17 @@ AffineTransform SVGRenderingContext::calculateTransformationToOutermostCoordinat
     // Continue walking up the layer tree, accumulating CSS transforms.
     RenderLayer* layer = ancestor ? ancestor->enclosingLayer() : nullptr;
     while (layer) {
-        if (TransformationMatrix* layerTransform = layer->transform())
-            absoluteTransform = layerTransform->toAffineTransform() * absoluteTransform;
-
         // We can stop at compositing layers, to match the backing resolution.
         if (layer->isComposited())
             break;
 
+        if (TransformationMatrix* layerTransform = layer->transform())
+            absoluteTransform = layerTransform->toAffineTransform() * absoluteTransform;
+
         layer = layer->parent();
     }
 
-    absoluteTransform.scale(deviceScaleFactor);
+    absoluteTransform.scale(renderer.document().deviceScaleFactor());
     return absoluteTransform;
 }
 


### PR DESCRIPTION
<pre>
REGRESSION (r145541): Incorrect local to device transformation when the SVG is rendered into a separate composited layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=115072">https://bugs.webkit.org/show_bug.cgi?id=115072</a>

Reviewed by NOBODY (OOPS!).

Patch Authored by Said Abou-Hallawa

Inspired from - <a href="https://src.chromium.org/viewvc/blink?revision=169472&view=revision">https://src.chromium.org/viewvc/blink?revision=169472&view=revision</a>

calculateTransformationToOutermostCoordinateSystem() should stop at the first composited layer to match its backing resolution.
Currently, we are incorrectly taking the layer transform into account (the stop condition is off by one).

* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(SVGRenderingContext::calculateTransformToOutermostCoordinate): Following changes:
1) Pushed "deviceScaleFactor" down with scale
2) Moved "Transform" after "Compositing" is stopped.
* LayoutTests/svg/custom/filter-css-transform-resolution.html: Added Test Case
* LayoutTests/svg/custom/filter-css-transform-resolution-expected.html: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc4df6a81c54e4964ec0960a38afc4032e5f5cb5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106857 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167120 "Found 1 new test failure: svg/custom/filter-css-transform-resolution.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6906 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35339 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103535 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103001 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5190 "Found 1 new test failure: svg/custom/filter-css-transform-resolution.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83967 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32186 "Found 1 new test failure: svg/custom/filter-css-transform-resolution.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/617 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20328 "Found 1 new test failure: svg/custom/filter-css-transform-resolution.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/600 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21792 "Found 1 new test failure: svg/custom/filter-css-transform-resolution.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5402 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44277 "Found 2 new test failures: fast/events/blur-remove-parent-crash.html, svg/custom/filter-css-transform-resolution.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41130 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->