### PR TITLE
DumpRenderTree does not seem to support PingLoad to HTTPS

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -426,7 +426,9 @@ imported/w3c/web-platform-tests/server-timing/navigation_timing_idl.https.html [
 imported/w3c/web-platform-tests/clear-site-data/executionContexts.sub.html [ Skip ]
 
 # Console log lines may appear in a different order so we silence them.
+http/tests/security/cookie-module.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/cookie-module-import-propagate.html [ DumpJSConsoleLogInStdErr ]
+http/tests/security/cookie-module-propagate.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/window-opened-from-sandboxed-iframe-should-inherit-sandbox.html [ DumpJSConsoleLogInStdErr ]
 http/wpt/html/cross-origin-embedder-policy/require-corp.https.html [ DumpJSConsoleLogInStdErr ]
 http/wpt/webauthn/public-key-credential-create-failure.https.html [ DumpJSConsoleLogInStdErr ]
@@ -5077,6 +5079,10 @@ webkit.org/b/227084 http/wpt/webxr/xrSession_ended_by_system.https.html [ Skip ]
 # rdar://79367325
 webkit.org/b/227086 imported/w3c/web-platform-tests/webxr/xrWebGLLayer_constructor.https.html [ Skip ]
 
+# Extra logging that needs to be silenced:
+imported/w3c/web-platform-tests/webxr/webxr_availability.http.sub.html [ DumpJSConsoleLogInStdErr ]
+
+
 # "Opacity on an inline element should apply on float child".
 webkit.org/b/234690 imported/w3c/web-platform-tests/css/css-color/inline-opacity-float-child.html [ ImageOnlyFailure ]
 
@@ -6062,3 +6068,9 @@ imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html [ Skip ]
 
 # WebKit2 Only
 fullscreen/fullscreen-enter-bottom-padding-animation.html [ Skip ]
+
+# Extra logging needed to be silenced:
+http/tests/loading/oauth.html [ DumpJSConsoleLogInStdErr ]
+http/tests/security/contentSecurityPolicy/video-with-https-url-allowed-by-csp-media-src-star.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-write/clipboard-write-disabled-by-feature-policy.tentative.https.sub.html [ DumpJSConsoleLogInStdErr ]
+imported/w3c/web-platform-tests/html/infrastructure/urls/terminology-0/document-base-url-initiated-grand-parent.https.window.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -307,8 +307,10 @@ imported/w3c/web-platform-tests/IndexedDB/storage-buckets.https.any.sharedworker
 webkit.org/b/246719 imported/w3c/web-platform-tests/reporting/generateTestReport-honors-endpoint.https.sub.html [ Failure ]
 webkit.org/b/246719 imported/w3c/web-platform-tests/reporting/cross-origin-report-no-credentials.https.sub.html [ Failure ]
 webkit.org/b/246719 imported/w3c/web-platform-tests/reporting/cross-origin-reports-isolated.https.sub.html [ Failure ]
-webkit.org/b/246351 imported/w3c/web-platform-tests/reporting/reporting-api-honors-limits.https.sub.html [ Failure ]
+
+# WebKitLegacy is flaky on reporting API
 webkit.org/b/246350 imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-sends-reports-on-violation.https.sub.html [ Pass Failure ]
+webkit.org/b/246350 imported/w3c/web-platform-tests/content-security-policy/reporting-api/report-to-directive-allowed-in-meta.https.sub.html [ Pass Failure ]
 
 http/wpt/mediarecorder [ Skip ]
 imported/w3c/web-platform-tests/mediacapture-record [ Skip ]
@@ -602,6 +604,7 @@ http/wpt/loading/redirect-headers.html [ Skip ]
 
 # No shared worker implementation for WK1
 http/wpt/shared-workers [ Skip ]
+imported/w3c/web-platform-tests/workers/modules/shared-worker-import-csp.html [ Skip ]
 
 # No service worker implementation for WK1
 http/tests/appcache/main-resource-redirect-with-sw.html [ Skip ]
@@ -1710,8 +1713,6 @@ webkit.org/b/225420 [ BigSur Release ] imported/w3c/web-platform-tests/css/css-s
 
 webkit.org/b/228238 [ BigSur Debug arm64 ] imported/w3c/web-platform-tests/IndexedDB/idbcursor-iterating-update.htm [ Pass Timeout ]
 
-webkit.org/b/228245 [ BigSur Release arm64 ] imported/w3c/web-platform-tests/workers/modules/shared-worker-import-csp.html [ Pass Failure ]
-
 webkit.org/b/244499 [ Debug ]  imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-referrer.html [ Pass Crash ]
 
 webkit.org/b/228260 [ BigSur Debug ] imported/w3c/web-platform-tests/IndexedDB/idb_binary_key_conversion.htm [ Pass Timeout ]
@@ -2149,3 +2150,7 @@ webkit.org/b/245102 imported/w3c/web-platform-tests/html/browsers/windows/auxili
 webkit.org/b/245902 [ Debug ] contentfiltering/allow-media-document.html [ Skip ]
 
 webkit.org/b/246653 [ Debug ] media/modern-media-controls/media-documents/click-on-video-should-not-pause.html [ Skip ]
+
+# CONSOLE MESSAGE output is nondeterministic and varies from run-to-run
+http/tests/security/basic-auth-subresource.html [ Failure Pass ]
+http/tests/security/contentSecurityPolicy/video-with-https-url-allowed-by-csp-media-src-star.html [ Failure Pass ]

--- a/LayoutTests/platform/mac-wk1/http/tests/inspector/network/getSerializedCertificate-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/inspector/network/getSerializedCertificate-expected.txt
@@ -1,0 +1,16 @@
+CONSOLE MESSAGE: Blocked https://localhost:8443/resources/square100.png from asking for credentials because it is a cross-origin request.
+Tests that the NetworkAgent is able to get a serialized certificate for a given request.
+
+
+== Running test suite: Network.getSerializedCertificate
+-- Running test case: Network.getSerializedCertificate.HTTP
+PASS: Should produce an exception.
+Error: Missing certificate of resource for given requestId
+
+-- Running test case: Network.getSerializedCertificate.HTTPS
+PASS: Request should have serializable certificate.
+
+-- Running test case: Network.getSerializedCertificate.Invalid
+PASS: Should produce an exception.
+Error: Missing resource for given requestId
+

--- a/LayoutTests/platform/mac-wk1/http/tests/loading/oauth-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/loading/oauth-expected.txt
@@ -1,0 +1,7 @@
+main frame - didStartProvisionalLoadForFrame
+main frame - didCommitLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+main frame - didHandleOnloadEventsForFrame
+main frame - didFinishLoadForFrame
+http://127.0.0.1:8000/loading/resources/oauth-subresource.py - didReceiveAuthenticationChallenge - Simulating cancelled authentication sheet
+

--- a/LayoutTests/platform/mac-wk1/http/tests/security/basic-auth-subresource-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/basic-auth-subresource-expected.txt
@@ -1,0 +1,67 @@
+http://127.0.0.1:8000/security/resources/subresource1/protected-image.py - didReceiveAuthenticationChallenge - Responding with testUser:testPassword
+CONSOLE MESSAGE: Blocked http://localhost:8000/security/resources/subresource1/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource1/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource1/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked http://localhost:8000/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+http://127.0.0.1:8000/security/resources/subresource2/protected-image.py - didReceiveAuthenticationChallenge - Responding with testUser:testPassword
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked http://localhost:8000/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/resources/subresource2/protected-image.py from asking for credentials because it is a cross-origin request.
+Tests whether credentials are requested for protected subresources. Credentials should be requested if and only if the origin of the subresource matches the origin of the top-most frame.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Images loaded from top-level frame:
+PASS did load image with origin http://127.0.0.1:8000.
+
+PASS did not load image with origin http://localhost:8000.
+
+PASS did not load image with origin https://localhost:8443.
+
+Images loaded from cross-origin iframe:
+PASS did not load image with origin http://localhost:8000.
+
+PASS did load image with origin http://127.0.0.1:8000.
+
+PASS did not load image with origin https://127.0.0.1:8443.
+
+PASS did not load image with origin https://localhost:8443.
+
+Images loaded from sandboxed same-origin iframe:
+PASS did load image with origin http://127.0.0.1:8000.
+
+PASS did load image with origin http://127.0.0.1:8000.
+
+PASS did not load image with origin https://127.0.0.1:8443.
+
+PASS did not load image with origin https://localhost:8443.
+
+Images loaded from sandboxed cross-origin iframe:
+PASS did not load image with origin http://localhost:8000.
+
+PASS did load image with origin http://127.0.0.1:8000.
+
+PASS did not load image with origin https://127.0.0.1:8443.
+
+PASS did not load image with origin https://localhost:8443.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image-https-expected.txt
@@ -1,0 +1,28 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/contentSecurityPolicy/resources/securitypolicyviolation-test.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/js-test-resources/js-test-post.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/resources/abe.png because it does not appear in the img-src directive of the Content Security Policy.
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Check that a SecurityPolicyViolationEvent is fired upon blocking an image.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Kicking off the tests:
+PASS window.e.documentURI is "https://127.0.0.1:8443/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image.html"
+PASS window.e.referrer is "http://127.0.0.1:8000/"
+PASS window.e.blockedURI is "http://127.0.0.1:8000/security/resources/abe.png"
+PASS window.e.violatedDirective is "img-src"
+PASS window.e.effectiveDirective is "img-src"
+PASS window.e.originalPolicy is "img-src 'none'"
+PASS window.e.sourceFile is "https://127.0.0.1:8443/security/contentSecurityPolicy/1.1/securitypolicyviolation-block-image.html"
+PASS window.e.lineNumber is 25
+PASS window.e.columnNumber is 16
+PASS window.e.statusCode is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/report-status-code-zero-when-using-https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/report-status-code-zero-when-using-https-expected.txt
@@ -1,0 +1,17 @@
+CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/security/contentSecurityPolicy/resources/go-to-echo-report.py?test=/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html from asking for credentials because it is a cross-origin request.
+This tests that the status-code is 0 in the Content Security Policy violation report for a protected resource delivered over HTTPS.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+CSP report received:
+CONTENT_TYPE: application/csp-report
+HTTP_HOST: 127.0.0.1:8443
+HTTP_REFERER: https://127.0.0.1:8443/security/contentSecurityPolicy/resources/generate-csp-report.py?test=/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html
+REQUEST_METHOD: POST
+REQUEST_URI: /security/contentSecurityPolicy/resources/save-report.py?test=/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html
+=== POST DATA ===
+{"type":"csp-violation","url":"https://127.0.0.1:8443/security/contentSecurityPolicy/resources/generate-csp-report.py?test=/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html","csp-report":{"document-uri":"https://127.0.0.1:8443/security/contentSecurityPolicy/resources/generate-csp-report.py?test=/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html","referrer":"http://127.0.0.1:8000/","violated-directive":"script-src-elem","effective-directive":"script-src-elem","original-policy":"script-src 'self'; report-uri save-report.py?test=/security/contentSecurityPolicy/report-status-code-zero-when-using-https.html","blocked-uri":"inline","status-code":0}}

--- a/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/video-with-https-url-allowed-by-csp-media-src-star-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/video-with-https-url-allowed-by-csp-media-src-star-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:8443/media-resources/content/test.mp4 from asking for credentials because it is a cross-origin request.
+This tests that loading a video with an HTTPS URL is allowed when the page has Content Security Policy "media-src *".
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS did load video.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/insecure-image-redirects-to-basic-auth-secure-image-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-image-redirects-to-basic-auth-secure-image.html was allowed to display insecure content from http://127.0.0.1:8080/resources/redirect.py?url=https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py.
+
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+This test opens a new window to a secure page that loads an insecure image that redirects to a secure image guarded by basic authentication. The secure image should be blocked because it requires credentials and was loaded via an insecure redirect.
+
+PASS did not load image.

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https-expected.txt
@@ -1,0 +1,15 @@
+CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/secure-redirect-to-insecure-redirect-to-basic-auth-secure-image.https.html was allowed to display insecure content from http://127.0.0.1:8080/resources/redirect.py?url=https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py.
+
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+This test loads a secure image that redirects to an insecure image that redirects to a secure image guarded by basic authentication. The secure image should be blocked because it requires credentials and was loaded via an insecure redirect.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS did not load image.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-secure-image.https-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://localhost:8443/security/mixedContent/resources/subresource/protected-image.py from asking for credentials because it is a cross-origin request.
+This test loads a secure image that redirects to a secure image that redirects to a secure image guarded by basic authentication. The secure image should not load because it is cross-origin.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS did not load image.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/common/media.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/feature-policy/resources/autoplay.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/media/A4.mp4 from asking for credentials because it is a cross-origin request.
+
+
+PASS Feature-Policy allow="autoplay" allows same-origin navigation in an iframe.
+FAIL Feature-Policy allow="autoplay" disallows cross-origin navigation in an iframe. assert_false: autoplay expected false got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute.https.sub-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/common/media.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/feature-policy/resources/autoplay.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/media/A4.mp4 from asking for credentials because it is a cross-origin request.
+
+
+PASS Feature policy "autoplay" can be enabled in same-origin iframe using allow="autoplay" attribute
+PASS Feature policy "autoplay" can be enabled in cross-origin iframe using allow="autoplay" attribute
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub-expected.txt
@@ -1,0 +1,9 @@
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/common/media.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/feature-policy/resources/autoplay.js from asking for credentials because it is a cross-origin request.
+CONSOLE MESSAGE: Blocked https://127.0.0.1:9443/media/A4.mp4 from asking for credentials because it is a cross-origin request.
+
+
+PASS Feature-Policy header: autoplay "none" has no effect on the top level document.
+FAIL Feature-Policy header: autoplay "none" disallows same-origin iframes. assert_false: autoplay expected false got true
+FAIL Feature-Policy header: autoplay "none" disallows cross-origin iframes. assert_false: autoplay expected false got true
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/infrastructure/server/wpt-server-http.sub-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/infrastructure/server/wpt-server-http.sub-expected.txt
@@ -1,0 +1,44 @@
+Blocked access to external URL http://www.localhost:8800/media/1x1-green.png
+Blocked access to external URL http://www.localhost:8801/media/1x1-green.png
+Blocked access to external URL http://www1.localhost:8800/media/1x1-green.png
+Blocked access to external URL http://www1.localhost:8801/media/1x1-green.png
+Blocked access to external URL http://www2.localhost:8800/media/1x1-green.png
+Blocked access to external URL http://www2.localhost:8801/media/1x1-green.png
+Blocked access to external URL http://xn--lve-6lad.localhost:8800/media/1x1-green.png
+Blocked access to external URL http://xn--lve-6lad.localhost:8801/media/1x1-green.png
+Blocked access to external URL http://xn--n8j6ds53lwwkrqhv28a.localhost:8800/media/1x1-green.png
+Blocked access to external URL http://xn--n8j6ds53lwwkrqhv28a.localhost:8801/media/1x1-green.png
+Blocked access to external URL http://nonexistent.localhost:8800/media/1x1-green.png
+Blocked access to external URL http://nonexistent.localhost:8801/media/1x1-green.png
+Blocked access to external URL https://www.localhost:9443/media/1x1-green.png
+Blocked access to external URL https://www1.localhost:9443/media/1x1-green.png
+Blocked access to external URL https://www2.localhost:9443/media/1x1-green.png
+Blocked access to external URL https://xn--lve-6lad.localhost:9443/media/1x1-green.png
+Blocked access to external URL https://xn--n8j6ds53lwwkrqhv28a.localhost:9443/media/1x1-green.png
+Blocked access to external URL https://nonexistent.localhost:8800/media/1x1-green.png
+Blocked access to external URL https://nonexistent.localhost:8801/media/1x1-green.png
+CONSOLE MESSAGE: Blocked https://localhost:9443/media/1x1-green.png from asking for credentials because it is a cross-origin request.
+
+PASS HTTP protocol, no subdomain, port #1
+PASS HTTP protocol, no subdomain, port #2
+FAIL HTTP protocol, www subdomain #1, port #1 assert_true: expected true got false
+FAIL HTTP protocol, www subdomain #1, port #2 assert_true: expected true got false
+FAIL HTTP protocol, www subdomain #2, port #1 assert_true: expected true got false
+FAIL HTTP protocol, www subdomain #2, port #2 assert_true: expected true got false
+FAIL HTTP protocol, www subdomain #3, port #1 assert_true: expected true got false
+FAIL HTTP protocol, www subdomain #3, port #2 assert_true: expected true got false
+FAIL HTTP protocol, punycode subdomain #1, port #1 assert_true: expected true got false
+FAIL HTTP protocol, punycode subdomain #1, port #2 assert_true: expected true got false
+FAIL HTTP protocol, punycode subdomain #2, port #1 assert_true: expected true got false
+FAIL HTTP protocol, punycode subdomain #2, port #2 assert_true: expected true got false
+PASS HTTP protocol, non-existent domain, port #1
+PASS HTTP protocol, non-existent domain, port #2
+PASS HTTPS protocol, no subdomain
+FAIL HTTPS protocol, www subdomain #1 assert_true: expected true got false
+FAIL HTTPS protocol, www subdomain #2 assert_true: expected true got false
+FAIL HTTPS protocol, www subdomain #3 assert_true: expected true got false
+FAIL HTTPS protocol, punycode subdomain #1 assert_true: expected true got false
+FAIL HTTPS protocol, punycode subdomain #2 assert_true: expected true got false
+PASS HTTPS protocol, non-existent domain, port #1
+PASS HTTPS protocol, non-existent domain, port #2
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/secure-contexts/basic-popup-and-iframe-tests-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/secure-contexts/basic-popup-and-iframe-tests-expected.txt
@@ -1,0 +1,21 @@
+CONSOLE MESSAGE: Blocked https://localhost:9443/secure-contexts/basic-popup-and-iframe-tests.https.js from asking for credentials because it is a cross-origin request.
+
+FAIL Test Window.isSecureContext for HTTP creator assert_false: http: creator should not be a Secure Context expected false got true
+FAIL Test Window.isSecureContext in an iframe loading an http: URI assert_false: an http: URI in an iframe should not create a Secure Context expected false got true
+PASS Test Window.isSecureContext in an iframe loading an https: URI
+PASS Test Window.isSecureContext in an iframe loading a blob: URI
+PASS Test Window.isSecureContext in an iframe loading a srcdoc
+PASS Test Window.isSecureContext in an iframe loading a javascript: URI
+PASS Test Window.isSecureContext in an iframe loading about:blank
+PASS Test Window.isSecureContext in an iframe loading initial about:blank
+FAIL Test Window.isSecureContext in a sandboxed iframe loading an http: URI assert_false: an http: URI in a sandboxed iframe should not create a Secure Context expected false got true
+PASS Test Window.isSecureContext in a sandboxed iframe loading an https: URI
+PASS Test Window.isSecureContext in a sandboxed iframe loading a blob: URI
+PASS Test Window.isSecureContext in a sandboxed iframe loading a srcdoc
+FAIL Test Window.isSecureContext in a popup loading an http: URI assert_false: an http: URI in a popup should not create a Secure Context expected false got true
+PASS Test Window.isSecureContext in a popup loading an https: URI
+PASS Test Window.isSecureContext in a popup loading a blob: URI
+PASS Test Window.isSecureContext in a popup loading a javascript: URI
+PASS Test Window.isSecureContext in a popup loading about:blank
+PASS Test Window.isSecureContext in a popup loading initial about:blank
+

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  *           (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -83,8 +83,7 @@ public:
 #endif
 
     WEBCORE_EXPORT static void setAllowsAnySSLCertificate(bool);
-    static bool allowsAnySSLCertificate();
-
+    WEBCORE_EXPORT static bool allowsAnySSLCertificate();
 
     static void setPaintTimingEnabled(bool isEnabled) { shared().m_isPaintTimingEnabled = isEnabled; }
     static bool paintTimingEnabled() { return shared().m_isPaintTimingEnabled; }

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -154,6 +154,11 @@ void setAllowsAnySSLCertificate(bool allowAnySSLCertificate)
     DeprecatedGlobalSettings::setAllowsAnySSLCertificate(allowAnySSLCertificate);
 }
 
+bool allowsAnySSLCertificate()
+{
+    return DeprecatedGlobalSettings::allowsAnySSLCertificate();
+}
+
 void setLinkedOnOrAfterEverythingForTesting()
 {
 #if PLATFORM(COCOA)

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -56,6 +56,7 @@ void setLogChannelToAccumulate(const String& name) TEST_SUPPORT_EXPORT;
 void clearAllLogChannelsToAccumulate() TEST_SUPPORT_EXPORT;
 void initializeLogChannelsIfNecessary() TEST_SUPPORT_EXPORT;
 void setAllowsAnySSLCertificate(bool) TEST_SUPPORT_EXPORT;
+bool allowsAnySSLCertificate() TEST_SUPPORT_EXPORT;
 void setLinkedOnOrAfterEverythingForTesting() TEST_SUPPORT_EXPORT;
 
 void installMockGamepadProvider() TEST_SUPPORT_EXPORT;

--- a/Tools/DumpRenderTree/TestRunner.cpp
+++ b/Tools/DumpRenderTree/TestRunner.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Joone Hur <joone@kldp.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -2337,6 +2337,11 @@ void TestRunner::uiScriptDidComplete(const String& result, unsigned callbackID)
 void TestRunner::setAllowsAnySSLCertificate(bool allowsAnySSLCertificate)
 {
     WebCoreTestSupport::setAllowsAnySSLCertificate(allowsAnySSLCertificate);
+}
+
+bool TestRunner::allowsAnySSLCertificate()
+{
+    return WebCoreTestSupport::allowsAnySSLCertificate();
 }
 
 void TestRunner::setOpenPanelFiles(JSContextRef context, JSValueRef filesValue)

--- a/Tools/DumpRenderTree/TestRunner.h
+++ b/Tools/DumpRenderTree/TestRunner.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,6 +60,10 @@ public:
     void addDisallowedURL(JSStringRef url);
     const std::set<std::string>& allowedHosts() const { return m_allowedHosts; }
     void setAllowedHosts(std::set<std::string> hosts) { m_allowedHosts = WTFMove(hosts); }
+    bool allowAnyHTTPSCertificateForAllowedHosts() const { return m_allowAnyHTTPSCertificateForAllowedHosts; }
+    void setAllowAnyHTTPSCertificateForAllowedHosts(bool allow) { m_allowAnyHTTPSCertificateForAllowedHosts = allow; }
+    const std::set<std::string>& localhostAliases() const { return m_localhostAliases; }
+    void setLocalhostAliases(std::set<std::string> hosts) { m_localhostAliases = WTFMove(hosts); }
     void addURLToRedirect(std::string origin, std::string destination);
     const char* redirectionDestinationForURL(const char*);
     void clearAllApplicationCaches();
@@ -134,6 +138,7 @@ public:
     void resetPageVisibility();
 
     static void setAllowsAnySSLCertificate(bool);
+    static bool allowsAnySSLCertificate();
 
     void waitForPolicyDelegate();
     size_t webHistoryItemCount();
@@ -405,6 +410,7 @@ private:
 
     void setGeolocationPermissionCommon(bool allow);
 
+    bool m_allowAnyHTTPSCertificateForAllowedHosts { false };
     bool m_disallowIncreaseForApplicationCacheQuota { false };
     bool m_dumpApplicationCacheDelegateCallbacks { false };
     bool m_dumpAsAudio { false };
@@ -473,6 +479,7 @@ private:
 
     std::set<std::string> m_willSendRequestClearHeaders;
     std::set<std::string> m_allowedHosts;
+    std::set<std::string> m_localhostAliases;
 
     std::vector<uint8_t> m_audioResult;
 

--- a/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
+++ b/Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007, 2011 Apple Inc.  All rights reserved.
+ * Copyright (C) 2007-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #import "DumpRenderTree.h"
 #import "TestRunner.h"
 #import <JavaScriptCore/RegularExpression.h>
+#import <WebCore/ProtectionSpaceCocoa.h>
 #import <WebKit/WebDataSourcePrivate.h>
 #import <WebKit/WebKitLegacy.h>
 #import <wtf/Assertions.h>
@@ -143,6 +144,11 @@ BOOL isAllowedHost(NSString *host)
     return gTestRunner->allowedHosts().count(host.UTF8String);
 }
 
+BOOL canAuthenticateServerTrustAgainstProtectionSpace(NSString *host)
+{
+    return isLocalhost(host) || gTestRunner->localhostAliases().contains(host.UTF8String) || (gTestRunner->allowAnyHTTPSCertificateForAllowedHosts() && isAllowedHost(host));
+}
+
 -(NSURLRequest *)webView: (WebView *)wv resource:identifier willSendRequest: (NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse fromDataSource:(WebDataSource *)dataSource
 {
     if (!done && gTestRunner->dumpResourceLoadCallbacks()) {
@@ -198,6 +204,14 @@ BOOL isAllowedHost(NSString *host)
 
         [[challenge sender] rejectProtectionSpaceAndContinueWithChallenge:challenge];
         return;
+    }
+
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        if (gTestRunner->allowsAnySSLCertificate()) {
+            [[challenge sender] useCredential:[NSURLCredential credentialWithUser:@"accept server trust" password:@"" persistence:NSURLCredentialPersistenceNone]
+                forAuthenticationChallenge:challenge];
+            return;
+        }
     }
 
     if (!gTestRunner->handlesAuthenticationChallenges()) {
@@ -279,4 +293,21 @@ BOOL isAllowedHost(NSString *host)
 
     return gTestRunner->shouldPaintBrokenImage();
 }
+
+-(BOOL)webView:(WebView *)webView resource:(id)identifier canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpaceNS forDataSource:(WebDataSource *)dataSource
+{
+    if (!done && gTestRunner->dumpResourceLoadCallbacks()) {
+        NSString *string = [NSString stringWithFormat:@"%@ - canAuthenticateAgainstProtectionSpace", identifier];
+        printf("%s\n", [string UTF8String]);
+    }
+
+    WebCore::ProtectionSpace protectionSpace(protectionSpaceNS);
+
+    auto scheme = protectionSpace.authenticationScheme();
+    if (scheme == WebCore::ProtectionSpaceBase::AuthenticationScheme::ServerTrustEvaluationRequested)
+        return canAuthenticateServerTrustAgainstProtectionSpace(protectionSpaceNS.host);
+
+    return scheme <= WebCore::ProtectionSpaceBase::AuthenticationScheme::HTTPDigest || scheme == WebCore::ProtectionSpaceBase::AuthenticationScheme::OAuth;
+}
+
 @end


### PR DESCRIPTION
#### 6db9bb4cc51f9fd26437c89e48a570944989bcfb
<pre>
DumpRenderTree does not seem to support PingLoad to HTTPS
<a href="https://bugs.webkit.org/show_bug.cgi?id=246719">https://bugs.webkit.org/show_bug.cgi?id=246719</a>
&lt;rdar://101040717&gt;

Reviewed by Chris Dumez.

Revise DumpRenderTree to handle ServerTrust protection space evaluations,
and to allow them under the same cases as Modern WebKit.

* LayoutTests/platform/mac-wk1/TestExpectations: Correct some expectations.
* Source/WebCore/page/DeprecatedGlobalSettings.h:
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::allowsAnySSLCertificate): Added getter to expose state to DRT.
* Source/WebCore/testing/js/WebCoreTestSupport.h:
* Tools/DumpRenderTree/TestRunner.cpp:
(TestRunner::allowsAnySSLCertificate): Added.
* Tools/DumpRenderTree/TestRunner.h:
(TestRunner::allowAnyHTTPSCertificateForAllowedHosts const): Added.
(TestRunner::setAllowAnyHTTPSCertificateForAllowedHosts): Added.
(TestRunner::localhostAliases const): Added.
(TestRunner::setLocalhostAliases): Added.
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(initializeGlobalsFromCommandLineOptions): Update to recognize the allowed hosts test runner argument.
(dumpRenderTree):
(runTest):
* Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm:
(canAuthenticateServerTrustAgainstProtectionSpace): Added.
(-[ResourceLoadDelegate webView:resource:didReceiveAuthenticationChallenge:fromDataSource:]): Updated to behave
the same way as WebKitTestRunner.
(-[ResourceLoadDelegate webView:resource:canAuthenticateAgainstProtectionSpace:forDataSource:]): Added.

Canonical link: <a href="https://commits.webkit.org/256173@main">https://commits.webkit.org/256173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca607b87019691dc9b156f3a652412304c51f9a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94921 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104527 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164791 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4154 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32250 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87224 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100448 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3001 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29987 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84915 "Found 1 new API test failure: TestWebKitAPI.TLSVersion.LegacySubresources (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72879 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38662 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18297 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19578 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40419 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38810 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->