### PR TITLE
[MSE][GStreamer] Relax h264/h265 codec check for MSE

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -57,6 +57,24 @@ public:
         bool isUsingHardware { false };
 
         operator bool() const { return isSupported; }
+
+        static RegistryLookupResult merge(const RegistryLookupResult& a, const RegistryLookupResult& b)
+        {
+            return RegistryLookupResult {
+                a.isSupported && b.isSupported,
+                a.isSupported && b.isSupported && a.isUsingHardware && b.isUsingHardware
+            };
+        }
+
+        friend bool operator==(const RegistryLookupResult& lhs, const RegistryLookupResult& rhs)
+        {
+            return lhs.isSupported == rhs.isSupported && lhs.isUsingHardware == rhs.isUsingHardware;
+        }
+
+        friend bool operator!=(const RegistryLookupResult& lhs, const RegistryLookupResult& rhs)
+        {
+            return !(lhs == rhs);
+        }
     };
     RegistryLookupResult isDecodingSupported(MediaConfiguration& mediaConfiguration) const { return isConfigurationSupported(Configuration::Decoding, mediaConfiguration); };
     RegistryLookupResult isEncodingSupported(MediaConfiguration& mediaConfiguration) const { return isConfigurationSupported(Configuration::Encoding, mediaConfiguration); }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -738,7 +738,16 @@ createOptionalParserForFormat(const AtomString& trackId, const GstCaps* caps)
         }
     }
     GST_DEBUG("Creating %s parser for stream with caps %" GST_PTR_FORMAT, elementClass, caps);
-    return GRefPtr<GstElement>(makeGStreamerElement(elementClass, parserName.ascii().data()));
+    GRefPtr<GstElement> result(makeGStreamerElement(elementClass, parserName.ascii().data()));
+    if (!result) {
+        if (g_strcmp0(elementClass, "identity")) {
+            GST_WARNING("Couldn't create %s, there might be problems processing some MSE streams. "
+                "Continue at your own risk and consider adding %s to your build.", elementClass, elementClass);
+            result = makeGStreamerElement("identity", parserName.ascii().data());
+        } else
+            GST_ERROR("Couldn't create identity");
+    }
+    return result;
 }
 
 AtomString AppendPipeline::generateTrackId(StreamType streamType, int padIndex)


### PR DESCRIPTION
#### b84521e66dedfbd7f984017dee3f5a7a8191b165
<pre>
[MSE][GStreamer] Relax h264/h265 codec check for MSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=247129">https://bugs.webkit.org/show_bug.cgi?id=247129</a>

Reviewed by Alicia Boya Garcia.

Some platforms disable/remove software parsers because of the way
encrypted playback is implemented, but we still want working MSE
playback there.

Although software parsers are strongly recommended for MSE playback
(eg: to complete info from buffers coming from some js transmuxers),
they aren&apos;t strictly needed (at your own risk!).

However, some video decoders (eg: the OMX h264 decoder) can only
accept some of the available formats (only stream-format=byte-stream
in the case of OMX). In that case, a parser is still needed in order
to convert between formats before supplying buffers to the decoder.

This patch checks that the most efficient decoder (hardware if
available, software if not) supports both formats. If the most
efficient decoder doesn&apos;t support all the formats, a parser is
demanded to be available. If it&apos;s not available, the affected codec
(h264, h265) is declared as not supported.

Inspired by work by Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/948">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/948</a>

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::initializeDecoders): Ask for the corresponding parser if any of the h264 or h265 decoders support don&apos;t support any of the possible stream-format variants. If the parser isn&apos;t present, declare the corresponding codec as unsupported.
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:
(WebCore::GStreamerRegistryScanner::RegistryLookupResult::merge): Added method to merge two results, supported when both are supported, and using hardware when both are using hardware.
(WebCore::GStreamerRegistryScanner::RegistryLookupResult::operator==): Added equality operator.
(WebCore::GStreamerRegistryScanner::RegistryLookupResult::operator!=): Added inequality operator.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::createOptionalParserForFormat): Warn when a parser can&apos;t be created.

Canonical link: <a href="https://commits.webkit.org/256222@main">https://commits.webkit.org/256222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5f613e4174d946da048b504afe6984ffb8f9ce4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27588 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104330 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164594 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3935 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32322 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100264 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2838 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81498 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29847 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72736 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38461 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18128 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4301 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40218 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42332 "Found 7 new test failures: http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/html/anonymous-iframe/embedding.tentative.https.window.html, imported/w3c/web-platform-tests/workers/baseurl/alpha/worker-in-worker.html, inspector/runtime/executionContextCreated-isolated-world.html, storage/indexeddb/closed-cursor-private.html, storage/indexeddb/value-undefined-private.html, tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-overflow-script.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38638 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->