### PR TITLE
Avoid geometry update assertions in some tests when UI side compositing is enabled on macOS

### DIFF
--- a/LayoutTests/platform/ios-simulator-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-simulator-wk2/TestExpectations
@@ -103,11 +103,6 @@ webkit.org/b/214824 [ Debug ] js/throw-large-string-oom.html [ Skip ]
 
 webkit.org/b/203112 scrollingcoordinator/ios/ui-scroll-fixed.html [ Pass Failure ]
 
-webkit.org/b/237557 [ Debug ] accessibility/visible-character-range-basic.html [ Crash ]
-webkit.org/b/237557 [ Debug ] accessibility/visible-character-range-height-changes.html [ Crash ]
-webkit.org/b/237557 [ Debug ] accessibility/visible-character-range-scrolling.html [ Crash ]
-webkit.org/b/237557 [ Debug ] accessibility/visible-character-range-width-changes.html [ Crash ]
-
 webkit.org/b/215033 imported/w3c/web-platform-tests/websockets/cookies/third-party-cookie-accepted.https.html [ Pass Failure ]
 
 webkit.org/b/215216 imported/w3c/web-platform-tests/svg/import/interact-zoom-01-t-manual.svg [ Pass Failure ]

--- a/LayoutTests/platform/ios-simulator-wk2/accessibility/visible-character-range-height-changes-expected.txt
+++ b/LayoutTests/platform/ios-simulator-wk2/accessibility/visible-character-range-height-changes-expected.txt
@@ -1,0 +1,22 @@
+This tests that visibleCharacterRange returns expected visible ranges with various view height values.
+
+
+Testing view height values 100 to 1300.
+Range with view 500x100, scrollTop 500: {2250, 360}
+Range with view 500x200, scrollTop 500: {2250, 810}
+Range with view 500x300, scrollTop 500: {2250, 1260}
+Range with view 500x400, scrollTop 500: {2250, 1710}
+Range with view 500x500, scrollTop 500: {2250, 2160}
+Range with view 500x600, scrollTop 500: {2250, 2610}
+Range with view 500x700, scrollTop 500: {2250, 3060}
+Range with view 500x800, scrollTop 500: {2250, 3489}
+Range with view 500x900, scrollTop 500: {1800, 3939}
+Range with view 500x1000, scrollTop 500: {1350, 4389}
+Range with view 500x1100, scrollTop 500: {900, 4839}
+Range with view 500x1200, scrollTop 500: {450, 5289}
+Range with view 500x1300, scrollTop 500: {0, 5739}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/ios-simulator-wk2/accessibility/visible-character-range-width-changes-expected.txt
+++ b/LayoutTests/platform/ios-simulator-wk2/accessibility/visible-character-range-width-changes-expected.txt
@@ -1,0 +1,22 @@
+This tests that visibleCharacterRange returns expected visible ranges with various view width values.
+
+
+Testing view width values 100 to 1300.
+Range with view 100x500, scrollTop 500: {225, 360}
+Range with view 200x500, scrollTop 500: {875, 840}
+Range with view 300x500, scrollTop 500: {1250, 1200}
+Range with view 400x500, scrollTop 500: {1750, 1680}
+Range with view 500x500, scrollTop 500: {2250, 2160}
+Range with view 600x500, scrollTop 500: {2750, 2640}
+Range with view 700x500, scrollTop 500: {2730, 3009}
+Range with view 800x500, scrollTop 500: {2250, 3489}
+Range with view 900x500, scrollTop 500: {1815, 3924}
+Range with view 1000x500, scrollTop 500: {1480, 4259}
+Range with view 1100x500, scrollTop 500: {820, 4919}
+Range with view 1200x500, scrollTop 500: {450, 5289}
+Range with view 1300x500, scrollTop 500: {0, 5739}
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -109,8 +109,8 @@ void RemoteLayerTreeDrawingAreaProxy::didUpdateGeometry()
 void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
 {
     m_lastSentSize = m_size;
-    send(Messages::DrawingArea::UpdateGeometry(m_size, false /* flushSynchronously */, MachSendRight()));
     m_isWaitingForDidUpdateGeometry = true;
+    send(Messages::DrawingArea::UpdateGeometry(m_size, false /* flushSynchronously */, MachSendRight()));
 }
 
 void RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree(TransactionID transactionID)


### PR DESCRIPTION
#### 216acdc0bca8c93ccd03e1fd0706bcbe5270652b
<pre>
Avoid geometry update assertions in some tests when UI side compositing is enabled on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=242884">https://bugs.webkit.org/show_bug.cgi?id=242884</a>
rdar://97583976

Reviewed by Kimmo Kinnunen.

Some tests hit this assertion when run on macOS with UI side compositing
enabeld:

ASSERTION FAILED: m_isWaitingForDidUpdateGeometry
.../OpenSource/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm(99) : virtual void WebKit::RemoteLayerTreeDrawingAreaProxy::didUpdateGeometry()

This is due to the set calling testRunner.setViewSize(...), which causes
UpdateGeometry / DidUpdateGeometry messages to be sent synchronously.

This means we re-entrantly call RemoteLayerTreeDrawingAreaProxy::didUpdateGeometry,
which asserts m_isWaitingForDidUpdateGeometry, before the
`m_isWaitingForDidUpdateGeometry = true` assignment just after the
send(Messages::DrawingArea::UpdateGeometry(...)) call in
RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry is run.

Move the assignment before the send() call to avoid this.

* LayoutTests/platform/ios-simulator-wk2/accessibility/visible-character-range-height-changes-expected.txt: Added.
* LayoutTests/platform/ios-simulator-wk2/accessibility/visible-character-range-width-changes-expected.txt: Added.
* LayoutTests/platform/ios-simulator-wk2/TestExpectations:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry):

Canonical link: <a href="https://commits.webkit.org/256042@main">https://commits.webkit.org/256042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/182930dc3c39ac739571d37646b9858282bafa76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104056 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164333 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3623 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31776 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100052 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2598 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80790 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29637 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84520 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38174 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36046 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1982 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41888 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/38440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->