### PR TITLE
[git-webkit] Deeply inspect potential gardening commits

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.7.2',
+    version='5.7.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 7, 2)
+version = Version(5, 7, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py
@@ -28,7 +28,7 @@ from datetime import datetime
 
 from webkitcorepy import OutputCapture, Terminal, testing
 from webkitcorepy.mocks import Time as MockTime
-from webkitscmpy import program, mocks, Commit
+from webkitscmpy import local, program, mocks, Commit
 
 
 class TestPickable(testing.PathTestCase):
@@ -182,3 +182,53 @@ class TestPickable(testing.PathTestCase):
             ))
 
         self.assertEqual(captured.stdout.getvalue(), '4.1@safari-xxx-branch | 6eedcf4492c3 | Versioning.\n')
+
+    def test_branch_gardening_exclude(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            project_config = os.path.join(self.path, 'metadata', local.Git.GIT_CONFIG_EXTENSION)
+            os.mkdir(os.path.dirname(project_config))
+            with open(project_config, 'w') as f:
+                f.write('[webkitscmpy "tests"]\n')
+                f.write('    api-tests = Source\n')
+
+            repo.commits['safari-xxx-branch'] = [
+                repo.commits['main'][3],
+                Commit(
+                    hash='6eedcf4492c3b14a97b886c4df59e8698f10539f',
+                    author=repo.commits['main'][3].author,
+                    timestamp=int(time.time()) - 1000,
+                    branch='safari-xxx-branch',
+                    message='[GARDENING] Mark test/abc as failing\n',
+                    identifier='4.1@safari-xxx-branch',
+                ),
+            ]
+            self.assertEqual(1, program.main(
+                args=('pickable', 'safari-xxx-branch'),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), "No commits in specified range are 'pickable'\n")
+        self.assertEqual(captured.stdout.getvalue(), '')
+
+    def test_branch_gardening_include(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime, Terminal.override_atty(sys.stdin, isatty=False):
+            repo.commits['safari-xxx-branch'] = [
+                repo.commits['main'][3],
+                Commit(
+                    hash='6eedcf4492c3b14a97b886c4df59e8698f10539f',
+                    author=repo.commits['main'][3].author,
+                    timestamp=int(time.time()) - 1000,
+                    branch='safari-xxx-branch',
+                    message='[GARDENING] Mark test/abc as failing\n',
+                    identifier='4.1@safari-xxx-branch',
+                ),
+            ]
+            self.assertEqual(0, program.main(
+                args=('pickable', 'safari-xxx-branch'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '4.1@safari-xxx-branch | 6eedcf4492c3 | [GARDENING] Mark test/abc as failing\n',
+        )

--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -14,3 +14,6 @@
         security = WebKit/teams/security
 [webkitscmpy "pre-pr"]
         style-checker = python3 Tools/Scripts/check-webkit-style
+[webkitscmpy "tests"]
+        layout-tests = LayoutTests
+        api-tests = Tools/TestWebKitAPI


### PR DESCRIPTION
#### 28f6affda69277f776b26535eaede7313689dc4b
<pre>
[git-webkit] Deeply inspect potential gardening commits
<a href="https://bugs.webkit.org/show_bug.cgi?id=247034">https://bugs.webkit.org/show_bug.cgi?id=247034</a>
rdar://101568509

Reviewed by Elliott Williams.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py:
(Pickable.Filters):
(Pickable.Filters.fuzzy): Move fuzzy_filter into scoping class.
(Pickable.Filters.gardening): If a commit matches a gardening pattern, inspect the files
changed to see if they are exclusively testing files.
(Pickable.pickable): Pass commit objects into callable filters.
(fuzzy_filter): Renamed Pickable.Filters.fuzzy.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pickable_unittest.py:
(TestPickable.test_branch_gardening_exclude):
(TestPickable.test_branch_gardening_include):
* metadata/git_config_extension: Add API and layout test paths.

Canonical link: <a href="https://commits.webkit.org/256014@main">https://commits.webkit.org/256014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b16789ed3e066900b0a0e94f191d9daca0a10a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3530 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3577 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31736 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100022 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80747 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/97944 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38131 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/93353 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/39895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1962 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41845 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->