### PR TITLE
Implement basic pinch-zooming for macOS ui-side compositing

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1241,7 +1241,7 @@ void Page::setZoomedOutPageScaleFactor(float scale)
 
 void Page::setPageScaleFactor(float scale, const IntPoint& origin, bool inStableState)
 {
-    LOG(Viewports, "Page::setPageScaleFactor %.2f - inStableState %d", scale, inStableState);
+    LOG_WITH_STREAM(Viewports, stream << "Page " << this << " setPageScaleFactor " << scale << " at " << origin << " - stable " << inStableState);
 
     Document* document = mainFrame().document();
     RefPtr<FrameView> view = document->view();
@@ -1273,7 +1273,7 @@ void Page::setPageScaleFactor(float scale, const IntPoint& origin, bool inStable
     }
 
     if (view && view->scrollPosition() != origin) {
-        if (!view->delegatesScrolling())
+        if (view->delegatedScrollingMode() != DelegatedScrollingMode::DelegatedToNativeScrollView)
             view->setScrollPosition(origin);
 #if USE(COORDINATED_GRAPHICS)
         else

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -268,6 +268,9 @@ public:
     bool scaleWasSetByUIProcess() const { return m_scaleWasSetByUIProcess; }
     void setScaleWasSetByUIProcess(bool scaleWasSetByUIProcess) { m_scaleWasSetByUIProcess = scaleWasSetByUIProcess; }
     
+    WebCore::GraphicsLayer::PlatformLayerID pageScalingLayerID() const { return m_pageScalingLayerID; }
+    void setPageScalingLayerID(WebCore::GraphicsLayer::PlatformLayerID layerID) { m_pageScalingLayerID = layerID; }
+    
     uint64_t renderTreeSize() const { return m_renderTreeSize; }
     void setRenderTreeSize(uint64_t renderTreeSize) { m_renderTreeSize = renderTreeSize; }
 
@@ -341,6 +344,9 @@ private:
     WebCore::Color m_themeColor;
     WebCore::Color m_pageExtendedBackgroundColor;
     WebCore::Color m_sampledPageTopColor;
+
+    WebCore::GraphicsLayer::PlatformLayerID m_pageScalingLayerID { 0 }; // Only used for non-delegated scaling.
+
     double m_pageScaleFactor { 1 };
     double m_minimumScaleFactor { 1 };
     double m_maximumScaleFactor { 1 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -599,6 +599,8 @@ void RemoteLayerTreeTransaction::encode(IPC::Encoder& encoder) const
     encoder << m_themeColor;
     encoder << m_pageExtendedBackgroundColor;
     encoder << m_sampledPageTopColor;
+    
+    encoder << m_pageScalingLayerID;
 
     encoder << m_pageScaleFactor;
     encoder << m_minimumScaleFactor;
@@ -703,6 +705,9 @@ bool RemoteLayerTreeTransaction::decode(IPC::Decoder& decoder, RemoteLayerTreeTr
         return false;
 
     if (!decoder.decode(result.m_sampledPageTopColor))
+        return false;
+
+    if (!decoder.decode(result.m_pageScalingLayerID))
         return false;
 
     if (!decoder.decode(result.m_pageScaleFactor))
@@ -1002,6 +1007,9 @@ String RemoteLayerTreeTransaction::description() const
 
     if (m_pageScaleFactor != 1)
         ts.dumpProperty("pageScaleFactor", m_pageScaleFactor);
+
+    if (m_pageScalingLayerID != 1)
+        ts.dumpProperty("pageScalingLayer", m_pageScalingLayerID);
 
     ts.dumpProperty("minimumScaleFactor", m_minimumScaleFactor);
     ts.dumpProperty("maximumScaleFactor", m_maximumScaleFactor);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -106,8 +106,10 @@ private:
     virtual void setPreferredFramesPerSecond(WebCore::FramesPerSecond) { }
     void willCommitLayerTree(TransactionID);
     void commitLayerTree(const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
+    virtual void didCommitLayerTree(const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) { }
+
     void asyncSetLayerContents(WebCore::GraphicsLayer::PlatformLayerID, ImageBufferBackendHandle&&);
-    
+
     void sendUpdateGeometry();
 
     std::unique_ptr<RemoteLayerTreeHost> m_remoteLayerTreeHost;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -138,6 +138,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(const RemoteLayerTreeTrans
 #endif
 
     m_webPageProxy.didCommitLayerTree(layerTreeTransaction);
+    didCommitLayerTree(layerTreeTransaction, scrollingTreeTransaction);
 
 #if ENABLE(ASYNC_SCROLLING)
     m_webPageProxy.scrollingCoordinatorProxy()->applyScrollingTreeLayerPositionsAfterCommit();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -52,6 +52,14 @@ private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
     std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const override;
 
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) override;
+
+    void adjustTransientZoom(double, WebCore::FloatPoint) override;
+    void commitTransientZoom(double, WebCore::FloatPoint) override;
+    
+    void applyTransientZoomToLayer();
+    void removeTransientZoomFromLayer();
+
     void scheduleDisplayRefreshCallbacks() override;
     void pauseDisplayRefreshCallbacks() override;
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond) override;
@@ -74,6 +82,11 @@ private:
     std::optional<DisplayLinkObserverID> m_displayRefreshObserverID;
     std::optional<DisplayLinkObserverID> m_fullSpeedUpdateObserverID;
     std::unique_ptr<RemoteLayerTreeDisplayLinkClient> m_displayLinkClient;
+    WebCore::GraphicsLayer::PlatformLayerID m_pageScalingLayerID;
+
+    std::optional<TransactionID> m_transactionIDAfterEndingTransientZoom;
+    std::optional<double> m_transientZoomScale;
+    std::optional<WebCore::FloatPoint> m_transientZoomOrigin;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -57,6 +57,9 @@ public:
     TransactionID nextTransactionID() const { return m_currentTransactionID.next(); }
     TransactionID lastCommittedTransactionID() const { return m_currentTransactionID; }
 
+protected:
+    void updateRendering();
+
 private:
     // DrawingArea
     void setNeedsDisplay() override;
@@ -71,6 +74,7 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) override;
 
     void addTransactionCallbackID(CallbackID) override;
+    virtual void willCommitLayerTree(RemoteLayerTreeTransaction&) { };
 
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) final;
     void willDestroyDisplayRefreshMonitor(WebCore::DisplayRefreshMonitor*);
@@ -111,7 +115,7 @@ private:
 
     void updateRootLayers();
 
-    void updateRendering();
+    void addCommitHandlers();
     void startRenderingUpdateTimer();
     void didCompleteRenderingUpdateDisplay() override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -345,6 +345,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         downcast<RemoteScrollingCoordinator>(*m_webPage.scrollingCoordinator()).buildTransaction(scrollingTransaction);
 #endif
 
+    willCommitLayerTree(layerTransaction);
+
     m_nextRenderingUpdateRequiresSynchronousImageDecoding = false;
     m_waitingForBackingStoreSwap = true;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -29,6 +29,10 @@
 
 #if PLATFORM(MAC)
 
+namespace WebCore {
+class TiledBacking;
+}
+
 namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaMac final : public RemoteLayerTreeDrawingArea {
@@ -43,6 +47,16 @@ private:
     std::optional<WebCore::DestinationColorSpace> displayColorSpace() const override;
 
     std::optional<WebCore::DestinationColorSpace> m_displayColorSpace;
+
+    bool usesDelegatedPageScaling() const override { return false; }
+
+    void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;
+    void commitTransientZoom(double scale, WebCore::FloatPoint origin) override;
+    void applyTransientZoomToPage(double scale, WebCore::FloatPoint);
+
+    void willCommitLayerTree(RemoteLayerTreeTransaction&) override;
+
+    WebCore::TiledBacking* mainFrameTiledBacking() const;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### b63bf15f23dce56ba4ccab0dc228b92b8d8f4b45
<pre>
Implement basic pinch-zooming for macOS ui-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247106">https://bugs.webkit.org/show_bug.cgi?id=247106</a>
rdar://101617575

Reviewed by Tim Horton.

Implement basic pinch-zoom support by hooking up adjustTransientZoom()
and commitTransientZoom() in RemoteLayerTreeDrawingAreaProxyMac, using the
same geometry computations that TiledCoreAnimationDrawingArea does.

To support responsive zooming even when the web process is busy, update
the scale transform to a layer in the UI process by overriding the transform
via a CAAnimation, which is removed when the gesture ends. In order to identify
the correct layer to apply this animation to, include in the transaction
the layerID of the RenderView&apos;s layer (which is where page scale is applied).

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setPageScaleFactor):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateChildrenTransformAndAnchorPoint):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::pageScalingLayerID const):
(WebKit::RemoteLayerTreeTransaction::setPageScalingLayerID):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::encode const):
(WebKit::RemoteLayerTreeTransaction::decode):
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree):
(WebKit::transientZoomTransformOverrideAnimation):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::applyTransientZoomToLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::removeTransientZoomFromLayer):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::mainFrameTiledBacking const):
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):
(WebKit::RemoteLayerTreeDrawingAreaMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaMac::commitTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree):

Canonical link: <a href="https://commits.webkit.org/258338@main">https://commits.webkit.org/258338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc129dcc6d3eab381bb16c82f31e35b80199f7a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110868 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171097 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1622 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108656 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35421 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78419 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4318 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1516 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44548 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5714 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6147 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->