### PR TITLE
Resync web-platform-tests/screen-orientation from upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,5 +1,8 @@
+fragment
 
-Harness Error (FAIL), message = Test named 'When performing a fragment navigation, the change must not abort' specified 1 'cleanup' function, and 1 failed.
+Harness Error (FAIL), message = Test named 'Performing a fragment navigation must not abort the screen orientation change' specified 1 'cleanup' function, and 1 failed.
 
-FAIL When performing a fragment navigation, the change must not abort promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+FAIL Performing a fragment navigation must not abort the screen orientation change promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+NOTRUN Performing a fragment navigation within an iframe must not abort the lock promise
+NOTRUN Unloading an iframe by navigating it must abort the lock promise
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
@@ -1,20 +1,55 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <p id="#fragment"></p>
+<a href="#fragment">fragment</a>
 <script type="module">
-  import { makeCleanup } from "./resources/orientation-utils.js";
+  import {
+    attachIframe,
+    getOppositeOrientation,
+    makeCleanup,
+  } from "./resources/orientation-utils.js";
+
   promise_test(async (t) => {
     t.add_cleanup(makeCleanup());
     await test_driver.bless("request full screen");
     await document.documentElement.requestFullscreen();
-    const orientation = screen.orientation.type.startsWith("portrait")
-      ? "landscape"
-      : "portrait";
-    const p = screen.orientation.lock(orientation);
-    window.location.href = "#fragment";
+    const orientation = getOppositeOrientation();
+    const p = screen.orientation.lock("landscape");
+    await test_driver.click(document.querySelector("a"));
     await p;
-  }, "When performing a fragment navigation, the change must not abort");
+  }, "Performing a fragment navigation must not abort the screen orientation change");
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    const iframe = await attachIframe();
+    iframe.contentDocument.body.innerHTML = `
+      <p id="#fragment"></p>
+      <a href="#fragment">fragment</a>
+    `;
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const orientation = getOppositeOrientation();
+    const p = iframe.contentWindow.screen.orientation.lock(orientation);
+    await test_driver.click(iframe.contentDocument.querySelector("a"));
+    await p;
+    iframe.remove();
+  }, "Performing a fragment navigation within an iframe must not abort the lock promise");
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    const iframe = await attachIframe();
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const orientation = getOppositeOrientation();
+    const p = iframe.contentWindow.screen.orientation.lock(orientation);
+    const frameDOMException = iframe.contentWindow.DOMException;
+    iframe.contentWindow.location.href = "./resources/empty.html";
+    await promise_rejects_dom(t, "AbortError", frameDOMException, p);
+    iframe.remove();
+  }, "Unloading an iframe by navigating it must abort the lock promise");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
@@ -1,3 +1,5 @@
 
+Harness Error (FAIL), message = Test named 'The 'change' event must fire before the [[orientationPendingPromise]] is resolved.' specified 1 'cleanup' function, and 1 failed.
+
 FAIL The 'change' event must fire before the [[orientationPendingPromise]] is resolved. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html
@@ -1,33 +1,26 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script>
-  promise_test(async t => {
-    t.add_cleanup(async () => {
-      try {
-        await document.exitFullscreen();
-      } catch (e) {}
-      screen.orientation.unlock();
-    });
-    await test_driver.bless("request full screen", () => {
-      return document.documentElement.requestFullscreen();
-    });
+<script type="module">
+  import {
+    getOppositeOrientation,
+    makeCleanup,
+  } from "./resources/orientation-utils.js";
 
-    const promiseToChange = new Promise(resolve => {
-      screen.orientation.addEventListener("change", resolve);
-    });
-
-    const newOrientationType =
-      screen.orientation.type.includes("portrait") ? "landscape" :
-                                                     "portrait";
-
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
     const result = await Promise.race([
-      screen.orientation.lock(newOrientationType),
-      promiseToChange,
+      new Promise((resolve) => {
+        screen.orientation.addEventListener("change", resolve);
+      }),
+      screen.orientation.lock(getOppositeOrientation())
     ]);
-
     assert_true(result instanceof Event, "Expected an instance of Event");
   }, "The 'change' event must fire before the [[orientationPendingPromise]] is resolved.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Fully unlocking the screen orientation causes a pending lock to be aborted promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
+FAIL Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+  import {
+    getOppositeOrientation,
+    attachIframe,
+  } from "./resources/orientation-utils.js";
+
+  promise_test(async (t) => {
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const lockPromise = screen.orientation.lock(getOppositeOrientation());
+    await document.exitFullscreen();
+    await promise_rejects_dom(t, "AbortError", lockPromise);
+  }, "Fully unlocking the screen orientation causes a pending lock to be aborted");
+
+  promise_test(async (t) => {
+    const iframe = await attachIframe();
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const lockPromise = iframe.contentWindow.screen.orientation.lock(
+      getOppositeOrientation()
+    );
+    await document.exitFullscreen();
+    const frameDOMException = iframe.contentWindow.DOMException;
+    await promise_rejects_dom(t, "AbortError", frameDOMException, lockPromise);
+  }, "Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
@@ -1,8 +1,7 @@
 
-PASS Test that screen.orientation.unlock() doesn't throw when there is no lock with fullscreen
-PASS Test that screen.orientation.unlock() doesn't throw when there is no lock
-PASS Test that screen.orientation.unlock() returns a void value
+Harness Error (FAIL), message = Test named 'Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.' specified 1 'cleanup' function, and 1 failed.
+
 FAIL Test that screen.orientation.lock returns a promise which will be fulfilled with a void value. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-PASS Test that screen.orientation.lock returns a pending promise.
-FAIL Test that screen.orientation.lock() is actually async promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+NOTRUN Test that screen.orientation.lock returns a pending promise.
+NOTRUN Test that screen.orientation.lock() is actually async
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic.html
@@ -1,47 +1,26 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script>
-async function cleanup() {
-  try {
-    await document.exitFullscreen();
-  } catch (e) {}
-  screen.orientation.unlock();
-}
+<script type="module">
+import { attachIframe, makeCleanup, getOppositeOrientation } from "./resources/orientation-utils.js";
 
 promise_test(async t => {
-  t.add_cleanup(cleanup);
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
-  screen.orientation.unlock();
-}, "Test that screen.orientation.unlock() doesn't throw when there is no lock with fullscreen");
-
-test(() => {
-  screen.orientation.unlock();
-}, "Test that screen.orientation.unlock() doesn't throw when there is no lock");
-
-test(() => {
-  const value = screen.orientation.unlock();
-  assert_equals(value, undefined);
-}, "Test that screen.orientation.unlock() returns a void value");
-
-promise_test(async t => {
-  t.add_cleanup(cleanup);
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen")
+  await document.documentElement.requestFullscreen();
   const value = await screen.orientation.lock('any');
   assert_equals(value, undefined);
 }, "Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.");
 
 promise_test(async t => {
-  t.add_cleanup(cleanup);
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen")
+  await document.documentElement.requestFullscreen();
+  const initialOrientation = screen.orientation.type;
   const orientations = [
     'any',
     'natural',
@@ -53,47 +32,45 @@ promise_test(async t => {
     'portrait-primary',
   ];
   for (const orientation of orientations) {
-    const promiseToChange = screen.orientation.lock(orientation);
-    assert_true(promiseToChange instanceof Promise, "Expected an instance of Promise");
     try {
-      await promiseToChange;
+      await screen.orientation.lock(orientation);
     } catch(err) {
       if (err.name === "NotSupportedError") {
         continue;
       }
       assert_unreached("Unknown error: " + err);
     }
-    const type = screen.orientation.type;
+    const { type } = screen.orientation;
     switch (orientation) {
     case 'any':
       break;
     case 'natural':
-      assert_true(type == "portrait-primary" || type == "landscape-primary");
+      assert_true(type.endsWith("primary"), `Expected primary orientation for "${orientation}", got "${type}"`);
       break;
     case 'portrait':
-      assert_true(type == "portrait-primary" || type == "portrait-secondary");
+      assert_true(type.startsWith("portrait"), `Expected portrait orientation for "${orientation}", got "${type}"`);
       break;
     case 'landscape':
-      assert_true(type == "landscape-primary" || type == "landscape-secondary");
+      assert_true(type.startsWith("landscape"), `Expected landscape orientation for "${orientation}", got "${type}"`);
       break;
     default:
       assert_equals(type, orientation, "Expected orientation to change");
       break;
     }
+    await screen.orientation.lock(initialOrientation);
   }
 }, "Test that screen.orientation.lock returns a pending promise.");
 
 promise_test(async t => {
-  t.add_cleanup(cleanup);
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
-  const preType = screen.orientation.type;
-  const isPortrait = preType.includes("portrait");
-  const newType = `${ isPortrait ? "landscape" : "portrait" }`;
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen")
+  await document.documentElement.requestFullscreen();
+  const initialType = screen.orientation.type;
+  const newType = getOppositeOrientation();
   const p = screen.orientation.lock(newType);
-  assert_equals(screen.orientation.type, preType, "Must not change orientation until next spin of event loop");
+  assert_equals(screen.orientation.type, initialType, "Must not change orientation until next spin of event loop");
   await p;
-  assert_true(screen.orientation.type.startsWith(newType), `Expected type to start with ${newType}`);
+  const finalType = screen.orientation.type;
+  assert_true(finalType.startsWith(newType), `Expected type to start with ${newType}, got "${finalType}"`);
 }, "Test that screen.orientation.lock() is actually async");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
@@ -1,6 +1,6 @@
 CONSOLE MESSAGE: Error while parsing the 'sandbox' attribute: 'allow-orientation-lock' is an invalid sandbox flag.
 
 
-FAIL Test without 'allow-orientation-lock' sandboxing directive assert_equals: screen.lockOrientation() throws a SecurityError expected "SecurityError" but got "error: NotSupportedError Screen orientation locking is not supported"
-FAIL Test with 'allow-orientation-lock' sandboxing directive assert_equals: screen.orientation lock to portrait-primary expected "portrait-primary" but got "error: NotSupportedError Screen orientation locking is not supported"
+FAIL Test without 'allow-orientation-lock' sandboxing directive assert_equals: screen.lockOrientation() throws a SecurityError expected "SecurityError" but got "NotSupportedError"
+FAIL Test with 'allow-orientation-lock' sandboxing directive assert_equals: screen.orientation lock to portrait-primary expected "portrait-primary" but got "NotSupportedError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe.html
@@ -1,45 +1,59 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+  import {
+    attachIframe
+  } from "./resources/orientation-utils.js";
 
-<iframe id="allowedIframe" sandbox="allow-scripts allow-same-origin allow-orientation-lock" allowfullscreen>
-</iframe>
-
-<iframe id="disallowedIframe" sandbox="allow-scripts allow-same-origin" allowfullscreen>
-</iframe>
-<script>
-function wait_result() {
-  return new Promise(resolve => {
-    function callback (evt) {
-      if (evt.data.type != "result") {
-        // test_driver.bless in child frame posted a message.
-        return;
+  function wait_result() {
+    return new Promise((resolve) => {
+      function callback(evt) {
+        switch (evt.data.result) {
+          case "locked":
+            resolve(evt.data.orientation);
+            break;
+          case "errored":
+            resolve(evt.data.name);
+            break;
+          default:
+            assert_unreached(`Unexpected message: ${evt.data.result}`);
+            return;
+        }
+        window.removeEventListener("message", callback);
+        resolve(evt.data.msg);
       }
-      window.removeEventListener("message", callback);
-      resolve(evt.data.msg);
-    }
+      window.addEventListener("message", callback);
+    });
+  }
 
-    window.addEventListener("message", callback);
-  });
-}
+  promise_test(async (t) => {
+    const iframe = await attachIframe({
+      src: "resources/sandboxed-iframe-locking.html",
+      sandbox: "allow-scripts allow-same-origin",
+    });
+    const message = await wait_result();
+    assert_equals(
+      message,
+      "SecurityError",
+      "screen.lockOrientation() throws a SecurityError"
+    );
+  }, "Test without 'allow-orientation-lock' sandboxing directive");
 
-promise_test(async t => {
-  const disallowedIframe = document.getElementById("disallowedIframe");
-  disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
-
-  const message = await wait_result();
-
-  assert_equals(message, "SecurityError", "screen.lockOrientation() throws a SecurityError");
-}, "Test without 'allow-orientation-lock' sandboxing directive");
-
-promise_test(async t => {
-  const allowedIframe = document.getElementById("allowedIframe");
-  allowedIframe.src = "resources/sandboxed-iframe-locking.html";
-
-  const message = await wait_result();
-
-  assert_equals(message, "portrait-primary", "screen.orientation lock to portrait-primary");
-}, "Test with 'allow-orientation-lock' sandboxing directive");
+  promise_test(async (t) => {
+    const iframe = await attachIframe({
+      src: "resources/sandboxed-iframe-locking.html",
+      sandbox: "allow-scripts allow-same-origin allow-orientation-lock",
+    });
+    const message = await wait_result();
+    assert_equals(
+      message,
+      "portrait-primary",
+      "screen.orientation lock to portrait-primary"
+    );
+  }, "Test with 'allow-orientation-lock' sandboxing directive");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
@@ -1,3 +1,4 @@
 
-FAIL Re-locking orientation during event dispatch must reject existing orientationPendingPromise promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
+FAIL Re-locking the screen orientation after a change event fires must not abort promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+FAIL Unlocking the screen orientation after a change event must not abort promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html
@@ -1,30 +1,36 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script type="module">
-  import { getOppositeOrientation } from "/screen-orientation/resources/orientation-utils.js";
-  promise_test(async t => {
-    t.add_cleanup(async () => {
-      try {
-        await document.exitFullscreen();
-      } catch (e) {}
+  import {
+    attachIframe,
+    getOppositeOrientation,
+  } from "./resources/orientation-utils.js";
+
+  promise_test(async (t) => {
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    screen.orientation.addEventListener(
+      "change",
+      async () => {
+        await screen.orientation.lock(getOppositeOrientation());
+      },
+      { once: true }
+    );
+    await screen.orientation.lock(getOppositeOrientation());
+  }, "Re-locking the screen orientation after a change event fires must not abort");
+
+  promise_test(async (t) => {
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    screen.orientation.onchange = async () => {
+      screen.orientation.onchange = null;
       screen.orientation.unlock();
-    });
-    await test_driver.bless("request full screen", () => {
-      return document.documentElement.requestFullscreen();
-    });
-    const newOrientation = getOppositeOrientation();
-    // This will reject, because the event will call lock() again.
-    const pMustReject = screen.orientation.lock(newOrientation);
-    // This one resolves, because we are re-locking.
-    const pMustResolve = new Promise(r => {
-      screen.orientation.onchange = () => {
-        r(screen.orientation.lock("any"));
-      };
-    });
-    await promise_rejects_dom(t, "AbortError", pMustReject);
-    await pMustResolve;
-  }, "Re-locking orientation during event dispatch must reject existing orientationPendingPromise");
+    };
+    await screen.orientation.lock(getOppositeOrientation());
+  }, "Unlocking the screen orientation after a change event must not abort");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SecurityError: Locking the screen orientation is only allowed when in fullscreen
+
+
+Harness Error (FAIL), message = Test named 'Requesting orientation lock from one document cancels the lock request from another document' specified 1 'cleanup' function, and 1 failed.
+
+FAIL Requesting orientation lock from one document cancels the lock request from another document promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
+NOTRUN The orientation lock from one document affects lock requests from other documents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+  <script type="module">
+    import {
+      attachIframe,
+      makeCleanup,
+      getOppositeOrientation,
+    } from "./resources/orientation-utils.js";
+
+    promise_test(async (t) => {
+      t.add_cleanup(makeCleanup());
+      const iframe = await attachIframe();
+      const iframeWin = iframe.contentWindow;
+
+      // Go full screen
+      await test_driver.bless("request full screen");
+      await iframe.contentDocument.documentElement.requestFullscreen();
+
+      // Lock the orientation from the iframe
+      const opposite = getOppositeOrientation();
+      const iframePromise = iframeWin.screen.orientation.lock(opposite);
+
+      // Calling lock() from top-level will cancel the iframe's promise
+      const topPromise = window.screen.orientation.lock(opposite);
+      await promise_rejects_dom(
+        t,
+        "AbortError",
+        iframeWin.DOMException,
+        iframePromise
+      );
+      await topPromise;
+    }, "Requesting orientation lock from one document cancels the lock request from another document");
+
+    promise_test(async (t) => {
+      t.add_cleanup(makeCleanup());
+      // Create 3 nested iframes
+      const src = "/screen-orientation/resources/empty.html";
+      const outerIframe = await attachIframe({ src: `${src}#1` });
+      const innerIframe = await attachIframe({
+        context: outerIframe.contentWindow,
+        src: `${src}#2`,
+      });
+
+      const iframes = [outerIframe, innerIframe];
+
+      // Go full screen
+      await test_driver.bless("request full screen");
+      await innerIframe.contentDocument.documentElement.requestFullscreen();
+      const opposite = getOppositeOrientation();
+
+      // Each iframe tries to lock the orientation
+      const requestToLock = iframes.map((iframe) => {
+        return {
+          promise: iframe.contentWindow.screen.orientation.lock(opposite),
+          context: iframe.contentWindow,
+        };
+      });
+
+      // But calling lock() from top-level will aborts all iframe's promises
+      const topPromise = window.screen.orientation.lock(opposite);
+
+      // Check that all promises are rejected with AbortError
+      const abortedPromises = [];
+      for (let i = 0; i < requestToLock.length; i++) {
+        const { promise, context } = requestToLock[i];
+        const p = promise_rejects_dom(
+          t,
+          "AbortError",
+          context.DOMException,
+          promise,
+          `Expected request to lock orientation from iframe ${i} to abort`
+        );
+        abortedPromises.push(p);
+      }
+      await Promise.all(abortedPromises);
+
+      // Finally, top-level promise resolves
+      await topPromise;
+    }, "The orientation lock from one document affects lock requests from other documents");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html
@@ -1,26 +1,17 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <body>
-<script>
-  async function attachIFrame() {
-    const iframe = document.createElement("iframe");
-    document.body.appendChild(iframe);
-    await new Promise((resolve) => {
-      iframe.onload = resolve;
-      iframe.src = "about:blank";
-    });
-    return iframe;
-  }
+<script type="module">
+  import { attachIframe, getOppositeOrientation } from "./resources/orientation-utils.js";
 
   promise_test(async (t) => {
-    const iframe = await attachIFrame();
+    const iframe = await attachIframe();
     const { orientation } = iframe.contentWindow.screen;
-    const opposite = orientation.type.startsWith("portrait")
-      ? "landscape"
-      : "portrait";
 
     const frameDOMException = iframe.contentWindow.DOMException;
     iframe.remove();
@@ -29,12 +20,12 @@
       t,
       "InvalidStateError",
       frameDOMException,
-      orientation.lock(opposite)
+      orientation.lock(getOppositeOrientation())
     );
   }, "Attempting to lock non-fully active documents results in a InvalidStateError");
 
   promise_test(async (t) => {
-    const iframe = await attachIFrame();
+    const iframe = await attachIframe();
     const { orientation } = iframe.contentWindow.screen;
 
     const frameDOMException = iframe.contentWindow.DOMException;
@@ -44,17 +35,13 @@
   }, "Attempting to unlock non-fully active documents results in a InvalidStateError");
 
   promise_test(async (t) => {
-    const iframe = await attachIFrame();
+    const iframe = await attachIframe();
     const { orientation } = iframe.contentWindow.screen;
-
-    const opposite = orientation.type.startsWith("portrait")
-      ? "landscape"
-      : "portrait";
 
     await test_driver.bless("request full screen", null, iframe.contentWindow);
     await iframe.contentDocument.documentElement.requestFullscreen();
 
-    const p = orientation.lock(opposite);
+    const p = orientation.lock(getOppositeOrientation());
 
     const frameDOMException = iframe.contentWindow.DOMException;
     iframe.remove();

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
@@ -1,4 +1,6 @@
 
+Harness Error (FAIL), message = Test named 'Test that orientationchange event is not fired when the orientation does not change.' specified 1 'cleanup' function, and 1 failed.
+
 FAIL Test that orientationchange event is not fired when the orientation does not change. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-FAIL Test that orientationchange event is fired when the orientation changes. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+NOTRUN Test that orientationchange event is fired when the orientation changes.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,3 +1,7 @@
 
+
+Harness Error (FAIL), message = Test named 'Test subframes receive orientation change events' specified 1 'cleanup' function, and 1 failed.
+
 FAIL Test subframes receive orientation change events promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+NOTRUN Check directly that events are fired in right order (from top to bottom)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
@@ -1,44 +1,83 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+  import {
+    attachIframe,
+    makeCleanup,
+    getOppositeOrientation,
+  } from "./resources/orientation-utils.js";
 
-<iframe
-  id="testIframe"
-  sandbox="allow-scripts allow-same-origin"
-  style="display:none"
-  src="resources/iframe-listen-orientation-change.html"
->
-</iframe>
-
-<script>
-  promise_test(async t => {
-    t.add_cleanup(async () => {
-      try {
-      await document.exitFullscreen();
-      } catch (e) {}
-      screen.orientation.unlock();
-    });
-    await test_driver.bless("request fullscreen", () => {
-      return document.documentElement.requestFullscreen();
-    });
-    let orientations = [
-      "portrait",
-      "landscape",
-    ];
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request fullscreen");
+    await document.documentElement.requestFullscreen();
+    let orientations = ["portrait", "landscape"];
     if (screen.orientation.type.includes("portrait")) {
       orientations = orientations.reverse();
     }
     const messageWatcher = new EventWatcher(t, window, "message");
-
+    const changeWatcher = new EventWatcher(t, screen.orientation, "change");
+    const iframe = await attachIframe({
+      src: "resources/iframe-listen-orientation-change.html",
+      sandbox: "allow-scripts allow-same-origin",
+    });
     for (const orientation of orientations) {
+      const messagePromise = messageWatcher.wait_for("message");
+      const eventPromise = changeWatcher.wait_for("change");
       await screen.orientation.lock(orientation);
-      const message = await messageWatcher.wait_for("message");
+      const winner = await Promise.race([eventPromise, messagePromise]);
+      assert_true(winner instanceof Event, "change event must be fired first");
+      const message = await messagePromise;
       assert_true(
         message.data.startsWith(orientation),
         "subframe receives orientation change event"
       );
     }
+    iframe.remove();
   }, "Test subframes receive orientation change events");
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    const iframe = await attachIframe();
+    const opposite = getOppositeOrientation();
+
+    const topEventPromise = new EventWatcher(
+      t,
+      screen.orientation,
+      "change"
+    ).wait_for("change");
+    const iframeEventPromise = new EventWatcher(
+      t,
+      iframe.contentWindow.screen.orientation,
+      "change"
+    ).wait_for("change");
+
+    // Lock from the iframe
+    await test_driver.bless("request fullscreen");
+    await document.documentElement.requestFullscreen();
+    const lockPromise = iframe.contentWindow.screen.orientation.lock(opposite);
+
+    const winningEvent = await Promise.race([
+      topEventPromise,
+      iframeEventPromise,
+    ]);
+    assert_true(
+      winningEvent instanceof window.Event,
+      "top-level change event must be fired first"
+    );
+
+    const iframeEvent = await iframeEventPromise;
+    assert_true(
+      iframeEvent instanceof iframe.contentWindow.Event,
+      "iframe event eventually fires"
+    );
+
+    await lockPromise;
+    iframe.remove();
+  }, "Check directly that events are fired in right order (from top to bottom)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event.html
@@ -1,19 +1,16 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script>
+<script type="module">
+import { makeCleanup } from "./resources/orientation-utils.js";
 promise_test(async t => {
-  t.add_cleanup(async () => {
-    try {
-      await document.exitFullscreen();
-    } catch (e) {}
-    screen.orientation.unlock();
-  });
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
   const type = screen.orientation.type.startsWith("portrait") ? "portrait" : "landscape";
   screen.orientation.onchange = t.unreached_func("change event should not be fired");
   await screen.orientation.lock(type);
@@ -21,15 +18,9 @@ promise_test(async t => {
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 
 promise_test(async t => {
-  t.add_cleanup(async () => {
-    try {
-      await document.exitFullscreen();
-    } catch (e) {}
-    screen.orientation.unlock();
-  });
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
   let orientations = [
     'portrait',
     'landscape',

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -1,20 +1,10 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: NotSupportedError: Screen orientation locking is not supported
 
-Harness Error (FAIL), message = Unhandled rejection: Screen orientation locking is not supported
-
-PASS Test screen.orientation properties
-FAIL Test screen.orientation default values. assert_true: expected true got false
-PASS Test the orientations and associated angles
-PASS Test that screen.orientation properties are not writable
-PASS Test that screen.orientation is always the same object
-TIMEOUT Test that screen.orientation values change if the orientation changes Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: Screen orientation locking is not supported
+Harness Error (FAIL), message = Test named 'Test the orientations and associated angles' specified 1 'cleanup' function, and 1 failed.
 
 PASS Test screen.orientation properties
 FAIL Test screen.orientation default values. assert_true: expected true got false
 PASS Test the orientations and associated angles
-PASS Test that screen.orientation properties are not writable
+FAIL Test that screen.orientation properties are not writable Attempted to assign to readonly property.
 PASS Test that screen.orientation is always the same object
-TIMEOUT Test that screen.orientation values change if the orientation changes Test timed out
+NOTRUN Test that screen.orientation values change if the orientation changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<script>
+<script type="module">
+
+import { makeCleanup, getOppositeOrientation } from "./resources/orientation-utils.js";
+
 test(() => {
   assert_true("type" in screen.orientation);
   assert_true("angle" in screen.orientation);
@@ -23,14 +28,9 @@ test(() => {
 }, "Test screen.orientation default values.");
 
 promise_test(async t => {
-  t.add_cleanup(async () => {
-    try {
-      await document.exitFullscreen();
-    } catch (e) {}
-  });
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
   try {
     await screen.orientation.lock("portrait-primary");
   } catch (err) {
@@ -102,35 +102,21 @@ test(() => {
 }, "Test that screen.orientation is always the same object");
 
 promise_test(async t => {
-  t.add_cleanup(async () => {
-    try {
-      await document.exitFullscreen();
-    } catch (e) {}
-    screen.orientation.unlock();
-  });
-  await test_driver.bless("request full screen", () => {
-    return document.documentElement.requestFullscreen();
-  });
-  const orientation = screen.orientation;
-  const orientationType = screen.orientation.type;
-  const orientationAngle = screen.orientation.angle;
-  const orientationWatcher = new EventWatcher(t, orientation, "change");
-
-  const newOrientationType =
-    orientationType.includes("portrait") ? "landscape" :
-                                           "portrait";
-  const promise = orientation.lock(newOrientationType);
+  t.add_cleanup(makeCleanup());
+  await test_driver.bless("request full screen");
+  await document.documentElement.requestFullscreen();
+  const initialType = screen.orientation.type;
+  const initialAngle = screen.orientation.angle;
+  const orientationWatcher = new EventWatcher(t, screen.orientation, "change");
+  const newOrientationType = getOppositeOrientation();
 
   // change event is fired before resolving promise by lock.
-  await orientationWatcher.wait_for("change");
-  await promise;
-  assert_equals(screen.orientation, orientation);
-  assert_equals(screen.orientation.type, orientation.type);
-  assert_equals(screen.orientation.angle, orientation.angle);
-  assert_not_equals(screen.orientation.type, orientationType);
-  assert_not_equals(screen.orientation.angle, orientationAngle);
-  // currently doesn't return a promise, makes it less racy against exitFullScreen
-  await screen.orientation.unlock();
-  return document.exitFullscreen();
+  const event = await Promise.race([
+    orientationWatcher.wait_for("change"),
+    screen.orientation.lock(newOrientationType)
+  ]);
+  assert_true(event instanceof Event, "expected event");
+  assert_not_equals(screen.orientation.type, initialType, "type should have changed");
+  assert_not_equals(screen.orientation.angle, initialAngle, "angle should have changed");
 }, "Test that screen.orientation values change if the orientation changes");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
@@ -1,29 +1,50 @@
-export async function loadIframe(src = "/screen-orientation/resources/blank.html") {
-  const iframe = document.createElement("iframe");
-  iframe.src = src;
-  document.body.appendChild(iframe);
-  return new Promise(r => {
-    if (iframe.contentDocument.readyState === "complete") {
-      return r(iframe);
-    }
-    iframe.onload = () => r(iframe);
+/**
+ *
+ * @param {object} options
+ * @param {string} options.src - The iframe src
+ * @param {Window} options.context - The browsing context in which the iframe will be created
+ * @param {string} options.sandbox - The sandbox attribute for the iframe
+ * @returns
+ */
+export async function attachIframe(options = {}) {
+  const { src, context, sandbox, allowFullscreen } = {
+    ...{
+      src: "about:blank",
+      context: self,
+      allowFullscreen: true,
+      sandbox: null,
+    },
+    ...options,
+  };
+  const iframe = context.document.createElement("iframe");
+  if (sandbox !== null) iframe.sandbox = sandbox;
+  iframe.allowFullscreen = allowFullscreen;
+  await new Promise((resolve) => {
+    iframe.onload = resolve;
+    iframe.src = src;
+    context.document.body.appendChild(iframe);
   });
+  return iframe;
 }
 
 export function getOppositeOrientation() {
-  const { type: currentOrientation } = screen.orientation;
-  const isPortrait = currentOrientation.includes("portrait");
-  return isPortrait ? "landscape" : "portrait";
+  return screen.orientation.type.startsWith("portrait")
+    ? "landscape"
+    : "portrait";
 }
 
-export function makeCleanup(initialOrientation = screen.orientation?.type.split(/-/)[0]) {
+export function makeCleanup(
+  initialOrientation = screen.orientation?.type.split(/-/)[0]
+) {
   return async () => {
     if (initialOrientation) {
       await screen.orientation.lock(initialOrientation);
     }
     screen.orientation.unlock();
     requestAnimationFrame(async () => {
-      await document.exitFullscreen();
+      try{
+        await document.exitFullscreen();
+      } catch {}
     });
-  }
+  };
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -8,21 +8,25 @@ test_driver.set_test_context(parent);
 screen.orientation?.unlock();
 
 test_driver.bless("request full screen", async () => {
-
-  let msg = "";
+  const data = {};
   try {
     await document.documentElement.requestFullscreen();
     await screen.orientation.lock("portrait")
-    msg = screen.orientation.type;
+    data.result = "locked";
+    data.orientation = screen.orientation.type;
   } catch (error) {
-    msg = `error: ${error.name} ${error.message}`;
+    data.result = "errored";
+    data.name = error.name;
   }
 
+  screen.orientation.unlock();
   try {
-    screen.orientation.unlock();
     await document.exitFullscreen();
   } catch (error) {
+    data.result = "errored";
+    data.name = "fullscreen exit failed";
   }
-  parent.window.postMessage({ type: "result", msg }, "*");
+
+  parent.window.postMessage(data, "*");
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
@@ -1,0 +1,9 @@
+
+Harness Error (FAIL), message = Test named 'unlock() doesn't throw when there is no lock with fullscreen' specified 1 'cleanup' function, and 1 failed.
+
+PASS unlock() doesn't throw when there is no lock
+PASS unlock() returns a void value
+PASS unlock() doesn't throw when there is no lock with fullscreen
+NOTRUN unlock() aborts a pending lock request
+NOTRUN unlock() aborts a pending lock request across documents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta viewport="width=device-width, initial-scale=1" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+  import {
+    getOppositeOrientation,
+    makeCleanup,
+    attachIframe,
+  } from "./resources/orientation-utils.js";
+
+  test(() => {
+    screen.orientation.unlock();
+  }, "unlock() doesn't throw when there is no lock");
+
+  test(() => {
+    const value = screen.orientation.unlock();
+    assert_equals(value, undefined);
+  }, "unlock() returns a void value");
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    screen.orientation.unlock();
+  }, "unlock() doesn't throw when there is no lock with fullscreen");
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const promise = screen.orientation.lock(getOppositeOrientation());
+    screen.orientation.unlock();
+    await promise_rejects_dom(t, "AbortError", promise);
+  }, "unlock() aborts a pending lock request");
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const iframe = await attachIframe();
+    const promise = iframe.contentWindow.screen.orientation.lock(
+      getOppositeOrientation()
+    );
+    screen.orientation.unlock();
+    await promise_rejects_dom(
+      t,
+      "AbortError",
+      iframe.contentWindow.DOMException,
+      promise
+    );
+  }, "unlock() aborts a pending lock request across documents");
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3757,3 +3757,6 @@ webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-con
 
 fast/images/animated-avif.html [ Pass ]
 http/tests/images/avif-partial-load-crash.html [ Pass ]
+
+# Screen Orientation API doesn't support nested frames yet
+imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Skip ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,3 +1,6 @@
+fragment
 
-PASS When performing a fragment navigation, the change must not abort
+PASS Performing a fragment navigation must not abort the screen orientation change
+FAIL Performing a fragment navigation within an iframe must not abort the lock promise promise_test: Unhandled rejection with value: object "SecurityError: Locking the screen orientation is only allowed when in fullscreen"
+FAIL Unloading an iframe by navigating it must abort the lock promise promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
@@ -1,0 +1,5 @@
+
+
+FAIL Fully unlocking the screen orientation causes a pending lock to be aborted assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
@@ -1,8 +1,5 @@
 
-PASS Test that screen.orientation.unlock() doesn't throw when there is no lock with fullscreen
-PASS Test that screen.orientation.unlock() doesn't throw when there is no lock
-PASS Test that screen.orientation.unlock() returns a void value
 PASS Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.
-PASS Test that screen.orientation.lock returns a pending promise.
+FAIL Test that screen.orientation.lock returns a pending promise. promise_test: Unhandled rejection with value: object "NotSupportedError: Lock type should be one of { "any", "natural", "portrait", "landscape" }"
 PASS Test that screen.orientation.lock() is actually async
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt
@@ -1,6 +1,6 @@
 CONSOLE MESSAGE: Error while parsing the 'sandbox' attribute: 'allow-orientation-lock' is an invalid sandbox flag.
 
 
-FAIL Test without 'allow-orientation-lock' sandboxing directive assert_equals: screen.lockOrientation() throws a SecurityError expected "SecurityError" but got "error: TypeError Type error"
-PASS Test with 'allow-orientation-lock' sandboxing directive
+FAIL Test without 'allow-orientation-lock' sandboxing directive assert_equals: screen.lockOrientation() throws a SecurityError expected "SecurityError" but got "portrait-primary"
+FAIL Test with 'allow-orientation-lock' sandboxing directive assert_equals: screen.orientation lock to portrait-primary expected "portrait-primary" but got "fullscreen exit failed"
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt
@@ -1,3 +1,4 @@
 
-PASS Re-locking orientation during event dispatch must reject existing orientationPendingPromise
+FAIL Re-locking the screen orientation after a change event fires must not abort promise_test: Unhandled rejection with value: object "AbortError: A new lock request was started"
+PASS Unlocking the screen orientation after a change event must not abort
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SecurityError: Locking the screen orientation is only allowed when in fullscreen
+
+
+Harness Error (FAIL), message = Test named 'Requesting orientation lock from one document cancels the lock request from another document' specified 1 'cleanup' function, and 1 failed.
+
+FAIL Requesting orientation lock from one document cancels the lock request from another document assert_unreached: Should have rejected: undefined Reached unreachable code
+NOTRUN The orientation lock from one document affects lock requests from other documents
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,3 +1,7 @@
 
+
+Harness Error (TIMEOUT), message = null
+
 PASS Test subframes receive orientation change events
+TIMEOUT Check directly that events are fired in right order (from top to bottom) Test timed out
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -2,7 +2,7 @@
 PASS Test screen.orientation properties
 PASS Test screen.orientation default values.
 PASS Test the orientations and associated angles
-PASS Test that screen.orientation properties are not writable
+FAIL Test that screen.orientation properties are not writable Attempted to assign to readonly property.
 PASS Test that screen.orientation is always the same object
 PASS Test that screen.orientation values change if the orientation changes
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS unlock() doesn't throw when there is no lock
+PASS unlock() returns a void value
+PASS unlock() doesn't throw when there is no lock with fullscreen
+PASS unlock() aborts a pending lock request
+FAIL unlock() aborts a pending lock request across documents promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+


### PR DESCRIPTION
#### 04aa3aef7ee6095372062da56f660e966f1bf465
<pre>
Resync web-platform-tests/screen-orientation from upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=247111">https://bugs.webkit.org/show_bug.cgi?id=247111</a>
rdar://101619487

Reviewed by Youenn Fablet.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/non-fully-active.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
(export.async attachIframe):
(export.async loadIframe): Deleted.
(export.getOppositeOrientation): Deleted.
(export.makeCleanup.return.async if): Deleted.
(export.makeCleanup): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/sandboxed-iframe-locking.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-sandboxed-iframe-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/256145@main">https://commits.webkit.org/256145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a92763e44362aeb2076fb5ac8a985a34e2262bee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104471 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164734 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4100 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32197 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100394 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2961 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81303 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29946 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84879 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72830 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38607 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36442 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2025 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38774 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->