### PR TITLE
Stop ignoring GCC's use-after-free warnings in CSSValue::deref()

### DIFF
--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -259,9 +259,7 @@ private:
 
 inline void CSSValue::deref() const
 {
-IGNORE_GCC_WARNINGS_BEGIN("use-after-free")
     unsigned tempRefCount = m_refCount - refCountIncrement;
-IGNORE_GCC_WARNINGS_END
 
     if (!tempRefCount) {
 IGNORE_GCC_WARNINGS_BEGIN("free-nonheap-object")

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -78,9 +78,9 @@ static bool isNormalValue(const RefPtr<CSSValue>& value)
     return value && value->isPrimitiveValue() && downcast<CSSPrimitiveValue>(value.get())->isValueID() && downcast<CSSPrimitiveValue>(value.get())->valueID() == CSSValueNormal;
 }
 
-static bool isValueID(const Ref<CSSValue>& value, CSSValueID id)
+static bool isValueID(const CSSValue& value, CSSValueID id)
 {
-    return value->isPrimitiveValue() && downcast<CSSPrimitiveValue>(value.get()).isValueID() && downcast<CSSPrimitiveValue>(value.get()).valueID() == id;
+    return value.isPrimitiveValue() && downcast<CSSPrimitiveValue>(value).isValueID() && downcast<CSSPrimitiveValue>(value).valueID() == id;
 }
 
 static bool isValueID(const RefPtr<CSSValue>& value, CSSValueID id)
@@ -88,12 +88,14 @@ static bool isValueID(const RefPtr<CSSValue>& value, CSSValueID id)
     return value && isValueID(*value, id);
 }
 
-static bool isValueIDIncludingList(const Ref<CSSValue>& value, CSSValueID id)
+static bool isValueIDIncludingList(const CSSValue& value, CSSValueID id)
 {
     if (is<CSSValueList>(value)) {
-        if (downcast<CSSValueList>(value.get()).size() != 1)
+        auto& valueList = downcast<CSSValueList>(value);
+        if (valueList.size() != 1)
             return false;
-        return isValueID(downcast<CSSValueList>(value.get()).item(0), id);
+        auto* item = valueList.item(0);
+        return item && isValueID(*item, id);
     }
     return isValueID(value, id);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -3018,9 +3018,9 @@ static RefPtr<CSSPrimitiveValue> consumeOverflowPositionKeyword(CSSParserTokenRa
     return isOverflowKeyword(range.peek().id()) ? consumeIdent(range) : nullptr;
 }
 
-static CSSValueID getBaselineKeyword(RefPtr<CSSValue> value)
+static CSSValueID getBaselineKeyword(const CSSValue& value)
 {
-    auto& primitiveValue = downcast<CSSPrimitiveValue>(*value);
+    auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.pairValue()) {
         ASSERT(primitiveValue.pairValue()->first()->valueID() == CSSValueLast);
         ASSERT(primitiveValue.pairValue()->second()->valueID() == CSSValueBaseline);
@@ -3054,7 +3054,7 @@ static RefPtr<CSSValue> consumeContentDistributionOverflowPosition(CSSParserToke
         RefPtr<CSSValue> baseline = consumeBaselineKeyword(range);
         if (!baseline)
             return nullptr;
-        return CSSContentDistributionValue::create(CSSValueInvalid, getBaselineKeyword(baseline), CSSValueInvalid);
+        return CSSContentDistributionValue::create(CSSValueInvalid, getBaselineKeyword(*baseline), CSSValueInvalid);
     }
 
     if (isContentDistributionKeyword(id))


### PR DESCRIPTION
#### 5cfc81b9eec95eec85ea355faec798f94c3912ac
<pre>
Stop ignoring GCC&apos;s use-after-free warnings in CSSValue::deref()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247120">https://bugs.webkit.org/show_bug.cgi?id=247120</a>

Reviewed by Michael Catanzaro.

The use-after-free warnings originating in CSSValue::deref() when compiling with
GCC were locally ignored. The few offending places are adjusted to fix the
warnings, and the IGNORE_GCC_WARNINGS macros are removed.

The warnings are usually thrown when specific optimization passes are enabled
and end up creating a use-after-free situation. In both current cases these
warnings can be ignored by simplifying the code.

In StyleProperties.cpp, the isValueID() and isValueIDIncludingList() functions
accepting a Ref&lt;CSSValue&gt; reference are simplified by accepting a trivial
CSSValue reference. If a Ref&lt;CSSValue&gt; is passed to these functions now, there&apos;s
a conversion operator on the Ref template that will handily retrieve the
reference. This also reduces reference-counting churn.

In CSSPropertyParser.cpp, getBaselineKeyword() is similarly simplified, now
accepting a CSSValue reference that&apos;s then downcasted into the primitive value,
and the sole call site is adjusted accordingly.

* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::deref const):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::isValueID):
(WebCore::isValueIDIncludingList):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::getBaselineKeyword):
(WebCore::consumeContentDistributionOverflowPosition):

Canonical link: <a href="https://commits.webkit.org/256063@main">https://commits.webkit.org/256063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c60ccbebbdbb8b0e893e361a3725d400385725cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104151 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164421 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3725 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31870 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100122 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100166 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80886 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29707 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84598 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38271 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/17996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36135 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19269 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4189 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40034 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38499 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->