### PR TITLE
[Curl] Add Timing-Allow-Origin checks for Curl port

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2134,3 +2134,7 @@ fast/text/crash-complex-text-surrogate.html [ Failure ]
 fast/text/punctuation-break-all-2.html [ ImageOnlyFailure ]
 
 webkit.org/b/188980 fast/css/vertical-align-block-elements.html [ ImageOnlyFailure ]
+
+imported/w3c/web-platform-tests/resource-timing/cross-origin-redirects.html [ Pass ]
+imported/w3c/web-platform-tests/resource-timing/cross-origin-start-end-time-with-redirects.html [ Pass ]
+imported/w3c/web-platform-tests/resource-timing/resource_reuse.sub.html [ Pass ]

--- a/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
+++ b/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
@@ -107,6 +107,8 @@ void CurlResourceHandleDelegate::curlDidReceiveResponse(CurlRequest& request, Cu
 
     m_response = ResourceResponse(receivedResponse);
     m_response.setCertificateInfo(WTFMove(receivedResponse.certificateInfo));
+
+    updateNetworkLoadMetrics(receivedResponse.networkLoadMetrics);
     m_response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(WTFMove(receivedResponse.networkLoadMetrics)));
 
     handleCookieHeaders(d(), request.resourceRequest(), receivedResponse);
@@ -160,6 +162,8 @@ void CurlResourceHandleDelegate::curlDidComplete(CurlRequest&, NetworkLoadMetric
     if (cancelledOrClientless())
         return;
 
+    updateNetworkLoadMetrics(metrics);
+
     CurlCacheManager::singleton().didFinishLoading(m_handle);
     client()->didFinishLoading(&m_handle, WTFMove(metrics));
 }
@@ -175,6 +179,12 @@ void CurlResourceHandleDelegate::curlDidFailWithError(CurlRequest&, ResourceErro
     client()->didFail(&m_handle, resourceError);
 }
 
+void CurlResourceHandleDelegate::updateNetworkLoadMetrics(NetworkLoadMetrics& networkLoadMetrics)
+{
+    m_handle.checkTAO(m_response);
+
+    networkLoadMetrics.failsTAOCheck = m_handle.failsTAOCheck();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.h
+++ b/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.h
@@ -59,6 +59,8 @@ public:
     void curlDidFailWithError(CurlRequest&, ResourceError&&, CertificateInfo&&) final;
 
 private:
+    void updateNetworkLoadMetrics(NetworkLoadMetrics&);
+
     ResourceHandle& m_handle;
     ResourceResponse m_response;
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -60,7 +60,7 @@ Ref<NetworkDataTask> NetworkDataTask::create(NetworkSession& session, NetworkDat
     return NetworkDataTaskSoup::create(session, client, parameters);
 #endif
 #if USE(CURL)
-    return NetworkDataTaskCurl::create(session, client, parameters.request, parameters.webFrameID, parameters.webPageID, parameters.storedCredentialsPolicy, parameters.contentSniffingPolicy, parameters.contentEncodingSniffingPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation, parameters.shouldRelaxThirdPartyCookieBlocking);
+    return NetworkDataTaskCurl::create(session, client, parameters);
 #endif
 }
 

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -45,6 +45,7 @@
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 #include <WebCore/SynchronousLoaderClient.h>
+#include <WebCore/TimingAllowOrigin.h>
 #include <pal/text/TextEncoding.h>
 #include <wtf/FileSystem.h>
 
@@ -52,13 +53,14 @@ namespace WebKit {
 
 using namespace WebCore;
 
-NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTaskClient& client, const ResourceRequest& requestWithCredentials, FrameIdentifier frameID, PageIdentifier& pageID, StoredCredentialsPolicy storedCredentialsPolicy, ContentSniffingPolicy shouldContentSniff, ContentEncodingSniffingPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool dataTaskIsForMainFrameNavigation, WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking)
-    : NetworkDataTask(session, client, requestWithCredentials, storedCredentialsPolicy, shouldClearReferrerOnHTTPSToHTTPRedirect, dataTaskIsForMainFrameNavigation)
-    , m_frameID(frameID)
-    , m_pageID(pageID)
-    , m_shouldRelaxThirdPartyCookieBlocking(shouldRelaxThirdPartyCookieBlocking)
+NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
+    : NetworkDataTask(session, client, parameters.request, parameters.storedCredentialsPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation)
+    , m_frameID(parameters.webFrameID)
+    , m_pageID(parameters.webPageID)
+    , m_shouldRelaxThirdPartyCookieBlocking(parameters.shouldRelaxThirdPartyCookieBlocking)
+    , m_sourceOrigin(parameters.sourceOrigin)
 {
-    auto request = requestWithCredentials;
+    auto request = parameters.request;
     if (request.url().protocolIsInHTTPFamily()) {
         if (m_storedCredentialsPolicy == StoredCredentialsPolicy::Use) {
             auto url = request.url();
@@ -159,6 +161,8 @@ void NetworkDataTaskCurl::curlDidReceiveResponse(CurlRequest& request, CurlRespo
 
     m_response = ResourceResponse(receivedResponse);
     m_response.setCertificateInfo(WTFMove(receivedResponse.certificateInfo));
+
+    updateNetworkLoadMetrics(receivedResponse.networkLoadMetrics);
     m_response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(WTFMove(receivedResponse.networkLoadMetrics)));
 
     handleCookieHeaders(request.resourceRequest(), receivedResponse);
@@ -221,6 +225,8 @@ void NetworkDataTaskCurl::curlDidComplete(CurlRequest&, NetworkLoadMetrics&& net
         download->didFinish();
         return;
     }
+
+    updateNetworkLoadMetrics(networkLoadMetrics);
 
     m_client->didCompleteWithError({ }, WTFMove(networkLoadMetrics));
 }
@@ -577,6 +583,17 @@ bool NetworkDataTaskCurl::shouldBlockCookies(const WebCore::ResourceRequest& req
 bool NetworkDataTaskCurl::isThirdPartyRequest(const WebCore::ResourceRequest& request)
 {
     return !WebCore::areRegistrableDomainsEqual(request.url(), request.firstPartyForCookies());
+}
+
+void NetworkDataTaskCurl::updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics& networkLoadMetrics)
+{
+    if (!m_failsTAOCheck) {
+        RefPtr<SecurityOrigin> origin = isTopLevelNavigation() ? SecurityOrigin::create(firstRequest().url()) : m_sourceOrigin;
+        if (origin)
+            m_failsTAOCheck = !passesTimingAllowOriginCheck(m_response, *origin);
+    }
+
+    networkLoadMetrics.failsTAOCheck = m_failsTAOCheck;
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 3f6d008b5fa784cb5550442fce0dc0f5240e0463
<pre>
[Curl] Add Timing-Allow-Origin checks for Curl port
<a href="https://bugs.webkit.org/show_bug.cgi?id=247048">https://bugs.webkit.org/show_bug.cgi?id=247048</a>

Reviewed by Fujii Hironori.

Add missing TAO checks to Curl backend.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp:
(WebCore::CurlResourceHandleDelegate::curlDidReceiveResponse):
(WebCore::CurlResourceHandleDelegate::curlDidComplete):
(WebCore::CurlResourceHandleDelegate::updateNetworkLoadMetrics):
* Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::create):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::NetworkDataTaskCurl):
(WebKit::NetworkDataTaskCurl::curlDidReceiveResponse):
(WebKit::NetworkDataTaskCurl::curlDidComplete):
(WebKit::NetworkDataTaskCurl::updateNetworkLoadMetrics):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h:

Canonical link: <a href="https://commits.webkit.org/256044@main">https://commits.webkit.org/256044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95d694988cd30ea91392ebaa639fc004f02dbbad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103981 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164255 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3534 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31698 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/99989 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/99984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2534 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80708 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29570 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84453 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72467 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38093 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4177 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41778 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38415 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->