### PR TITLE
[Wasm-GC] Add support for subtyping declarations

### DIFF
--- a/JSTests/wasm/gc/sub.js
+++ b/JSTests/wasm/gc/sub.js
@@ -1,0 +1,421 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testSubDeclaration() {
+  instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (func))
+      (type (sub 0 (func)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (array i32))
+      (type (sub 0 (array i32)))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (array (mut i32)))
+      (type (sub 0 (array (mut i32))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (func))
+      (type (sub 0 (func)))
+      (func (type 1))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (func))
+      (type (func (result funcref)))
+      (type (sub 1 (func (result (ref 0)))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (func))
+      (type (func (param (ref 0))))
+      (type (sub 1 (func (param funcref))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct (field i32))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (func))
+      (type (array (ref func)))
+      (type (sub 1 (array (ref 0))))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (rec
+        (type $r1 (struct (field i32 (ref $r1)))))
+      (rec
+        (type $r2 (sub $r1 (struct (field i32 (ref $r3)))))
+        (type $r3 (sub $r1 (struct (field i32 (ref $r2))))))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (sub 0 (struct)))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (sub 0 (array i32)))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  /*
+   * (module
+   *   (type (func))
+   *   ;; multiple supertypes not supported in MVP, not possible to express in text format.
+   *   (type (sub (0 0) (struct)))
+   * )
+   */
+  assert.throws(
+    () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8a\x80\x80\x80\x00\x02\x60\x00\x00\x50\x02\x00\x00\x5f\x00")),
+    WebAssembly.CompileError,
+    "number of supertypes for subtype at position 1 is too big"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (struct (field i32)))
+        (type (sub 0 (struct)))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (struct (field (mut i32))))
+        (type (sub 0 (struct (field i32))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (struct (field i32)))
+        (type (sub 0 (struct (field (mut i32)))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (struct (field i64)))
+        (type (sub 0 (struct (field i32))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  instantiate(`
+    (module
+      (type (func))
+      (type (struct (field funcref)))
+      (type (sub 1 (struct (field (ref 0)))))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (struct (field (mut funcref))))
+        (type (sub 1 (struct (field (mut (ref 0))))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct (field i32))))
+      (func (result (ref null 0)) (ref.null 1))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct (field i32))))
+      (type (sub 1 (struct (field i32) (field i64))))
+      (func (result (ref null 0)) (ref.null 2))
+      (func (result (ref null 1)) (ref.null 2))
+    )
+  `);
+
+  instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct (field i32))))
+      (type (sub 1 (struct (field i32) (field i64))))
+      (type (sub 2 (struct (field i32) (field i64) (field f32))))
+      (func (result (ref null 0)) (ref.null 3))
+      (func (result (ref null 1)) (ref.null 3))
+      (func (result (ref null 2)) (ref.null 3))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (struct))
+        (type (sub 0 (struct (field i32))))
+        (type (sub 1 (struct (field i32) (field i64))))
+        (type (sub 1 (struct (field i32) (field f64))))
+        (type (sub 2 (struct (field i32) (field i64) (field f32))))
+        (func (result (ref null 3)) (ref.null 4))
+      )
+    `),
+    WebAssembly.CompileError,
+    "control flow returns with unexpected type. RefNull is not a RefNull, in function at index 0"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type $s (func))
+        (type $t (sub $s (func)))
+        (elem declare funcref (ref.func 0))
+        (func (type $s))
+        (func (result (ref $t)) (ref.func 0))
+      )
+    `),
+    WebAssembly.CompileError,
+    "control flow returns with unexpected type. Ref is not a Ref, in function at index 1"
+  );
+
+  instantiate(`
+    (module
+      (rec
+        (type (struct))
+        (type (sub 0 (struct (field i32)))))
+    )
+  `);
+
+  assert.throws(
+    () => compile(`
+      (module
+        (rec
+          (type (struct (field f32)))
+          (type (sub 0 (struct (field i32)))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (sub 0 (func (result i32))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (sub 0 (func (param i32))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func (param i32)))
+        (type (sub 0 (func)))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (func (param funcref)))
+        (type (sub 1 (func (param (ref 0)))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (func (result (ref 0))))
+        (type (sub 1 (func (result funcref))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (array (mut i32)))
+        (type (sub 0 (array i32)))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (array i32))
+        (type (sub 0 (array (mut i32))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  assert.throws(
+    () => compile(`
+      (module
+        (type (func))
+        (type (array (mut (ref func))))
+        (type (sub 1 (array (mut (ref 0)))))
+      )
+    `),
+    WebAssembly.CompileError,
+    "structural type is not a subtype"
+  );
+
+  {
+    let m1 = instantiate(`
+      (module
+        (type (func))
+        (type (struct))
+        (type (sub 1 (struct (field i32))))
+        (global (export "g") (ref null 2) (ref.null 2))
+      )
+    `);
+    instantiate(`
+      (module
+        (type (struct))
+        (type (sub 0 (struct (field i32))))
+        (global (import "m" "g") (ref null 1))
+      )
+    `, { m: { g: m1.exports.g } });
+  }
+
+  {
+    let m1 = instantiate(`
+      (module
+        (type (func))
+        (type (struct))
+        (type (sub 1 (struct (field i32))))
+        (global (export "g") (ref null 2) (ref.null 2))
+      )
+    `);
+    instantiate(`
+      (module
+        (type (struct))
+        (type (sub 0 (struct (field i32))))
+        ;; Note 0 index here to test subtyping in linking
+        (global (import "m" "g") (ref null 0))
+      )
+    `, { m: { g: m1.exports.g } });
+  }
+
+  {
+    let m1 = instantiate(`
+      (module
+        (type (struct (field i32)))
+        (type (sub 0 (struct (field i32))))
+        (global (export "g") (ref null 1) (ref.null 1))
+      )
+    `);
+    assert.throws(
+      () => instantiate(`
+        (module
+          (type (struct))
+          (type (sub 0 (struct (field i32))))
+          (global (import "m" "g") (ref null 1))
+        )
+      `, { m: { g: m1.exports.g } }),
+      WebAssembly.LinkError,
+      "imported global m:g must be a same type"
+    );
+  }
+}
+
+testSubDeclaration();

--- a/JSTests/wasm/wasm.json
+++ b/JSTests/wasm/wasm.json
@@ -21,6 +21,7 @@
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void",   "width": 0 },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void",   "width": 0 },
         "array":     { "type": "varint7", "value":  -34, "b3type": "B3::Void",   "width": 0 },
+        "sub":       { "type": "varint7", "value":  -48, "b3type": "B3::Void",   "width": 0 },
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
     },

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -675,6 +675,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
+        case TypeKind::Sub:
             RELEASE_ASSERT_NOT_REACHED();
         }
     };
@@ -738,6 +739,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
+        case TypeKind::Sub:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }
@@ -773,6 +775,7 @@ auto LLIntGenerator::callInformationForCaller(const FunctionSignature& signature
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
+        case TypeKind::Sub:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }
@@ -836,6 +839,7 @@ auto LLIntGenerator::callInformationForCallee(const FunctionSignature& signature
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
+        case TypeKind::Sub:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }
@@ -892,6 +896,7 @@ auto LLIntGenerator::addArguments(const TypeDefinition& signature) -> PartialRes
         case TypeKind::Arrayref:
         case TypeKind::I31ref:
         case TypeKind::Rec:
+        case TypeKind::Sub:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -46,6 +46,7 @@ constexpr size_t maxGlobals = 1000000;
 constexpr size_t maxDataSegments = 100000;
 constexpr size_t maxStructFieldCount = 10000;
 constexpr size_t maxRecursionGroupCount = 10000;
+constexpr size_t maxSubtypeSupertypeCount = 1;
 
 constexpr size_t maxStringSize = 100000;
 constexpr size_t maxModuleSize = 1024 * 1024 * 1024;

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -51,6 +51,8 @@ public:
     PartialResult WARN_UNUSED_RETURN parseCustom();
 
 private:
+    enum class DeferSubtypeCheck { Yes, No };
+
     template <typename ...Args>
     NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const
     {
@@ -73,6 +75,7 @@ private:
     PartialResult WARN_UNUSED_RETURN parseStructType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseArrayType(uint32_t position, RefPtr<TypeDefinition>&);
     PartialResult WARN_UNUSED_RETURN parseRecursionGroup(uint32_t position, RefPtr<TypeDefinition>&);
+    PartialResult WARN_UNUSED_RETURN parseSubtype(uint32_t position, RefPtr<TypeDefinition>&, Vector<TypeIndex>&, DeferSubtypeCheck = DeferSubtypeCheck::No);
 
     PartialResult WARN_UNUSED_RETURN validateElementTableIdx(uint32_t);
     PartialResult WARN_UNUSED_RETURN parseI32InitExprForElementSection(std::optional<I32InitExpr>&);
@@ -82,6 +85,9 @@ private:
     PartialResult WARN_UNUSED_RETURN parseElementSegmentVectorOfIndexes(Vector<uint32_t>&, const unsigned, const unsigned);
 
     PartialResult WARN_UNUSED_RETURN parseI32InitExprForDataSection(std::optional<I32InitExpr>&);
+
+    static bool checkStructuralSubtype(const TypeDefinition&, const TypeDefinition&);
+    static bool checkSubtypeValidity(const TypeDefinition&);
 
     size_t m_offsetInSource;
     Ref<ModuleInformation> m_info;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -136,6 +136,7 @@ void JSWebAssemblyStruct::set(JSGlobalObject* globalObject, uint32_t fieldIndex,
     case TypeKind::Struct:
     case TypeKind::Array:
     case TypeKind::Void:
+    case TypeKind::Sub:
     case TypeKind::Rec:
     case TypeKind::I31ref: {
         break;

--- a/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
+++ b/Source/JavaScriptCore/wasm/js/WasmToJS.cpp
@@ -152,6 +152,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Arrayref:
             case TypeKind::I31ref:
             case TypeKind::Rec:
+            case TypeKind::Sub:
             case TypeKind::V128:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:
@@ -238,6 +239,7 @@ Expected<MacroAssemblerCodeRef<WasmEntryPtrTag>, BindingFailure> wasmToJS(VM& vm
             case TypeKind::Arrayref:
             case TypeKind::I31ref:
             case TypeKind::Rec:
+            case TypeKind::Sub:
             case TypeKind::V128:
                 RELEASE_ASSERT_NOT_REACHED(); // Handled above.
             case TypeKind::RefNull:

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -240,7 +240,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             if (global.mutability == Wasm::Immutable) {
                 if (value.inherits<JSWebAssemblyGlobal>()) {
                     JSWebAssemblyGlobal* globalValue = jsCast<JSWebAssemblyGlobal*>(value);
-                    if (globalValue->global()->type() != global.type)
+                    if (!isSubtype(globalValue->global()->type(), global.type))
                         return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global", "must be a same type")));
                     if (globalValue->global()->mutability() != Wasm::Immutable)
                         return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "imported global", "must be a same mutability")));

--- a/Source/JavaScriptCore/wasm/wasm.json
+++ b/Source/JavaScriptCore/wasm/wasm.json
@@ -21,6 +21,7 @@
         "func":      { "type": "varint7", "value":  -32, "b3type": "B3::Void",   "width": 0 },
         "struct":    { "type": "varint7", "value":  -33, "b3type": "B3::Void",   "width": 0 },
         "array":     { "type": "varint7", "value":  -34, "b3type": "B3::Void",   "width": 0 },
+        "sub":       { "type": "varint7", "value":  -48, "b3type": "B3::Void",   "width": 0 },
         "rec":       { "type": "varint7", "value":  -49, "b3type": "B3::Void",   "width": 0 },
         "void":      { "type": "varint7", "value":  -64, "b3type": "B3::Void",   "width": 0 }
     },


### PR DESCRIPTION
#### 431164ca6a4b101688188966ce5384a7f8c68681
<pre>
[Wasm-GC] Add support for subtyping declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=239668">https://bugs.webkit.org/show_bug.cgi?id=239668</a>

Reviewed by Justin Michaud.

Adds support for `sub` type section forms. These introduce subtyping
declarations that can specify parent types for a `func`, `struct`,
etc. type (the MVP GC proposal only allows a single parent type).

Adding `sub` forms changes type expansion slightly, and requires that
checking `isSubtype` look at the type hierarchy if the LHS type is a
`sub` type. This patch also memoizes type expansion to avoid repeated
unrolling of recursive types.

With the addition of `sub`, a bare `func`, `struct`, etc declaration
is treated as implicitly having a `sub` with zero/empty supertypes.
To avoid `(sub () (func))` and `(func)` being represented differently,
we normalize empty-supertype `sub` to be represented as just the
underlying type.

Subtype checking for indexed reference types is done using a display
data structure. Each `sub` declaration has an associated display that
records an array of supertype indices. This allows subtype checking in
constant-time by checking if the supertype index is present in the
subtype at the correct display offset, rather than with a linear
traversal of the hierarchy. If multiple parent types are allowed in the
future, this algorithm will need to change.

* JSTests/wasm/gc/sub.js: Added.
(module):
(testSubDeclaration):
* JSTests/wasm/wasm.json:
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::isSubtypeIndex):
(JSC::Wasm::isSubtype):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::callInformationForCaller):
(JSC::Wasm::LLIntGenerator::callInformationForCallee):
(JSC::Wasm::LLIntGenerator::addArguments):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseRecursionGroup):
(JSC::Wasm::SectionParser::checkStructuralSubtype):
(JSC::Wasm::SectionParser::checkSubtypeValidity):
(JSC::Wasm::SectionParser::parseSubtype):
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeDefinition::dump const):
(JSC::Wasm::Subtype::toString const):
(JSC::Wasm::Subtype::dump const):
(JSC::Wasm::computeSubtypeHash):
(JSC::Wasm::TypeDefinition::hash const):
(JSC::Wasm::TypeDefinition::tryCreateSubtype):
(JSC::Wasm::TypeDefinition::replacePlaceholders const):
(JSC::Wasm::TypeDefinition::unroll const):
(JSC::Wasm::TypeDefinition::expand const):
(JSC::Wasm::TypeDefinition::hasRecursiveReference const):
(JSC::Wasm::SubtypeParameterTypes::hash):
(JSC::Wasm::SubtypeParameterTypes::equal):
(JSC::Wasm::SubtypeParameterTypes::translate):
(JSC::Wasm::TypeInformation::typeDefinitionForSubtype):
(JSC::Wasm::TypeInformation::addCachedUnrolling):
(JSC::Wasm::TypeInformation::tryGetCachedUnrolling):
(JSC::Wasm::TypeInformation::tryCleanup):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::typeKindSizeInBytes):
(JSC::Wasm::Subtype::Subtype):
(JSC::Wasm::Subtype::superType const):
(JSC::Wasm::Subtype::underlyingType const):
(JSC::Wasm::Subtype::displayType const):
(JSC::Wasm::Subtype::displaySize const):
(JSC::Wasm::Subtype::getSuperType):
(JSC::Wasm::Subtype::getUnderlyingType):
(JSC::Wasm::Subtype::getDisplayType):
(JSC::Wasm::Subtype::storage):
(JSC::Wasm::Subtype::storage const):
(JSC::Wasm::TypeDefinition::allocatedSubtypeSize):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::set):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
* Source/JavaScriptCore/wasm/wasm.json:

Canonical link: <a href="https://commits.webkit.org/256243@main">https://commits.webkit.org/256243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cf3b5a3a44f692220988bc79785066765d4d1a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4193 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104652 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164905 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4283 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32380 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100553 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3111 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81715 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30095 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85023 "Found 1 new API test failure: TestWebKitAPI.WKUserContentController.InjectUserScriptImmediately (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86915 "Build was cancelled. Recent messages:") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72992 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86168 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38783 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18470 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81415 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19751 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28031 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40539 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84089 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38993 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19009 "Passed tests") | 
<!--EWS-Status-Bubble-End-->