### PR TITLE
CSSStyleValue.parse() should throw when passed an empty string as custom property value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parse-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parse-invalid-expected.txt
@@ -3,5 +3,5 @@ PASS CSSStyleValue.parse() with empty property name throws TypeError
 PASS CSSStyleValue.parse() with unsupported property name throws TypeError
 PASS CSSStyleValue.parse() with invalid value for valid property throws TypeError
 PASS CSSStyleValue.parse() with invalid value for shorthand property throws TypeError
-FAIL CSSStyleValue.parse() with invalid value for custom property throws TypeError assert_throws_js: function "() => CSSStyleValue.parse('--foo', '')" did not throw
+PASS CSSStyleValue.parse() with invalid value for custom property throws TypeError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-invalid-expected.txt
@@ -3,5 +3,5 @@ PASS CSSStyleValue.parseAll() with empty property name throws TypeError
 PASS CSSStyleValue.parseAll() with unsupported property name throws TypeError
 PASS CSSStyleValue.parseAll() with invalid value for valid property throws TypeError
 PASS CSSStyleValue.parseAll() with invalid value for shorthand property throws TypeError
-FAIL CSSStyleValue.parseAll() with invalid value for custom property throws TypeError assert_throws_js: function "() => CSSStyleValue.parseAll('--foo', '')" did not throw
+PASS CSSStyleValue.parseAll() with invalid value for custom property throws TypeError
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -91,6 +91,9 @@ ExceptionOr<void> CSSStyleValueFactory::extractShorthandCSSValues(Vector<Ref<CSS
 
 ExceptionOr<void> CSSStyleValueFactory::extractCustomCSSValues(Vector<Ref<CSSValue>>& cssValues, const AtomString& customPropertyName, const String& cssText)
 {
+    if (cssText.isEmpty())
+        return Exception { TypeError, "Value cannot be parsed"_s };
+
     auto styleDeclaration = MutableStyleProperties::create();
     
     constexpr bool important = true;


### PR DESCRIPTION
#### 98e13fd6a1c257a63bb5be5ddf8b9be9d87f602f
<pre>
CSSStyleValue.parse() should throw when passed an empty string as custom property value
<a href="https://bugs.webkit.org/show_bug.cgi?id=247026">https://bugs.webkit.org/show_bug.cgi?id=247026</a>

Reviewed by Geoffrey Garen.

CSSStyleValue.parse() / CSSStyleValue.parseAll() should throw when passed an
empty string as custom property value.

This matches Blink&apos;s behavior and this behavior is covered by WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parse-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-invalid-expected.txt:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::extractCustomCSSValues):

Canonical link: <a href="https://commits.webkit.org/256011@main">https://commits.webkit.org/256011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76ac25a4273fa50bb4cafa2b568a331a6011bb3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/25410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103919 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164197 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3459 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31643 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99939 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2477 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80649 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84396 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72433 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38027 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19156 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41741 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1960 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41735 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38385 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->