### PR TITLE
Unreviewed GCC warning fixes

### DIFF
--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -74,8 +74,8 @@ constexpr uint8_t elementCount(SIMDLane lane)
         return 2;
     case SIMDLane::v128:
         RELEASE_ASSERT_NOT_REACHED();
-        return 0;
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 constexpr bool scalarTypeIsFloatingPoint(SIMDLane lane)
@@ -119,6 +119,7 @@ constexpr SIMDLane narrowedLane(SIMDLane lane)
     case SIMDLane::f64x2:
         return SIMDLane::f32x4;
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 constexpr SIMDLane promotedLane(SIMDLane lane)
@@ -138,6 +139,7 @@ constexpr SIMDLane promotedLane(SIMDLane lane)
     case SIMDLane::f32x4:
         return SIMDLane::f64x2;
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 constexpr unsigned elementByteSize(SIMDLane simdLane)
@@ -156,6 +158,7 @@ constexpr unsigned elementByteSize(SIMDLane simdLane)
     case SIMDLane::v128:
         return 16;
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -73,6 +73,7 @@ constexpr Type simdScalarType(SIMDLane lane)
     case SIMDLane::f32x4:
         return Types::F32;
     }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 using FunctionArgCount = uint32_t;

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -102,7 +102,7 @@ float AccessibilityProgressIndicator::maxValueForRange() const
 
 float AccessibilityProgressIndicator::minValueForRange() const
 {
-    if (auto* progress = progressElement())
+    if (progressElement())
         return 0.0;
 
     if (auto* meter = meterElement())

--- a/Tools/wpe/backends/fdo/WindowViewBackend.cpp
+++ b/Tools/wpe/backends/fdo/WindowViewBackend.cpp
@@ -297,6 +297,8 @@ const struct wl_pointer_listener WindowViewBackend::s_pointerListener = {
             break;
         }
     },
+    // axis_value120
+    [](void*, struct wl_pointer*, uint32_t, int32_t) { }
 };
 
 const struct wl_keyboard_listener WindowViewBackend::s_keyboardListener = {


### PR DESCRIPTION
#### 9ff8ffb8786e5ff45fff43c8000eea63d14a3e85
<pre>
Unreviewed GCC warning fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=247014">https://bugs.webkit.org/show_bug.cgi?id=247014</a>

* Source/JavaScriptCore/jit/SIMDInfo.h:
(JSC::elementCount):
(JSC::narrowedLane):
(JSC::promotedLane):
(JSC::elementByteSize):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::simdScalarType):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::minValueForRange const):
* Tools/wpe/backends/fdo/WindowViewBackend.cpp:

Canonical link: <a href="https://commits.webkit.org/255972@main">https://commits.webkit.org/255972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c18c90dae75bc0e4f6990e25ee3b77b194ebd54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/94226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/3416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/25027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/103906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/98225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/3444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/99927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/99882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/3444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/80636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/3444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/25027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/85461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/25027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/80601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/35897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/25027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/80601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/39776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/80636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/37/builds/83265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/41720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/25027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/37/builds/83265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->