### PR TITLE
[WebCodecs] Expose encoder color space in decoder config

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test VideoEncoder construction
 PASS Test VideoEncoder.configure()
-FAIL Test successful configure(), encode(), and flush() promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'decoderConfig.colorSpace.primaries')"
+PASS Test successful configure(), encode(), and flush()
 PASS encodeQueueSize test
 PASS Test successful reset() and re-confiugre()
 PASS Test successful encode() after re-configure().

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -177,7 +177,7 @@ WebCodecsEncodedVideoChunkMetadata WebCodecsVideoEncoder::createEncodedChunkMeta
         m_activeConfiguration.visibleHeight ? m_activeConfiguration.visibleHeight : m_baseConfiguration.height,
         m_activeConfiguration.displayWidth ? m_activeConfiguration.displayWidth : m_baseConfiguration.displayWidth,
         m_activeConfiguration.displayHeight ? m_activeConfiguration.displayHeight : m_baseConfiguration.displayHeight,
-        { },
+        m_activeConfiguration.colorSpace,
         HardwareAcceleration::NoPreference,
         { }
     };

--- a/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp
@@ -92,7 +92,10 @@ void LibWebRTCVPXVideoEncoder::create(Type type, const VideoEncoder::Config& con
                 return;
             }
             callback(UniqueRef<VideoEncoder> { WTFMove(encoder) });
-            descriptionCallback({ });
+
+            VideoEncoder::ActiveConfiguration configuration;
+            configuration.colorSpace = PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Smpte170m, false };
+            descriptionCallback(WTFMove(configuration));
         });
     });
 }

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include "PlatformVideoColorSpace.h"
 #include "VideoFrame.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
@@ -53,6 +54,7 @@ public:
         std::optional<size_t> displayWidth;
         std::optional<size_t> displayHeight;
         std::optional<Vector<uint8_t>> description;
+        std::optional<PlatformVideoColorSpace> colorSpace;
     };
     struct EncodedFrame {
         Vector<uint8_t> data;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -297,7 +297,7 @@ void RemoteVideoEncoderCallbacks::notifyEncoderDescription(Vector<uint8_t>&& des
         if (protectedThis->m_isClosed)
             return;
 
-        protectedThis->m_descriptionCallback(VideoEncoder::ActiveConfiguration { { }, { }, { }, { }, { }, WTFMove(description) });
+        protectedThis->m_descriptionCallback(VideoEncoder::ActiveConfiguration { { }, { }, { }, { }, { }, WTFMove(description), { } });
     });
 }
 


### PR DESCRIPTION
#### 55403b23f358a666f864f90892cd67f4b176d0c7
<pre>
[WebCodecs] Expose encoder color space in decoder config
<a href="https://bugs.webkit.org/show_bug.cgi?id=247054">https://bugs.webkit.org/show_bug.cgi?id=247054</a>
rdar://problem/101582123

Reviewed by Eric Carlson.

Set colorSpace to BT 601 for VP8 and VP9 as per spec.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::createEncodedChunkMetadata):
* Source/WebCore/platform/LibWebRTCVPXVideoEncoder.cpp:
(WebCore::LibWebRTCVPXVideoEncoder::create):
* Source/WebCore/platform/VideoEncoder.h:

Canonical link: <a href="https://commits.webkit.org/256052@main">https://commits.webkit.org/256052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/694c507b7559253424808171f3e39de4152f2c4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3515 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27265 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit; Reverted pull request changes; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104005 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164279 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3560 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31722 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100006 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2554 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80733 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29603 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84475 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72494 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38117 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17919 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4183 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41798 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38420 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->