### PR TITLE
[MSE] Bring back some useful SourceBuffer logs

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -62,6 +62,7 @@
 #include <limits>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/StringPrintStream.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -492,6 +493,10 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     if (isRemoved() || m_updating)
         return Exception { InvalidStateError };
 
+    StringPrintStream message;
+    message.printf("SourceBuffer::appendBufferInternal(%p) - append size = %u, buffered = %s\n", this, size, toString(m_private->buffered()->ranges()).utf8().data());
+    DEBUG_LOG(LOGIDENTIFIER, message.toString());
+
     // 3. If the readyState attribute of the parent media source is in the "ended" state then run the following steps:
     // 3.1. Set the readyState attribute of the parent media source to "open"
     // 3.2. Queue a task to fire a simple event named sourceopen at the parent media source .
@@ -587,7 +592,9 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(AppendResult result)
     m_source->monitorSourceBuffers();
     m_private->reenqueueMediaIfNeeded(m_source->currentTime());
 
-    DEBUG_LOG(LOGIDENTIFIER);
+    StringPrintStream message;
+    message.printf("SourceBuffer::sourceBufferPrivateAppendComplete(%p) - buffered = %s", this, toString(m_private->buffered()->ranges()).utf8().data());
+    DEBUG_LOG(LOGIDENTIFIER, message.toString());
 }
 
 void SourceBuffer::sourceBufferPrivateDidReceiveRenderingError(int64_t error)


### PR DESCRIPTION
#### e5e73c6cc13de7853fde82bf4db544153af1eb7f
<pre>
[MSE] Bring back some useful SourceBuffer logs
<a href="https://bugs.webkit.org/show_bug.cgi?id=247122">https://bugs.webkit.org/show_bug.cgi?id=247122</a>

Reviewed by Xabier Rodriguez-Calvar.

Changeset <a href="https://trac.webkit.org/changeset/241148/webkit">https://trac.webkit.org/changeset/241148/webkit</a> from
<a href="https://bugs.webkit.org/show_bug.cgi?id=194348">https://bugs.webkit.org/show_bug.cgi?id=194348</a> removed line
<a href="https://github.com/WebKit/WebKit/commit/cd4e7ebee1a6aaa956534cb8709d95ec2c75b85a#diff-78280e252e732edbf1f9b6517bd2f98eb1475f16fc781a5f3e2e2e6bf9b2a9beL710">https://github.com/WebKit/WebKit/commit/cd4e7ebee1a6aaa956534cb8709d95ec2c75b85a#diff-78280e252e732edbf1f9b6517bd2f98eb1475f16fc781a5f3e2e2e6bf9b2a9beL710</a>
, which was very useful when debugging MSE append problems.

This patch is bringing that line back and adding a similar one
to appendBufferInternal(), which will be helpful to track how
the buffered ranges evolve as the append is processed.

Original author: Pawel Lampe &lt;pawel.lampe@gmail.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/955">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/955</a>

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::appendBufferInternal): Added log line.
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete): Ditto.

Canonical link: <a href="https://commits.webkit.org/256224@main">https://commits.webkit.org/256224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f68c2c7bab7bd552dfc3b9d609dae32301eb61f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104153 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164423 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3727 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31872 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86825 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100124 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2679 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80888 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29710 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72604 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38273 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/17999 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36137 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19272 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4303 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41912 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/41989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38502 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->