### PR TITLE
[JSC] Allow the same array for fast concat

### DIFF
--- a/JSTests/microbenchmarks/same-array-concat.js
+++ b/JSTests/microbenchmarks/same-array-concat.js
@@ -1,0 +1,14 @@
+function test(array1, array2)
+{
+    return array1.concat(array2);
+}
+noInline(test);
+
+var array0 = [];
+var array1 = [0, 1, 2];
+var array2 = ["String", 2];
+for (var i = 0; i < 1e5; ++i) {
+    test(array0, array0);
+    test(array1, array1);
+    test(array2, array2);
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1434,7 +1434,7 @@ static bool moveElements(JSGlobalObject* globalObject, VM& vm, JSArray* target, 
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (LIKELY(!hasAnyArrayStorage(source->indexingType()) && !holesMustForwardToPrototype(source))) {
+    if (LIKELY(!hasAnyArrayStorage(source->indexingType()) && !source->holesMustForwardToPrototype())) {
         for (unsigned i = 0; i < sourceLength; ++i) {
             JSValue value = source->tryGetIndexQuickly(i);
             if (value) {

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -483,7 +483,7 @@ bool JSArray::appendMemcpy(JSGlobalObject* globalObject, VM& vm, unsigned startI
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (!canFastCopy(otherArray))
+    if (!canFastAppend(otherArray))
         return false;
 
     IndexingType type = indexingType();
@@ -926,7 +926,7 @@ bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsign
         unsigned end = oldLength - count;
         unsigned moveCount = end - startIndex;
         if (moveCount) {
-            if (UNLIKELY(this->structure()->holesMustForwardToPrototype(this))) {
+            if (UNLIKELY(holesMustForwardToPrototype())) {
                 for (unsigned i = startIndex; i < end; ++i) {
                     JSValue v = butterfly->contiguous().at(this, i + count).get();
                     if (UNLIKELY(!v)) {
@@ -971,7 +971,7 @@ bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsign
         unsigned end = oldLength - count;
         unsigned moveCount = end - startIndex;
         if (moveCount) {
-            if (UNLIKELY(this->structure()->holesMustForwardToPrototype(this))) {
+            if (UNLIKELY(holesMustForwardToPrototype())) {
                 for (unsigned i = startIndex; i < end; ++i) {
                     double v = butterfly->contiguousDouble().at(this, i + count);
                     if (UNLIKELY(v != v)) {

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -106,8 +106,10 @@ public:
 
     static JSArray* fastSlice(JSGlobalObject*, JSObject* source, uint64_t startIndex, uint64_t count);
 
-    bool canFastCopy(JSArray* otherArray);
-    bool canDoFastIndexedAccess();
+    bool holesMustForwardToPrototype() const;
+    bool canFastCopy(JSArray* otherArray) const;
+    bool canFastAppend(JSArray* otherArray) const;
+    bool canDoFastIndexedAccess() const;
     // This function returns NonArray if the indexing types are not compatable for copying.
     IndexingType mergeIndexingTypeForCopying(IndexingType other);
     bool appendMemcpy(JSGlobalObject*, VM&, unsigned startIndex, JSArray* otherArray);


### PR DESCRIPTION
#### 9285fb4a8ca01205fa4043717926c887b6bc51f1
<pre>
[JSC] Allow the same array for fast concat
<a href="https://bugs.webkit.org/show_bug.cgi?id=247038">https://bugs.webkit.org/show_bug.cgi?id=247038</a>
rdar://101569531

Reviewed by Alexey Shvayka.

This patch allows the same array used for concat. We added this check in 42bc7339d2e189dae66571273ad8dd84b8801cdd,
but this is necessary only for concat&apos;s @appendMemcpy path since it modifies |this|. So we should not prohibit using
the fast code in the concat&apos;s fast path (@concatMemcpy) since it creates a new array. We also clean up the holesMustForwardToPrototype
implementation to use already-configured WatchpointSet.

                                  ToT                     Patched

    same-array-concat       15.1125+-0.0547     ^      6.7147+-0.0203        ^ definitely 2.2507x faster

* JSTests/microbenchmarks/same-array-concat.js: Added.
(test):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::moveElements):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::appendMemcpy):
(JSC::JSArray::shiftCountWithAnyIndexingType):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::holesMustForwardToPrototype const):
(JSC::JSArray::canFastCopy const):
(JSC::JSArray::canFastAppend const):
(JSC::JSArray::canDoFastIndexedAccess const):
(JSC::JSArray::canFastCopy): Deleted.
(JSC::JSArray::canDoFastIndexedAccess): Deleted.

Canonical link: <a href="https://commits.webkit.org/256040@main">https://commits.webkit.org/256040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea63be2a210c64f6a6cf4cb71727fff0b0b7d7b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3592 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3642 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80808 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/85623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38191 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80785 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27776 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39953 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83452 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1980 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41905 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18852 "Passed tests") | 
<!--EWS-Status-Bubble-End-->