### PR TITLE
Validate import-assertions in static module imports

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/content-type-checking-expected.txt
@@ -1,12 +1,14 @@
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'application/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/html css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
 
-FAIL text/css assert_unreached: Reached unreachable code
-PASS application/css
-PASS text/html+css
-FAIL text/css;boundary=something assert_unreached: Reached unreachable code
-FAIL text/css;foo=bar assert_unreached: Reached unreachable code
+Harness Error (FAIL), message = TypeError: Import assertion type "css" is not valid
+
+NOTRUN text/css
+NOTRUN application/css
+NOTRUN text/html+css
+NOTRUN text/css;boundary=something
+NOTRUN text/css;foo=bar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/import-css-module-basic-expected.txt
@@ -5,6 +5,6 @@ I am a test div.
 I am a test div.
 I am a test div.
 
-Harness Error (FAIL), message = ReferenceError: Can't find variable: unreachable
+Harness Error (FAIL), message = TypeError: Import assertion type "css" is not valid
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/integrity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/integrity-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL The integrity attribute must be verified on the top-level of a module loading a CSS module and allow it to execute when it matches assert_array_equals: The module and its dependency must have executed lengths differ, expected array ["integrity-matches,css:#test { background-color: rgb(255, 0, 0); }"] length 1, got [] length 0
-PASS The integrity attribute must be verified on the top-level of a module loading a CSS module and not allow it to execute when there's a mismatch
+Harness Error (FAIL), message = TypeError: Import assertion type "css" is not valid
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/load-error-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/load-error-events-expected.txt
@@ -1,14 +1,20 @@
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
 
-FAIL inline, 200, parser-inserted assert_unreached: Error event should not be fired. Reached unreachable code
-PASS inline, 404, parser-inserted
-FAIL src, 200, parser-inserted assert_unreached: Error event should not be fired. Reached unreachable code
-PASS src, 404, parser-inserted
-FAIL src, 200, not parser-inserted assert_unreached: Error event should not be fired. Reached unreachable code
-PASS src, 404, not parser-inserted
-FAIL inline, 200, not parser-inserted assert_unreached: Error event should not be fired. Reached unreachable code
-PASS inline, 404, not parser-inserted
+Harness Error (FAIL), message = TypeError: Import assertion type "css" is not valid
+
+NOTRUN inline, 200, parser-inserted
+NOTRUN inline, 404, parser-inserted
+NOTRUN src, 200, parser-inserted
+NOTRUN src, 404, parser-inserted
+NOTRUN src, 200, not parser-inserted
+NOTRUN src, 404, not parser-inserted
+NOTRUN inline, 200, not parser-inserted
+NOTRUN inline, 404, not parser-inserted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/import-assertions/invalid-type-assertion-error-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/import-assertions/invalid-type-assertion-error-expected.txt
@@ -1,3 +1,7 @@
+CONSOLE MESSAGE: TypeError: Import assertion type "notARealType" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "js" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "javascript" is not valid
 
-FAIL Test that invalid module type assertion leads to TypeError on window. assert_equals: expected 4 but got 8
+PASS Test that invalid module type assertion leads to TypeError on window.
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/css-module/credentials.sub-expected.txt
@@ -1,9 +1,9 @@
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
-CONSOLE MESSAGE: TypeError: 'text/css' is not a valid JavaScript MIME type.
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
+CONSOLE MESSAGE: TypeError: Import assertion type "css" is not valid
 
 
 FAIL CSS Modules should be loaded with or without the credentials based on the same-origin-ness and the crossOrigin attribute assert_equals: Descendant CSS modules should be loaded with the credentials when the crossOrigin attribute is not specified and the target is same-origin expected (boolean) true but got (undefined) undefined

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
@@ -97,14 +97,15 @@ void ModuleAnalyzer::exportVariable(ModuleProgramNode& moduleProgramNode, const 
 
 
 
-JSModuleRecord* ModuleAnalyzer::analyze(ModuleProgramNode& moduleProgramNode)
+Expected<JSModuleRecord*, String> ModuleAnalyzer::analyze(ModuleProgramNode& moduleProgramNode)
 {
     // Traverse the module AST and collect
     // * Import entries
     // * Export entries that have FromClause (e.g. export { a } from "mod")
     // * Export entries that have star (e.g. export * from "mod")
     // * Aliased export names (e.g. export { a as b })
-    moduleProgramNode.analyzeModule(*this);
+    if (!moduleProgramNode.analyzeModule(*this))
+        return makeUnexpected(m_errorMessage);
 
     // Based on the collected information, categorize export entries into 3 types.
     // 1. Local export entries

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.h
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.h
@@ -39,7 +39,7 @@ class ModuleAnalyzer {
 public:
     ModuleAnalyzer(JSGlobalObject*, const Identifier& moduleKey, const SourceCode&, const VariableEnvironment& declaredVariables, const VariableEnvironment& lexicalVariables, CodeFeatures);
 
-    JSModuleRecord* analyze(ModuleProgramNode&);
+    Expected<JSModuleRecord*, String> analyze(ModuleProgramNode&);
 
     VM& vm() { return m_vm; }
 
@@ -47,12 +47,15 @@ public:
 
     void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&);
 
+    void fail(const String& errorMessage) { m_errorMessage = errorMessage; }
+
 private:
     void exportVariable(ModuleProgramNode&, const RefPtr<UniquedStringImpl>&, const VariableEnvironmentEntry&);
 
     VM& m_vm;
     JSModuleRecord* m_moduleRecord;
     IdentifierSet m_requestedModules;
+    String m_errorMessage;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -1636,7 +1636,7 @@ namespace JSC {
         bool hasEarlyBreakOrContinue() const;
 
         void emitBytecode(BytecodeGenerator&, RegisterID* destination);
-        void analyzeModule(ModuleAnalyzer&);
+        bool analyzeModule(ModuleAnalyzer&);
 
     private:
         StatementNode* m_head { nullptr };
@@ -1976,7 +1976,7 @@ namespace JSC {
 
         void emitStatementsBytecode(BytecodeGenerator&, RegisterID* destination);
         
-        void analyzeModule(ModuleAnalyzer&);
+        bool analyzeModule(ModuleAnalyzer&);
 
     protected:
         int m_startLineNumber;
@@ -2101,7 +2101,7 @@ namespace JSC {
 
     class ModuleDeclarationNode : public StatementNode {
     public:
-        virtual void analyzeModule(ModuleAnalyzer&) = 0;
+        virtual bool analyzeModule(ModuleAnalyzer&) = 0;
         bool hasCompletionValue() const override { return false; }
         bool isModuleDeclarationNode() const override { return true; }
 
@@ -2119,7 +2119,7 @@ namespace JSC {
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
-        void analyzeModule(ModuleAnalyzer&) final;
+        bool analyzeModule(ModuleAnalyzer&) final;
 
         ImportSpecifierListNode* m_specifierList;
         ModuleNameNode* m_moduleName;
@@ -2135,7 +2135,7 @@ namespace JSC {
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
-        void analyzeModule(ModuleAnalyzer&) final;
+        bool analyzeModule(ModuleAnalyzer&) final;
 
         ModuleNameNode* m_moduleName;
         ImportAssertionListNode* m_assertionList;
@@ -2150,7 +2150,7 @@ namespace JSC {
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
-        void analyzeModule(ModuleAnalyzer&) final;
+        bool analyzeModule(ModuleAnalyzer&) final;
         StatementNode* m_declaration;
         const Identifier& m_localName;
     };
@@ -2163,7 +2163,7 @@ namespace JSC {
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
-        void analyzeModule(ModuleAnalyzer&) final;
+        bool analyzeModule(ModuleAnalyzer&) final;
         StatementNode* m_declaration;
     };
 
@@ -2204,7 +2204,7 @@ namespace JSC {
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;
-        void analyzeModule(ModuleAnalyzer&) final;
+        bool analyzeModule(ModuleAnalyzer&) final;
         ExportSpecifierListNode* m_specifierList;
         ModuleNameNode* m_moduleName { nullptr };
         ImportAssertionListNode* m_assertionList { nullptr };

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -83,8 +83,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 
     PrivateName privateName(PrivateName::Description, "EntryPointModule"_s);
     ModuleAnalyzer moduleAnalyzer(globalObject, Identifier::fromUid(privateName), source, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables(), moduleProgramNode->features());
-    moduleAnalyzer.analyze(*moduleProgramNode);
-    return true;
+    return !!moduleAnalyzer.analyze(*moduleProgramNode);
 }
 
 RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source, FileSystem::PlatformFileHandle fd, BytecodeCacheError& error)

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -369,8 +369,12 @@ JSC_DEFINE_HOST_FUNCTION(moduleLoaderParseModule, (JSGlobalObject* globalObject,
     ModuleAnalyzer moduleAnalyzer(globalObject, moduleKey, sourceCode, moduleProgramNode->varDeclarations(), moduleProgramNode->lexicalVariables(), moduleProgramNode->features());
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
 
+    auto result = moduleAnalyzer.analyze(*moduleProgramNode);
+    if (!result)
+        RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(createTypeError(globalObject, result.error()))));
+
     scope.release();
-    promise->resolve(globalObject, moduleAnalyzer.analyze(*moduleProgramNode));
+    promise->resolve(globalObject, result.value());
     return JSValue::encode(promise);
 }
 

--- a/Source/JavaScriptCore/runtime/ScriptFetchParameters.h
+++ b/Source/JavaScriptCore/runtime/ScriptFetchParameters.h
@@ -61,8 +61,6 @@ public:
     {
         if (string == "json"_s)
             return Type::JSON;
-        if (string == "javascript"_s)
-            return Type::JavaScript;
         if (string == "webassembly"_s)
             return Type::WebAssembly;
         return std::nullopt;


### PR DESCRIPTION
#### 04c8018f9ff3545cd078536028a654d6ab2cc8d5
<pre>
Validate import-assertions in static module imports
<a href="https://bugs.webkit.org/show_bug.cgi?id=247102">https://bugs.webkit.org/show_bug.cgi?id=247102</a>
rdar://101616551

Reviewed by Alexey Shvayka.

This patch adds validation of import-assertions&apos; invalid &quot;type&quot; field in static module imports (not dynamic-import).
1. &quot;javascript&quot; is not allowed. We remove this.
2. we validate &quot;type&quot; field in module analyzer, and throws a TypeError if it does not meet the requirement.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/import-assertions/invalid-type-assertion-error-expected.txt:
* Source/JavaScriptCore/parser/ModuleAnalyzer.cpp:
(JSC::ModuleAnalyzer::analyze):
* Source/JavaScriptCore/parser/ModuleAnalyzer.h:
(JSC::ModuleAnalyzer::fail):
* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp:
(JSC::tryCreateAssertion):
(JSC::ScopeNode::analyzeModule):
(JSC::SourceElements::analyzeModule):
(JSC::ImportDeclarationNode::analyzeModule):
(JSC::ExportAllDeclarationNode::analyzeModule):
(JSC::ExportDefaultDeclarationNode::analyzeModule):
(JSC::ExportLocalDeclarationNode::analyzeModule):
(JSC::ExportNamedDeclarationNode::analyzeModule):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkModuleSyntax):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ScriptFetchParameters.h:
(JSC::ScriptFetchParameters::parseType):

Canonical link: <a href="https://commits.webkit.org/256075@main">https://commits.webkit.org/256075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21bda3635d329e2ba86a3a6b64494e562b0e760

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104174 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164447 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3752 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31896 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100148 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2698 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80913 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29727 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84623 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85723 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38296 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18011 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80891 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36161 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19284 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27801 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40060 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83559 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/1993 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38514 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18878 "Passed tests") | 
<!--EWS-Status-Bubble-End-->