### PR TITLE
CSSValue pointer returned from DeclaredStylePropertyMap::propertyValue() causes use-after-free errors

### DIFF
--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -51,7 +51,7 @@ ExceptionOr<RefPtr<CSSStyleValue>> ComputedStylePropertyMapReadOnly::get(ScriptE
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
     if (isCustomPropertyName(property))
-        return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property).get(), m_element->document());
+        return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property), m_element->document());
 
     auto propertyID = cssPropertyID(property);
     if (!propertyID || !isCSSPropertyExposed(propertyID, &m_element->document().settings()))
@@ -62,14 +62,14 @@ ExceptionOr<RefPtr<CSSStyleValue>> ComputedStylePropertyMapReadOnly::get(ScriptE
         return CSSStyleValue::create(WTFMove(value), String(property)).ptr();
     }
 
-    return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed).get(), m_element->document());
+    return StylePropertyMapReadOnly::reifyValue(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed), m_element->document());
 }
 
 ExceptionOr<Vector<RefPtr<CSSStyleValue>>> ComputedStylePropertyMapReadOnly::getAll(ScriptExecutionContext&, const AtomString& property) const
 {
     // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getall
     if (isCustomPropertyName(property))
-        return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property).get(), m_element->document());
+        return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).customPropertyValue(property), m_element->document());
 
     auto propertyID = cssPropertyID(property);
     if (!propertyID || !isCSSPropertyExposed(propertyID, &m_element->document().settings()))
@@ -80,7 +80,7 @@ ExceptionOr<Vector<RefPtr<CSSStyleValue>>> ComputedStylePropertyMapReadOnly::get
         return Vector<RefPtr<CSSStyleValue>> { CSSStyleValue::create(WTFMove(value), String(property)) };
     }
 
-    return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed).get(), m_element->document());
+    return StylePropertyMapReadOnly::reifyValueToVector(ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::Yes, ComputedStyleExtractor::PropertyValueType::Computed), m_element->document());
 }
 
 ExceptionOr<bool> ComputedStylePropertyMapReadOnly::has(ScriptExecutionContext& context, const AtomString& property) const
@@ -118,12 +118,12 @@ Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMap
     for (auto propertyID : exposedComputedCSSPropertyIDs) {
         auto key = getPropertyNameString(propertyID);
         auto value = ComputedStyleExtractor(m_element.ptr()).propertyValue(propertyID, ComputedStyleExtractor::UpdateLayout::No, ComputedStyleExtractor::PropertyValueType::Computed);
-        values.uncheckedAppend(makeKeyValuePair(WTFMove(key), StylePropertyMapReadOnly::reifyValueToVector(value.get(), m_element->document())));
+        values.uncheckedAppend(makeKeyValuePair(WTFMove(key), StylePropertyMapReadOnly::reifyValueToVector(WTFMove(value), m_element->document())));
     }
 
     for (auto* map : { &nonInheritedCustomProperties, &inheritedCustomProperties }) {
         for (const auto& it : *map)
-            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.get(), m_element->document())));
+            values.uncheckedAppend(makeKeyValuePair(it.key, StylePropertyMapReadOnly::reifyValueToVector(it.value.copyRef(), m_element->document())));
     }
 
     std::sort(values.begin(), values.end(), [](const auto& a, const auto& b) {

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -65,25 +65,25 @@ auto DeclaredStylePropertyMap::entries(ScriptExecutionContext* context) const ->
     result.reserveInitialCapacity(declaredStyleSet.propertyCount());
     for (unsigned i = 0; i < declaredStyleSet.propertyCount(); ++i) {
         auto propertyReference = declaredStyleSet.propertyAt(i);
-        result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(propertyReference.value(), document)));
+        result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document)));
     }
     return result;
 }
 
-CSSValue* DeclaredStylePropertyMap::propertyValue(CSSPropertyID propertyID) const
+RefPtr<CSSValue> DeclaredStylePropertyMap::propertyValue(CSSPropertyID propertyID) const
 {
     auto* styleRule = this->styleRule();
     if (!styleRule)
         return nullptr;
-    return styleRule->properties().getPropertyCSSValue(propertyID).get();
+    return styleRule->properties().getPropertyCSSValue(propertyID);
 }
 
-CSSValue* DeclaredStylePropertyMap::customPropertyValue(const AtomString& propertyName) const
+RefPtr<CSSValue> DeclaredStylePropertyMap::customPropertyValue(const AtomString& propertyName) const
 {
     auto* styleRule = this->styleRule();
     if (!styleRule)
         return nullptr;
-    return styleRule->properties().getCustomPropertyCSSValue(propertyName.string()).get();
+    return styleRule->properties().getCustomPropertyCSSValue(propertyName.string());
 }
 
 void DeclaredStylePropertyMap::removeProperty(CSSPropertyID propertyID)

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -47,8 +47,8 @@ private:
     StyleRule* styleRule() const;
 
     void clear() final;
-    CSSValue* propertyValue(CSSPropertyID) const final;
-    CSSValue* customPropertyValue(const AtomString&) const final;
+    RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
+    RefPtr<CSSValue> customPropertyValue(const AtomString&) const final;
     void removeProperty(CSSPropertyID) final;
     void removeCustomProperty(const AtomString&) final;
 

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
@@ -42,8 +42,8 @@ protected:
 
     static Document* documentFromContext(ScriptExecutionContext&);
 
-    virtual CSSValue* propertyValue(CSSPropertyID) const = 0;
-    virtual CSSValue* customPropertyValue(const AtomString&) const = 0;
+    virtual RefPtr<CSSValue> propertyValue(CSSPropertyID) const = 0;
+    virtual RefPtr<CSSValue> customPropertyValue(const AtomString&) const = 0;
 
 private:
     RefPtr<CSSStyleValue> shorthandPropertyValue(Document&, CSSPropertyID) const;

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.h
@@ -58,9 +58,8 @@ public:
     virtual ExceptionOr<bool> has(ScriptExecutionContext&, const AtomString&) const = 0;
     virtual unsigned size() const = 0;
 
-    static RefPtr<CSSStyleValue> reifyValue(CSSValue*, Document&);
-    static RefPtr<CSSStyleValue> customPropertyValueOrDefault(const String& name, Document&, CSSValue*);
-    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(CSSValue*, Document&);
+    static RefPtr<CSSStyleValue> reifyValue(RefPtr<CSSValue>&&, Document&);
+    static Vector<RefPtr<CSSStyleValue>> reifyValueToVector(RefPtr<CSSValue>&&, Document&);
 
 protected:
     virtual Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const = 0;

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -87,17 +87,17 @@ public:
     }
 
 private:
-    CSSValue* propertyValue(CSSPropertyID propertyID) const final
+    RefPtr<CSSValue> propertyValue(CSSPropertyID propertyID) const final
     {
         if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
-            return inlineStyle->getPropertyCSSValue(propertyID).get();
+            return inlineStyle->getPropertyCSSValue(propertyID);
         return nullptr;
     }
 
-    CSSValue* customPropertyValue(const AtomString& property) const final
+    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final
     {
         if (auto* inlineStyle = m_element ? m_element->inlineStyle() : nullptr)
-            return inlineStyle->getCustomPropertyCSSValue(property.string()).get();
+            return inlineStyle->getCustomPropertyCSSValue(property.string());
         return nullptr;
     }
 
@@ -121,7 +121,7 @@ private:
         result.reserveInitialCapacity(inlineStyle->propertyCount());
         for (unsigned i = 0; i < inlineStyle->propertyCount(); ++i) {
             auto propertyReference = inlineStyle->propertyAt(i);
-            result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(propertyReference.value(), document)));
+            result.uncheckedAppend(makeKeyValuePair(propertyReference.cssName(), reifyValueToVector(RefPtr<CSSValue> { propertyReference.value() }, document)));
         }
         return result;
     }

--- a/Source/WebCore/html/CustomPaintImage.cpp
+++ b/Source/WebCore/html/CustomPaintImage.cpp
@@ -101,12 +101,12 @@ private:
     {
     }
 
-    CSSValue* propertyValue(CSSPropertyID propertyID) const final
+    RefPtr<CSSValue> propertyValue(CSSPropertyID propertyID) const final
     {
         return m_map.get(getPropertyNameAtomString(propertyID));
     }
 
-    CSSValue* customPropertyValue(const AtomString& property) const final
+    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final
     {
         return m_map.get(property);
     }


### PR DESCRIPTION
#### 85237c9326a2c76a8445d031f0ed3d2d0680291c
<pre>
CSSValue pointer returned from DeclaredStylePropertyMap::propertyValue() causes use-after-free errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=247055">https://bugs.webkit.org/show_bug.cgi?id=247055</a>

Reviewed by Chris Dumez.

Have MainThreadStylePropertyMapReadOnly&apos;s propertyValue() and
customPropertyValue() methods return RefPtr&lt;CSSValue&gt; values instead of raw
CSSValue pointers. This enables ensuring lifetime of the CSSValue object,
avoiding use-after-free errors thrown by newer GCC versions when the pointer
value is first retrieved from one subsequently-destroyed RefPtr and then used to
construct a new RefPtr from that same pointer value, with GCC worried about the
object possibly being freed by that first RefPtr&apos;s destruction.

All the propertyValue() and customPropertyValue() overrides are able to return
the exact RefPtr object from which the pointer value has been retrieved so far.

StylePropertyMapReadOnly&apos;s reifyValue() and reifyValueToVector() functions are
changed to accept a RefPtr&lt;CSSValue&gt; rvalue as their first parameter, with a few
other callsites properly adjusted. The customPropertyValueOrDefault() method is
removed since it&apos;s unused.

* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::get const):
(WebCore::ComputedStylePropertyMapReadOnly::getAll const):
(WebCore::ComputedStylePropertyMapReadOnly::entries const):
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
(WebCore::DeclaredStylePropertyMap::entries const):
(WebCore::DeclaredStylePropertyMap::propertyValue const):
(WebCore::DeclaredStylePropertyMap::customPropertyValue const):
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.h:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.cpp:
(WebCore::StylePropertyMapReadOnly::reifyValue):
(WebCore::StylePropertyMapReadOnly::reifyValueToVector):
(WebCore::StylePropertyMapReadOnly::customPropertyValueOrDefault): Deleted.
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.h:
* Source/WebCore/dom/StyledElement.cpp:
* Source/WebCore/html/CustomPaintImage.cpp:

Canonical link: <a href="https://commits.webkit.org/256055@main">https://commits.webkit.org/256055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9428e5ccab04429532d420bee7da68d466098e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104124 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164394 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3699 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31844 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86795 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100141 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80860 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84576 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38245 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36111 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4184 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38479 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->