### PR TITLE
Support for the Curve 25519 in order to be able to work with such type of curves  and implementation of X25519 Algorithm

### DIFF
--- a/LayoutTests/crypto/subtle/X25519-derive-bits-length-limits-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-derive-bits-length-limits-expected.txt
@@ -1,0 +1,14 @@
+Test X25519 deriveBits operation for corner-case length values.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS deriveBits(..., 0) successfully derived 256 bits for a 25519 curve
+PASS deriveBits(..., 8) successfully derived 8 bits for a 25519 curve
+PASS deriveBits(..., 256) successfully derived 256 bits for a 25519 curve
+PASS Bit derivations for X25519 with minimum and maximum lengths succeeded
+PASS deriveBits(X25519_privateKey, X25519_publicKey, 256 + 8) rejected promise  with OperationError: The operation failed for an operation-specific reason.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-derive-bits-length-limits.html
+++ b/LayoutTests/crypto/subtle/X25519-derive-bits-length-limits.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test X25519 deriveBits operation for corner-case length values.");
+
+jsTestIsAsync = true;
+
+var extractable = false;
+var PrivateKeyX25519 = new Uint8Array([2,0,0,0,7,0,0,0,6,69,12,57,1,0,0,0,4,255,28,168,2,0,0,0,120,0,0,0,44,32,48,41]);
+var PublicKeyX25519 = new Uint8Array([2,0,0,0,4,0,0,0,95,176,234,133,2,0,0,0,4,153,228,133,0,0,0,0,192,164,13,7,1,0,0,0]);
+var X25519_privateKey;
+var X25519_publicKey;
+
+crypto.subtle.importKey("raw", PrivateKeyX25519, { name: "X25519"}, extractable,[]).then(function(result) {
+    X25519_privateKey = result;
+    extractable = true;
+    return crypto.subtle.importKey("raw", PublicKeyX25519, { name: "X25519" }, extractable, [ ]);
+}).then(function(result) {
+    X25519_publicKey = result;
+    deriveBits = function(PrivateKey,PublicKey, length, expectedLength) {
+        return crypto.subtle.deriveBits({ name: "X25519", public: PublicKey },PrivateKey, length).then(function(result) {
+            if (result.byteLength * 8 != expectedLength)
+                return Promise.reject();
+            testPassed("deriveBits(..., " + length + ") successfully derived " + expectedLength + " bits for a 25519 curve");
+            return Promise.resolve();
+        });
+    };
+    return Promise.resolve().then(function(result) {
+        return Promise.all([
+            deriveBits(X25519_privateKey, X25519_publicKey, 0, 256),
+            deriveBits(X25519_privateKey, X25519_publicKey, 8, 8),
+            deriveBits(X25519_privateKey, X25519_publicKey, 256, 256),
+        ]).then(function(result) {
+            testPassed("Bit derivations for X25519 with minimum and maximum lengths succeeded");
+            return shouldReject('deriveBits(X25519_privateKey, X25519_publicKey, 256 + 8)');
+        });
+    });
+}).then(finishJSTest, finishJSTest);
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/crypto/subtle/X25519-derive-bits-malformed-parameters-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-derive-bits-malformed-parameters-expected.txt
@@ -1,0 +1,20 @@
+Test X25519 deriveBits operation with malformed parameters
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crypto.subtle.deriveBits("X25519", privateKey, null) rejected promise  with TypeError: Member X25519Params.publicKey is required and must be an instance of CryptoKey.
+PASS crypto.subtle.deriveBits({name: "X25519"}, privateKey, null) rejected promise  with TypeError: Member X25519Params.publicKey is required and must be an instance of CryptoKey.
+PASS crypto.subtle.deriveBits({name: "X25519", public: true}, privateKey, null) rejected promise  with TypeError: Type error.
+PASS crypto.subtle.deriveBits({name: "X25519", public: null}, privateKey, null) rejected promise  with TypeError: Type error.
+PASS crypto.subtle.deriveBits({name: "X25519", public: undefined}, privateKey, null) rejected promise  with TypeError: Member X25519Params.publicKey is required and must be an instance of CryptoKey.
+PASS crypto.subtle.deriveBits({name: "X25519", public: Symbol()}, privateKey, null) rejected promise  with TypeError: Type error.
+PASS crypto.subtle.deriveBits({name: "X25519", public: { }}, privateKey, null) rejected promise  with TypeError: Type error.
+PASS crypto.subtle.deriveBits({name: "X25519", public: 1}, privateKey, null) rejected promise  with TypeError: Type error.
+PASS crypto.subtle.deriveBits({ name:"X25519", public:publicKey }, publicKey, null) rejected promise  with InvalidAccessError: CryptoKey doesn't support bits derivation.
+PASS crypto.subtle.deriveBits({ name:"X25519", public:privateKey }, privateKey, null) rejected promise  with InvalidAccessError: The requested operation is not valid for the provided key.
+PASS crypto.subtle.deriveBits({ name:"X25519", public:publicKey }, privateKey, 384) rejected promise  with OperationError: The operation failed for an operation-specific reason.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-derive-bits-malformed-parameters.html
+++ b/LayoutTests/crypto/subtle/X25519-derive-bits-malformed-parameters.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test X25519 deriveBits operation with malformed parameters");
+
+jsTestIsAsync = true;
+
+var extractable = false;
+var rawPrivateKey = new Uint8Array([2,0,0,0,7,0,0,0,6,69,12,57,1,0,0,0,4,255,28,168,2,0,0,0,120,0,0,0,44,32,48,41]);
+var rawPublicKey = new Uint8Array([2,0,0,0,4,0,0,0,95,176,234,133,2,0,0,0,4,153,228,133,0,0,0,0,192,164,13,7,1,0,0,0]);
+var rawFakeKey = new Uint8Array([2,0,0,0,4,0,1,0,95,176,234,133,2,0,0,0,4,153,228,133,0,0,0,0,192,164,13,7,1,0,0,0]);
+
+
+crypto.subtle.importKey("raw", rawPrivateKey, { name: "X25519" }, extractable, []).then(function(result) {
+    privateKey = result;
+    extractable = true;
+    return crypto.subtle.importKey("raw", rawPublicKey, { name: "X25519" }, extractable, [ ]);
+}).then(function(result) {
+    publicKey = result;
+    // Malformed AlgorithmIdentifiers
+    shouldReject('crypto.subtle.deriveBits("X25519", privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519"}, privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519", public: true}, privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519", public: null}, privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519", public: undefined}, privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519", public: Symbol()}, privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519", public: { }}, privateKey, null)');
+    shouldReject('crypto.subtle.deriveBits({name: "X25519", public: 1}, privateKey, null)');
+    // base key is public
+    shouldReject('crypto.subtle.deriveBits({ name:"X25519", public:publicKey }, publicKey, null)');
+    // public key is private
+    shouldReject('crypto.subtle.deriveBits({ name:"X25519", public:privateKey }, privateKey, null)');
+    // Wrong length
+    return shouldReject('crypto.subtle.deriveBits({ name:"X25519", public:publicKey }, privateKey, 384)');
+}).then(finishJSTest, finishJSTest);
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/crypto/subtle/X25519-generate-export-key-raw-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-generate-export-key-raw-expected.txt
@@ -1,0 +1,12 @@
+Test exporting a X25519 public key with raw format.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Generating a key pair...
+Exporting the public key...
+PASS publicKey.byteLength is 32
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-generate-export-key-raw.html
+++ b/LayoutTests/crypto/subtle/X25519-generate-export-key-raw.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test exporting a X25519 public key with raw format.");
+
+jsTestIsAsync = true;
+
+var algorithmKeyGen = {
+    name: "X25519"
+};
+var extractable = true;
+
+var keyPair;
+debug("Generating a key pair...");
+crypto.subtle.generateKey(algorithmKeyGen, extractable, ["deriveKey", "deriveBits"]).then(function(result) {
+    keyPair = result;
+    debug("Exporting the public key...");
+    return crypto.subtle.exportKey("raw", keyPair.publicKey);
+}).then(function(result) {
+    publicKey = result;
+    shouldBe("publicKey.byteLength", "32");
+    finishJSTest();
+});
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/crypto/subtle/X25519-generate-key-derive-bits-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-generate-key-derive-bits-expected.txt
@@ -1,0 +1,10 @@
+Test X25519 deriveBits operation with generated base key and null length
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS derivedKey.byteLength is 32
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-generate-key-derive-bits.html
+++ b/LayoutTests/crypto/subtle/X25519-generate-key-derive-bits.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test X25519 deriveBits operation with generated base key and null length");
+
+jsTestIsAsync = true;
+
+var extractable = true;
+var rawPublicKey = new Uint8Array([233, 47, 177, 106, 82, 224, 122, 208, 149, 79, 30, 251, 246, 35, 88, 194, 200, 75, 31, 47, 233, 93, 241, 52, 51, 218, 46, 210, 51, 54, 156, 4]);
+
+
+crypto.subtle.generateKey({ name: "X25519" }, extractable, ["deriveBits"]).then(function(result) {
+    privateKey = result.privateKey;
+    return crypto.subtle.importKey("raw", rawPublicKey, { name: "X25519" }, extractable, [ ]);
+}).then(function(result) {
+    publicKey = result;
+    return crypto.subtle.deriveBits({ name:"X25519", public:publicKey }, privateKey, null);
+}).then(function(result) {
+    derivedKey = result;
+
+    shouldBe("derivedKey.byteLength", "32");
+
+    finishJSTest();
+}, failAndFinishJSTest);
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/crypto/subtle/X25519-generate-key-exctractable-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-generate-key-exctractable-expected.txt
@@ -1,0 +1,19 @@
+Test generating an extractable EC key pair with Curve25519 using X25519 algorithm.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Generating a key pair...
+PASS keyPair.toString() is '[object Object]'
+PASS keyPair.publicKey.type is 'public'
+PASS keyPair.publicKey.extractable is true
+PASS keyPair.publicKey.algorithm.name is 'X25519'
+PASS keyPair.publicKey.usages is [ ]
+PASS keyPair.privateKey.type is 'private'
+PASS keyPair.privateKey.extractable is true
+PASS keyPair.privateKey.algorithm.name is 'X25519'
+PASS keyPair.privateKey.usages is ['deriveBits', 'deriveKey']
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-generate-key-exctractable.html
+++ b/LayoutTests/crypto/subtle/X25519-generate-key-exctractable.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test generating an extractable EC key pair with Curve25519 using X25519 algorithm.");
+
+jsTestIsAsync = true;
+
+var extractable = true;
+
+debug("Generating a key pair...");
+crypto.subtle.generateKey({ name: "X25519" }, extractable, ["deriveKey", "deriveBits"]).then(function(result) {
+    keyPair = result;
+    shouldBe("keyPair.toString()", "'[object Object]'");
+    shouldBe("keyPair.publicKey.type", "'public'");
+    shouldBe("keyPair.publicKey.extractable", "true");
+    shouldBe("keyPair.publicKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.publicKey.usages", "[ ]");
+    shouldBe("keyPair.privateKey.type", "'private'");
+    shouldBe("keyPair.privateKey.extractable", "true");
+    shouldBe("keyPair.privateKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.privateKey.usages", "['deriveBits', 'deriveKey']");
+
+    finishJSTest();
+});
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/crypto/subtle/X25519-generate-key-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-generate-key-expected.txt
@@ -1,0 +1,19 @@
+Test generating an EC key pair with Curve25519 using X25519 algorithm.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Generating a key pair...
+PASS keyPair.toString() is '[object Object]'
+PASS keyPair.publicKey.type is 'public'
+PASS keyPair.publicKey.extractable is true
+PASS keyPair.publicKey.algorithm.name is 'X25519'
+PASS keyPair.publicKey.usages is [ ]
+PASS keyPair.privateKey.type is 'private'
+PASS keyPair.privateKey.extractable is false
+PASS keyPair.privateKey.algorithm.name is 'X25519'
+PASS keyPair.privateKey.usages is ['deriveBits']
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-generate-key.html
+++ b/LayoutTests/crypto/subtle/X25519-generate-key.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test generating an EC key pair with Curve25519 using X25519 algorithm.");
+
+jsTestIsAsync = true;
+
+var nonExtractable = false;
+
+debug("Generating a key pair...");
+crypto.subtle.generateKey({ name: "X25519" }, nonExtractable, ["deriveBits"]).then(function(result) {
+    keyPair = result;
+    shouldBe("keyPair.toString()", "'[object Object]'");
+    shouldBe("keyPair.publicKey.type", "'public'");
+    shouldBe("keyPair.publicKey.extractable", "true");
+    shouldBe("keyPair.publicKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.publicKey.usages", "[ ]");
+    shouldBe("keyPair.privateKey.type", "'private'");
+    shouldBe("keyPair.privateKey.extractable", "false");
+    shouldBe("keyPair.privateKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.privateKey.usages", "['deriveBits']");
+
+    finishJSTest();
+});
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/crypto/subtle/X25519-generate-single-usage-expected.txt
+++ b/LayoutTests/crypto/subtle/X25519-generate-single-usage-expected.txt
@@ -1,0 +1,28 @@
+Test generating a key pair with Curve25519 using X25519 algorithm with a single usage.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Generating a key pair...
+PASS keyPair.toString() is '[object Object]'
+PASS keyPair.publicKey.type is 'public'
+PASS keyPair.publicKey.extractable is true
+PASS keyPair.publicKey.algorithm.name is 'X25519'
+PASS keyPair.publicKey.usages is [ ]
+PASS keyPair.privateKey.type is 'private'
+PASS keyPair.privateKey.extractable is false
+PASS keyPair.privateKey.algorithm.name is 'X25519'
+PASS keyPair.privateKey.usages is ['deriveKey']
+PASS keyPair.toString() is '[object Object]'
+PASS keyPair.publicKey.type is 'public'
+PASS keyPair.publicKey.extractable is true
+PASS keyPair.publicKey.algorithm.name is 'X25519'
+PASS keyPair.publicKey.usages is [ ]
+PASS keyPair.privateKey.type is 'private'
+PASS keyPair.privateKey.extractable is false
+PASS keyPair.privateKey.algorithm.name is 'X25519'
+PASS keyPair.privateKey.usages is ['deriveBits']
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/crypto/subtle/X25519-generate-single-usage.html
+++ b/LayoutTests/crypto/subtle/X25519-generate-single-usage.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/common.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+
+<script>
+description("Test generating a key pair with Curve25519 using X25519 algorithm with a single usage.");
+
+jsTestIsAsync = true;
+
+var nonExtractable = false;
+
+debug("Generating a key pair...");
+crypto.subtle.generateKey({ name: "X25519" }, nonExtractable, ["deriveKey"]).then(function(result) {
+    keyPair = result;
+    shouldBe("keyPair.toString()", "'[object Object]'");
+    shouldBe("keyPair.publicKey.type", "'public'");
+    shouldBe("keyPair.publicKey.extractable", "true");
+    shouldBe("keyPair.publicKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.publicKey.usages", "[ ]");
+    shouldBe("keyPair.privateKey.type", "'private'");
+    shouldBe("keyPair.privateKey.extractable", "false");
+    shouldBe("keyPair.privateKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.privateKey.usages", "['deriveKey']");
+
+    return crypto.subtle.generateKey({ name: "X25519" }, nonExtractable, ["deriveBits"]);
+}).then(function(result) {
+    keyPair = result;
+    shouldBe("keyPair.toString()", "'[object Object]'");
+    shouldBe("keyPair.publicKey.type", "'public'");
+    shouldBe("keyPair.publicKey.extractable", "true");
+    shouldBe("keyPair.publicKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.publicKey.usages", "[ ]");
+    shouldBe("keyPair.privateKey.type", "'private'");
+    shouldBe("keyPair.privateKey.extractable", "false");
+    shouldBe("keyPair.privateKey.algorithm.name", "'X25519'");
+    shouldBe("keyPair.privateKey.usages", "['deriveBits']");
+
+    finishJSTest();
+});
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>
+

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -571,6 +571,15 @@ webkit.org/b/175199 crypto/subtle/ecdsa-import-key-sign-p521.html [ Skip ]
 webkit.org/b/175199 crypto/subtle/ecdsa-import-key-verify-p521.html [ Skip ]
 webkit.org/b/175199 crypto/subtle/ecdsa-import-pkcs8-key-p521-validate-ecprivatekey-parameters-publickey.html [ Skip ]
 
+#Missing support for the X25519 algorithm
+webkit.org/b/249017 crypto/subtle/X25519-derive-bits-length-limits.html [ Skip ]
+webkit.org/b/249017 crypto/subtle/X25519-derive-bits-malformed-parameters.html [ Skip ]
+webkit.org/b/249017 crypto/subtle/X25519-generate-export-key-raw.html [ Skip ]
+webkit.org/b/249017 crypto/subtle/X25519-generate-key-derive-bits.html [ Skip ]
+webkit.org/b/249017 crypto/subtle/X25519-generate-key-exctractable.html [ Skip ]
+webkit.org/b/249017 crypto/subtle/X25519-generate-key.html [ Skip ]
+webkit.org/b/249017 crypto/subtle/X25519-generate-single-usage.html [ Skip ]
+
 # GTK does not implement setAutomaticLinkDetectionEnabled
 editing/inserting/typing-space-to-trigger-smart-link.html [ Skip ]
 editing/inserting/smart-link-when-caret-is-moved-before-URL.html [ Skip ]

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -817,6 +817,7 @@ set(WebCore_NON_SVG_IDL_FILES
     crypto/parameters/RsaKeyGenParams.idl
     crypto/parameters/RsaOaepParams.idl
     crypto/parameters/RsaPssParams.idl
+    crypto/parameters/X25519Params.idl
 
     css/CSSConditionRule.idl
     css/CSSContainerRule.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -940,6 +940,7 @@ $(PROJECT_DIR)/crypto/parameters/RsaHashedKeyGenParams.idl
 $(PROJECT_DIR)/crypto/parameters/RsaKeyGenParams.idl
 $(PROJECT_DIR)/crypto/parameters/RsaOaepParams.idl
 $(PROJECT_DIR)/crypto/parameters/RsaPssParams.idl
+$(PROJECT_DIR)/crypto/parameters/X25519Params.idl
 $(PROJECT_DIR)/css/CSSConditionRule.idl
 $(PROJECT_DIR)/css/CSSContainerRule.idl
 $(PROJECT_DIR)/css/CSSCounterStyleRule.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3015,6 +3015,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWritableStreamDefaultWriter.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWritableStreamDefaultWriter.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWritableStreamSink.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWritableStreamSink.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSX25519Params.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSX25519Params.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXMLDocument.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXMLDocument.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSXMLHttpRequest.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -811,6 +811,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/crypto/parameters/EcKeyParams.idl \
     $(WebCore)/crypto/parameters/EcdhKeyDeriveParams.idl \
     $(WebCore)/crypto/parameters/EcdsaParams.idl \
+    $(WebCore)/crypto/parameters/X25519Params.idl \
     $(WebCore)/crypto/parameters/HkdfParams.idl \
     $(WebCore)/crypto/parameters/HmacKeyParams.idl \
     $(WebCore)/crypto/parameters/Pbkdf2Params.idl \

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -82,7 +82,6 @@
 		416E995323DAE6BE00E871CB /* AudioToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */; };
 		41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995523DAEFF700E871CB /* VideoToolboxSoftLink.cpp */; };
 		41E9EE2328BB57A0006A2298 /* MediaExperienceAVSystemControllerSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E9EE2228BB57A0006A2298 /* MediaExperienceAVSystemControllerSPI.h */; };
-		41E9EE2628BCA19E006A2298 /* SBSStatusBarSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 41E9EE2528BCA19E006A2298 /* SBSStatusBarSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4450FC9F21F5F602004DFA56 /* QuickLookSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4450FC9D21F5F602004DFA56 /* QuickLookSoftLink.mm */; };
 		4469328B28483EF700614F16 /* FoundationSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4469328A2848321C00614F16 /* FoundationSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		44E1A8B021FA54EB00C3048E /* LookupSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 44E1A8AE21FA54DA00C3048E /* LookupSoftLink.mm */; };
@@ -91,6 +90,7 @@
 		57FD318A22B3593E008D0E8B /* AppSSOSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57FD318922B3593E008D0E8B /* AppSSOSoftLink.mm */; };
 		5C7C787423AC3E770065F47E /* ManagedConfigurationSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C7C787223AC3E770065F47E /* ManagedConfigurationSoftLink.mm */; };
 		5CB898B2286274FA00CA3485 /* QuarantineSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CB898B1286274FA00CA3485 /* QuarantineSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5CF873A728D390EF00DD8391 /* CoreCryptoSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CF873A628D390EF00DD8391 /* CoreCryptoSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B47F2A128587B9700E793C8 /* CoreGraphicsSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7B47F2A428587B9700E793C8 /* CoreGraphicsSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B47F2A228587B9700E793C8 /* CoreGraphicsSoftLink.cpp */; };
 		93B38EC025821CD800198E63 /* SpeechSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93B38EBF25821CD700198E63 /* SpeechSoftLink.mm */; };
@@ -906,7 +906,6 @@
 		416E995623DAEFF700E871CB /* VideoToolboxSoftLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoToolboxSoftLink.h; sourceTree = "<group>"; };
 		41B99E4525DD70150007829A /* AVStreamDataParserSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVStreamDataParserSPI.h; sourceTree = "<group>"; };
 		41E9EE2228BB57A0006A2298 /* MediaExperienceAVSystemControllerSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaExperienceAVSystemControllerSPI.h; sourceTree = "<group>"; };
-		41E9EE2528BCA19E006A2298 /* SBSStatusBarSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SBSStatusBarSPI.h; sourceTree = "<group>"; };
 		442956CC218A72DE0080DB54 /* RevealSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RevealSPI.h; sourceTree = "<group>"; };
 		445097BB26EBF66D003EF771 /* CFNotificationCenterSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFNotificationCenterSPI.h; sourceTree = "<group>"; };
 		4450FC9D21F5F602004DFA56 /* QuickLookSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuickLookSoftLink.mm; sourceTree = "<group>"; };
@@ -930,6 +929,7 @@
 		5C7C787223AC3E770065F47E /* ManagedConfigurationSoftLink.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ManagedConfigurationSoftLink.mm; sourceTree = "<group>"; };
 		5C7C787523AC3E850065F47E /* ManagedConfigurationSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ManagedConfigurationSPI.h; sourceTree = "<group>"; };
 		5CB898B1286274FA00CA3485 /* QuarantineSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = QuarantineSPI.h; sourceTree = "<group>"; };
+		5CF873A628D390EF00DD8391 /* CoreCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreCryptoSPI.h; sourceTree = "<group>"; };
 		63E369F921AFA83F001C14BC /* NSProgressSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSProgressSPI.h; sourceTree = "<group>"; };
 		71B1141F26823ACD004D6701 /* SystemPreviewSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemPreviewSPI.h; sourceTree = "<group>"; };
 		7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonCryptoSPI.h; sourceTree = "<group>"; };
@@ -1097,6 +1097,7 @@
 				29CDEB9E2548D055007C07B7 /* AXSpeechManagerSPI.h */,
 				0C2DA1231F3BEB4900DBC317 /* CFNSURLConnectionSPI.h */,
 				7A36D0F8223AD9AB00B0522E /* CommonCryptoSPI.h */,
+				5CF873A628D390EF00DD8391 /* CoreCryptoSPI.h */,
 				ABCA536724895DB900361BFF /* CoreMotionSPI.h */,
 				C138EA1A2436447200656DF1 /* CoreServicesSPI.h */,
 				DF83E208263734F1000825EF /* CryptoKitPrivateSPI.h */,
@@ -1163,7 +1164,6 @@
 				0C5AF9141F43A4C7002EAC02 /* MobileGestaltSPI.h */,
 				0C5AF9151F43A4C7002EAC02 /* OpenGLESSPI.h */,
 				0C5AF9161F43A4C7002EAC02 /* QuickLookSPI.h */,
-				41E9EE2528BCA19E006A2298 /* SBSStatusBarSPI.h */,
 				0C5AF9171F43A4C7002EAC02 /* SQLite3SPI.h */,
 				31308B1320A21705003FB929 /* SystemPreviewSPI.h */,
 				0C5AF9181F43A4C7002EAC02 /* UIKitSPI.h */,
@@ -1762,6 +1762,7 @@
 				DD20DDE027BC90D70093D175 /* CommonCryptoSPI.h in Headers */,
 				DD20DE6527BC90F90093D175 /* config.h in Headers */,
 				DD20DDCE27BC90D70093D175 /* CoreAudioSPI.h in Headers */,
+				5CF873A728D390EF00DD8391 /* CoreCryptoSPI.h in Headers */,
 				7B47F2A328587B9700E793C8 /* CoreGraphicsSoftLink.h in Headers */,
 				DD20DDD327BC90D70093D175 /* CoreGraphicsSPI.h in Headers */,
 				DD20DD1627BC90D60093D175 /* CoreMediaSoftLink.h in Headers */,
@@ -1887,7 +1888,6 @@
 				DD20DDC227BC90D70093D175 /* ReplayKitSoftLink.h in Headers */,
 				DD20DD2327BC90D60093D175 /* RevealSoftLink.h in Headers */,
 				DD20DE0627BC90D80093D175 /* RevealSPI.h in Headers */,
-				41E9EE2628BCA19E006A2298 /* SBSStatusBarSPI.h in Headers */,
 				DD20DE0727BC90D80093D175 /* SceneKitSPI.h in Headers */,
 				DD20DDC827BC90D70093D175 /* ScreenCaptureKitSoftLink.h in Headers */,
 				DD20DE4027BC90D80093D175 /* ScreenCaptureKitSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+WTF_EXTERN_C_BEGIN
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <corecrypto/ccec25519.h>
+#include <corecrypto/ccec25519_priv.h>
+#include <corecrypto/ccsha2.h>
+#else
+
+#define CC_SPTR(_sn_, _n_) _n_
+
+#define CC_WIDE_NULL nullptr
+
+#define CCRNG_STATE_COMMON \
+int(*CC_SPTR(ccrng_state, generate))(struct ccrng_state *rng, size_t outlen, void *out);
+
+struct ccrng_state {
+    CCRNG_STATE_COMMON
+};
+struct ccrng_state *ccrng(int *error);
+
+#define ccrng_generate(rng, outlen, out) \
+((rng)->generate((struct ccrng_state *)(rng), (outlen), (out)))
+
+typedef uint8_t ccec25519key[32];
+typedef ccec25519key ccec25519secretkey;
+typedef ccec25519key ccec25519pubkey;
+typedef ccec25519key ccec25519base;
+
+typedef uint8_t ccec25519signature[64];
+
+const struct ccdigest_info *ccsha512_di(void);
+#define ccoid_sha512 ((unsigned char *)"\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03")
+#define ccoid_sha512_len 11
+/* SHA512 */
+#define CCSHA512_BLOCK_SIZE  128
+#define    CCSHA512_OUTPUT_SIZE  64
+#define    CCSHA512_STATE_SIZE   64
+extern const struct ccdigest_info ccsha512_ltc_di;
+
+void cccurve25519(ccec25519key out, const ccec25519secretkey sk, const ccec25519base);
+inline void cccurve25519_make_priv(struct ccrng_state *rng, ccec25519secretkey sk)
+{
+    ccrng_generate(rng, 32, sk);
+    sk[0] &= 248;
+    sk[31] &= 127;
+    sk[31] |= 64;
+}
+
+inline void cccurve25519_make_pub(ccec25519pubkey pk, const ccec25519secretkey sk)
+{
+    cccurve25519(pk, sk, CC_WIDE_NULL);
+}
+
+inline void cccurve25519_make_key_pair(struct ccrng_state *rng, ccec25519pubkey pk, ccec25519secretkey sk)
+{
+    cccurve25519_make_priv(rng, sk);
+    cccurve25519_make_pub(pk, sk);
+}
+
+int cced25519_make_pub(const struct ccdigest_info *, ccec25519pubkey pk, const ccec25519secretkey sk);
+
+void cced25519_make_key_pair(const struct ccdigest_info *, struct ccrng_state *, ccec25519pubkey pk, ccec25519secretkey sk);
+#if __has_feature(bounds_attributes)
+#define cc_sized_by(x) __attribute__((sized_by(x)))
+#else
+#define cc_sized_by(x)
+#endif // __has_feature(bounds_attributes)
+
+void cced25519_sign(const struct ccdigest_info *, ccec25519signature, size_t len, const void *cc_sized_by(len) msg, const ccec25519pubkey pk, const ccec25519secretkey sk);
+int cced25519_verify(const struct ccdigest_info *, size_t len, const void *cc_sized_by(len) msg, const ccec25519signature, const ccec25519pubkey pk);
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+WTF_EXTERN_C_END

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -708,6 +708,7 @@ crypto/algorithms/CryptoAlgorithmAES_GCM.cpp
 crypto/algorithms/CryptoAlgorithmAES_KW.cpp
 crypto/algorithms/CryptoAlgorithmECDH.cpp
 crypto/algorithms/CryptoAlgorithmECDSA.cpp
+crypto/algorithms/CryptoAlgorithmX25519.cpp
 crypto/algorithms/CryptoAlgorithmHKDF.cpp
 crypto/algorithms/CryptoAlgorithmHMAC.cpp
 crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -4117,6 +4118,7 @@ JSCSSStyleValue.cpp
 JSCSSUnitValue.cpp
 JSCSSUnparsedValue.cpp
 JSFullscreenOptions.cpp
+JSX25519Params.cpp
 JSUIEvent.cpp
 JSUIEventInit.cpp
 JSURLSearchParams.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -151,6 +151,7 @@ crypto/mac/CryptoAlgorithmAES_GCMMac.cpp
 crypto/mac/CryptoAlgorithmAES_KWMac.cpp
 crypto/mac/CryptoAlgorithmECDHMac.cpp
 crypto/mac/CryptoAlgorithmECDSAMac.cpp
+crypto/mac/CryptoAlgorithmX25519Mac.cpp
 crypto/mac/CryptoAlgorithmHKDFMac.cpp
 crypto/mac/CryptoAlgorithmHMACMac.cpp
 crypto/mac/CryptoAlgorithmPBKDF2Mac.cpp

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -336,8 +336,10 @@ enum class CryptoAlgorithmIdentifierTag {
     SHA_512 = 18,
     HKDF = 20,
     PBKDF2 = 21,
+    Ed25519 = 22,
+    X25519 = 23,
 };
-const uint8_t cryptoAlgorithmIdentifierTagMaximumValue = 21;
+const uint8_t cryptoAlgorithmIdentifierTagMaximumValue = 23;
 
 static unsigned countUsages(CryptoKeyUsageBitmap usages)
 {
@@ -1831,6 +1833,12 @@ private:
         case CryptoAlgorithmIdentifier::ECDH:
             write(CryptoAlgorithmIdentifierTag::ECDH);
             break;
+        case CryptoAlgorithmIdentifier::Ed25519:
+            write(CryptoAlgorithmIdentifierTag::Ed25519);
+            break;
+        case CryptoAlgorithmIdentifier::X25519:
+            write(CryptoAlgorithmIdentifierTag::X25519);
+            break;
         case CryptoAlgorithmIdentifier::AES_CTR:
             write(CryptoAlgorithmIdentifierTag::AES_CTR);
             break;
@@ -2999,6 +3007,12 @@ private:
             break;
         case CryptoAlgorithmIdentifierTag::ECDH:
             result = CryptoAlgorithmIdentifier::ECDH;
+            break;
+        case CryptoAlgorithmIdentifierTag::Ed25519:
+            result = CryptoAlgorithmIdentifier::Ed25519;
+            break;
+        case CryptoAlgorithmIdentifierTag::X25519:
+            result  = CryptoAlgorithmIdentifier::X25519;
             break;
         case CryptoAlgorithmIdentifierTag::AES_CTR:
             result = CryptoAlgorithmIdentifier::AES_CTR;

--- a/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmIdentifier.h
@@ -36,6 +36,8 @@ enum class CryptoAlgorithmIdentifier {
     RSA_OAEP,
     ECDSA,
     ECDH,
+    Ed25519,
+    X25519,
     AES_CTR,
     AES_CBC,
     AES_GCM,

--- a/Source/WebCore/crypto/CryptoAlgorithmParameters.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmParameters.h
@@ -53,6 +53,7 @@ public:
         RsaKeyGenParams,
         RsaOaepParams,
         RsaPssParams,
+        X25519Params,
     };
 
     // FIXME: Consider merging name and identifier.

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithm.h"
 #include "CryptoAlgorithmRegistry.h"
+#include "CryptoAlgorithmX25519Params.h"
 #include "JSAesCbcCfbParams.h"
 #include "JSAesCtrParams.h"
 #include "JSAesGcmParams.h"
@@ -51,6 +52,7 @@
 #include "JSRsaKeyGenParams.h"
 #include "JSRsaOaepParams.h"
 #include "JSRsaPssParams.h"
+#include "JSX25519Params.h"
 #include <JavaScriptCore/JSONObject.h>
 
 namespace WebCore {
@@ -233,6 +235,11 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             result = makeUnique<CryptoAlgorithmEcKeyParams>(params);
             break;
         }
+        case CryptoAlgorithmIdentifier::X25519: {
+            auto result = makeUnique<CryptoAlgorithmParameters>();
+            result->identifier = identifier.value();
+            return result;
+        }
         default:
             return Exception { NotSupportedError };
         }
@@ -250,6 +257,19 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             auto params = convertDictionary<CryptoAlgorithmEcdhKeyDeriveParams>(state, newValue);
             RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             result = makeUnique<CryptoAlgorithmEcdhKeyDeriveParams>(params);
+            break;
+        }
+        case CryptoAlgorithmIdentifier::X25519: {
+            // Remove this hack once https://bugs.webkit.org/show_bug.cgi?id=169333 is fixed.
+            JSValue nameValue = value.get()->get(&state, Identifier::fromString(vm, "name"_s));
+            JSValue publicValue = value.get()->get(&state, Identifier::fromString(vm, "public"_s));
+            JSObject* newValue = constructEmptyObject(&state);
+            newValue->putDirect(vm, Identifier::fromString(vm, "name"_s), nameValue);
+            newValue->putDirect(vm, Identifier::fromString(vm, "publicKey"_s), publicValue);
+
+            auto params = convertDictionary<CryptoAlgorithmX25519Params>(state, newValue);
+            RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
+            result = makeUnique<CryptoAlgorithmX25519Params>(params);
             break;
         }
         case CryptoAlgorithmIdentifier::HKDF: {
@@ -316,6 +336,11 @@ static ExceptionOr<std::unique_ptr<CryptoAlgorithmParameters>> normalizeCryptoAl
             RETURN_IF_EXCEPTION(scope, Exception { ExistingExceptionError });
             result = makeUnique<CryptoAlgorithmEcKeyParams>(params);
             break;
+        }
+        case CryptoAlgorithmIdentifier::X25519: {
+            auto result = makeUnique<CryptoAlgorithmParameters>();
+            result->identifier = identifier.value();
+            return result;
         }
         case CryptoAlgorithmIdentifier::HKDF:
         case CryptoAlgorithmIdentifier::PBKDF2:
@@ -497,6 +522,7 @@ static bool isSupportedExportKey(CryptoAlgorithmIdentifier identifier)
     case CryptoAlgorithmIdentifier::HMAC:
     case CryptoAlgorithmIdentifier::ECDSA:
     case CryptoAlgorithmIdentifier::ECDH:
+    case CryptoAlgorithmIdentifier::X25519:
         return true;
     default:
         return false;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp
@@ -54,6 +54,11 @@ void CryptoAlgorithmECDH::generateKey(const CryptoAlgorithmParameters& parameter
         return;
     }
 
+    if (ecParameters.namedCurve != "P-256"_s && ecParameters.namedCurve != "P-384"_s && ecParameters.namedCurve != "P-521"_s) {
+        exceptionCallback(NotSupportedError);
+        return;
+    }
+
     auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, ecParameters.namedCurve, extractable, usages);
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp
@@ -90,6 +90,11 @@ void CryptoAlgorithmECDSA::generateKey(const CryptoAlgorithmParameters& paramete
         return;
     }
 
+    if (ecParameters.namedCurve != "P-256"_s && ecParameters.namedCurve != "P-384"_s && ecParameters.namedCurve != "P-521"_s) {
+        exceptionCallback(NotSupportedError);
+        return;
+    }
+
     auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDSA, ecParameters.namedCurve, extractable, usages);
     if (result.hasException()) {
         exceptionCallback(result.releaseException().code());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+#include "CryptoAlgorithmX25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmEcKeyParams.h"
+#include "CryptoAlgorithmX25519Params.h"
+#include "CryptoKeyEC.h"
+#include "ScriptExecutionContext.h"
+
+
+namespace WebCore {
+
+Ref<CryptoAlgorithm> CryptoAlgorithmX25519::create()
+{
+    return adoptRef(*new CryptoAlgorithmX25519);
+}
+
+CryptoAlgorithmIdentifier CryptoAlgorithmX25519::identifier() const
+{
+    return s_identifier;
+}
+
+void CryptoAlgorithmX25519::generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext&)
+{
+    if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageSign | CryptoKeyUsageVerify | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey)) {
+        exceptionCallback(SyntaxError);
+        return;
+    }
+
+    auto result = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::X25519, "Curve25519"_s, extractable, usages);
+    if (result.hasException()) {
+        exceptionCallback(result.releaseException().code());
+        return;
+    }
+
+    auto pair = result.releaseReturnValue();
+    pair.publicKey->setUsagesBitmap(0);
+    pair.privateKey->setUsagesBitmap(pair.privateKey->usagesBitmap() & (CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits));
+    callback(WTFMove(pair));
+}
+
+void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& parameters, Ref<CryptoKey>&& baseKey, size_t length, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, ScriptExecutionContext& context, WorkQueue& workQueue)
+{
+    if (baseKey->type() != CryptoKey::Type::Private) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    auto& ecParameters = downcast<CryptoAlgorithmX25519Params>(parameters);
+    ASSERT(ecParameters.publicKey);
+    if (ecParameters.publicKey->type() != CryptoKey::Type::Public) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    if (baseKey->algorithmIdentifier() != ecParameters.publicKey->algorithmIdentifier()) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+    auto& ecBaseKey = downcast<CryptoKeyEC>(baseKey.get());
+    auto& ecPublicKey = downcast<CryptoKeyEC>(*(ecParameters.publicKey.get()));
+    if (ecBaseKey.namedCurve() != ecPublicKey.namedCurve()) {
+        exceptionCallback(InvalidAccessError);
+        return;
+    }
+
+    auto unifiedCallback = [callback = WTFMove(callback), exceptionCallback = WTFMove(exceptionCallback)](std::optional<Vector<uint8_t>>&& derivedKey, size_t length) mutable {
+        if (!derivedKey) {
+            exceptionCallback(OperationError);
+            return;
+        }
+        if (!length) {
+            callback(WTFMove(*derivedKey));
+            return;
+        }
+        auto lengthInBytes = std::ceil(length / 8.);
+        if (lengthInBytes > (*derivedKey).size()) {
+            exceptionCallback(OperationError);
+            return;
+        }
+        (*derivedKey).shrink(lengthInBytes);
+        callback(WTFMove(*derivedKey));
+    };
+
+    // This is a special case that can't use dispatchOperation() because it bundles
+    // the result validation and callback dispatch into unifiedCallback.
+    workQueue.dispatch(
+        [baseKey = WTFMove(baseKey), publicKey = ecParameters.publicKey, length, unifiedCallback = WTFMove(unifiedCallback), contextIdentifier = context.identifier()]() mutable {
+            auto derivedKey = platformDeriveBits(downcast<CryptoKeyEC>(baseKey.get()), downcast<CryptoKeyEC>(*publicKey));
+            ScriptExecutionContext::postTaskTo(contextIdentifier, [derivedKey = WTFMove(derivedKey), length, unifiedCallback = WTFMove(unifiedCallback)](auto&) mutable {
+                unifiedCallback(WTFMove(derivedKey), length);
+            });
+        });
+}
+
+void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+{
+    RefPtr<CryptoKeyEC> result;
+    switch (format) {
+    case CryptoKeyFormat::Jwk: {
+        JsonWebKey key = WTFMove(std::get<JsonWebKey>(data));
+
+        bool isUsagesAllowed = false;
+        if (!key.d.isNull()) {
+            isUsagesAllowed = isUsagesAllowed || !(usages ^ CryptoKeyUsageDeriveKey);
+            isUsagesAllowed = isUsagesAllowed || !(usages ^ CryptoKeyUsageDeriveBits);
+            isUsagesAllowed = isUsagesAllowed || !(usages ^ (CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits));
+        }
+        isUsagesAllowed = isUsagesAllowed || !usages;
+        if (!isUsagesAllowed) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+
+        if (usages && !key.use.isNull() && key.use != "enc"_s) {
+            exceptionCallback(DataError);
+            return;
+        }
+
+        result = CryptoKeyEC::importJwk(CryptoAlgorithmIdentifier::X25519, "Curve25519"_s, WTFMove(key), extractable, usages);
+        break;
+    }
+    case CryptoKeyFormat::Raw:
+        if (usages) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+            
+        if (!extractable)
+            usages = CryptoKeyUsageDeriveBits;
+        result = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::X25519, "Curve25519"_s, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    case CryptoKeyFormat::Spki:
+        if (usages) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyEC::importSpki(CryptoAlgorithmIdentifier::X25519, "Curve25519"_s, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    case CryptoKeyFormat::Pkcs8:
+        if (usages && (usages ^ CryptoKeyUsageDeriveKey) && (usages ^ CryptoKeyUsageDeriveBits) && (usages ^ (CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits))) {
+            exceptionCallback(SyntaxError);
+            return;
+        }
+        result = CryptoKeyEC::importPkcs8(CryptoAlgorithmIdentifier::X25519, "Curve25519"_s, WTFMove(std::get<Vector<uint8_t>>(data)), extractable, usages);
+        break;
+    }
+    if (!result) {
+        exceptionCallback(DataError);
+        return;
+    }
+
+    callback(*result);
+}
+
+void CryptoAlgorithmX25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+{
+    const auto& ecKey = downcast<CryptoKeyEC>(key.get());
+
+    if (!ecKey.keySizeInBits()) {
+        exceptionCallback(OperationError);
+        return;
+    }
+
+    KeyData result;
+    switch (format) {
+    case CryptoKeyFormat::Jwk: {
+        auto jwk = ecKey.exportJwk();
+        if (jwk.hasException()) {
+            exceptionCallback(jwk.releaseException().code());
+            return;
+        }
+        result = jwk.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Raw: {
+        auto raw = ecKey.exportRaw();
+        if (raw.hasException()) {
+            exceptionCallback(raw.releaseException().code());
+            return;
+        }
+        result = raw.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Spki: {
+        auto spki = ecKey.exportSpki();
+        if (spki.hasException()) {
+            exceptionCallback(spki.releaseException().code());
+            return;
+        }
+        result = spki.releaseReturnValue();
+        break;
+    }
+    case CryptoKeyFormat::Pkcs8: {
+        auto pkcs8 = ecKey.exportPkcs8();
+        if (pkcs8.hasException()) {
+            exceptionCallback(pkcs8.releaseException().code());
+            return;
+        }
+        result = pkcs8.releaseReturnValue();
+        break;
+    }
+    }
+
+    callback(format, WTFMove(result));
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "CryptoAlgorithm.h"
+
+#if ENABLE(WEB_CRYPTO)
+namespace WebCore {
+
+class CryptoAlgorithmX25519Params;
+class CryptoKeyEC;
+
+class CryptoAlgorithmX25519 final : public CryptoAlgorithm {
+public:
+    static constexpr ASCIILiteral s_name = "X25519"_s;
+    static constexpr CryptoAlgorithmIdentifier s_identifier = CryptoAlgorithmIdentifier::X25519;
+    static Ref<CryptoAlgorithm> create();
+    
+    // Operations can be performed directly.
+    WEBCORE_EXPORT static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&);
+private:
+    CryptoAlgorithmX25519() = default;
+    CryptoAlgorithmIdentifier identifier() const final;
+    
+    void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
+    void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
@@ -46,6 +46,7 @@
 #include "CryptoAlgorithmSHA256.h"
 #include "CryptoAlgorithmSHA384.h"
 #include "CryptoAlgorithmSHA512.h"
+#include "CryptoAlgorithmX25519.h"
 
 namespace WebCore {
 
@@ -69,6 +70,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmSHA256>();
     registerAlgorithm<CryptoAlgorithmSHA384>();
     registerAlgorithm<CryptoAlgorithmSHA512>();
+    registerAlgorithm<CryptoAlgorithmX25519>();
 }
 
 }

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Metrological Group B.V.
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmX25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmX25519Params.h"
+#include "CryptoKeyEC.h"
+#include "GCryptUtilities.h"
+#include "NotImplemented.h"
+#include <pal/crypto/gcrypt/Handle.h>
+#include <pal/crypto/gcrypt/Utilities.h>
+
+namespace WebCore {
+
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)
+

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -46,6 +46,9 @@ static const char* curveName(CryptoKeyEC::NamedCurve curve)
         return "NIST P-384";
     case CryptoKeyEC::NamedCurve::P521:
         return "NIST P-521";
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();
@@ -61,6 +64,9 @@ static const uint8_t* curveIdentifier(CryptoKeyEC::NamedCurve curve)
         return CryptoConstants::s_secp384r1Identifier.data();
     case CryptoKeyEC::NamedCurve::P521:
         return CryptoConstants::s_secp521r1Identifier.data();
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();
@@ -76,6 +82,9 @@ static size_t curveSize(CryptoKeyEC::NamedCurve curve)
         return 384;
     case CryptoKeyEC::NamedCurve::P521:
         return 521;
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();
@@ -91,6 +100,9 @@ static unsigned curveUncompressedFieldElementSize(CryptoKeyEC::NamedCurve curve)
         return 48;
     case CryptoKeyEC::NamedCurve::P521:
         return 66;
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.cpp
@@ -30,13 +30,17 @@
 
 #include "CryptoAlgorithmRegistry.h"
 #include "JsonWebKey.h"
+#include <wtf/CommaPrinter.h>
+#include <wtf/HexNumber.h>
 #include <wtf/text/Base64.h>
+#include <wtf/text/UniquedStringImpl.h>
 
 namespace WebCore {
 
 static const ASCIILiteral P256 { "P-256"_s };
 static const ASCIILiteral P384 { "P-384"_s };
 static const ASCIILiteral P521 { "P-521"_s };
+static const ASCIILiteral Curve25519 { "Curve25519"_s };
 
 static std::optional<CryptoKeyEC::NamedCurve> toNamedCurve(const String& curve)
 {
@@ -46,6 +50,8 @@ static std::optional<CryptoKeyEC::NamedCurve> toNamedCurve(const String& curve)
         return CryptoKeyEC::NamedCurve::P384;
     if (curve == P521)
         return CryptoKeyEC::NamedCurve::P521;
+    if (curve ==  Curve25519)
+        return CryptoKeyEC::NamedCurve:: Curve25519;
 
     return std::nullopt;
 }
@@ -159,6 +165,9 @@ ExceptionOr<JsonWebKey> CryptoKeyEC::exportJwk() const
     case NamedCurve::P521:
         result.crv = P521;
         break;
+    case NamedCurve::Curve25519:
+        result.crv = Curve25519;
+        break;
     }
     result.key_ops = usages();
     result.ext = extractable();
@@ -198,6 +207,8 @@ String CryptoKeyEC::namedCurveString() const
         return String(P384);
     case NamedCurve::P521:
         return String(P521);
+    case NamedCurve::Curve25519:
+        return String(Curve25519);
     }
 
     ASSERT_NOT_REACHED();
@@ -206,7 +217,7 @@ String CryptoKeyEC::namedCurveString() const
 
 bool CryptoKeyEC::isValidECAlgorithm(CryptoAlgorithmIdentifier algorithm)
 {
-    return algorithm == CryptoAlgorithmIdentifier::ECDSA || algorithm == CryptoAlgorithmIdentifier::ECDH;
+    return algorithm == CryptoAlgorithmIdentifier::ECDSA || algorithm == CryptoAlgorithmIdentifier::ECDH || algorithm == CryptoAlgorithmIdentifier:: X25519;
 }
 
 auto CryptoKeyEC::algorithm() const -> KeyAlgorithm
@@ -223,6 +234,9 @@ auto CryptoKeyEC::algorithm() const -> KeyAlgorithm
         break;
     case NamedCurve::P521:
         result.namedCurve = P521;
+        break;
+    case NamedCurve::Curve25519:
+        result.namedCurve = Curve25519;
         break;
     }
 

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -33,14 +33,16 @@
 
 #if OS(DARWIN) && !PLATFORM(GTK)
 #include "CommonCryptoUtilities.h"
+#include <wtf/Vector.h>
 
-typedef CCECCryptorRef PlatformECKey;
+typedef std::variant<CCECCryptorRef, Vector<uint8_t>>PlatformECKey;
+
 namespace WebCore {
 struct CCECCryptorRefDeleter {
     void operator()(CCECCryptorRef key) const { CCECCryptorRelease(key); }
 };
 }
-typedef std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter> PlatformECKeyContainer;
+typedef std::variant<std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>, Vector<uint8_t>> PlatformECKeyContainer;
 #endif
 
 #if USE(GCRYPT)
@@ -66,6 +68,7 @@ public:
         P256,
         P384,
         P521,
+        Curve25519,
     };
 
     static Ref<CryptoKeyEC> create(CryptoAlgorithmIdentifier identifier, NamedCurve curve, CryptoKeyType type, PlatformECKeyContainer&& platformKey, bool extractable, CryptoKeyUsageBitmap usages)
@@ -89,7 +92,16 @@ public:
     size_t keySizeInBytes() const { return std::ceil(keySizeInBits() / 8.); }
     NamedCurve namedCurve() const { return m_curve; }
     String namedCurveString() const;
+#if OS(DARWIN) && !PLATFORM(GTK)
+    PlatformECKey platformKey() const { return WTF::switchOn( m_platformKey, [&](const std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>& options) -> PlatformECKey {
+        return options.get();
+        }, [&](const Vector<uint8_t>& options) -> PlatformECKey {
+        return options;
+        });
+    }
+#else
     PlatformECKey platformKey() const { return m_platformKey.get(); }
+#endif
     static bool isValidECAlgorithm(CryptoAlgorithmIdentifier);
 
 private:

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp
@@ -38,7 +38,9 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const Cry
     std::optional<Vector<uint8_t>> result = std::nullopt;
     Vector<uint8_t> derivedKey(baseKey.keySizeInBytes()); // Per https://tools.ietf.org/html/rfc6090#section-4.
     size_t size = derivedKey.size();
-    if (!CCECCryptorComputeSharedSecret(baseKey.platformKey(), publicKey.platformKey(), derivedKey.data(), &size))
+    CCECCryptorRef cceccbasekey = std::get<CCECCryptorRef>(baseKey.platformKey());
+    CCECCryptorRef cceccpublickey = std::get<CCECCryptorRef>(publicKey.platformKey());
+    if (!CCECCryptorComputeSharedSecret(cceccbasekey, cceccpublickey, derivedKey.data(), &size))
         result = WTFMove(derivedKey);
     return result;
 }

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp
@@ -55,8 +55,8 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     // tag + length(1) + tag + length(1) + InitialOctet(?) + keyLength in bytes + tag + length(1) + InitialOctet(?) + keyLength in bytes
     Vector<uint8_t> signature(8 + keyLengthInBytes * 2);
     size_t signatureSize = signature.size();
-
-    CCCryptorStatus status = CCECCryptorSignHash(key, digestData.data(), digestData.size(), signature.data(), &signatureSize);
+    CCECCryptorRef ccecckey = std::get<CCECCryptorRef>(key);
+    CCCryptorStatus status = CCECCryptorSignHash(ccecckey, digestData.data(), digestData.size(), signature.data(), &signatureSize);
     if (status)
         return Exception { OperationError };
 
@@ -149,7 +149,8 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     newSignature.append(signature.data() + sStart, keyLengthInBytes * 2 - sStart);
 
     uint32_t valid;
-    CCCryptorStatus status = CCECCryptorVerifyHash(key, digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
+    CCECCryptorRef ccecckey = std::get<CCECCryptorRef>(key);
+    CCCryptorStatus status = CCECCryptorVerifyHash(ccecckey, digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
     if (status) {
         WTFLogAlways("ERROR: CCECCryptorVerifyHash() returns error=%d", status);
         return false;

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp
@@ -27,7 +27,7 @@
 #include "CryptoAlgorithmHKDF.h"
 
 #if ENABLE(WEB_CRYPTO)
-
+#include "CommonCryptoUtilities.h"
 #include "CryptoAlgorithmHkdfParams.h"
 #include "CryptoKeyRaw.h"
 #include "CryptoUtilitiesCocoa.h"

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp
@@ -47,6 +47,7 @@
 #include "CryptoAlgorithmSHA256.h"
 #include "CryptoAlgorithmSHA384.h"
 #include "CryptoAlgorithmSHA512.h"
+#include "CryptoAlgorithmX25519.h"
 
 namespace WebCore {
 
@@ -65,6 +66,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmRSAES_PKCS1_v1_5>();
     registerAlgorithm<CryptoAlgorithmRSASSA_PKCS1_v1_5>();
     registerAlgorithm<CryptoAlgorithmRSA_OAEP>();
+    registerAlgorithm<CryptoAlgorithmX25519>();
 #if HAVE(RSA_PSS)
     registerAlgorithm<CryptoAlgorithmRSA_PSS>();
 #endif

--- a/Source/WebCore/crypto/mac/CryptoAlgorithmX25519Mac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoAlgorithmX25519Mac.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmX25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CommonCryptoUtilities.h"
+#include "CryptoAlgorithmX25519Params.h"
+#include "CryptoKeyEC.h"
+#include <pal/spi/cocoa/CoreCryptoSPI.h>
+#include <stdio.h>
+#include <string.h>
+#include <wtf/Assertions.h>
+#include <wtf/text/Base64.h>
+
+
+namespace WebCore {
+
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
+{
+    ccec25519key sharedsecret = { };
+    Vector<uint8_t> cceccbasekey = std::get<Vector<uint8_t>>(baseKey.platformKey());
+    Vector<uint8_t> cceccpublickey = std::get<Vector<uint8_t>>(publicKey.platformKey());
+    cccurve25519(sharedsecret, cceccbasekey.data(), cceccpublickey.data());
+    return Vector<uint8_t>(sharedsecret, 32);
+}
+
+}
+#endif // ENABLE(WEB_CRYPTO)
+
+
+

--- a/Source/WebCore/crypto/mac/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/mac/CryptoKeyECMac.cpp
@@ -30,6 +30,8 @@
 
 #include "CommonCryptoDERUtilities.h"
 #include "JsonWebKey.h"
+#include <pal/spi/cocoa/CoreCryptoSPI.h>
+#include <stdlib.h>
 #include <wtf/text/Base64.h>
 
 namespace WebCore {
@@ -43,6 +45,7 @@ static constexpr unsigned char Secp256r1[] = {0x06, 0x08, 0x2a, 0x86, 0x48, 0xce
 static constexpr unsigned char Secp384r1[] = {0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x22};
 // OID secp521r1 1.3.132.0.35
 static constexpr unsigned char Secp521r1[] = {0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x23};
+static constexpr unsigned char Curve25519[] = { 0x06, 0x09, 0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01 };
 
 // Version 1. Per https://tools.ietf.org/html/rfc5915#section-3
 static const unsigned char PrivateKeyVersion[] = {0x02, 0x01, 0x01};
@@ -64,6 +67,8 @@ static constexpr size_t keySizeInBitsFromNamedCurve(CryptoKeyEC::NamedCurve curv
         return 384;
     case CryptoKeyEC::NamedCurve::P521:
         return 521;
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        return 256;
     }
 
     ASSERT_NOT_REACHED();
@@ -90,48 +95,93 @@ static constexpr bool doesFieldElementMatchNamedCurve(CryptoKeyEC::NamedCurve cu
 
 size_t CryptoKeyEC::keySizeInBits() const
 {
-    int result = CCECGetKeySize(m_platformKey.get());
-    return result ? result : 0;
+
+    return WTF::switchOn(m_platformKey, [&](const std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>& options) ->int {
+        return CCECGetKeySize(options.get());
+        },
+        [](const Vector<uint8_t>& options) -> int {
+            return options.size() * 8;
+    });
 }
 
 bool CryptoKeyEC::platformSupportedCurve(NamedCurve curve)
 {
-    return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521;
+    return curve == NamedCurve::P256 || curve == NamedCurve::P384 || curve == NamedCurve::P521 || curve == NamedCurve::Curve25519;
 }
 
 std::optional<CryptoKeyPair> CryptoKeyEC::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve curve, bool extractable, CryptoKeyUsageBitmap usages)
 {
+    
     size_t size = keySizeInBitsFromNamedCurve(curve);
-    CCECCryptorRef ccPublicKey = nullptr;
-    CCECCryptorRef ccPrivateKey = nullptr;
-    if (CCECCryptorGeneratePair(size, &ccPublicKey, &ccPrivateKey))
-        return std::nullopt;
-
-    auto publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(ccPublicKey), true, usages);
-    auto privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, PlatformECKeyContainer(ccPrivateKey), extractable, usages);
+    if (curve != NamedCurve::Curve25519) {
+        CCECCryptorRef ccPublicKey = nullptr;
+        CCECCryptorRef ccPrivateKey = nullptr;
+        if (CCECCryptorGeneratePair(size, &ccPublicKey, &ccPrivateKey))
+            return std::nullopt;
+        auto publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPublicKey), true, usages);
+        auto privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPrivateKey), extractable, usages);
+        return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
+        
+    }
+    ccec25519pubkey ccPublicKey;
+    ccec25519secretkey ccPrivateKey;
+    int ccerror = 0;
+    
+    if (identifier == CryptoAlgorithmIdentifier::Ed25519) {
+        const struct ccdigest_info* di = ccsha512_di();
+        cced25519_make_key_pair(di, ccrng(&ccerror),  ccPublicKey, ccPrivateKey);
+        
+    } else {
+        int ccerror = 0;
+        cccurve25519_make_key_pair(ccrng(&ccerror), ccPublicKey, ccPrivateKey);
+    }
+    auto publicKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Public, Vector<uint8_t>(ccPublicKey), true, usages);
+    auto privateKey = CryptoKeyEC::create(identifier, curve, CryptoKeyType::Private, Vector<uint8_t>(ccPrivateKey), extractable, usages);
     return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportRaw(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    if (!doesUncompressedPointMatchNamedCurve(curve, keyData.size()))
+    if (curve != NamedCurve::Curve25519) {
+        if (!doesUncompressedPointMatchNamedCurve(curve, keyData.size()))
+            return nullptr;
+        
+        CCECCryptorRef ccPublicKey = nullptr;
+        if (CCECCryptorImportKey(kCCImportKeyBinary, keyData.data(), keyData.size(), ccECKeyPublic, &ccPublicKey))
+            return nullptr;
+        
+        return create(identifier, curve, CryptoKeyType::Public, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPublicKey), extractable, usages);
+
+    }
+    if (!doesFieldElementMatchNamedCurve(curve, keyData.size()))
         return nullptr;
 
-    CCECCryptorRef ccPublicKey = nullptr;
-    if (CCECCryptorImportKey(kCCImportKeyBinary, keyData.data(), keyData.size(), ccECKeyPublic, &ccPublicKey))
-        return nullptr;
+    if ((usages & CryptoKeyUsageSign) || !extractable)
+        return create(identifier, curve, CryptoKeyType::Private, Vector<uint8_t>(keyData), extractable, usages);
 
-    return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(ccPublicKey), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Public, Vector<uint8_t>(keyData), extractable, usages);
+        
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
-    size_t expectedSize = 2 * keySizeInBytes() + 1; // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
-    Vector<uint8_t> result(expectedSize);
-    size_t size = result.size();
-    if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, m_platformKey.get()) || size != expectedSize))
-        return { };
-    return result;
+    // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
+    return WTF::switchOn(m_platformKey, [&](const std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>& options) -> Vector<uint8_t> {
+        size_t expectedSize = 2 * keySizeInBytes() + 1;
+        Vector<uint8_t> result(expectedSize);
+        size_t size = result.size();
+        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, options.get()) || size != expectedSize))
+            return { };
+        return result;
+        },
+        [&](const Vector<uint8_t>& options) -> Vector<uint8_t> {
+        size_t expectedSize = keySizeInBytes();
+        Vector<uint8_t> result(expectedSize);
+        size_t size = result.size();
+        if (options.size() != size)
+            return { };
+        return result;
+    });
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, bool extractable, CryptoKeyUsageBitmap usages)
@@ -144,7 +194,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifi
     if (CCECCryptorCreateFromData(size, x.data(), x.size(), y.data(), y.size(), &ccPublicKey))
         return nullptr;
 
-    return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(ccPublicKey), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Public, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPublicKey), extractable, usages);
 }
 
 RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& x, Vector<uint8_t>&& y, Vector<uint8_t>&& d, bool extractable, CryptoKeyUsageBitmap usages)
@@ -164,7 +214,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
     if (CCECCryptorImportKey(kCCImportKeyBinary, binaryInput.data(), binaryInput.size(), ccECKeyPrivate, &ccPrivateKey))
         return nullptr;
 
-    return create(identifier, curve, CryptoKeyType::Private, PlatformECKeyContainer(ccPrivateKey), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Private, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPrivateKey), extractable, usages);
 }
 
 bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
@@ -172,29 +222,32 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
     size_t keySizeInBytes = this->keySizeInBytes();
     size_t publicKeySize = keySizeInBytes * 2 + 1; // 04 + X + Y per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
     size_t privateKeySize = keySizeInBytes * 3 + 1; // 04 + X + Y + D
-
     Vector<uint8_t> result(privateKeySize);
     size_t size = result.size();
-    switch (type()) {
-    case CryptoKeyType::Public:
-        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, m_platformKey.get())))
+    return WTF::switchOn(m_platformKey, [&result, &size, this, &publicKeySize, &privateKeySize, &jwk, &keySizeInBytes](const std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>& options)mutable -> bool {
+        switch (type()) {
+        case CryptoKeyType::Public:
+            if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPublic, options.get())))
+                return false;
+            break;
+        case CryptoKeyType::Private:
+            if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPrivate, options.get())))
+                return false;
+            break;
+        default:
+            ASSERT_NOT_REACHED();
             return false;
-        break;
-    case CryptoKeyType::Private:
-        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, result.data(), &size, ccECKeyPrivate, m_platformKey.get())))
+        }
+        if (UNLIKELY((size != publicKeySize) && (size != privateKeySize)))
             return false;
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-        return false;
-    }
-
-    if (UNLIKELY((size != publicKeySize) && (size != privateKeySize)))
-        return false;
-    jwk.x = base64URLEncodeToString(result.data() + 1, keySizeInBytes);
-    jwk.y = base64URLEncodeToString(result.data() + keySizeInBytes + 1, keySizeInBytes);
-    if (size > publicKeySize)
-        jwk.d = base64URLEncodeToString(result.data() + publicKeySize, keySizeInBytes);
+        jwk.x = base64URLEncodeToString(result.data() + 1, keySizeInBytes);
+        jwk.y = base64URLEncodeToString(result.data() + keySizeInBytes + 1, keySizeInBytes);
+        if (size > publicKeySize)
+            jwk.d = base64URLEncodeToString(result.data() + publicKeySize, keySizeInBytes);
+        return true;
+    }, [&](const Vector<uint8_t>&options) -> bool {
+        return options.size()>0;
+    });
     return true;
 }
 
@@ -213,6 +266,10 @@ static size_t getOID(CryptoKeyEC::NamedCurve curve, const uint8_t*& oid)
     case CryptoKeyEC::NamedCurve::P521:
         oid = Secp521r1;
         oidSize = sizeof(Secp521r1);
+        break;
+    case CryptoKeyEC::NamedCurve::Curve25519:
+        oid =Curve25519;
+        oidSize = sizeof(Curve25519);
         break;
     }
     return oidSize;
@@ -254,16 +311,14 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportSpki(CryptoAlgorithmIdentifier id
         return nullptr;
     index += bytesUsedToEncodedLength(keyData[index]) + 1; // Read length
     CCECCryptorRef ccPublicKey = nullptr;
-    if (doesUncompressedPointMatchNamedCurve(curve, keyData.size() - index)) {
-        if (CCECCryptorImportKey(kCCImportKeyBinary, keyData.data() + index, keyData.size() - index, ccECKeyPublic, &ccPublicKey))
+    if (!doesUncompressedPointMatchNamedCurve(curve, keyData.size() - index)) {
+        if (CCECCryptorImportKey(kCCImportKeyCompact, keyData.data() + index+1, keyData.size() - index-1, ccECKeyPublic, &ccPublicKey))
             return nullptr;
     } else {
-        ++index;
-        if (CCECCryptorImportKey(kCCImportKeyCompact, keyData.data() + index, keyData.size() - index, ccECKeyPublic, &ccPublicKey))
+        if (CCECCryptorImportKey(kCCImportKeyBinary, keyData.data() + index, keyData.size() - index, ccECKeyPublic, &ccPublicKey))
             return nullptr;
-        
     }
-    return create(identifier, curve, CryptoKeyType::Public, PlatformECKeyContainer(ccPublicKey), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Public, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPublicKey), extractable, usages);
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
@@ -271,32 +326,34 @@ Vector<uint8_t> CryptoKeyEC::platformExportSpki() const
     size_t expectedKeySize = 2 * keySizeInBytes() + 1; // Per Section 2.3.4 of http://www.secg.org/sec1-v2.pdf
     Vector<uint8_t> keyBytes(expectedKeySize);
     size_t keySize = keyBytes.size();
-    if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPublic, m_platformKey.get()) || keySize != expectedKeySize))
-        return { };
-
-    // The following addes SPKI header to a raw EC public key.
-    // Once the underlying crypto library is updated to output SPKI EC Key, we should remove this hack.
-    // <rdar://problem/30987628>
-    const uint8_t* oid;
-    size_t oidSize = getOID(namedCurve(), oid);
-
-    // SEQUENCE + length(1) + OID id-ecPublicKey + OID secp256r1/OID secp384r1/OID secp521r1 + BIT STRING + length(?) + InitialOctet + Key size
-    size_t totalSize = sizeof(IdEcPublicKey) + oidSize + bytesNeededForEncodedLength(keySize + 1) + keySize + 4;
-
     Vector<uint8_t> result;
-    result.reserveInitialCapacity(totalSize + bytesNeededForEncodedLength(totalSize) + 1);
-    result.append(SequenceMark);
-    addEncodedASN1Length(result, totalSize);
-    result.append(SequenceMark);
-    addEncodedASN1Length(result, sizeof(IdEcPublicKey) + oidSize);
-    result.append(IdEcPublicKey, sizeof(IdEcPublicKey));
-    result.append(oid, oidSize);
-    result.append(BitStringMark);
-    addEncodedASN1Length(result, keySize + 1);
-    result.append(InitialOctet);
-    result.append(keyBytes.data(), keyBytes.size());
+    auto keyBytesData = keyBytes.data();
+    return WTF::switchOn(m_platformKey, [&](const std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>& options) mutable->Vector<uint8_t> {
+        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, keyBytesData , &keySize, ccECKeyPublic, options.get()) || keySize != expectedKeySize))
+            return { };
+        // The following addes SPKI header to a raw EC public key.
+        // Once the underlying crypto library is updated to output SPKI EC Key, we should remove this hack.
+        // <rdar://problem/30987628>
+        const uint8_t* oid;
+        size_t oidSize = getOID(namedCurve(), oid);
 
-    return result;
+        // SEQUENCE + length(1) + OID id-ecPublicKey + OID secp256r1/OID secp384r1/OID secp521r1 + BIT STRING + length(?) + InitialOctet + Key size
+        size_t totalSize = sizeof(IdEcPublicKey) + oidSize + bytesNeededForEncodedLength(keySize + 1) + keySize + 4;
+        result.reserveInitialCapacity(totalSize + bytesNeededForEncodedLength(totalSize) + 1);
+        result.append(SequenceMark);
+        addEncodedASN1Length(result, totalSize);
+        result.append(SequenceMark);
+        addEncodedASN1Length(result, sizeof(IdEcPublicKey) + oidSize);
+        result.append(IdEcPublicKey, sizeof(IdEcPublicKey));
+        result.append(oid, oidSize);
+        result.append(BitStringMark);
+        addEncodedASN1Length(result, keySize + 1);
+        result.append(InitialOctet);
+        result.append(keyBytes.data(), keyBytes.size());
+        return result;
+    }, [&](const Vector<uint8_t>&options) -> Vector<uint8_t> {
+        return options;
+    });
 }
 
 // Per https://www.ietf.org/rfc/rfc5208.txt
@@ -355,12 +412,11 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     if (!doesUncompressedPointMatchNamedCurve(curve, keyBinary.size()))
         return nullptr;
     keyBinary.append(keyData.data() + privateKeyPos, privateKeySize);
-
     CCECCryptorRef ccPrivateKey = nullptr;
     if (CCECCryptorImportKey(kCCImportKeyBinary, keyBinary.data(), keyBinary.size(), ccECKeyPrivate, &ccPrivateKey))
         return nullptr;
 
-    return create(identifier, curve, CryptoKeyType::Private, PlatformECKeyContainer(ccPrivateKey), extractable, usages);
+    return create(identifier, curve, CryptoKeyType::Private, std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>(ccPrivateKey), extractable, usages);
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
@@ -369,51 +425,60 @@ Vector<uint8_t> CryptoKeyEC::platformExportPkcs8() const
     size_t expectedKeySize = keySizeInBytes * 3 + 1; // 04 + X + Y + D
     Vector<uint8_t> keyBytes(expectedKeySize);
     size_t keySize = keyBytes.size();
-    if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPrivate, m_platformKey.get()) || keySize != expectedKeySize))
-        return { };
+    Vector<uint8_t> result;
+    return WTF::switchOn(m_platformKey, [&](const std::unique_ptr<typename std::remove_pointer<CCECCryptorRef>::type, WebCore::CCECCryptorRefDeleter>& options) mutable ->Vector<uint8_t> {
+
+        if (UNLIKELY(CCECCryptorExportKey(kCCImportKeyBinary, keyBytes.data(), &keySize, ccECKeyPrivate, options.get()) || keySize != expectedKeySize))
+            return { };
+
+        const uint8_t* oid;
+        size_t oidSize = getOID(namedCurve(), oid);
+
+        // InitialOctet + 04 + X + Y
+        size_t publicKeySize = keySizeInBytes * 2 + 2;
+        // BIT STRING + length(?) + publicKeySize
+        size_t taggedTypeSize = bytesNeededForEncodedLength(publicKeySize) + publicKeySize + 1;
+        // VERSION + OCTET STRING + length(1) + private key + TaggedType1(1) + length(?) + BIT STRING + length(?) + publicKeySize
+        size_t ecPrivateKeySize = sizeof(Version) + keySizeInBytes + bytesNeededForEncodedLength(taggedTypeSize) + bytesNeededForEncodedLength(publicKeySize) + publicKeySize + 4;
+        // SEQUENCE + length(?) + ecPrivateKeySize
+        size_t privateKeySize = bytesNeededForEncodedLength(ecPrivateKeySize) + ecPrivateKeySize + 1;
+        // VERSION + SEQUENCE + length(1) + OID id-ecPublicKey + OID secp256r1/OID secp384r1/OID secp521r1 + OCTET STRING + length(?) + privateKeySize
+        size_t totalSize = sizeof(Version) + sizeof(IdEcPublicKey) + oidSize + bytesNeededForEncodedLength(privateKeySize) + privateKeySize + 3;
+
+
+        result.reserveInitialCapacity(totalSize + bytesNeededForEncodedLength(totalSize) + 1);
+        result.append(SequenceMark);
+        addEncodedASN1Length(result, totalSize);
+        result.append(Version, sizeof(Version));
+        result.append(SequenceMark);
+        addEncodedASN1Length(result, sizeof(IdEcPublicKey) + oidSize);
+        result.append(IdEcPublicKey, sizeof(IdEcPublicKey));
+        result.append(oid, oidSize);
+        result.append(OctetStringMark);
+        addEncodedASN1Length(result, privateKeySize);
+        result.append(SequenceMark);
+        addEncodedASN1Length(result, ecPrivateKeySize);
+        result.append(PrivateKeyVersion, sizeof(PrivateKeyVersion));
+        result.append(OctetStringMark);
+        addEncodedASN1Length(result, keySizeInBytes);
+        result.append(keyBytes.data() + publicKeySize - 1, keySizeInBytes);
+        result.append(TaggedType1);
+        addEncodedASN1Length(result, taggedTypeSize);
+        result.append(BitStringMark);
+        addEncodedASN1Length(result, publicKeySize);
+        result.append(InitialOctet);
+        result.append(keyBytes.data(), publicKeySize - 1);
+
+        return result;
+    }, [&](const Vector<uint8_t>&options) -> Vector<uint8_t> {
+        return options;
+
+    });
 
     // The following addes PKCS8 header to a raw EC private key.
     // Once the underlying crypto library is updated to output PKCS8 EC Key, we should remove this hack.
     // <rdar://problem/30987628>
-    const uint8_t* oid;
-    size_t oidSize = getOID(namedCurve(), oid);
 
-    // InitialOctet + 04 + X + Y
-    size_t publicKeySize = keySizeInBytes * 2 + 2;
-    // BIT STRING + length(?) + publicKeySize
-    size_t taggedTypeSize = bytesNeededForEncodedLength(publicKeySize) + publicKeySize + 1;
-    // VERSION + OCTET STRING + length(1) + private key + TaggedType1(1) + length(?) + BIT STRING + length(?) + publicKeySize
-    size_t ecPrivateKeySize = sizeof(Version) + keySizeInBytes + bytesNeededForEncodedLength(taggedTypeSize) + bytesNeededForEncodedLength(publicKeySize) + publicKeySize + 4;
-    // SEQUENCE + length(?) + ecPrivateKeySize
-    size_t privateKeySize = bytesNeededForEncodedLength(ecPrivateKeySize) + ecPrivateKeySize + 1;
-    // VERSION + SEQUENCE + length(1) + OID id-ecPublicKey + OID secp256r1/OID secp384r1/OID secp521r1 + OCTET STRING + length(?) + privateKeySize
-    size_t totalSize = sizeof(Version) + sizeof(IdEcPublicKey) + oidSize + bytesNeededForEncodedLength(privateKeySize) + privateKeySize + 3;
-
-    Vector<uint8_t> result;
-    result.reserveInitialCapacity(totalSize + bytesNeededForEncodedLength(totalSize) + 1);
-    result.append(SequenceMark);
-    addEncodedASN1Length(result, totalSize);
-    result.append(Version, sizeof(Version));
-    result.append(SequenceMark);
-    addEncodedASN1Length(result, sizeof(IdEcPublicKey) + oidSize);
-    result.append(IdEcPublicKey, sizeof(IdEcPublicKey));
-    result.append(oid, oidSize);
-    result.append(OctetStringMark);
-    addEncodedASN1Length(result, privateKeySize);
-    result.append(SequenceMark);
-    addEncodedASN1Length(result, ecPrivateKeySize);
-    result.append(PrivateKeyVersion, sizeof(PrivateKeyVersion));
-    result.append(OctetStringMark);
-    addEncodedASN1Length(result, keySizeInBytes);
-    result.append(keyBytes.data() + publicKeySize - 1, keySizeInBytes);
-    result.append(TaggedType1);
-    addEncodedASN1Length(result, taggedTypeSize);
-    result.append(BitStringMark);
-    addEncodedASN1Length(result, publicKeySize);
-    result.append(InitialOctet);
-    result.append(keyBytes.data(), publicKeySize - 1);
-
-    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmRegistryOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmRegistryOpenSSL.cpp
@@ -47,6 +47,7 @@
 #include "CryptoAlgorithmSHA256.h"
 #include "CryptoAlgorithmSHA384.h"
 #include "CryptoAlgorithmSHA512.h"
+#include "CryptoAlgorithmX25519.h"
 
 namespace WebCore {
 
@@ -71,6 +72,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmSHA256>();
     registerAlgorithm<CryptoAlgorithmSHA384>();
     registerAlgorithm<CryptoAlgorithmSHA512>();
+    registerAlgorithm<CryptoAlgorithmX25519>();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmX25519OpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmX25519OpenSSL.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmX25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoAlgorithmX25519Params.h"
+#include "CryptoKeyEC.h"
+#include "CryptoKeyRaw.h"
+#include "NotImplemented.h"
+#include "OpenSSLUtilities.h"
+
+namespace WebCore {
+
+std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&)
+{
+    notImplemented();
+    return std::nullopt;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017-2019 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParameters.h"
+#include "CryptoKey.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+#include <variant>
+
+#if ENABLE(WEB_CRYPTO)
+
+namespace WebCore {
+
+class CryptoAlgorithmX25519Params final : public CryptoAlgorithmParameters {
+public:
+    RefPtr<CryptoKey> publicKey;
+    Class parametersClass() const final { return Class::X25519Params; }
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CRYPTO_ALGORITHM_PARAMETERS(X25519Params)
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/parameters/X25519Params.h
+++ b/Source/WebCore/crypto/parameters/X25519Params.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once

--- a/Source/WebCore/crypto/parameters/X25519Params.idl
+++ b/Source/WebCore/crypto/parameters/X25519Params.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+[
+    Conditional=WEB_CRYPTO,
+    ImplementedAs=CryptoAlgorithmX25519Params,
+] dictionary X25519Params : CryptoAlgorithmParameters {
+    required CryptoKey publicKey;
+    
+};

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "CSSPropertyNames.h"
+#include "CSSValueKeywords.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/OpenSSL.cmake
+++ b/Source/WebCore/platform/OpenSSL.cmake
@@ -14,6 +14,7 @@ if (ENABLE_WEB_CRYPTO)
         crypto/openssl/CryptoAlgorithmRSASSA_PKCS1_v1_5OpenSSL.cpp
         crypto/openssl/CryptoAlgorithmRSA_OAEPOpenSSL.cpp
         crypto/openssl/CryptoAlgorithmRSA_PSSOpenSSL.cpp
+        crypto/openssl/CryptoAlgorithmX25519OpenSSL.cpp
         crypto/openssl/CryptoAlgorithmRegistryOpenSSL.cpp
         crypto/openssl/CryptoKeyECOpenSSL.cpp
         crypto/openssl/CryptoKeyRSAOpenSSL.cpp

--- a/Source/WebCore/platform/SourcesGCrypt.txt
+++ b/Source/WebCore/platform/SourcesGCrypt.txt
@@ -35,6 +35,7 @@ crypto/gcrypt/CryptoAlgorithmRSAES_PKCS1_v1_5GCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
+crypto/gcrypt/CryptoAlgorithmX25519GCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
 crypto/gcrypt/CryptoKeyECGCrypt.cpp
 crypto/gcrypt/CryptoKeyRSAGCrypt.cpp


### PR DESCRIPTION
#### 848712e66eea7929e31f37f110c7f67b33f97907
<pre>
Support for the Curve 25519 in order to be able to work with such type of curves  and implementation of X25519 Algorithm

Support for Curve 25519 - Algorithm X25519
<a href="https://bugs.webkit.org/show_bug.cgi?id=246145">https://bugs.webkit.org/show_bug.cgi?id=246145</a>
rdar://100401588

Reviewed by Youenn Fablet

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
(WebCore::CloneDeserializer::read):
* Source/WebCore/crypto/CryptoAlgorithmIdentifier.h:
* Source/WebCore/crypto/CryptoAlgorithmParameters.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::isSupportedExportKey):
(WebCore::SubtleCrypto::deriveBits):
(WebCore::SubtleCrypto::exportKey):
(WebCore::SubtleCrypto::unwrapKey):
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
(WebCore::toNamedCurve):
(WebCore::CryptoKeyEC::CryptoKeyEC):
(WebCore::CryptoKeyEC::platformKey const):
(WebCore::CryptoKeyEC::exportRaw const):
(WebCore::CryptoKeyEC::exportJwk const):
(WebCore::CryptoKeyEC::namedCurveString const):
(WebCore::CryptoKeyEC::isValidECAlgorithm):
(WebCore::CryptoKeyEC::algorithm const):
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/mac/CryptoAlgorithmECDHMac.cpp:
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSA):
(WebCore::verifyECDSA):
* Source/WebCore/crypto/mac/CryptoAlgorithmHKDFMac.cpp:
* Source/WebCore/crypto/mac/CryptoAlgorithmRegistryMac.cpp:
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms):
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::keySizeInBitsFromNamedCurve):
(WebCore::CryptoKeyEC::keySizeInBits const):
(WebCore::CryptoKeyEC::platformSupportedCurve):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::getOID):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):

Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebCore/PAL/pal/spi/cocoa/CoreCryptoSPI.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::SubtleCrypto::deriveBits):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
(WebCore::CryptoKeyEC::CryptoKeyEC):
(WebCore::CryptoKeyEC::importPkcs8):
(WebCore::CryptoKeyEC::namedCurveString const):
* Source/WebCore/crypto/mac/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSA):
* Source/WebCore/crypto/mac/CryptoAlgorithmEd25519Mac.cpp:
(WebCore::signEd25519):
(WebCore::verifyEd25519):
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::keySizeInBits const):

Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* LayoutTests/crypto/subtle/ed25519-import-raw-key.html:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.js:
(run_test.):
(run_test.importVectorKeys):
* LayoutTests/imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa_vectors.js:
(getTestVectors):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp:
(WebCore::CryptoAlgorithmEd25519::importKey):
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformImportRaw):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::WebNotificationManager):
* Source/WebKit/WebProcess/WebProcess.cpp:
* enable-notifications.patch: Added.

Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/crypto/CryptoAlgorithmIdentifier.h:
* Source/WebCore/crypto/CryptoAlgorithmParameters.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::isSupportedExportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp: Added.
(WebCore::CryptoAlgorithmX25519::create):
(WebCore::CryptoAlgorithmX25519::identifier const):
(WebCore::CryptoAlgorithmX25519::generateKey):
(WebCore::CryptoAlgorithmX25519::deriveBits):
(WebCore::CryptoAlgorithmX25519::importKey):
(WebCore::CryptoAlgorithmX25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h: Added.
* Source/WebCore/crypto/mac/CryptoAlgorithmX25519.cpp: Added.
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519.h: Added.
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h: Added.
* Source/WebCore/crypto/parameters/X25519Params.cpp: Copied from Source/WebCore/crypto/CryptoAlgorithmIdentifier.h.
* Source/WebCore/crypto/parameters/X25519Params.h: Copied from Source/WebCore/crypto/CryptoAlgorithmIdentifier.h.
* Source/WebCore/crypto/parameters/X25519Params.idl: Copied from Source/WebCore/crypto/CryptoAlgorithmIdentifier.h.

Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

* LayoutTests/crypto/subtle/X25519-derive-bits-length-limits.html: Added.
* LayoutTests/crypto/subtle/X25519-generate-export-key-raw.html: Added.
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::generateKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::deriveBits):
* Source/WebCore/crypto/mac/CryptoAlgorithmX25519Mac.cpp: Added.
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformGeneratePair):
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h:
* Source/WebCore/crypto/parameters/X25519Params.idl:

Support for Curve 25519 - Algorithm X25519
<a href="https://bugs.webkit.org/show_bug.cgi?id=246145">https://bugs.webkit.org/show_bug.cgi?id=246145</a>
rdar://100401693

Reviewed by NOBODY (OOPS!).

This  is  part of  rdar://59005287, which requires adding support for the Curve 25519 . Here it is the second part, X25519 Algorithm.
* Source/WebCore/crypto/CryptoAlgorithmRegistry.cpp:
(WebCore::CryptoAlgorithmRegistry::identifier):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::normalizeCryptoAlgorithmParameters):
(WebCore::SubtleCrypto::generateKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h:
* Source/WebCore/crypto/mac/CryptoAlgorithmX25519Mac.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/mac/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformGeneratePair):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/762c690c4251c9dbb8860bd7ece7262fad562efb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100287 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109610 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169835 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10538 "Built successfully") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92706 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107495 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34515 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/89891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/77468 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24023 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/3188 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9313 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43513 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5014 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->