### PR TITLE
Implement ImageBufferPipe for CoreAnimation so that we can update frames without using the main-thread

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -274,6 +274,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/ca/TileGrid.cpp
     platform/graphics/ca/TransformationMatrixCA.cpp
 
+    platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
     platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
     platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
     platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -643,6 +644,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ca/PlatformCALayerClient.h
     platform/graphics/ca/TileController.h
 
+    platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h
     platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
     platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
     platform/graphics/ca/cocoa/WebVideoContainerLayer.h

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -357,6 +357,7 @@ platform/graphics/ca/TileController.cpp
 platform/graphics/ca/TileCoverageMap.cpp
 platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/TransformationMatrixCA.cpp
+platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -486,8 +486,7 @@ void OffscreenCanvas::commitToPlaceholderCanvas()
     }
 
     if (m_placeholderData->bufferPipeSource) {
-        if (auto bufferCopy = imageBuffer->clone())
-            m_placeholderData->bufferPipeSource->handle(WTFMove(bufferCopy));
+        m_placeholderData->bufferPipeSource->handle(*imageBuffer);
     }
 
     Locker locker { m_placeholderData->bufferLock };

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -89,6 +89,11 @@ RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext::layerConten
     return nullptr;
 }
 
+void CanvasRenderingContext::setContentsToLayer(GraphicsLayer& layer)
+{
+    layer.setContentsDisplayDelegate(layerContentsDisplayDelegate(), GraphicsLayer::ContentsLayerPurpose::Canvas);
+}
+
 PixelFormat CanvasRenderingContext::pixelFormat() const
 {
     return PixelFormat::BGRA8;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -80,6 +80,7 @@ public:
     virtual void prepareForDisplayWithPaint() { }
     virtual void paintRenderingResultsToCanvas() { }
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
+    virtual void setContentsToLayer(GraphicsLayer&);
 
     bool hasActiveInspectorCanvasCallTracer() const { return m_hasActiveInspectorCanvasCallTracer; }
     void setHasActiveInspectorCanvasCallTracer(bool hasActiveInspectorCanvasCallTracer) { m_hasActiveInspectorCanvasCallTracer = hasActiveInspectorCanvasCallTracer; }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -52,12 +52,14 @@ HTMLCanvasElement* PlaceholderRenderingContext::canvas() const
     return &downcast<HTMLCanvasElement>(base);
 }
 
-RefPtr<GraphicsLayerContentsDisplayDelegate> PlaceholderRenderingContext::layerContentsDisplayDelegate()
+void PlaceholderRenderingContext::setContentsToLayer(GraphicsLayer& layer)
 {
-    if (m_imageBufferPipe)
-        return m_imageBufferPipe->layerContentsDisplayDelegate();
+    if (m_imageBufferPipe) {
+        m_imageBufferPipe->setContentsToLayer(layer);
+        return;
+    }
 
-    return nullptr;
+    return CanvasRenderingContext::setContentsToLayer(layer);
 }
 
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -46,10 +46,9 @@ public:
 private:
     bool isPlaceholder() const final { return true; }
 
-    RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final;
-
     bool isAccelerated() const final { return !!m_imageBufferPipe; }
     bool isGPUBased() const final { return !!m_imageBufferPipe; }
+    void setContentsToLayer(GraphicsLayer&);
 
     RefPtr<ImageBufferPipe> m_imageBufferPipe;
 };

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -630,6 +630,11 @@ void GraphicsLayer::setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDispl
 {
 }
 
+RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayer::createAsyncContentsDisplayDelegate()
+{
+    return nullptr;
+}
+
 void GraphicsLayer::getDebugBorderInfo(Color& color, float& width) const
 {
     width = 2;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -59,6 +59,7 @@ class Animation;
 class GraphicsContext;
 class GraphicsLayerFactory;
 class GraphicsLayerContentsDisplayDelegate;
+class GraphicsLayerAsyncContentsDisplayDelegate;
 class Image;
 class Model;
 class TiledBacking;
@@ -518,6 +519,7 @@ public:
     virtual void setContentsToSolidColor(const Color&) { }
     virtual void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) { }
     virtual void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose);
+    WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate();
 #if ENABLE(MODEL_ELEMENT)
     enum class ModelInteraction : uint8_t { Enabled, Disabled };
     virtual void setContentsToModel(RefPtr<Model>&&, ModelInteraction) { }

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GraphicsLayer.h"
+#include "ImageBuffer.h"
 #include <wtf/RefCounted.h>
 
 #if !USE(CA)
@@ -51,6 +52,13 @@ public:
 #else
     virtual PlatformLayer* platformLayer() const = 0;
 #endif
+};
+
+class WEBCORE_EXPORT GraphicsLayerAsyncContentsDisplayDelegate : public RefCounted<GraphicsLayerAsyncContentsDisplayDelegate> {
+public:
+    virtual ~GraphicsLayerAsyncContentsDisplayDelegate() = default;
+
+    virtual bool tryCopyToLayer(ImageBuffer&) = 0;
 };
 
 }

--- a/Source/WebCore/platform/graphics/ImageBufferPipe.h
+++ b/Source/WebCore/platform/graphics/ImageBufferPipe.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "GraphicsLayerContentsDisplayDelegate.h"
+#include "GraphicsLayer.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -42,7 +42,7 @@ public:
     public:
         virtual ~Source() = default;
 
-        virtual void handle(RefPtr<ImageBuffer>&&) = 0;
+        virtual void handle(ImageBuffer&) = 0;
     };
 
     static RefPtr<ImageBufferPipe> create();
@@ -50,7 +50,7 @@ public:
     virtual ~ImageBufferPipe() = default;
 
     virtual RefPtr<Source> source() const = 0;
-    virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() =0;
+    virtual void setContentsToLayer(GraphicsLayer&) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -68,6 +68,7 @@
 #endif
 
 #if PLATFORM(COCOA)
+#include "GraphicsLayerAsyncContentsDisplayDelegateCocoa.h"
 #include "PlatformCAAnimationCocoa.h"
 #include "PlatformCALayerCocoa.h"
 #endif
@@ -4909,6 +4910,15 @@ Vector<std::pair<String, double>> GraphicsLayerCA::acceleratedAnimationsForTesti
     }
 
     return animations;
+}
+
+RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCA::createAsyncContentsDisplayDelegate()
+{
+#if PLATFORM(COCOA)
+    return adoptRef(new GraphicsLayerAsyncContentsDisplayDelegateCocoa(*this));
+#else
+    return nullptr;
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -197,6 +197,8 @@ public:
 
     constexpr static CompositingCoordinatesOrientation defaultContentsOrientation = CompositingCoordinatesOrientation::TopDown;
 
+    WEBCORE_EXPORT RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate() override;
+
 private:
     bool isGraphicsLayerCA() const override { return true; }
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GraphicsLayerContentsDisplayDelegate.h"
+
+namespace WebCore {
+
+class GraphicsLayerCA;
+
+class GraphicsLayerAsyncContentsDisplayDelegateCocoa : public GraphicsLayerAsyncContentsDisplayDelegate {
+public:
+    GraphicsLayerAsyncContentsDisplayDelegateCocoa(GraphicsLayerCA&);
+    bool tryCopyToLayer(ImageBuffer&) final;
+
+private:
+    RetainPtr<CALayer> m_layer;
+};
+
+}

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "GraphicsLayerAsyncContentsDisplayDelegateCocoa.h"
+
+#import "GraphicsLayerCA.h"
+#import "NativeImage.h"
+#import "WebCoreCALayerExtras.h"
+
+namespace WebCore {
+
+GraphicsLayerAsyncContentsDisplayDelegateCocoa::GraphicsLayerAsyncContentsDisplayDelegateCocoa(GraphicsLayerCA& layer)
+{
+    m_layer = adoptNS([[CALayer alloc] init]);
+    [m_layer setName:@"OffscreenCanvasLayer"];
+
+    layer.setContentsToPlatformLayer(m_layer.get(), GraphicsLayer::ContentsLayerPurpose::Canvas);
+}
+
+bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer& image)
+{
+    auto native = image.clone()->sinkIntoNativeImage();
+
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+
+    [m_layer setFrame:CGRectMake(0, 0, native->size().width(), native->size().height())];
+    [m_layer setContents:(__bridge id)native->platformImage().get()];
+
+    [CATransaction commit];
+
+    return true;
+}
+
+}

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -53,9 +53,10 @@ NicosiaImageBufferPipeSource::~NicosiaImageBufferPipeSource()
     downcast<Nicosia::ContentLayerTextureMapperImpl>(m_nicosiaLayer->impl()).invalidateClient();
 }
 
-void NicosiaImageBufferPipeSource::handle(RefPtr<ImageBuffer>&& buffer)
+void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
 {
-    if (!buffer)
+    auto clone = buffer.clone();
+    if (!clone)
         return;
 
     Locker locker { m_imageBufferLock };
@@ -101,7 +102,7 @@ void NicosiaImageBufferPipeSource::handle(RefPtr<ImageBuffer>&& buffer)
         proxyOperation(downcast<Nicosia::ContentLayerTextureMapperImpl>(m_nicosiaLayer->impl()).proxy());
     }
 
-    m_imageBuffer = WTFMove(buffer);
+    m_imageBuffer = WTFMove(clone);
 }
 
 void NicosiaImageBufferPipeSource::swapBuffersIfNeeded()
@@ -119,9 +120,9 @@ RefPtr<ImageBufferPipe::Source> NicosiaImageBufferPipe::source() const
     return m_source.ptr();
 }
 
-RefPtr<GraphicsLayerContentsDisplayDelegate> NicosiaImageBufferPipe::layerContentsDisplayDelegate()
+void NicosiaImageBufferPipe::setContentsToLayer(GraphicsLayer& layer)
 {
-    return m_layerContentsDisplayDelegate.ptr();
+    layer.setContentsDisplayDelegate(m_layerContentsDisplayDelegate.ptr(), GraphicsLayer::ContentsLayerPurpose::Canvas);
 }
 
 } // namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "GraphicsLayerContentsDisplayDelegate.h"
 #include "ImageBufferPipe.h"
 #include "NicosiaContentLayerTextureMapperImpl.h"
 
@@ -55,7 +56,7 @@ public:
     virtual ~NicosiaImageBufferPipeSource();
 
     // ImageBufferPipe::Source overrides.
-    void handle(RefPtr<WebCore::ImageBuffer>&&) final;
+    void handle(WebCore::ImageBuffer&) final;
 
     // ContentLayerTextureMapperImpl::Client overrides.
     void swapBuffersIfNeeded() override;
@@ -74,7 +75,7 @@ public:
 
     // ImageBufferPipe overrides.
     RefPtr<WebCore::ImageBufferPipe::Source> source() const final;
-    RefPtr<WebCore::GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() final;
+    void setContentsToLayer(WebCore::GraphicsLayer&) final;
 private:
     Ref<NicosiaImageBufferPipeSource> m_source;
     Ref<NicosiaImageBufferPipeSourceDisplayDelegate> m_layerContentsDisplayDelegate;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1117,7 +1117,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     else if (shouldSetContentsDisplayDelegate()) {
         auto* canvas = downcast<HTMLCanvasElement>(renderer().element());
         if (auto* context = canvas->renderingContext())
-            m_graphicsLayer->setContentsDisplayDelegate(context->layerContentsDisplayDelegate(), GraphicsLayer::ContentsLayerPurpose::Canvas);
+            context->setContentsToLayer(*m_graphicsLayer);
 
         layerConfigChanged = true;
     }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -55,6 +55,8 @@ private:
     // PlatformCALayerRemote can't currently proxy directly composited image contents, so opt out of this optimization.
     bool shouldDirectlyCompositeImage(WebCore::Image*) const override { return false; }
     
+    RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate() final { return nullptr; }
+
     RemoteLayerTreeContext* m_context;
 };
 


### PR DESCRIPTION
#### f92c75b5eb3f5701b5a37283816170d8f861e829
<pre>
Implement ImageBufferPipe for CoreAnimation so that we can update frames without using the main-thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=244878">https://bugs.webkit.org/show_bug.cgi?id=244878</a>
&lt;rdar://problem/99902985&gt;

Creates a new API for pushing contents to a layer. The requirements here are that it works asynchronously (from a worker thread),
and that it works with UI process compositing (can&apos;t access any platform layers).

The existing APIs are insufficient, since setContentsToPlatformLayer won&apos;t work in the WebProcess if UI-side compositing is enabled,
and setContentsDisplayDelegate has main-thread callbacks for the delegate to provide new contents.

This adds a new API GraphicsLayerAsyncContentsDisplayDelegate, which get allocated on-demand by the GraphicsLayer implementation and
allows the consumer to push an ImageBuffer that will be copied into the GraphicsLayer asynchronously.

It adds an implementation of this new delegate type for GraphicsLayerCA, and a non-nicosia implementation of ImageBufferPipe which
uses it for frame transfer.

ImageBufferPipe (and the new delegate) both work by providing an ImageBuffer reference that needs to be copied if it succeeds, so that we
never end up copying in the caller and not using the frame.

Reviewed by Simon Fraser.

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::usesPlatformLayer const):
(WebCore::CanvasRenderingContext::platformLayer):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::usesPlatformLayer const):
(WebCore::PlaceholderRenderingContext::platformLayer):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/platform/graphics/ImageBufferPipe.cpp:
* Source/WebCore/platform/graphics/ImageBufferPipe.h:
(WebCore::ImageBufferPipe::usesPlatformLayer const):
(WebCore::ImageBufferPipe::platformLayer):
* Source/WebCore/platform/graphics/cocoa/ImageBufferPipeCA.mm: Added.
(WebCore::ImageBufferPipeSourceCA::ImageBufferPipeSourceCA):
(WebCore::ImageBufferPipeCA::ImageBufferPipeCA):
(WebCore::ImageBufferPipe::create):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):

Canonical link: <a href="https://commits.webkit.org/257696@main">https://commits.webkit.org/257696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/037640b9da7835b15254ccfbcc5f7daca944dfec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109079 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169312 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86182 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106987 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105486 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34111 "An unexpected error occured. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22028 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5290 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43016 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->