### PR TITLE
HashMapStylePropertyMap is readonly and shouldn't be subclassing StylePropertyMap

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -900,6 +900,7 @@ css/typedom/CSSUnitValue.cpp
 css/typedom/CSSUnparsedValue.cpp
 css/typedom/CSSOMVariableReferenceValue.cpp
 css/typedom/DeclaredStylePropertyMap.cpp
+css/typedom/MainThreadStylePropertyMapReadOnly.cpp
 css/typedom/StylePropertyMap.cpp
 css/typedom/color/CSSColor.cpp
 css/typedom/color/CSSHSL.cpp

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MainThreadStylePropertyMapReadOnly.h"
+
+#include "CSSPendingSubstitutionValue.h"
+#include "CSSPropertyNames.h"
+#include "CSSPropertyParser.h"
+#include "CSSStyleValue.h"
+#include "CSSUnparsedValue.h"
+#include "CSSValueList.h"
+#include "CSSVariableData.h"
+#include "Document.h"
+#include "PaintWorkletGlobalScope.h"
+#include "StylePropertyShorthand.h"
+
+namespace WebCore {
+
+MainThreadStylePropertyMapReadOnly::MainThreadStylePropertyMapReadOnly() = default;
+
+Document* MainThreadStylePropertyMapReadOnly::documentFromContext(ScriptExecutionContext& context)
+{
+    ASSERT(isMainThread());
+#if ENABLE(CSS_PAINTING_API)
+    if (auto* paintWorklet = dynamicDowncast<PaintWorkletGlobalScope>(context))
+        return paintWorklet->responsibleDocument();
+#endif
+    return &downcast<Document>(context);
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
+ExceptionOr<RefPtr<CSSStyleValue>> MainThreadStylePropertyMapReadOnly::get(ScriptExecutionContext& context, const AtomString& property) const
+{
+    auto* document = documentFromContext(context);
+    if (!document)
+        return nullptr;
+
+    if (isCustomPropertyName(property))
+        return reifyValue(customPropertyValue(property), *document);
+
+    auto propertyID = cssPropertyID(property);
+    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document->settings()))
+        return Exception { TypeError, makeString("Invalid property ", property) };
+
+    if (isShorthandCSSProperty(propertyID))
+        return shorthandPropertyValue(*document, propertyID);
+
+    return reifyValue(propertyValue(propertyID), *document);
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
+ExceptionOr<Vector<RefPtr<CSSStyleValue>>> MainThreadStylePropertyMapReadOnly::getAll(ScriptExecutionContext& context, const AtomString& property) const
+{
+    auto* document = documentFromContext(context);
+    if (!document)
+        return Vector<RefPtr<CSSStyleValue>> { };
+
+    if (isCustomPropertyName(property))
+        return reifyValueToVector(customPropertyValue(property), *document);
+
+    auto propertyID = cssPropertyID(property);
+    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document->settings()))
+        return Exception { TypeError, makeString("Invalid property ", property) };
+
+    if (isShorthandCSSProperty(propertyID)) {
+        if (RefPtr value = shorthandPropertyValue(*document, propertyID))
+            return Vector<RefPtr<CSSStyleValue>> { WTFMove(value) };
+        return Vector<RefPtr<CSSStyleValue>> { };
+    }
+
+    return reifyValueToVector(propertyValue(propertyID), *document);
+}
+
+// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
+ExceptionOr<bool> MainThreadStylePropertyMapReadOnly::has(ScriptExecutionContext& context, const AtomString& property) const
+{
+    auto result = get(context, property);
+    if (result.hasException())
+        return result.releaseException();
+    return !!result.returnValue();
+}
+
+RefPtr<CSSStyleValue> MainThreadStylePropertyMapReadOnly::shorthandPropertyValue(Document& document, CSSPropertyID propertyID) const
+{
+    auto shorthand = shorthandForProperty(propertyID);
+    Vector<Ref<CSSValue>> values;
+    for (auto& longhand : shorthand) {
+        RefPtr value = propertyValue(longhand);
+        if (!value)
+            return nullptr;
+        if (value->isImplicitInitialValue())
+            continue;
+        // VariableReference set from the shorthand.
+        if (is<CSSPendingSubstitutionValue>(*value))
+            return CSSUnparsedValue::create(downcast<CSSPendingSubstitutionValue>(*value).shorthandValue().data().tokenRange());
+        values.append(value.releaseNonNull());
+    }
+    if (values.isEmpty())
+        return nullptr;
+
+    if (values.size() == 1)
+        return reifyValue(values[0].ptr(), document);
+
+    auto valueList = CSSValueList::createSpaceSeparated();
+    for (auto& value : values)
+        valueList->append(WTFMove(value));
+    return CSSStyleValue::create(WTFMove(valueList));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StylePropertyMapReadOnly.h"
+
+namespace WebCore {
+
+class Document;
+
+class MainThreadStylePropertyMapReadOnly : public StylePropertyMapReadOnly {
+public:
+    ExceptionOr<RefPtr<CSSStyleValue>> get(ScriptExecutionContext&, const AtomString&) const final;
+    ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const final;
+    ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const final;
+
+protected:
+    MainThreadStylePropertyMapReadOnly();
+
+    static Document* documentFromContext(ScriptExecutionContext&);
+
+    virtual CSSValue* propertyValue(CSSPropertyID) const = 0;
+    virtual CSSValue* customPropertyValue(const AtomString&) const = 0;
+
+private:
+    RefPtr<CSSStyleValue> shorthandPropertyValue(Document&, CSSPropertyID) const;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -26,108 +26,10 @@
 #include "config.h"
 #include "StylePropertyMap.h"
 
-#include "CSSPendingSubstitutionValue.h"
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
-#include "CSSStyleValue.h"
-#include "CSSStyleValueFactory.h"
-#include "CSSUnparsedValue.h"
-#include "CSSValueList.h"
-#include "CSSVariableData.h"
-#include "Document.h"
-#include "PaintWorkletGlobalScope.h"
-#include "StylePropertyShorthand.h"
 
 namespace WebCore {
-
-Document* StylePropertyMap::documentFromContext(ScriptExecutionContext& context)
-{
-    ASSERT(isMainThread());
-#if ENABLE(CSS_PAINTING_API)
-    if (auto* paintWorklet = dynamicDowncast<PaintWorkletGlobalScope>(context))
-        return paintWorklet->responsibleDocument();
-#endif
-    return &downcast<Document>(context);
-}
-
-RefPtr<CSSStyleValue> StylePropertyMap::shorthandPropertyValue(Document& document, CSSPropertyID propertyID) const
-{
-    auto shorthand = shorthandForProperty(propertyID);
-    Vector<Ref<CSSValue>> values;
-    for (auto& longhand : shorthand) {
-        RefPtr value = propertyValue(longhand);
-        if (!value)
-            return nullptr;
-        if (value->isImplicitInitialValue())
-            continue;
-        // VariableReference set from the shorthand.
-        if (is<CSSPendingSubstitutionValue>(*value))
-            return CSSUnparsedValue::create(downcast<CSSPendingSubstitutionValue>(*value).shorthandValue().data().tokenRange());
-        values.append(value.releaseNonNull());
-    }
-    if (values.isEmpty())
-        return nullptr;
-
-    if (values.size() == 1)
-        return reifyValue(values[0].ptr(), document);
-
-    auto valueList = CSSValueList::createSpaceSeparated();
-    for (auto& value : values)
-        valueList->append(WTFMove(value));
-    return CSSStyleValue::create(WTFMove(valueList));
-}
-
-// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
-ExceptionOr<RefPtr<CSSStyleValue>> StylePropertyMap::get(ScriptExecutionContext& context, const AtomString& property) const
-{
-    auto* document = documentFromContext(context);
-    if (!document)
-        return nullptr;
-
-    if (isCustomPropertyName(property))
-        return reifyValue(customPropertyValue(property), *document);
-
-    auto propertyID = cssPropertyID(property);
-    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document->settings()))
-        return Exception { TypeError, makeString("Invalid property ", property) };
-
-    if (isShorthandCSSProperty(propertyID))
-        return shorthandPropertyValue(*document, propertyID);
-
-    return reifyValue(propertyValue(propertyID), *document);
-}
-
-// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
-ExceptionOr<Vector<RefPtr<CSSStyleValue>>> StylePropertyMap::getAll(ScriptExecutionContext& context, const AtomString& property) const
-{
-    auto* document = documentFromContext(context);
-    if (!document)
-        return Vector<RefPtr<CSSStyleValue>> { };
-
-    if (isCustomPropertyName(property))
-        return reifyValueToVector(customPropertyValue(property), *document);
-
-    auto propertyID = cssPropertyID(property);
-    if (propertyID == CSSPropertyInvalid || !isCSSPropertyExposed(propertyID, &document->settings()))
-        return Exception { TypeError, makeString("Invalid property ", property) };
-
-    if (isShorthandCSSProperty(propertyID)) {
-        if (RefPtr value = shorthandPropertyValue(*document, propertyID))
-            return Vector<RefPtr<CSSStyleValue>> { WTFMove(value) };
-        return Vector<RefPtr<CSSStyleValue>> { };
-    }
-
-    return reifyValueToVector(propertyValue(propertyID), *document);
-}
-
-// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
-ExceptionOr<bool> StylePropertyMap::has(ScriptExecutionContext& context, const AtomString& property) const
-{
-    auto result = get(context, property);
-    if (result.hasException())
-        return result.releaseException();
-    return !!result.returnValue();
-}
 
 // https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-set
 ExceptionOr<void> StylePropertyMap::set(Document&, const AtomString&, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&&)

--- a/Source/WebCore/css/typedom/StylePropertyMap.h
+++ b/Source/WebCore/css/typedom/StylePropertyMap.h
@@ -25,16 +25,12 @@
 
 #pragma once
 
-#include "StylePropertyMapReadOnly.h"
+#include "MainThreadStylePropertyMapReadOnly.h"
 
 namespace WebCore {
 
-class StylePropertyMap : public StylePropertyMapReadOnly {
+class StylePropertyMap : public MainThreadStylePropertyMapReadOnly {
 public:
-    ExceptionOr<RefPtr<CSSStyleValue>> get(ScriptExecutionContext&, const AtomString& property) const final;
-    ExceptionOr<Vector<RefPtr<CSSStyleValue>>> getAll(ScriptExecutionContext&, const AtomString&) const final;
-    ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const final;
-
     ExceptionOr<void> set(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
     ExceptionOr<void> append(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
     ExceptionOr<void> remove(Document&, const AtomString& property);
@@ -43,15 +39,8 @@ public:
     virtual void clearElement() { }
 
 protected:
-    static Document* documentFromContext(ScriptExecutionContext&);
-
-    virtual CSSValue* propertyValue(CSSPropertyID) const = 0;
-    virtual CSSValue* customPropertyValue(const AtomString&) const = 0;
     virtual void removeProperty(CSSPropertyID) = 0;
     virtual void removeCustomProperty(const AtomString&) = 0;
-
-private:
-    RefPtr<CSSStyleValue> shorthandPropertyValue(Document&, CSSPropertyID) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -42,9 +42,9 @@
 #include "ImageBuffer.h"
 #include "JSCSSPaintCallback.h"
 #include "JSDOMExceptionHandling.h"
+#include "MainThreadStylePropertyMapReadOnly.h"
 #include "PaintRenderingContext2D.h"
 #include "RenderElement.h"
-#include "StylePropertyMap.h"
 #include <JavaScriptCore/ConstructData.h>
 
 namespace WebCore {
@@ -74,11 +74,9 @@ static RefPtr<CSSValue> extractComputedProperty(const AtomString& name, Element&
     return extractor.propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No);
 }
 
-// FIXME: This should subclass StylePropertyMapReadonly (or similar), not StylePropertyMap
-// since this is readonly.
-class HashMapStylePropertyMap final : public StylePropertyMap {
+class HashMapStylePropertyMap final : public MainThreadStylePropertyMapReadOnly {
 public:
-    static Ref<StylePropertyMap> create(HashMap<AtomString, RefPtr<CSSValue>>&& map)
+    static Ref<HashMapStylePropertyMap> create(HashMap<AtomString, RefPtr<CSSValue>>&& map)
     {
         return adoptRef(*new HashMapStylePropertyMap(WTFMove(map)));
     }
@@ -127,11 +125,6 @@ private:
             result.uncheckedAppend(makeKeyValuePair(propertyName,  Vector<RefPtr<CSSStyleValue>> { reifyValue(cssValue.get(), *document) }));
         return result;
     }
-
-    // FIXME: This type is readonly and we shouldn't need to override functions that modify the map.
-    void removeProperty(CSSPropertyID) final { }
-    void removeCustomProperty(const AtomString&) final { }
-    void clear() final { }
 
     HashMap<AtomString, RefPtr<CSSValue>> m_map;
 };


### PR DESCRIPTION
#### b902c3b0e0c7e62d8bdf627e5acee6b9cf7acaa4
<pre>
HashMapStylePropertyMap is readonly and shouldn&apos;t be subclassing StylePropertyMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=247012">https://bugs.webkit.org/show_bug.cgi?id=247012</a>

Reviewed by Youenn Fablet.

HashMapStylePropertyMap is readonly and shouldn&apos;t be subclassing StylePropertyMap.
Instead, introduce a MainThreadStylePropertyMapReadonly and have both
HashMapStylePropertyMap and StylePropertyMap subclass it.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp: Copied from Source/WebCore/css/typedom/StylePropertyMap.cpp.
(WebCore::MainThreadStylePropertyMapReadOnly::documentFromContext):
(WebCore::MainThreadStylePropertyMapReadOnly::get const):
(WebCore::MainThreadStylePropertyMapReadOnly::getAll const):
(WebCore::MainThreadStylePropertyMapReadOnly::has const):
(WebCore::MainThreadStylePropertyMapReadOnly::shorthandPropertyValue const):
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h: Copied from Source/WebCore/css/typedom/StylePropertyMap.h.
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::documentFromContext): Deleted.
(WebCore::StylePropertyMap::shorthandPropertyValue const): Deleted.
(WebCore::StylePropertyMap::get const): Deleted.
(WebCore::StylePropertyMap::getAll const): Deleted.
(WebCore::StylePropertyMap::has const): Deleted.
* Source/WebCore/css/typedom/StylePropertyMap.h:
* Source/WebCore/html/CustomPaintImage.cpp:

Canonical link: <a href="https://commits.webkit.org/256012@main">https://commits.webkit.org/256012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b3b9a221e4954189cae71249164c62527ce9c0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/25047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103900 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164176 "Found 1 new test failure: http/wpt/webcodecs/videoFrame-serialization.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3437 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31650 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99921 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2465 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80630 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29508 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84384 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72430 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38006 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35890 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19151 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41734 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1959 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38380 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->