### PR TITLE
Calling CSSStyleValue.parseAll() on a list-valued CSS property should split its value list

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-expected.txt
@@ -1,7 +1,7 @@
 
 PASS CSSStyleValue.parseAll() with a valid property returns a list with a single CSSStyleValue
 PASS CSSStyleValue.parseAll() is not case sensitive
-FAIL CSSStyleValue.parseAll() with a valid list-valued property returns a list with a single CSSStyleValue assert_equals: Result must be a list with three elements expected 3 but got 1
+PASS CSSStyleValue.parseAll() with a valid list-valued property returns a list with a single CSSStyleValue
 FAIL CSSStyleValue.parseAll() with a valid shorthand property returns a CSSStyleValue assert_equals: Result must be a list with one element expected 1 but got 4
 PASS CSSStyleValue.parseAll() with a valid custom property returns a list with a single CSSStyleValue
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -125,6 +125,10 @@
         "Indicates that this CSS property is a FillLayer property. It must have",
         "corresponding methods on the FillLayer class.",
         "",
+        "* separator:",
+        "Indicates separator for list-valued CSS property (populates",
+        "CSSProperty::listPropertySeparator().",
+        "",
         "* skip-builder:",
         "Ignore this property in the StyleBuilder.",
         "",
@@ -1013,7 +1017,8 @@
                 "aliases": [
                     "-webkit-animation-delay"
                 ],
-                "name-for-methods": "Delay"
+                "name-for-methods": "Delay",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1032,7 +1037,8 @@
                 "aliases": [
                     "-webkit-animation-direction"
                 ],
-                "name-for-methods": "Direction"
+                "name-for-methods": "Direction",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1045,7 +1051,8 @@
                 "aliases": [
                     "-webkit-animation-duration"
                 ],
-                "name-for-methods": "Duration"
+                "name-for-methods": "Duration",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1064,7 +1071,8 @@
                 "aliases": [
                     "-webkit-animation-fill-mode"
                 ],
-                "name-for-methods": "FillMode"
+                "name-for-methods": "FillMode",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1077,7 +1085,8 @@
                 "aliases": [
                     "-webkit-animation-iteration-count"
                 ],
-                "name-for-methods": "IterationCount"
+                "name-for-methods": "IterationCount",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1090,7 +1099,8 @@
                 "aliases": [
                     "-webkit-animation-name"
                 ],
-                "name-for-methods": "Name"
+                "name-for-methods": "Name",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1107,7 +1117,8 @@
                 "aliases": [
                     "-webkit-animation-play-state"
                 ],
-                "name-for-methods": "PlayState"
+                "name-for-methods": "PlayState",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1120,7 +1131,8 @@
                 "aliases": [
                     "-webkit-animation-timing-function"
                 ],
-                "name-for-methods": "TimingFunction"
+                "name-for-methods": "TimingFunction",
+                "separator": ","
             },
             "specification": {
                 "category": "css-animations",
@@ -1154,7 +1166,8 @@
             ],
             "codegen-properties": {
                 "name-for-methods": "Attachment",
-                "fill-layer-property": true
+                "fill-layer-property": true,
+                "separator": ","
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1182,7 +1195,8 @@
             ],
             "codegen-properties": {
                 "name-for-methods": "BlendMode",
-                "fill-layer-property": true
+                "fill-layer-property": true,
+                "separator": ","
             },
             "specification": {
                 "category": "css-compositing",
@@ -1203,7 +1217,8 @@
             "codegen-properties": {
                 "related-property": "-webkit-background-clip",
                 "name-for-methods": "Clip",
-                "fill-layer-property": true
+                "fill-layer-property": true,
+                "separator": " "
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1223,7 +1238,8 @@
         "background-image": {
             "codegen-properties": {
                 "name-for-methods": "Image",
-                "fill-layer-property": true
+                "fill-layer-property": true,
+                "separator": " "
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1234,7 +1250,8 @@
             "codegen-properties": {
                 "related-property": "-webkit-background-origin",
                 "name-for-methods": "Origin",
-                "fill-layer-property": true
+                "fill-layer-property": true,
+                "separator": " "
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1286,7 +1303,8 @@
         "background-size": {
             "codegen-properties": {
                 "name-for-methods": "Size",
-                "fill-layer-property": true
+                "fill-layer-property": true,
+                "separator": " "
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -2483,7 +2501,8 @@
         },
         "content": {
             "codegen-properties": {
-                "custom": "All"
+                "custom": "All",
+                "separator": ","
             },
             "specification": {
                 "category": "css-content",
@@ -4945,7 +4964,8 @@
                 "aliases": [
                     "-webkit-transition-delay"
                 ],
-                "name-for-methods": "Delay"
+                "name-for-methods": "Delay",
+                "separator": ","
             },
             "specification": {
                 "category": "css-transitions",
@@ -4958,7 +4978,8 @@
                 "aliases": [
                     "-webkit-transition-duration"
                 ],
-                "name-for-methods": "Duration"
+                "name-for-methods": "Duration",
+                "separator": ","
             },
             "specification": {
                 "category": "css-transitions",
@@ -6196,7 +6217,8 @@
         },
         "grid-auto-columns": {
             "codegen-properties": {
-                "converter": "GridTrackSizeList"
+                "converter": "GridTrackSizeList",
+                "separator": " "
             },
             "specification": {
                 "category": "css-grid",
@@ -6205,7 +6227,8 @@
         },
         "grid-auto-rows": {
             "codegen-properties": {
-                "converter": "GridTrackSizeList"
+                "converter": "GridTrackSizeList",
+                "separator": " "
             },
             "specification": {
                 "category": "css-grid",

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -87,6 +87,8 @@ public:
     static bool areInSameLogicalPropertyGroupWithDifferentMappingLogic(CSSPropertyID, CSSPropertyID);
     static bool isDescriptorOnly(CSSPropertyID);
     static bool isColorProperty(CSSPropertyID);
+    static UChar listValuedPropertySeparator(CSSPropertyID);
+    static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
 

--- a/Source/WebCore/css/makeprop.pl
+++ b/Source/WebCore/css/makeprop.pl
@@ -72,6 +72,7 @@ my %nameIsHighPriority;
 my %nameIsDeferred;
 my %nameIsInherited;
 my %namePriorityShouldSink;
+my %nameListPropertySeparator;
 my %logicalPropertyGroups;
 my %logicalPropertyGroupResolvers = (
     "logical" => {
@@ -325,6 +326,8 @@ sub addProperty($$)
                     $settingsFlags{$name} = $codegenProperties->{"settings-flag"};
                 } elsif ($codegenOptionName eq "color-property") {
                     $nameIsColorProperty{$name} = 1;
+                } elsif ($codegenOptionName eq "separator") {
+                    $nameListPropertySeparator{$name} = $codegenProperties->{"separator"};;
                 } elsif ($codegenOptionName eq "logical-property-group") {
                     die "Shorthand property $name can't belong to a logical property group\n" if exists $codegenProperties->{"longhands"};
                     $nameIsDeferred{$name} = 1;
@@ -733,6 +736,21 @@ print GPERF << "EOF";
     default:
         return false;
     }
+}
+
+UChar CSSProperty::listValuedPropertySeparator(CSSPropertyID id)
+{
+    switch (id) {
+EOF
+for my $name (sort keys %nameListPropertySeparator) {
+    print GPERF "    case CSSPropertyID::CSSProperty" . $nameToId{$name} . ":\n";
+    print GPERF "        return '" . substr($nameListPropertySeparator{$name}, 0, 1) . "';\n";
+}
+print GPERF << "EOF";
+    default:
+        break;
+    }
+    return '\\0';
 }
 
 bool CSSProperty::isDirectionAwareProperty(CSSPropertyID id)

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -42,17 +42,16 @@ class StylePropertyShorthand;
 
 class CSSStyleValueFactory {
 public:
-    
     static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, Document* = nullptr);
-    
-    static ExceptionOr<void> extractCSSValues(Vector<Ref<CSSValue>>&, const CSSPropertyID&, const String&);
-    static ExceptionOr<void> extractShorthandCSSValues(Vector<Ref<CSSValue>>&, const CSSPropertyID&, const String&);
-    static ExceptionOr<void> extractCustomCSSValues(Vector<Ref<CSSValue>>&, const AtomString&, const String&);
-
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
 
 protected:
     CSSStyleValueFactory() = delete;
+
+private:
+    static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(const CSSPropertyID&, const String&);
+    static ExceptionOr<void> extractShorthandCSSValues(Vector<Ref<CSSValue>>&, const CSSPropertyID&, const String&);
+    static ExceptionOr<void> extractCustomCSSValues(Vector<Ref<CSSValue>>&, const AtomString&, const String&);
 };
 
 } // namespace WebCore

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -305,6 +305,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'no-default-color': self.validate_boolean,
             'related-property': self.validate_string,
             'runtime-flag': self.validate_string,
+            'separator': self.validate_string,
             'setter': self.validate_string,
             'settings-flag': self.validate_string,
             'sink-priority': self.validate_boolean,


### PR DESCRIPTION
#### fcf22dcd95dc580101151f2bbe0e8ae601b22f3b
<pre>
Calling CSSStyleValue.parseAll() on a list-valued CSS property should split its value list
<a href="https://bugs.webkit.org/show_bug.cgi?id=247063">https://bugs.webkit.org/show_bug.cgi?id=247063</a>

Reviewed by Antti Koivisto.

Calling CSSStyleValue.parseAll() on a list-valued CSS property [1] should split its value list:
- <a href="https://drafts.css-houdini.org/css-typed-om/#parse-a-cssstylevalue">https://drafts.css-houdini.org/css-typed-om/#parse-a-cssstylevalue</a> (Step 4)
- <a href="https://drafts.css-houdini.org/css-typed-om/#subdivide-into-iterations">https://drafts.css-houdini.org/css-typed-om/#subdivide-into-iterations</a>

List-valued properties now indicate their separator in CSSProperties.json so that makeprop.pl
can property generate CSSProperty::listValuedPropertySeparator(), on which
CSSProperty::isListValuedProperty() relies. Right now, we only make use of the fact that a
property is list-valued or not. However, we will eventually need to know which separator its
uses in order to implement other parts of the CSS Typed OM specification.

[1] <a href="https://drafts.css-houdini.org/css-typed-om/#list-valued-properties">https://drafts.css-houdini.org/css-typed-om/#list-valued-properties</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSProperty.h:
(WebCore::CSSProperty::isListValuedProperty):
* Source/WebCore/css/makeprop.pl:
(addProperty):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::extractCSSValue):
(WebCore::CSSStyleValueFactory::parseStyleValue):
(WebCore::CSSStyleValueFactory::extractCSSValues): Deleted.
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:

Canonical link: <a href="https://commits.webkit.org/256070@main">https://commits.webkit.org/256070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6f21b4ce420276ac0387721b97479ab822dbb5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104022 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164297 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3580 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31739 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100022 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2569 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80750 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29610 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/97947 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84106 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72501 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38134 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17932 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19205 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/39898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41811 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1990 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38434 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->