### PR TITLE
XMLSerializer.serializeToString() should support Attr node as parameter

### DIFF
--- a/LayoutTests/fast/dom/XMLSerializer-expected.txt
+++ b/LayoutTests/fast/dom/XMLSerializer-expected.txt
@@ -1,6 +1,7 @@
-This tests XMLSerializer on different node types. If the test is successful, there should be five lines of output. The first line should be the child1 tag. The second should be the child2 tag. The third one should be a comment, the fourth one should be the complete document and the fifth one should be the complete document but serialized from a document fragment node.
-<child1>First child</child1>
-<child2 attr="an attribute">Second child</child2>
-<!-- A comment -->
-<test><child1>First child</child1><child2 attr="an attribute">Second child</child2><!-- A comment --></test>
-<test><child1>First child</child1><child2 attr="an attribute">Second child</child2><!-- A comment --></test>
+
+PASS Check Element serialization.
+PASS Check Comment serialization.
+PASS Check Document serialization.
+PASS Check DocumentFragment serialization.
+PASS Check Attr serializiation.
+

--- a/LayoutTests/fast/dom/XMLSerializer.html
+++ b/LayoutTests/fast/dom/XMLSerializer.html
@@ -1,53 +1,52 @@
+<!DOCTYPE html>
 <html>
-<head>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div id="log"></div>
 <script>
-function debug(str) {
-	li = document.createElement('li');
-	li.appendChild(document.createTextNode(str));
-	document.getElementById('console').appendChild(li);
-}
-
 function parseDocument() {
-	str = '<test><child1>First child</child1>';
-	str += '<child2 attr="an attribute">Second child</child2>';
-	str += '<!-- A comment --></test>';
+    str = '<test><child1>First child</child1>';
+    str += '<child2 attr="an attribute">Second child</child2>';
+    str += '<!-- A comment --></test>';
 	
-	parser = new DOMParser();
-	doc = parser.parseFromString(str, 'text/xml');
-	
-	
-	return doc;
+    parser = new DOMParser();
+    return parser.parseFromString(str, 'text/xml');
 }
 
-function runTests() {
-	if (window.testRunner) {
-    	testRunner.dumpAsText();
-	}
+var doc = parseDocument();
+var child1 = doc.documentElement.firstChild;
+var child2 = child1.nextSibling
+var serializer = new XMLSerializer();
+var comment = child2.nextSibling;
 
-	doc = parseDocument();
-	
-	child1 = doc.documentElement.firstChild;
-	child2 = child1.nextSibling
-	comment = child2.nextSibling;
-	
-	fragment = doc.createDocumentFragment();
-	fragment.appendChild(doc.documentElement.cloneNode(true))
-	
-	serializer = new XMLSerializer();
-	
-	debug(serializer.serializeToString(child1));
-	debug(serializer.serializeToString(child2));
-	debug(serializer.serializeToString(comment));	
-	debug(serializer.serializeToString(doc));
-	debug(serializer.serializeToString(fragment));
-	
-}
+test(function() {
+    assert_equals(serializer.serializeToString(child1), '<child1>First child</child1>');
+    assert_equals(serializer.serializeToString(child2), '<child2 attr="an attribute">Second child</child2>');
+}, 'Check Element serialization.');
 
+test(function() {
+    assert_equals(serializer.serializeToString(comment), '<!-- A comment -->');
+}, 'Check Comment serialization.');
+
+test(function() {
+    assert_equals(serializer.serializeToString(doc), '<test><child1>First child</child1><child2 attr="an attribute">Second child</child2><!-- A comment --></test>');
+}, 'Check Document serialization.');
+
+test(function() {
+    var fragment = doc.createDocumentFragment();
+    fragment.appendChild(doc.documentElement.cloneNode(true));
+    assert_equals(serializer.serializeToString(fragment), '<test><child1>First child</child1><child2 attr="an attribute">Second child</child2><!-- A comment --></test>');
+}, 'Check DocumentFragment serialization.');
+
+test(function() {
+    var attr = child2.getAttributeNode('attr');
+    assert_equals(serializer.serializeToString(attr), 'an attribute');
+
+    var element = doc.createElement('foo');
+    element.setAttribute('attr1', ' abc\ndef\tghi\r');
+    assert_equals(serializer.serializeToString(element), '<foo attr1=" abc&#10;def&#9;ghi&#13;"/>');
+}, 'Check Attr serializiation.');
 </script>
-</head>
-<body onload="runTests()">
-This tests XMLSerializer on different node types. If the test is successful, there should be five lines of output. The first line should be the child1 tag. The second should be the child2 tag. The third one should be a comment, the fourth one should be the complete document and the fifth one should be the complete document but serialized from a document fragment node.
-<ul id="console">
-</ul>
 </body>
 </html>

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004-2017 Apple Inc. All rights reserved.
- * Copyright (C) 2009, 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "MarkupAccumulator.h"
 
+#include "Attr.h"
 #include "CDATASection.h"
 #include "Comment.h"
 #include "CommonAtomStrings.h"
@@ -599,7 +600,8 @@ void MarkupAccumulator::appendNonElementNode(StringBuilder& result, const Node& 
         result.append("<![CDATA[", downcast<CDATASection>(node).data(), "]]>");
         break;
     case Node::ATTRIBUTE_NODE:
-        ASSERT_NOT_REACHED();
+        // Only XMLSerializer can pass an Attr. So, |documentIsHTML| flag is false.
+        appendAttributeValue(result, downcast<Attr>(node).value(), false);
         break;
     }
 }


### PR DESCRIPTION
#### 38ce5b803b349852d5800b8027e123ca8248e30f
<pre>
XMLSerializer.serializeToString() should support Attr node as parameter

XMLSerializer.serializeToString() should support Attr node as parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=247096">https://bugs.webkit.org/show_bug.cgi?id=247096</a>

Reviewed by Ryosuke Niwa.

This is to align Webkit with Blink / Chrome.

Inspired from - <a href="https://chromium.googlesource.com/chromium/src.git/+/271184ec08ca181a7d93eed532f3ce9efb9c0bcc">https://chromium.googlesource.com/chromium/src.git/+/271184ec08ca181a7d93eed532f3ce9efb9c0bcc</a>

The specification [1] doesn&apos;t define the behavior for Attr because the
specification assumes Attr is not a Node. However, passing an Attr is possible
now and we should not have an assertion failure.

This patch is aimed to serializeToString() matching to Web Specification.
It means serializing the attribute value.

[1] <a href="https://w3c.github.io/DOM-Parsing/#dfn-concept-serialize-xml">https://w3c.github.io/DOM-Parsing/#dfn-concept-serialize-xml</a>

* Source/WebCore/editing/MarkupAccumulator.cpp: Added &quot;Attr.h&quot; header
(MarkAccumulator::appendNonElementNode): Add result value for &quot;Attribute Node&quot;
* LayoutTests/fast/dom/XMLSerializer.html: Updated to use &quot;testharness&quot; and Attr test as well
* LayoutTests/fast/dom/XMLSerializer-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256126@main">https://commits.webkit.org/256126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2432e72a83e7f2253e6cde8e60eb145d34eaf473

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104210 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164482 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3797 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31933 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100179 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2732 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80950 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29756 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72651 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38335 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18042 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36196 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19316 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4228 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41962 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38545 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->