### PR TITLE
WTF::removeQueryParameters should not reencode and reparse the query string if nothing was removed

### DIFF
--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -56,8 +56,9 @@ public:
     WTF_EXPORT_PRIVATE static bool allValuesEqual(const URL&, const URL&);
     WTF_EXPORT_PRIVATE static bool internalValuesConsistent(const URL&);
     
-    using URLEncodedForm = Vector<WTF::KeyValuePair<String, String>>;
+    using URLEncodedForm = Vector<KeyValuePair<String, String>>;
     WTF_EXPORT_PRIVATE static URLEncodedForm parseURLEncodedForm(StringView);
+    WTF_EXPORT_PRIVATE static std::optional<KeyValuePair<String, String>> parseQueryNameAndValue(StringView);
     WTF_EXPORT_PRIVATE static String serialize(const URLEncodedForm&);
 
     WTF_EXPORT_PRIVATE static bool isSpecialScheme(StringView);

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -516,55 +516,61 @@ TEST_F(WTF_URL, URLIsEqualIgnoringQueryAndFragments)
 
 TEST_F(WTF_URL, URLRemoveQueryParameters)
 {
-    URL url = createURL("http://www.webkit.org/?key=val"_s);
-    URL url1 = createURL("http://www.webkit.org/?key=val&key1=val1"_s);
-    URL url2 = createURL("http://www.webkit.org/?"_s);
-    URL url3 = createURL("http://www.webkit.org/?key=val#fragment"_s);
-    URL url4 = createURL("http://www.webkit.org/?key=val&key=val#fragment"_s);
-    URL url5 = createURL("http://www.webkit.org/?key&key=#fragment"_s);
-    URL url6 = createURL("http://www.webkit.org/#fragment"_s);
-    URL url7 = createURL("http://www.webkit.org/?key=val#fragment"_s);
-    URL url8 = createURL("http://www.webkit.org/"_s);
-    URL url9 = createURL("http://www.webkit.org/#fragment"_s);
-    URL url10 = createURL("http://www.webkit.org/?key=val#fragment"_s);
-    URL url11 = createURL("http://www.webkit.org/?key=val&key1=val1#fragment"_s);
-    URL url12 = createURL("http://www.webkit.org/?key=val&key1=val1#fragment"_s);
-    URL url13 = createURL("http://www.webkit.org"_s);
-    
+    const auto url = createURL("http://www.webkit.org/?key=val"_s);
+    auto url1 = createURL("http://www.webkit.org/?key=val&key1=val1"_s);
+    auto url2 = createURL("http://www.webkit.org/?"_s);
+    auto url3 = createURL("http://www.webkit.org/?key=val#fragment"_s);
+    auto url4 = createURL("http://www.webkit.org/?key=val&key=val#fragment"_s);
+    auto url5 = createURL("http://www.webkit.org/?key&key=#fragment"_s);
+    auto url6 = createURL("http://www.webkit.org/#fragment"_s);
+    auto url7 = createURL("http://www.webkit.org/?key=val#fragment"_s);
+    const auto url8 = createURL("http://www.webkit.org/"_s);
+    const auto url9 = createURL("http://www.webkit.org/#fragment"_s);
+    const auto url10 = createURL("http://www.webkit.org/?key=val#fragment"_s);
+    auto url11 = createURL("http://www.webkit.org/?key=val&key1=val1#fragment"_s);
+    auto url12 = createURL("http://www.webkit.org/?key=val&key1=val1#fragment"_s);
+    auto url13 = createURL("http://www.webkit.org"_s);
+    auto url14 = createURL("http://www.webkit.org/?u+v=x+%20y&key1=foo"_s);
+    auto url15 = createURL("http://www.webkit.org/?u+v=x+%20y"_s);
+
     HashSet<String> keyRemovalSet1 { "key"_s };
     HashSet<String> keyRemovalSet2 { "key1"_s };
     HashSet<String> keyRemovalSet3 { "key2"_s };
     HashSet<String> keyRemovalSet4 { "key"_s, "key1"_s };
-    
+
     removeQueryParameters(url1, keyRemovalSet2);
     EXPECT_EQ(url1.string(), url.string());
-    
+
+    const auto originalURL2 = url2;
     removeQueryParameters(url2, keyRemovalSet1);
-    EXPECT_EQ(url2.string(), url8.string());
-    
+    EXPECT_EQ(url2.string(), originalURL2.string());
+
     removeQueryParameters(url3, keyRemovalSet1);
     EXPECT_EQ(url3.string(), url6.string());
-    
+
     removeQueryParameters(url4, keyRemovalSet1);
     EXPECT_EQ(url4.string(), url6.string());
-    
+
     removeQueryParameters(url5, keyRemovalSet1);
     EXPECT_EQ(url5.string(), url6.string());
-    
+
     removeQueryParameters(url6, keyRemovalSet1);
     EXPECT_EQ(url6.string(), url9.string());
-    
+
     removeQueryParameters(url7, keyRemovalSet2);
     EXPECT_EQ(url7.string(), url10.string());
-    
+
     removeQueryParameters(url11, keyRemovalSet3);
     EXPECT_EQ(url11.string(), url12.string());
-    
+
     removeQueryParameters(url12, keyRemovalSet4);
     EXPECT_EQ(url12.string(), url9.string());
-    
+
     removeQueryParameters(url13, keyRemovalSet1);
     EXPECT_EQ(url13.string(), url8.string());
+
+    removeQueryParameters(url14, keyRemovalSet4);
+    EXPECT_EQ(url14.string(), url15.string());
 }
 
 TEST_F(WTF_URL, IsolatedCopy)


### PR DESCRIPTION
#### e9fd9cc2e7f15f9c93c833bfcb443d28da33276e
<pre>
WTF::removeQueryParameters should not reencode and reparse the query string if nothing was removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=247131">https://bugs.webkit.org/show_bug.cgi?id=247131</a>

Reviewed by Chris Dumez.

Add a minor optimization to the `WTF::removeQueryParameters` helper function. In the case where no
query parameters were removed, we should leave that part of the query string alone, instead of
forcing both the key and value to become percent-encoded. Additionally, in the case where no query
parameters were removed altogether, we can skip setting (and re-parsing) the query string
altogether, and instead simply return without modifying the given URL.

* Source/WTF/wtf/URL.cpp:
(WTF::removeQueryParameters):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::parseURLEncodedForm):
(WTF::URLParser::parseQueryNameAndValue):
* Source/WTF/wtf/URLParser.h:
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:

Augment an existing API test to exercise this change.

(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/256078@main">https://commits.webkit.org/256078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5ebdc5a18ebf3cf36c93209c4c635f6778532f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3735 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3794 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/31930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100236 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80947 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/86886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/86886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/85755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38332 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/80940 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/27815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4197 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40094 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83609 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42055 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18890 "Passed tests") | 
<!--EWS-Status-Bubble-End-->