### PR TITLE
[GTK] Add GTK 4 migration guide

### DIFF
--- a/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
+++ b/Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md
@@ -1,0 +1,28 @@
+Title: Migrating WebKitGTK Applications to GTK 4
+Slug: migrating-to-webkitgtk-6.0
+
+# Migrating WebKitGTK Applications to GTK 4
+
+This document contains guidance to application developers looking to migrate
+applications that use WebKitGTK from GTK 3 to GTK 4.
+
+webkitgtk-6.0 is a new API version of WebKitGTK designed for use with GTK 4 and
+libsoup 3. This API version obsoletes webkit2gtk-4.0 and webkit2gtk-4.1, the
+GTK 3 API versions for libsoup 2 and libsoup 3, respectively. It also obsoletes
+webkit2gtk-5.0, which was an earlier unstable API version for GTK 4.
+
+libsoup 2 and libsoup 3 cannot be linked together. If your application currently
+uses webkit2gtk-4.0, you must first port to webkit2gtk-4.1 by eliminating use
+of libsoup 2. See [Migrating from libsoup 2](https://libsoup.org/libsoup-3.0/migrating-from-libsoup-2.html)
+for guidance on this. After first migrating to webkit2gtk-4.1, then it is
+time to start looking into webkitgtk-6.0.
+
+## Mandatory Process Swap on Cross-site Navigation
+
+The `WebKitWebContext:process-swap-on-cross-site-navigation-enabled` property
+has been removed. Process swapping is now mandatory. Your application should be
+prepared for the web view's web process to be replaced when navigating between
+different security origins. You can ensure that your application is prepared for
+this change before porting to GTK 4 by testing your application with the
+`WebKitWebContext:process-swap-on-cross-site-navigation-enabled` property
+enabled. This property was previously disabled by default.

--- a/Source/WebKit/gtk/webkitgtk.toml.in
+++ b/Source/WebKit/gtk/webkitgtk.toml.in
@@ -38,4 +38,8 @@ show_class_hierarchy = true
 base_url = "https://github.com/WebKit/WebKit/tree/main"
 
 [extra]
+content_files = [
+    "migrating-to-webkitgtk-6.0.md"
+]
+
 urlmap_file = "urlmap.js"


### PR DESCRIPTION
#### 99f4041e6cb2250026638cf31e650e1170af71b4
<pre>
[GTK] Add GTK 4 migration guide
<a href="https://bugs.webkit.org/show_bug.cgi?id=247133">https://bugs.webkit.org/show_bug.cgi?id=247133</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/gtk/migrating-to-webkitgtk-6.0.md: Added.
* Source/WebKit/gtk/webkitgtk.toml.in:

Canonical link: <a href="https://commits.webkit.org/256100@main">https://commits.webkit.org/256100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fdcb6254893d0f0e4fb7c153b9202dc561cbd3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104171 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3748 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31892 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100142 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100188 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80909 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29722 "Found 1 new test failure: media/video-seek-to-current-time.html (failure)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84184 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38293 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18008 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4210 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41926 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38511 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->