### PR TITLE
[CMake] Clang warnings about C code being built in C++ mode

### DIFF
--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -683,7 +683,7 @@ set_source_files_properties(
     libpas/src/libpas/bmalloc_heap_config.c
     libpas/src/libpas/pas_heap_config_kind.c
     libpas/src/libpas/pas_segregated_page_config_kind.c
-    PROPERTIES LANGUAGE CXX
+    PROPERTIES COMPILE_OPTIONS ${COMPILE_C_AS_CXX}
 )
 
 WEBKIT_FRAMEWORK_DECLARE(bmalloc)

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -534,7 +534,9 @@ static inline void pas_atomic_store_uint8(uint8_t* ptr, uint8_t value)
         /* clobbers */ : "memory"
     );
 #elif PAS_COMPILER(CLANG)
+PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     __c11_atomic_store((_Atomic uint8_t*)ptr, value, __ATOMIC_SEQ_CST);
+PAS_IGNORE_WARNINGS_END
 #else
     __atomic_store_n(ptr, value, __ATOMIC_SEQ_CST);
 #endif
@@ -913,7 +915,9 @@ static inline bool pas_compare_and_swap_pair_weak(void* raw_ptr,
     );
     return cond;
 #elif PAS_COMPILER(CLANG)
+PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     return __c11_atomic_compare_exchange_weak((_Atomic pas_pair*)raw_ptr, &old_value, new_value, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+PAS_IGNORE_WARNINGS_END
 #else
     return __atomic_compare_exchange_n((pas_pair*)raw_ptr, &old_value, new_value, true, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 #endif
@@ -951,7 +955,9 @@ static inline pas_pair pas_compare_and_swap_pair_strong(void* raw_ptr,
     );
     return pas_pair_create(low, high);
 #elif PAS_COMPILER(CLANG)
+PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     __c11_atomic_compare_exchange_strong((_Atomic pas_pair*)raw_ptr, &old_value, new_value, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+PAS_IGNORE_WARNINGS_END
     return old_value;
 #else
     __atomic_compare_exchange_n((pas_pair*)raw_ptr, &old_value, new_value, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
@@ -963,7 +969,9 @@ static inline pas_pair pas_atomic_load_pair_relaxed(void* raw_ptr)
 {
 #if PAS_COMPILER(CLANG)
     /* Since it is __ATOMIC_RELAXED, we do not need to care about memory barrier even when the implementation uses LL/SC. */
+PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     return __c11_atomic_load((_Atomic pas_pair*)raw_ptr, __ATOMIC_RELAXED);
+PAS_IGNORE_WARNINGS_END
 #else
     return __atomic_load_n((pas_pair*)raw_ptr, __ATOMIC_RELAXED);
 #endif
@@ -986,7 +994,9 @@ static inline void pas_atomic_store_pair(void* raw_ptr, pas_pair value)
         /* clobbers */ : "cc", "memory"
     );
 #elif PAS_COMPILER(CLANG)
+PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     __c11_atomic_store((_Atomic pas_pair*)raw_ptr, value, __ATOMIC_SEQ_CST);
+PAS_IGNORE_WARNINGS_END
 #else
     __atomic_store_n((pas_pair*)raw_ptr, value, __ATOMIC_SEQ_CST);
 #endif
@@ -996,7 +1006,9 @@ static inline void pas_atomic_store_pair_relaxed(void* raw_ptr, pas_pair value)
 {
     /* Since it is __ATOMIC_RELAXED, we do not need to care about memory barrier even when the implementation uses LL/SC. */
 #if PAS_COMPILER(CLANG)
+PAS_IGNORE_WARNINGS_BEGIN("atomic-alignment")
     __c11_atomic_store((_Atomic pas_pair*)raw_ptr, value, __ATOMIC_RELAXED);
+PAS_IGNORE_WARNINGS_END
 #else
     __atomic_store_n((pas_pair*)raw_ptr, value, __ATOMIC_RELAXED);
 #endif

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -439,3 +439,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     check_cxx_source_compiles("${REMOVE_CVREF_TEST_SOURCE}" STD_REMOVE_CVREF_IS_AVAILABLE)
     unset(CMAKE_REQUIRED_FLAGS)
 endif ()
+
+if (COMPILER_IS_GCC_OR_CLANG)
+    set(COMPILE_C_AS_CXX "-xc++")
+endif ()


### PR DESCRIPTION
#### e071c895f5fcd0dcbc1854af9dbdbc18883583a7
<pre>
[CMake] Clang warnings about C code being built in C++ mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=245176">https://bugs.webkit.org/show_bug.cgi?id=245176</a>

Reviewed by Yusuke Suzuki.

* Source/bmalloc/CMakeLists.txt: Use a flag to control how to treat C as
  CXX.
* Source/bmalloc/libpas/src/libpas/pas_utils.h: Add ignore
  atomic-alignment in some clang atomics
* Source/cmake/WebKitCompilerFlags.cmake: Set the C_AS_CXX flag for gcc
  and clang.

Canonical link: <a href="https://commits.webkit.org/256626@main">https://commits.webkit.org/256626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a6ef8615d2c68f9132a9f64f627aa5a2d9a4a82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104146 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164416 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3721 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31866 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100119 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2671 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80882 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29705 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84185 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72599 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85695 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38267 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18009 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80863 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36131 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19282 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27795 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4599 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41906 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83530 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41982 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38512 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18871 "Passed tests") | 
<!--EWS-Status-Bubble-End-->