### PR TITLE
"A MediaStreamTrack ended due to a capture failure" when selecting bluetooth headphones as audio input device

### DIFF
--- a/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html
@@ -29,6 +29,9 @@
         });
 
         assert_equals(track.label, "Mock audio device 2");
+
+        await new Promise(resolve => setTimeout(resolve, 2000));
+        assert_equals(track.readyState, "live");
     }, "Trigger configurationchange event in case OS changes microphone on its own");
     </script>
 </body>

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -63,6 +63,7 @@ public:
         virtual OSStatus defaultInputDevice(uint32_t*) = 0;
         virtual OSStatus defaultOutputDevice(uint32_t*) = 0;
         virtual void delaySamples(Seconds) { }
+        virtual Seconds verifyCaptureInterval(bool isProducingSamples) const { return isProducingSamples ? 10_s : 2_s; }
     };
 
     WEBCORE_EXPORT static CoreAudioSharedUnit& unit();
@@ -120,8 +121,6 @@ private:
 
     void verifyIsCapturing();
 
-    Seconds verifyCaptureInterval() { return isProducingMicrophoneSamples() ? 10_s : 2_s; }
-
     CreationCallback m_creationCallback;
     GetSampleRateCallback m_getSampleRateCallback;
     std::unique_ptr<InternalUnit> m_ioUnit;
@@ -155,7 +154,7 @@ private:
     uint64_t m_microphoneProcsCalledLastTime { 0 };
     Timer m_verifyCapturingTimer;
 
-    bool m_shouldUpdateMicrophoneSampleBufferSize { false };
+    std::optional<size_t> m_minimumMicrophoneSampleFrames;
     bool m_isReconfiguring { false };
     bool m_shouldNotifySpeakerSamplesProducer { false };
     bool m_hasNotifiedSpeakerSamplesProducer { false };

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.h
@@ -34,6 +34,7 @@ namespace WebCore {
 namespace MockAudioSharedUnit {
 
 CoreAudioSharedUnit& singleton();
+void increaseBufferSize();
 
 }
 

--- a/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm
@@ -125,6 +125,7 @@ private:
     OSStatus defaultInputDevice(uint32_t*) final;
     OSStatus defaultOutputDevice(uint32_t*) final;
     void delaySamples(Seconds) final;
+    Seconds verifyCaptureInterval(bool) const final { return 1_s; }
 
     int sampleRate() const { return m_streamFormat.mSampleRate; }
     void tick();
@@ -160,11 +161,13 @@ private:
     AURenderCallbackStruct m_speakerCallback;
 };
 
+static bool s_shouldIncreaseBufferSize;
 CoreAudioSharedUnit& MockAudioSharedUnit::singleton()
 {
     static NeverDestroyed<CoreAudioSharedUnit> unit;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] () {
+        s_shouldIncreaseBufferSize = false;
         unit->setSampleRateRange(CapabilityValueOrRange(44100, 48000));
         unit->setInternalUnitCreationCallback([] {
             UniqueRef<CoreAudioSharedUnit::InternalUnit> result = makeUniqueRef<MockAudioSharedInternalUnit>();
@@ -173,6 +176,11 @@ CoreAudioSharedUnit& MockAudioSharedUnit::singleton()
         unit->setInternalUnitGetSampleRateCallback([] { return 44100; });
     });
     return unit;
+}
+
+void MockAudioSharedUnit::increaseBufferSize()
+{
+    s_shouldIncreaseBufferSize = true;
 }
 
 static AudioStreamBasicDescription createAudioFormat(Float64 sampleRate, UInt32 channelCount)
@@ -292,8 +300,10 @@ void MockAudioSharedInternalUnit::emitSampleBuffers(uint32_t frameCount)
     memset(&timeStamp, 0, sizeof(AudioTimeStamp));
     timeStamp.mSampleTime = sampleTime;
     timeStamp.mHostTime = static_cast<UInt64>(sampleTime);
+
+    auto exposedFrameCount = s_shouldIncreaseBufferSize ? 10 * frameCount : frameCount;
     if (m_microphoneCallback.inputProc)
-        m_microphoneCallback.inputProc(m_microphoneCallback.inputProcRefCon, &ioActionFlags, &timeStamp, 1, frameCount, bufferList);
+        m_microphoneCallback.inputProc(m_microphoneCallback.inputProcRefCon, &ioActionFlags, &timeStamp, 1, exposedFrameCount, nullptr);
 
     ioActionFlags = 0;
     if (m_speakerCallback.inputProc)
@@ -340,6 +350,14 @@ void MockAudioSharedInternalUnit::generateSampleBuffers(MonotonicTime renderTime
 
 OSStatus MockAudioSharedInternalUnit::render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32, UInt32 frameCount, AudioBufferList* buffer)
 {
+    if (s_shouldIncreaseBufferSize) {
+        auto copySize = frameCount * m_streamFormat.mBytesPerPacket;
+        if (buffer->mNumberBuffers && copySize <= buffer->mBuffers[0].mDataByteSize)
+            s_shouldIncreaseBufferSize = false;
+        // We still return an error in case s_shouldIncreaseBufferSize is false since we do not have enough data to write.
+        return kAudio_ParamError;
+    }
+
     auto* sourceBuffer = m_audioBufferList->list();
     if (buffer->mNumberBuffers > sourceBuffer->mNumberBuffers)
         return kAudio_ParamError;

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -326,6 +326,7 @@ void MockRealtimeMediaSourceCenter::triggerMockMicrophoneConfigurationChange()
     auto devices = audioCaptureDeviceManager().captureDevices();
     if (devices.size() <= 1)
         return;
+    MockAudioSharedUnit::increaseBufferSize();
     MockAudioSharedUnit::singleton().handleNewCurrentMicrophoneDevice(WTFMove(devices[1]));
 #endif
 }


### PR DESCRIPTION
#### b818b253da1d92e9e5f802dea4a735b8adeb1994
<pre>
&quot;A MediaStreamTrack ended due to a capture failure&quot; when selecting bluetooth headphones as audio input device
<a href="https://bugs.webkit.org/show_bug.cgi?id=247119">https://bugs.webkit.org/show_bug.cgi?id=247119</a>
rdar://problem/101628857

Reviewed by Eric Carlson.

Replace the boolean to update the sample buffer by a minimum buffer sample frames, which is set when render fails.
This minimum buffer sample frames is used to compute a minimum buffer size when setting up the audio unit.

Update Mock implementation to cover that case.
We do this by triggering this code path when triggerMockMicrophoneConfigurationChange is called.
We also update the capture verification timer so that timer for mock unit is reduced to 1 second.

Update LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html to cover that case.

* LayoutTests/fast/mediastream/mediastreamtrack-configurationchange.html:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::configureMicrophoneProc):
(WebCore::CoreAudioSharedUnit::processMicrophoneSamples):
(WebCore::CoreAudioSharedUnit::startInternal):
(WebCore::CoreAudioSharedUnit::isProducingMicrophoneSamplesChanged):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/MockAudioSharedUnit.mm:
(WebCore::MockAudioSharedUnit::singleton):
(WebCore::MockAudioSharedUnit::increaseBufferSize):
(WebCore::MockAudioSharedInternalUnit::emitSampleBuffers):
(WebCore::MockAudioSharedInternalUnit::render):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockRealtimeMediaSourceCenter::triggerMockMicrophoneConfigurationChange):

Canonical link: <a href="https://commits.webkit.org/256091@main">https://commits.webkit.org/256091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0525aa9e1aafd3a54a3ed26b698c644139fe99af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104266 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164535 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3869 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31995 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86950 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100311 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81011 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/29816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84708 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38398 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19356 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4205 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40156 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38589 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->