### PR TITLE
[GStreamer][WebRTC] Events forwarding between end-point and its consumers

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -51,6 +51,10 @@
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
+#if USE(GSTREAMER)
+typedef struct _GstEvent GstEvent;
+#endif
+
 namespace WTF {
 class MediaTime;
 }
@@ -91,6 +95,10 @@ public:
         virtual bool preventSourceFromStopping() { return false; }
 
         virtual void hasStartedProducingData() { }
+
+#if USE(GSTREAMER)
+        virtual void handleDownstreamEvent(GRefPtr<GstEvent>&&) { }
+#endif
     };
     class AudioSampleObserver {
     public:

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -127,6 +127,7 @@ private:
 static void webkitMediaStreamSrcEnsureStreamCollectionPosted(WebKitMediaStreamSrc*);
 
 class InternalSource final : public MediaStreamTrackPrivate::Observer,
+    public RealtimeMediaSource::Observer,
     public RealtimeMediaSource::AudioSampleObserver,
     public RealtimeMediaSource::VideoFrameObserver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -162,6 +163,21 @@ public:
         g_signal_connect(m_src.get(), "need-data", G_CALLBACK(+[](GstElement*, unsigned, InternalSource* data) {
             data->m_enoughData = false;
         }), this);
+
+#if USE(GSTREAMER_WEBRTC)
+        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        gst_pad_add_probe(pad.get(), GST_PAD_PROBE_TYPE_EVENT_UPSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, InternalSource* internalSource) -> GstPadProbeReturn {
+            auto& trackSource = internalSource->m_track.source();
+            if (trackSource.isIncomingAudioSource()) {
+                auto& source = static_cast<RealtimeIncomingAudioSourceGStreamer&>(trackSource);
+                source.handleUpstreamEvent(GRefPtr<GstEvent>(GST_PAD_PROBE_INFO_EVENT(info)));
+            } else if (trackSource.isIncomingVideoSource()) {
+                auto& source = static_cast<RealtimeIncomingVideoSourceGStreamer&>(trackSource);
+                source.handleUpstreamEvent(GRefPtr<GstEvent>(GST_PAD_PROBE_INFO_EVENT(info)));
+            }
+            return GST_PAD_PROBE_OK;
+        }), this, nullptr);
+#endif
     }
 
     virtual ~InternalSource()
@@ -295,6 +311,12 @@ public:
             if (!m_track.enabled())
                 pushBlackFrame();
         }
+    }
+
+    void handleDownstreamEvent(GRefPtr<GstEvent>&& event) final
+    {
+        auto pad = adoptGRef(gst_element_get_static_pad(m_src.get(), "src"));
+        gst_pad_push_event(pad.get(), event.leakRef());
     }
 
     void videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata) final

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
@@ -31,8 +31,7 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
 namespace WebCore {
 
 RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer(AtomString&& audioTrackId)
-    : RealtimeMediaSource(RealtimeMediaSource::Type::Audio, WTFMove(audioTrackId))
-    , RealtimeIncomingSourceGStreamer()
+    : RealtimeIncomingSourceGStreamer(RealtimeMediaSource::Type::Audio, WTFMove(audioTrackId))
 {
     static Atomic<uint64_t> sourceCounter = 0;
     gst_element_set_name(bin(), makeString("incoming-audio-source-", sourceCounter.exchangeAdd(1)).ascii().data());
@@ -43,21 +42,6 @@ RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer(AtomS
 RealtimeIncomingAudioSourceGStreamer::~RealtimeIncomingAudioSourceGStreamer()
 {
     stop();
-}
-
-void RealtimeIncomingAudioSourceGStreamer::startProducingData()
-{
-    openValve();
-}
-
-void RealtimeIncomingAudioSourceGStreamer::stopProducingData()
-{
-    closeValve();
-}
-
-const RealtimeMediaSourceCapabilities& RealtimeIncomingAudioSourceGStreamer::capabilities()
-{
-    return RealtimeMediaSourceCapabilities::emptyCapabilities();
 }
 
 const RealtimeMediaSourceSettings& RealtimeIncomingAudioSourceGStreamer::settings()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.h
@@ -22,11 +22,10 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "RealtimeIncomingSourceGStreamer.h"
-#include "RealtimeMediaSource.h"
 
 namespace WebCore {
 
-class RealtimeIncomingAudioSourceGStreamer : public RealtimeMediaSource, public RealtimeIncomingSourceGStreamer {
+class RealtimeIncomingAudioSourceGStreamer : public RealtimeIncomingSourceGStreamer {
 public:
     static Ref<RealtimeIncomingAudioSourceGStreamer> create(AtomString&& audioTrackId) { return adoptRef(*new RealtimeIncomingAudioSourceGStreamer(WTFMove(audioTrackId))); }
 
@@ -36,9 +35,6 @@ protected:
 
 private:
     // RealtimeMediaSource API
-    void startProducingData() final;
-    void stopProducingData() final;
-    const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     bool isIncomingAudioSource() const final { return true; }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -31,7 +31,8 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
 
 namespace WebCore {
 
-RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer()
+RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer(Type type, AtomString&& name)
+    : RealtimeMediaSource(type, WTFMove(name))
 {
     m_bin = gst_bin_new(nullptr);
     m_valve = gst_element_factory_make("valve", nullptr);
@@ -45,6 +46,23 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer()
 
     auto sinkPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
+}
+
+void RealtimeIncomingSourceGStreamer::startProducingData()
+{
+    GST_DEBUG_OBJECT(bin(), "Starting data flow");
+    openValve();
+}
+
+void RealtimeIncomingSourceGStreamer::stopProducingData()
+{
+    GST_DEBUG_OBJECT(bin(), "Stopping data flow");
+    closeValve();
+}
+
+const RealtimeMediaSourceCapabilities& RealtimeIncomingSourceGStreamer::capabilities()
+{
+    return RealtimeMediaSourceCapabilities::emptyCapabilities();
 }
 
 void RealtimeIncomingSourceGStreamer::closeValve() const
@@ -79,12 +97,40 @@ void RealtimeIncomingSourceGStreamer::registerClient()
         return GST_FLOW_OK;
     }), this);
 
+    g_signal_connect_swapped(sink, "new-serialized-event", G_CALLBACK(+[](RealtimeIncomingSourceGStreamer* self, GstElement* sink) -> gboolean {
+        auto event = adoptGRef(GST_EVENT_CAST(gst_app_sink_pull_object(GST_APP_SINK(sink))));
+        switch (GST_EVENT_TYPE(event.get())) {
+        case GST_EVENT_STREAM_START:
+        case GST_EVENT_CAPS:
+            return false;
+        default:
+            break;
+        }
+        self->handleDownstreamEvent(WTFMove(event));
+        return true;
+    }), this);
+
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), queue, sink, nullptr);
     gst_element_link_many(m_tee.get(), queue, sink, nullptr);
     gst_element_sync_state_with_parent(queue);
     gst_element_sync_state_with_parent(sink);
 
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, GST_OBJECT_NAME(m_bin.get()));
+}
+
+void RealtimeIncomingSourceGStreamer::handleUpstreamEvent(GRefPtr<GstEvent>&& event)
+{
+    GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, event.get());
+    auto pad = adoptGRef(gst_element_get_static_pad(m_tee.get(), "sink"));
+    gst_pad_push_event(pad.get(), event.leakRef());
+}
+
+void RealtimeIncomingSourceGStreamer::handleDownstreamEvent(GRefPtr<GstEvent>&& event)
+{
+    GST_DEBUG_OBJECT(bin(), "Handling %" GST_PTR_FORMAT, event.get());
+    forEachObserver([event = WTFMove(event)](Observer& observer) {
+        observer.handleDownstreamEvent(GRefPtr<GstEvent>(event.get()));
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -22,16 +22,19 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "GRefPtrGStreamer.h"
+#include "RealtimeMediaSource.h"
 
 namespace WebCore {
 
-class RealtimeIncomingSourceGStreamer {
+class RealtimeIncomingSourceGStreamer : public RealtimeMediaSource {
 public:
     GstElement* bin() { return m_bin.get(); }
     void registerClient();
 
+    void handleUpstreamEvent(GRefPtr<GstEvent>&&);
+
 protected:
-    RealtimeIncomingSourceGStreamer();
+    RealtimeIncomingSourceGStreamer(Type, AtomString&& name);
 
     void closeValve() const;
     void openValve() const;
@@ -39,7 +42,13 @@ protected:
     GRefPtr<GstElement> m_valve;
 
 private:
+    // RealtimeMediaSource API
+    void startProducingData() final;
+    void stopProducingData() final;
+    const RealtimeMediaSourceCapabilities& capabilities() final;
+
     virtual void dispatchSample(GRefPtr<GstSample>&&) { }
+    void handleDownstreamEvent(GRefPtr<GstEvent>&&);
 
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_tee;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -33,8 +33,7 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
 namespace WebCore {
 
 RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomString&& videoTrackId)
-    : RealtimeMediaSource(RealtimeMediaSource::Type::Video, WTFMove(videoTrackId))
-    , RealtimeIncomingSourceGStreamer()
+    : RealtimeIncomingSourceGStreamer(RealtimeMediaSource::Type::Video, WTFMove(videoTrackId))
 {
     static Atomic<uint64_t> sourceCounter = 0;
     gst_element_set_name(bin(), makeString("incoming-video-source-", sourceCounter.exchangeAdd(1)).ascii().data());
@@ -63,23 +62,6 @@ RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomS
     }, nullptr, nullptr);
 
     start();
-}
-
-void RealtimeIncomingVideoSourceGStreamer::startProducingData()
-{
-    GST_DEBUG_OBJECT(bin(), "Starting data flow");
-    openValve();
-}
-
-void RealtimeIncomingVideoSourceGStreamer::stopProducingData()
-{
-    GST_DEBUG_OBJECT(bin(), "Stopping data flow");
-    closeValve();
-}
-
-const RealtimeMediaSourceCapabilities& RealtimeIncomingVideoSourceGStreamer::capabilities()
-{
-    return RealtimeMediaSourceCapabilities::emptyCapabilities();
 }
 
 const RealtimeMediaSourceSettings& RealtimeIncomingVideoSourceGStreamer::settings()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
@@ -22,11 +22,10 @@
 #if USE(GSTREAMER_WEBRTC)
 
 #include "RealtimeIncomingSourceGStreamer.h"
-#include "RealtimeMediaSource.h"
 
 namespace WebCore {
 
-class RealtimeIncomingVideoSourceGStreamer : public RealtimeMediaSource, public RealtimeIncomingSourceGStreamer {
+class RealtimeIncomingVideoSourceGStreamer : public RealtimeIncomingSourceGStreamer {
 public:
     static Ref<RealtimeIncomingVideoSourceGStreamer> create(AtomString&& videoTrackId) { return adoptRef(*new RealtimeIncomingVideoSourceGStreamer(WTFMove(videoTrackId))); }
     ~RealtimeIncomingVideoSourceGStreamer() = default;
@@ -36,10 +35,7 @@ protected:
 
 private:
     // RealtimeMediaSource API
-    void startProducingData() final;
-    void stopProducingData()  final;
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
-    const RealtimeMediaSourceCapabilities& capabilities() final;
     const RealtimeMediaSourceSettings& settings() final;
     bool isIncomingVideoSource() const final { return true; }
 


### PR DESCRIPTION
#### e6b4012424bfe6b5d91858df2959e7535285b452
<pre>
[GStreamer][WebRTC] Events forwarding between end-point and its consumers
<a href="https://bugs.webkit.org/show_bug.cgi?id=247126">https://bugs.webkit.org/show_bug.cgi?id=247126</a>

Reviewed by Xabier Rodriguez-Calvar.

We need to relay upstream events coming from depayloaders to webrtcbin and we also need to relay
downstream events from webrtcbin to the incoming media sources. This should help improving RTP
retransmission, for instance.

RealtimeIncomingSourceGStreamer now directly inherits from RealtimeMediaSource in order to avoid
duplication of the downstream event handling in each sub-class.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp:
(WebCore::RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
(WebCore::RealtimeIncomingSourceGStreamer::handleUpstreamEvent):
(WebCore::RealtimeIncomingSourceGStreamer::handleDownstreamEvent):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/256149@main">https://commits.webkit.org/256149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e87bbfc5f920563235da47a4c2a11f3beadc75c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104502 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164765 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4130 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32226 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87199 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100423 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81359 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29967 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72854 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38637 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18278 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19558 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40394 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2028 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42370 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38791 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->