### PR TITLE
[GTK][WPE] Add API to check if a response policy decision is for the main resource

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp
@@ -167,6 +167,26 @@ gboolean webkit_response_policy_decision_is_mime_type_supported(WebKitResponsePo
     return decision->priv->navigationResponse->canShowMIMEType();
 }
 
+/**
+ * webkit_response_policy_decision_is_main_frame_main_resource:
+ * @decision: a #WebKitResponsePolicyDecision
+ *
+ * Gets whether the request is the main frame main resource
+ *
+ * Returns: %TRUE if the request is the main frame main resouce or %FALSE otherwise
+ *
+ * Since: 2.40
+ */
+gboolean webkit_response_policy_decision_is_main_frame_main_resource(WebKitResponsePolicyDecision* decision)
+{
+    g_return_val_if_fail(WEBKIT_IS_RESPONSE_POLICY_DECISION(decision), FALSE);
+
+    if (!decision->priv->navigationResponse->frame().isMainFrame())
+        return FALSE;
+
+    return decision->priv->navigationResponse->request().requester() == ResourceRequest::Requester::Main;
+}
+
 WebKitPolicyDecision* webkitResponsePolicyDecisionCreate(Ref<API::NavigationResponse>&& response, Ref<WebKit::WebFramePolicyListenerProxy>&& listener)
 {
     WebKitResponsePolicyDecision* responseDecision = WEBKIT_RESPONSE_POLICY_DECISION(g_object_new(WEBKIT_TYPE_RESPONSE_POLICY_DECISION, nullptr));

--- a/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in
@@ -59,16 +59,19 @@ struct _WebKitResponsePolicyDecisionClass {
 };
 
 WEBKIT_API GType
-webkit_response_policy_decision_get_type               (void);
+webkit_response_policy_decision_get_type                    (void);
 
 WEBKIT_API WebKitURIRequest *
-webkit_response_policy_decision_get_request            (WebKitResponsePolicyDecision *decision);
+webkit_response_policy_decision_get_request                 (WebKitResponsePolicyDecision *decision);
 
 WEBKIT_API WebKitURIResponse *
-webkit_response_policy_decision_get_response           (WebKitResponsePolicyDecision *decision);
+webkit_response_policy_decision_get_response                (WebKitResponsePolicyDecision *decision);
 
 WEBKIT_API gboolean
-webkit_response_policy_decision_is_mime_type_supported (WebKitResponsePolicyDecision *decision);
+webkit_response_policy_decision_is_mime_type_supported      (WebKitResponsePolicyDecision *decision);
+
+WEBKIT_API gboolean
+webkit_response_policy_decision_is_main_frame_main_resource (WebKitResponsePolicyDecision* decision);
 
 G_END_DECLS
 

--- a/Tools/MiniBrowser/gtk/BrowserTab.c
+++ b/Tools/MiniBrowser/gtk/BrowserTab.c
@@ -125,10 +125,7 @@ static gboolean decidePolicy(WebKitWebView *webView, WebKitPolicyDecision *decis
     if (webkit_response_policy_decision_is_mime_type_supported(responseDecision))
         return FALSE;
 
-    WebKitWebResource *mainResource = webkit_web_view_get_main_resource(webView);
-    WebKitURIRequest *request = webkit_response_policy_decision_get_request(responseDecision);
-    const char *requestURI = webkit_uri_request_get_uri(request);
-    if (g_strcmp0(webkit_web_resource_get_uri(mainResource), requestURI))
+    if (!webkit_response_policy_decision_is_main_frame_main_resource(responseDecision))
         return FALSE;
 
     webkit_policy_decision_download(decision);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp
@@ -222,6 +222,7 @@ static void testResponsePolicy(PolicyClientTest* test, gconstpointer)
     ASSERT_CMP_CSTRING(webkit_uri_response_get_uri(response), ==, kServer->getURIForPath("/"));
     g_assert_cmpint(webkit_web_view_can_show_mime_type(test->m_webView, webkit_uri_response_get_mime_type(response)), ==,
         webkit_response_policy_decision_is_mime_type_supported(decision));
+    g_assert_true(webkit_response_policy_decision_is_main_frame_main_resource(decision));
 
     test->m_respondToPolicyDecisionAsynchronously = true;
     test->loadURI(kServer->getURIForPath("/").data());


### PR DESCRIPTION
#### e35d40906d10a1494e117ab696ab323191803f7c
<pre>
[GTK][WPE] Add API to check if a response policy decision is for the main resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=247059">https://bugs.webkit.org/show_bug.cgi?id=247059</a>

Reviewed by Adrian Perez de Castro and Michael Catanzaro.

Apps are currently checking if request uri is the same as web view main
resource uri which might not be accurate.

* Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp:
(webkit_response_policy_decision_is_main_frame_main_resource):
* Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in:
* Tools/MiniBrowser/gtk/BrowserTab.c:
(decidePolicy):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitPolicyClient.cpp:
(testResponsePolicy):

Canonical link: <a href="https://commits.webkit.org/256058@main">https://commits.webkit.org/256058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ffd8f2c74ed180e4eaf752e31e8a19c662eb2db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/103999 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164273 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3554 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31716 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100001 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2548 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80726 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29595 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72486 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38111 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/35988 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4186 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41792 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38418 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->