### PR TITLE
GPU process enabled macOS layout tests bot should use --remote-layer-tree

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -198,7 +198,7 @@
                     },
                     { "name": "Apple-Ventura-Debug-WK2-GPUProcess-Tests", "factory": "TestAllButJSCFactory",
                     "platform": "mac-ventura", "configuration": "debug", "architectures": ["x86_64", "arm64"],
-                    "additionalArguments": ["--no-retry-failures", "--use-gpu-process"],
+                    "additionalArguments": ["--no-retry-failures", "--use-gpu-process", "--remote-layer-tree"],
                     "workernames": ["bot234"]
                     },
                     { "name": "Apple-Monterey-Release-Build", "factory": "BuildFactory",


### PR DESCRIPTION
#### 894274daff0e22edba3dc2fdfc93dfa0e5a3661e
<pre>
GPU process enabled macOS layout tests bot should use --remote-layer-tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=246929">https://bugs.webkit.org/show_bug.cgi?id=246929</a>
rdar://101484140

Reviewed by Jonathan Bedard.

* Tools/CISupport/build-webkit-org/config.json:

Canonical link: <a href="https://commits.webkit.org/256406@main">https://commits.webkit.org/256406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7047e6d157ddb64414369783180638f5ce316bd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104936 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165200 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4628 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33346 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87716 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100818 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3386 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81936 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30449 "Found 1 new test failure: media/video-seek-to-current-time.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39067 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18739 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/94322 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20034 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40826 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42677 "Found 1 new test failure: storage/indexeddb/crash-on-getdatabases.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2122 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39273 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->