### PR TITLE
Fix divide by zero warning in TextureMapperLayer

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -460,13 +460,13 @@ IntRect transformedBoundingBox(const TransformationMatrix& transform, FloatRect 
         ASSERT(positive.w > 0);
         ASSERT(negative.w <= 0);
         auto v = positive.w * negative - negative.w * positive;
-        v.w = 0;
+        v.w = 1;
         return v;
     };
     auto boundingBoxPPP = [&](Point p1, Point p2, Point p3) -> IntRect {
-        ASSERT(p1.w >= 0);
-        ASSERT(p2.w >= 0);
-        ASSERT(p3.w >= 0);
+        ASSERT(p1.w > 0);
+        ASSERT(p2.w > 0);
+        ASSERT(p3.w > 0);
         auto xMinMax = minMax3(p1.x / p1.w, p2.x / p2.w, p3.x / p3.w);
         auto yMinMax = minMax3(p1.y / p1.w, p2.y / p2.w, p3.y / p3.w);
         return clipped(xMinMax, yMinMax);


### PR DESCRIPTION
#### b2c43e9a61353c70704c05e2441bda9088c3a27f
<pre>
Fix divide by zero warning in TextureMapperLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=247033">https://bugs.webkit.org/show_bug.cgi?id=247033</a>

Reviewed by NOBODY (OOPS!).

The `toPositive` lambda creates a point where the `w` component is `0`.
In `boundingBoxPPN` the results of `toPositive` are padded to
`boundingBoxPPP` which has a division using the `w` component which is
set to `0`.

Found by a warning in Visual Studio. Updated the ASSERT to be `&gt; 0`.

* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2c43e9a61353c70704c05e2441bda9088c3a27f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/26270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103943 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164222 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3491 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31667 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99960 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2503 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80673 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29533 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84422 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72446 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38054 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35935 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19165 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41753 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38394 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->