### PR TITLE
Fix CSSKeywordValue serialization to properly escape identifier

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssKeywordValue.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssKeywordValue.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 PASS CSSKeywordValue constructed from IDL serializes correctly
-FAIL CSSKeywordValue constructed from IDL serializes to escaped strings assert_equals: expected "\\ Hello\\ World" but got " Hello World"
+PASS CSSKeywordValue constructed from IDL serializes to escaped strings
 PASS CSSKeywordValue from DOMString modified through "value" setter serializes correctly
 PASS CSSKeywordValue from CSSOM modified through "value" setter serializes correctly
 

--- a/Source/WebCore/css/typedom/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSKeywordValue.h"
 
+#include "CSSMarkup.h"
 #include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -68,7 +69,7 @@ ExceptionOr<void> CSSKeywordValue::setValue(const String& value)
 void CSSKeywordValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#keywordvalue-serialization
-    builder.append(m_value);
+    serializeIdentifier(m_value, builder);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 3f16ccf37cb5d6c83a3f4ac23df6d8e9d2e0f868
<pre>
Fix CSSKeywordValue serialization to properly escape identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=247022">https://bugs.webkit.org/show_bug.cgi?id=247022</a>

Reviewed by Antti Koivisto.

Fix CSSKeywordValue serialization to properly escape identifier.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssKeywordValue.tentative-expected.txt:
* Source/WebCore/css/typedom/CSSKeywordValue.cpp:
(WebCore::CSSKeywordValue::serialize const):

Canonical link: <a href="https://commits.webkit.org/256022@main">https://commits.webkit.org/256022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d136d7f562200d765f30359968eea1e92a3a660a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/25284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103912 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164190 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3451 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31636 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86586 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99933 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2470 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80642 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29509 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84389 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38019 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17882 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19154 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41738 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1968 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38383 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->