### PR TITLE
Add support for creating accelerated WebGL contexts in a worker

### DIFF
--- a/Source/WebCore/platform/GraphicsClient.h
+++ b/Source/WebCore/platform/GraphicsClient.h
@@ -30,7 +30,10 @@
 namespace WebCore {
 
 class DestinationColorSpace;
+class GraphicsContextGL;
 class ImageBuffer;
+
+struct GraphicsContextGLAttributes;
 
 enum class PixelFormat : uint8_t;
 enum class RenderingMode : bool;
@@ -45,6 +48,10 @@ public:
     virtual PlatformDisplayID displayID() const = 0;
 
     virtual RefPtr<ImageBuffer> createImageBuffer(const FloatSize&, RenderingMode, RenderingPurpose, float resolutionScale, const DestinationColorSpace&, PixelFormat, bool avoidBackendSizeCheck = false) const = 0;
+#if ENABLE(WEBGL)
+    virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const = 0;
+#endif
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/HostWindow.h
+++ b/Source/WebCore/platform/HostWindow.h
@@ -31,9 +31,6 @@
 namespace WebCore {
 
 class Cursor;
-class GraphicsContextGL;
-
-struct GraphicsContextGLAttributes;
 
 using FramesPerSecond = unsigned;
 
@@ -60,10 +57,6 @@ public:
     virtual IntRect rootViewToScreen(const IntRect&) const = 0;
     virtual IntPoint accessibilityScreenToRootView(const IntPoint&) const = 0;
     virtual IntRect rootViewToAccessibilityScreen(const IntRect&) const = 0;
-
-#if ENABLE(WEBGL)
-    virtual RefPtr<GraphicsContextGL> createGraphicsContextGL(const GraphicsContextGLAttributes&) const = 0;
-#endif
 
     // Method for retrieving the native client of the page.
     virtual PlatformPageClient platformPageClient() const = 0;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Connection.h"
 #include "RemoteRenderingBackendCreationParameters.h"
 #include <WebCore/WorkerClient.h>
 
@@ -47,7 +48,7 @@ public:
     // worker thread of the outer worker, and then transferred to the
     // nested worker.
 #if ENABLE(GPU_PROCESS)
-    WebWorkerClient(SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&);
+    WebWorkerClient(IPC::Connection&, SerialFunctionDispatcher&, RemoteRenderingBackendCreationParameters&, WebCore::PlatformDisplayID&);
 #else
     WebWorkerClient(SerialFunctionDispatcher&, WebCore::PlatformDisplayID&);
 #endif
@@ -57,6 +58,9 @@ public:
     WebCore::PlatformDisplayID displayID() const final;
 
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, bool avoidBackendSizeCheck = false) const final;
+#if ENABLE(WEBGL)
+    RefPtr<WebCore::GraphicsContextGL> createGraphicsContextGL(const WebCore::GraphicsContextGLAttributes&) const final;
+#endif
 
 private:
 #if ENABLE(GPU_PROCESS)
@@ -65,6 +69,7 @@ private:
 
     SerialFunctionDispatcher& m_dispatcher;
 #if ENABLE(GPU_PROCESS)
+    Ref<IPC::Connection> m_connection;
     mutable std::unique_ptr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     RemoteRenderingBackendCreationParameters m_creationParameters;
 #endif


### PR DESCRIPTION
#### cfc4f8094badecccd86eeaf81c072cb43cd6a41a
<pre>
Add support for creating accelerated WebGL contexts in a worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=247103">https://bugs.webkit.org/show_bug.cgi?id=247103</a>

Reviewed by Dean Jackson.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::getGraphicsClient):
(WebCore::WebGLRenderingContextBase::create):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
* Source/WebCore/platform/GraphicsClient.h:
* Source/WebCore/platform/HostWindow.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::createGraphicsContextGL const):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:

Canonical link: <a href="https://commits.webkit.org/257541@main">https://commits.webkit.org/257541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87922be384a2e587b04e6a0510724dfaff1246e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108647 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168895 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85781 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106579 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90360 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21707 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23223 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2238 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5184 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/7706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42698 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->