### PR TITLE
[WebDriver] Support "Get Computed Label" command

### DIFF
--- a/Source/WebDriver/Session.h
+++ b/Source/WebDriver/Session.h
@@ -110,6 +110,7 @@ public:
     void getElementRect(const String& elementID, Function<void (CommandResult&&)>&&);
     void isElementEnabled(const String& elementID, Function<void (CommandResult&&)>&&);
     void getComputedRole(const String& elementID, Function<void (CommandResult&&)>&&);
+    void getComputedLabel(const String& elementID, Function<void (CommandResult&&)>&&);
     void isElementDisplayed(const String& elementID, Function<void (CommandResult&&)>&&);
     void elementClick(const String& elementID, Function<void (CommandResult&&)>&&);
     void elementClear(const String& elementID, Function<void (CommandResult&&)>&&);

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -188,6 +188,7 @@ const WebDriverService::Command WebDriverService::s_commands[] = {
     { HTTPMethod::Get, "/session/$sessionId/element/$elementId/rect", &WebDriverService::getElementRect },
     { HTTPMethod::Get, "/session/$sessionId/element/$elementId/enabled", &WebDriverService::isElementEnabled },
     { HTTPMethod::Get, "/session/$sessionId/element/$elementId/computedrole", &WebDriverService::getComputedRole },
+    { HTTPMethod::Get, "/session/$sessionId/element/$elementId/computedlabel", &WebDriverService::getComputedLabel },
 
     { HTTPMethod::Post, "/session/$sessionId/element/$elementId/click", &WebDriverService::elementClick },
     { HTTPMethod::Post, "/session/$sessionId/element/$elementId/clear", &WebDriverService::elementClear },
@@ -1628,6 +1629,20 @@ void WebDriverService::getComputedRole(RefPtr<JSON::Object>&& parameters, Functi
         return;
 
     m_session->getComputedRole(elementID.value(), WTFMove(completionHandler));
+}
+
+void WebDriverService::getComputedLabel(RefPtr<JSON::Object>&& parameters, Function<void (CommandResult&&)>&& completionHandler)
+{
+    // §12.4.10 Get Computed Role
+    // https://www.w3.org/TR/webdriver/#get-computed-label
+    if (!findSessionOrCompleteWithError(*parameters, completionHandler))
+        return;
+
+    auto elementID = findElementOrCompleteWithError(*parameters, completionHandler);
+    if (!elementID)
+        return;
+
+    m_session->getComputedLabel(elementID.value(), WTFMove(completionHandler));
 }
 
 void WebDriverService::isElementDisplayed(RefPtr<JSON::Object>&& parameters, Function<void (CommandResult&&)>&& completionHandler)

--- a/Source/WebDriver/WebDriverService.h
+++ b/Source/WebDriver/WebDriverService.h
@@ -101,6 +101,7 @@ private:
     void getElementRect(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     void isElementEnabled(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     void getComputedRole(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
+    void getComputedLabel(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     void isElementDisplayed(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     void elementClick(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);
     void elementClear(RefPtr<JSON::Object>&&, Function<void (CommandResult&&)>&&);

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1581,8 +1581,7 @@
     },
     "imported/w3c/webdriver/tests/get_computed_label/get.py": {
         "expected": {
-            "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/246814"},
-            "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/246814"}
+            "all": {"status": ["FAIL"], "bug": "webkit.org/b/246845"}
         }
     }
 }


### PR DESCRIPTION
#### 65f0b17d5ddf4be81078c810fd814b50a65d7f31
<pre>
[WebDriver] Support &quot;Get Computed Label&quot; command
<a href="https://bugs.webkit.org/show_bug.cgi?id=246814">https://bugs.webkit.org/show_bug.cgi?id=246814</a>

Reviewed by Carlos Garcia Campos.

Tests still marked as xfailure as they need a fix yet to be imported into
local copy. Manually applying the fix shows that they should be passing,
though.

* Source/WebDriver/Session.cpp:
(WebDriver::Session::getComputedRole): Refactor to use getComputedRole
command.
(WebDriver::Session::getComputedLabel): Added
* Source/WebDriver/Session.h:
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::getComputedLabel): Added
* Source/WebDriver/WebDriverService.h:
* WebDriverTests/TestExpectations.json: Update referenced bug

Canonical link: <a href="https://commits.webkit.org/256146@main">https://commits.webkit.org/256146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb3b20f968a06e0c253014ea8541f7e555d4ccc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94787 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104393 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164658 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4013 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32121 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100314 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2891 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81300 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29891 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72775 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38530 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18176 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19457 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40288 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42218 "Build is in progress. Recent messages:Pull request 5794 is already closed") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38688 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->