### PR TITLE
[MSE] Ensure we are not removing the current time during automatic eviction

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end-expected.txt
@@ -1,0 +1,23 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EXPECTED (video.currentTime == '18') OK
+Appending PTS=0, DTS=0, sync
+Appending PTS=3, DTS=1
+Appending PTS=1, DTS=2
+Appending PTS=2, DTS=3
+Appending PTS=4, DTS=4
+Appending PTS=5, DTS=5, sync
+Appending PTS=8, DTS=6
+Appending PTS=6, DTS=7
+Appending PTS=7, DTS=8
+Appending PTS=9, DTS=9
+Appending PTS=10, DTS=10, sync
+Appending PTS=13, DTS=11
+Appending PTS=11, DTS=12
+Appending PTS=12, DTS=13
+Appending PTS=14, DTS=14
+EXPECTED (exception != 'QuotaExceededError: The quota has been exceeded.') OK
+EXPECTED (bufferedRanges() == '[ 10...15 ]') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end.html
+++ b/LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var exception;
+
+    function bufferedRanges() {
+        var bufferedRanges = '[ ';
+        var timeRanges = sourceBuffer.buffered;
+        for (var i = 0 ; i < timeRanges.length ; i++) {
+            if (i)
+                bufferedRanges += ', ';
+            bufferedRanges += timeRanges.start(i) + '...' + timeRanges.end(i);
+        }
+        bufferedRanges += ' ]';
+        return bufferedRanges;
+    }
+
+    function doBufferedRangesContain(time) {
+        var timeRanges = sourceBuffer.buffered;
+        for (var i = 0 ; i < timeRanges.length ; i++) {
+            if (timeRanges.start(i) <= time && time <= timeRanges.end(i))
+                return true;
+        }
+        return false;
+    }
+
+    async function appendSample(dts, pts) {
+         const flag = dts % 5 == 0 ? SAMPLE_FLAG.SYNC : SAMPLE_FLAG.NONE;
+         consoleWrite('Appending PTS=' + pts + ', DTS=' + dts + (flag == SAMPLE_FLAG.SYNC ? ', sync' : ''));
+         sourceBuffer.appendBuffer(makeASample(pts, dts, 1, 1, 1, flag, 1));
+         await waitFor(sourceBuffer, 'updateend', true);
+    }
+
+    async function appendDtsRange(firstDts, lastDts) {
+        if (firstDts >= lastDts)
+            return null;
+
+        var resultException = null;
+        try {
+            for (var dts = firstDts; dts <= lastDts; dts += 5) {
+                await appendSample(dts + 0, dts + 0);
+                await appendSample(dts + 1, dts + 3);
+                await appendSample(dts + 2, dts + 1);
+                await appendSample(dts + 3, dts + 2);
+                await appendSample(dts + 4, dts + 4);
+            }
+        } catch (e) {
+            resultException = e;
+            sourceBuffer.abort();
+        }
+        return resultException;
+    }
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async() => {
+        findMediaElement();
+        source = new MediaSource();
+
+        const videoSource = document.createElement('source');
+        videoSource.type = 'video/mock; codecs=mock';
+        videoSource.src = URL.createObjectURL(source);
+        video.appendChild(videoSource);
+
+        await waitFor(source, 'sourceopen');
+        sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock");
+        initSegment = makeAInit(350, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        sourceBuffer.appendBuffer(initSegment);
+        await waitFor(sourceBuffer, 'updateend');
+        waitFor(sourceBuffer, 'error');
+
+        internals.settings.setMaximumSourceBufferSize(500);
+
+        video.currentTime = 18;
+        testExpected('video.currentTime', 18, '==');
+        exception = await appendDtsRange(0, 14);
+
+        testExpected('exception', 'QuotaExceededError: The quota has been exceeded.', '!=');
+        testExpected('bufferedRanges()', '[ 10...15 ]', '==');
+
+        endTest();
+        });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -164,6 +164,7 @@ private:
     void provideMediaData(TrackBuffer&, const AtomString& trackID);
     void setBufferedDirty(bool);
     void trySignalAllSamplesInTrackEnqueued(TrackBuffer&, const AtomString& trackID);
+    MediaTime findPreviousSyncSamplePresentationTime(const MediaTime&);
 
     bool m_isAttached { false };
     bool m_hasAudio { false };


### PR DESCRIPTION
#### 6d7afcf0850ffbb4b6f06f3063ca131fbbf281cd
<pre>
[MSE] Ensure we are not removing the current time during automatic eviction
<a href="https://bugs.webkit.org/show_bug.cgi?id=247052">https://bugs.webkit.org/show_bug.cgi?id=247052</a>

Reviewed by Alicia Boya Garcia.

In certain cases, depending on the sync frame positions, we could end up removing the current time, which would lead to
playback stopping. Now we ensure that the previous sync frame to current time is taking into account when calculating
the maximumRangeEnd.

* LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end-expected.txt: Added.
* LayoutTests/media/media-source/media-source-append-buffer-full-evict-prior-to-end.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::findPreviousSyncSamplePresentationTime):
(WebCore::SourceBufferPrivate::evictCodedFrames):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:

Canonical link: <a href="https://commits.webkit.org/256939@main">https://commits.webkit.org/256939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14e4a38a91dd5a2f19f288e9fd0943b0eaaf1324

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106809 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167075 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6850 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35289 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103490 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102953 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83919 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32130 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86997 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/570 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4782 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41081 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->