### PR TITLE
Port ResourceRequest and related to the new CoreIPC serialization format

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -123,7 +123,7 @@ ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& 
 
     ResourceRequest request(parsedUrl);
     request.setHTTPMethod("POST"_s);
-    request.setRequester(ResourceRequest::Requester::Beacon);
+    request.setRequester(ResourceRequestRequester::Beacon);
     if (auto* documentLoader = document.loader())
         request.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.h
+++ b/Source/WebCore/Modules/fetch/FetchRequest.h
@@ -115,7 +115,7 @@ inline FetchRequest::FetchRequest(ScriptExecutionContext* context, std::optional
     , m_referrer(WTFMove(referrer))
     , m_signal(AbortSignal::create(context))
 {
-    m_request.setRequester(ResourceRequest::Requester::Fetch);
+    m_request.setRequester(ResourceRequestRequester::Fetch);
     updateContentType();
 }
 

--- a/Source/WebCore/dom/ElementContext.h
+++ b/Source/WebCore/dom/ElementContext.h
@@ -47,50 +47,10 @@ struct ElementContext {
     {
         return webPageIdentifier == other.webPageIdentifier && documentIdentifier == other.documentIdentifier && elementIdentifier == other.elementIdentifier;
     }
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<ElementContext> decode(Decoder&);
 };
 
 inline bool operator==(const ElementContext& a, const ElementContext& b)
 {
     return a.boundingRect == b.boundingRect && a.isSameElement(b);
 }
-
-template<class Encoder>
-void ElementContext::encode(Encoder& encoder) const
-{
-    encoder << boundingRect;
-    encoder << webPageIdentifier;
-    encoder << documentIdentifier;
-    encoder << elementIdentifier;
-}
-
-template<class Decoder>
-std::optional<ElementContext> ElementContext::decode(Decoder& decoder)
-{
-    ElementContext context;
-
-    if (!decoder.decode(context.boundingRect))
-        return std::nullopt;
-
-    auto pageIdentifier = PageIdentifier::decode(decoder);
-    if (!pageIdentifier)
-        return std::nullopt;
-    context.webPageIdentifier = *pageIdentifier;
-
-    std::optional<ScriptExecutionContextIdentifier> documentIdentifier;
-    decoder >> documentIdentifier;
-    if (!documentIdentifier)
-        return std::nullopt;
-    context.documentIdentifier = *documentIdentifier;
-
-    auto elementIdentifier = ElementIdentifier::decode(decoder);
-    if (!elementIdentifier)
-        return std::nullopt;
-    context.elementIdentifier = *elementIdentifier;
-
-    return context;
-}
-
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp
@@ -362,7 +362,7 @@ void InspectorDOMDebuggerAgent::didFireTimer(bool oneShot)
 
 void InspectorDOMDebuggerAgent::willSendRequest(ResourceRequest& request)
 {
-    if (request.requester() == ResourceRequest::Requester::XHR || request.requester() == ResourceRequest::Requester::Fetch)
+    if (request.requester() == ResourceRequestRequester::XHR || request.requester() == ResourceRequestRequester::Fetch)
         return;
 
     breakOnURLIfNeeded(request.url().string());

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -471,9 +471,9 @@ void InspectorNetworkAgent::willSendRequest(ResourceLoaderIdentifier identifier,
     String targetId = request.initiatorIdentifier();
 
     if (type == InspectorPageAgent::OtherResource) {
-        if (m_loadingXHRSynchronously || request.requester() == ResourceRequest::Requester::XHR)
+        if (m_loadingXHRSynchronously || request.requester() == ResourceRequestRequester::XHR)
             type = InspectorPageAgent::XHRResource;
-        else if (request.requester() == ResourceRequest::Requester::Fetch)
+        else if (request.requester() == ResourceRequestRequester::Fetch)
             type = InspectorPageAgent::FetchResource;
         else if (loader && equalIgnoringFragmentIdentifier(request.url(), loader->url()) && !loader->isCommitted())
             type = InspectorPageAgent::DocumentResource;

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -284,11 +284,11 @@ InspectorPageAgent::ResourceType InspectorPageAgent::inspectorResourceType(const
 {
     if (cachedResource.type() == CachedResource::Type::RawResource) {
         switch (cachedResource.resourceRequest().requester()) {
-        case ResourceRequest::Requester::Fetch:
+        case ResourceRequestRequester::Fetch:
             return InspectorPageAgent::FetchResource;
-        case ResourceRequest::Requester::Main:
+        case ResourceRequestRequester::Main:
             return InspectorPageAgent::DocumentResource;
-        case ResourceRequest::Requester::EventSource:
+        case ResourceRequestRequester::EventSource:
             return InspectorPageAgent::EventSourceResource;
         default:
             return InspectorPageAgent::XHRResource;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2109,7 +2109,7 @@ void DocumentLoader::startLoadingMainResource()
     ASSERT(timing().startTime());
 
     willSendRequest(ResourceRequest(m_request), ResourceResponse(), [this, protectedThis = WTFMove(protectedThis)] (ResourceRequest&& request) mutable {
-        request.setRequester(ResourceRequest::Requester::Main);
+        request.setRequester(ResourceRequestRequester::Main);
 
         m_request = request;
         // FIXME: Implement local URL interception by getting the service worker of the parent.

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -154,37 +154,7 @@ struct SystemPreviewInfo {
 
     IntRect previewRect;
     bool isPreview { false };
-
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static std::optional<SystemPreviewInfo> decode(Decoder&);
 };
-
-template<class Encoder>
-void SystemPreviewInfo::encode(Encoder& encoder) const
-{
-    encoder << element << previewRect << isPreview;
-}
-
-template<class Decoder>
-std::optional<SystemPreviewInfo> SystemPreviewInfo::decode(Decoder& decoder)
-{
-    std::optional<ElementContext> element;
-    decoder >> element;
-    if (!element)
-        return std::nullopt;
-
-    std::optional<IntRect> previewRect;
-    decoder >> previewRect;
-    if (!previewRect)
-        return std::nullopt;
-
-    std::optional<bool> isPreview;
-    decoder >> isPreview;
-    if (!isPreview)
-        return std::nullopt;
-
-    return { { WTFMove(*element), WTFMove(*previewRect), WTFMove(*isPreview) } };
-}
 
 enum class LoadCompletionType : bool {
     Finish,

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -88,7 +88,7 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     DataBufferingPolicy bufferingPolicy = options & LoadOption::BufferData ? DataBufferingPolicy::BufferData : DataBufferingPolicy::DoNotBufferData;
     auto cachingPolicy = options & LoadOption::DisallowCaching ? CachingPolicy::DisallowCaching : CachingPolicy::AllowCaching;
 
-    request.setRequester(ResourceRequest::Requester::Media);
+    request.setRequester(ResourceRequestRequester::Media);
 
     if (m_element)
         request.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*m_element));

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -196,7 +196,7 @@ public:
         bool refresh = equalIgnoringFragmentIdentifier(frame.document()->url(), url());
         ResourceRequest resourceRequest { url(), referrer(), refresh ? ResourceRequestCachePolicy::ReloadIgnoringCacheData : ResourceRequestCachePolicy::UseProtocolCachePolicy };
         if (initiatedByMainFrame() == InitiatedByMainFrame::Yes)
-            resourceRequest.setRequester(ResourceRequest::Requester::Main);
+            resourceRequest.setRequester(ResourceRequestRequester::Main);
         FrameLoadRequest frameLoadRequest { initiatingDocument(), *securityOrigin(), WTFMove(resourceRequest), selfTargetFrameName(), initiatedByMainFrame() };
         frameLoadRequest.setLockHistory(lockHistory());
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -125,7 +125,7 @@ void PingLoader::sendPing(Frame& frame, const URL& pingURL, const URL& destinati
         return;
 
     ResourceRequest request(pingURL);
-    request.setRequester(ResourceRequest::Requester::Ping);
+    request.setRequester(ResourceRequestRequester::Ping);
 
 #if ENABLE(CONTENT_EXTENSIONS)
     if (processContentRuleListsForLoad(frame, request, ContentExtensions::ResourceType::Ping))

--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -42,7 +42,7 @@ static_assert(!(LoadContextMask & ActionConditionMask), "LoadContextMask and Act
 static_assert(!(LoadTypeMask & ActionConditionMask), "LoadTypeMask and ActionConditionMask should be mutually exclusive because they are stored in the same uint32_t");
 static_assert(static_cast<uint64_t>(AllResourceFlags) << 32 == ActionFlagMask, "ActionFlagMask should cover all the action flags");
 
-OptionSet<ResourceType> toResourceType(CachedResource::Type type, ResourceRequestBase::Requester requester)
+OptionSet<ResourceType> toResourceType(CachedResource::Type type, ResourceRequestRequester requester)
 {
     switch (type) {
     case CachedResource::Type::LinkPrefetch:
@@ -69,8 +69,8 @@ OptionSet<ResourceType> toResourceType(CachedResource::Type type, ResourceReques
         return { ResourceType::Media };
 
     case CachedResource::Type::RawResource:
-        if (requester == ResourceRequestBase::Requester::XHR
-            || requester == ResourceRequestBase::Requester::Fetch)
+        if (requester == ResourceRequestRequester::XHR
+            || requester == ResourceRequestRequester::Fetch)
             return { ResourceType::Fetch };
         FALLTHROUGH;
     case CachedResource::Type::Beacon:

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -79,7 +79,7 @@ constexpr ResourceFlags AllResourceFlags = LoadTypeMask | ResourceTypeMask | Loa
 // The values -1 and -2 are used for removed and empty values in HashTables.
 static constexpr uint64_t ActionFlagMask = 0x0007FFFF00000000;
 
-OptionSet<ResourceType> toResourceType(CachedResource::Type, ResourceRequestBase::Requester);
+OptionSet<ResourceType> toResourceType(CachedResource::Type, ResourceRequestRequester);
 std::optional<OptionSet<ResourceType>> readResourceType(StringView);
 std::optional<OptionSet<LoadType>> readLoadType(StringView);
 std::optional<OptionSet<LoadContext>> readLoadContext(StringView);

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -305,7 +305,7 @@ void ResourceLoader::loadDataURL()
         scheduleContext.scheduledPairs = *page->scheduledRunLoopPairs();
 #endif
     auto mode = DataURLDecoder::Mode::Legacy;
-    if (m_request.requester() == ResourceRequest::Requester::Fetch)
+    if (m_request.requester() == ResourceRequestRequester::Fetch)
         mode = DataURLDecoder::Mode::ForgivingBase64;
     DataURLDecoder::decode(url, scheduleContext, mode, [this, protectedThis = Ref { *this }, url](auto decodeResult) mutable {
         if (this->reachedTerminalState())

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -209,7 +209,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         return completionHandler(WTFMove(newRequest));
     }
 
-    if (newRequest.requester() != ResourceRequestBase::Requester::Main) {
+    if (newRequest.requester() != ResourceRequestRequester::Main) {
         ResourceLoadObserver::shared().logSubresourceLoading(m_frame.get(), newRequest, redirectResponse,
             (isScriptLikeDestination(options().destination) ? ResourceLoadObserver::FetchDestinationIsScriptLike::Yes : ResourceLoadObserver::FetchDestinationIsScriptLike::No));
     }

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -95,7 +95,7 @@ void EventSource::connect()
     ASSERT(!m_requestInFlight);
 
     ResourceRequest request { m_url };
-    request.setRequester(ResourceRequest::Requester::EventSource);
+    request.setRequester(ResourceRequestRequester::EventSource);
     request.setHTTPMethod("GET"_s);
     request.setHTTPHeaderField(HTTPHeaderName::Accept, "text/event-stream"_s);
     request.setHTTPHeaderField(HTTPHeaderName::CacheControl, "no-cache"_s);

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -35,6 +35,7 @@
 #include "HTTPHeaderMap.h"
 #include "NavigationPreloadState.h"
 #include "RegistrationDatabase.h"
+#include "ResourceRequest.h"
 #include "ResourceResponse.h"
 #include <wtf/persistence/PersistentCoders.h>
 
@@ -176,6 +177,109 @@ std::optional<WebCore::ImportedScriptAttributes> Coder<WebCore::ImportedScriptAt
     } };
 }
 #endif
+
+void Coder<WebCore::ResourceRequest>::encode(Encoder& encoder, const WebCore::ResourceRequest& instance)
+{
+    ASSERT(!instance.httpBody());
+    ASSERT(!instance.platformRequestUpdated());
+    encoder << instance.url();
+    encoder << instance.timeoutInterval();
+    encoder << instance.firstPartyForCookies().string();
+    encoder << instance.httpMethod();
+    encoder << instance.httpHeaderFields();
+    encoder << instance.responseContentDispositionEncodingFallbackArray();
+    encoder << instance.cachePolicy();
+    encoder << instance.allowCookies();
+    encoder << instance.sameSiteDisposition();
+    encoder << instance.isTopSite();
+    encoder << instance.priority();
+    encoder << instance.requester();
+    encoder << instance.isAppInitiated();
+}
+
+std::optional<WebCore::ResourceRequest> Coder<WebCore::ResourceRequest>::decode(Decoder& decoder)
+{
+    std::optional<URL> url;
+    decoder >> url;
+    if (!url)
+        return std::nullopt;
+
+    std::optional<double> timeoutInterval;
+    decoder >> timeoutInterval;
+    if (!timeoutInterval)
+        return std::nullopt;
+
+    std::optional<String> firstPartyForCookies;
+    decoder >> firstPartyForCookies;
+    if (!firstPartyForCookies)
+        return std::nullopt;
+
+    std::optional<String> httpMethod;
+    decoder >> httpMethod;
+    if (!httpMethod)
+        return std::nullopt;
+
+    std::optional<WebCore::HTTPHeaderMap> fields;
+    decoder >> fields;
+    if (!fields)
+        return std::nullopt;
+
+    std::optional<Vector<String>> array;
+    decoder >> array;
+    if (!array)
+        return std::nullopt;
+
+    std::optional<WebCore::ResourceRequestCachePolicy> cachePolicy;
+    decoder >> cachePolicy;
+    if (!cachePolicy)
+        return std::nullopt;
+
+    std::optional<bool> allowCookies;
+    decoder >> allowCookies;
+    if (!allowCookies)
+        return std::nullopt;
+
+    std::optional<WebCore::ResourceRequestBase::SameSiteDisposition> sameSiteDisposition;
+    decoder >> sameSiteDisposition;
+    if (!sameSiteDisposition)
+        return std::nullopt;
+
+    std::optional<bool> isTopSite;
+    decoder >> isTopSite;
+    if (!isTopSite)
+        return std::nullopt;
+
+    std::optional<WebCore::ResourceLoadPriority> priority;
+    decoder >> priority;
+    if (!priority)
+        return std::nullopt;
+
+    std::optional<WebCore::ResourceRequestRequester> requester;
+    decoder >> requester;
+    if (!requester)
+        return std::nullopt;
+
+    std::optional<bool> isAppInitiated;
+    decoder >> isAppInitiated;
+    if (!isAppInitiated)
+        return std::nullopt;
+
+    WebCore::ResourceRequest request;
+    request.setURL(WTFMove(*url));
+    request.setTimeoutInterval(WTFMove(*timeoutInterval));
+    request.setFirstPartyForCookies(URL({ }, *firstPartyForCookies));
+    request.setHTTPMethod(WTFMove(*httpMethod));
+    request.setHTTPHeaderFields(WTFMove(*fields));
+    request.setResponseContentDispositionEncodingFallbackArray(WTFMove(*array));
+    request.setCachePolicy(*cachePolicy);
+    request.setAllowCookies(*allowCookies);
+    request.setSameSiteDisposition(*sameSiteDisposition);
+    request.setIsTopSite(*isTopSite);
+    request.setPriority(*priority);
+    request.setRequester(*requester);
+    request.setIsAppInitiated(*isAppInitiated);
+    return { request };
+}
 
 #if PLATFORM(COCOA)
 

--- a/Source/WebCore/platform/WebCorePersistentCoders.h
+++ b/Source/WebCore/platform/WebCorePersistentCoders.h
@@ -36,6 +36,7 @@ class CertificateInfo;
 class ContentSecurityPolicyResponseHeaders;
 class HTTPHeaderMap;
 class ResourceResponse;
+class ResourceRequest;
 
 struct ClientOrigin;
 struct CrossOriginEmbedderPolicy;
@@ -71,6 +72,7 @@ DECLARE_CODER(WebCore::HTTPHeaderMap);
 DECLARE_CODER(WebCore::ImportedScriptAttributes);
 #endif
 DECLARE_CODER(WebCore::ResourceResponse);
+DECLARE_CODER(WebCore::ResourceRequest);
 DECLARE_CODER(WebCore::SecurityOriginData);
 #if ENABLE(SERVICE_WORKER)
 DECLARE_CODER(WebCore::NavigationPreloadState);

--- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
@@ -42,6 +42,12 @@ HTTPHeaderMap::HTTPHeaderMap()
 {
 }
 
+HTTPHeaderMap::HTTPHeaderMap(CommonHeadersVector&& commonHeaders, UncommonHeadersVector&& uncommonHeaders)
+    : m_commonHeaders(WTFMove(commonHeaders))
+    , m_uncommonHeaders(WTFMove(uncommonHeaders))
+{
+}
+
 HTTPHeaderMap HTTPHeaderMap::isolatedCopy() const &
 {
     HTTPHeaderMap map;

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -78,24 +78,24 @@ void ResourceRequestBase::setAsIsolatedCopy(const ResourceRequest& other)
     setIsTopSite(other.isTopSite());
 
     updateResourceRequest();
-    m_httpHeaderFields = other.httpHeaderFields().isolatedCopy();
+    m_requestData.m_httpHeaderFields = other.httpHeaderFields().isolatedCopy();
 
-    size_t encodingCount = other.m_responseContentDispositionEncodingFallbackArray.size();
+    size_t encodingCount = other.m_requestData.m_responseContentDispositionEncodingFallbackArray.size();
     if (encodingCount > 0) {
-        String encoding1 = other.m_responseContentDispositionEncodingFallbackArray[0].isolatedCopy();
+        String encoding1 = other.m_requestData.m_responseContentDispositionEncodingFallbackArray[0].isolatedCopy();
         String encoding2;
         String encoding3;
         if (encodingCount > 1) {
-            encoding2 = other.m_responseContentDispositionEncodingFallbackArray[1].isolatedCopy();
+            encoding2 = other.m_requestData.m_responseContentDispositionEncodingFallbackArray[1].isolatedCopy();
             if (encodingCount > 2)
-                encoding3 = other.m_responseContentDispositionEncodingFallbackArray[2].isolatedCopy();
+                encoding3 = other.m_requestData.m_responseContentDispositionEncodingFallbackArray[2].isolatedCopy();
         }
         ASSERT(encodingCount <= 3);
         setResponseContentDispositionEncodingFallbackArray(encoding1, encoding2, encoding3);
     }
     if (other.m_httpBody)
         setHTTPBody(other.m_httpBody->isolatedCopy());
-    setAllowCookies(other.m_allowCookies);
+    setAllowCookies(other.m_requestData.m_allowCookies);
     setIsAppInitiated(other.isAppInitiated());
 }
 
@@ -103,28 +103,28 @@ bool ResourceRequestBase::isEmpty() const
 {
     updateResourceRequest(); 
     
-    return m_url.isEmpty(); 
+    return url().isEmpty();
 }
 
 bool ResourceRequestBase::isNull() const
 {
     updateResourceRequest(); 
     
-    return m_url.isNull();
+    return url().isNull();
 }
 
 const URL& ResourceRequestBase::url() const 
 {
     updateResourceRequest(); 
     
-    return m_url;
+    return m_requestData.m_url;
 }
 
 void ResourceRequestBase::setURL(const URL& url)
 { 
     updateResourceRequest(); 
 
-    m_url = url; 
+    m_requestData.m_url = url;
     
     m_platformRequestUpdated = false;
 }
@@ -144,10 +144,10 @@ void ResourceRequestBase::redirectAsGETIfNeeded(const ResourceRequestBase &redir
     if (shouldUseGet(redirectRequest, redirectResponse)) {
         setHTTPMethod("GET"_s);
         setHTTPBody(nullptr);
-        m_httpHeaderFields.remove(HTTPHeaderName::ContentLength);
-        m_httpHeaderFields.remove(HTTPHeaderName::ContentLanguage);
-        m_httpHeaderFields.remove(HTTPHeaderName::ContentEncoding);
-        m_httpHeaderFields.remove(HTTPHeaderName::ContentLocation);
+        m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::ContentLength);
+        m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::ContentLanguage);
+        m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::ContentEncoding);
+        m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::ContentLocation);
         clearHTTPContentType();
     }
 }
@@ -171,7 +171,7 @@ ResourceRequest ResourceRequestBase::redirectedRequest(const ResourceResponse& r
     if (!protocolHostAndPortAreEqual(request.url(), redirectResponse.url()))
         request.clearHTTPOrigin();
     request.clearHTTPAuthorization();
-    request.m_httpHeaderFields.remove(HTTPHeaderName::ProxyAuthorization);
+    request.m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::ProxyAuthorization);
 
     return request;
 }
@@ -180,10 +180,10 @@ void ResourceRequestBase::removeCredentials()
 {
     updateResourceRequest(); 
 
-    if (!m_url.hasCredentials())
+    if (!m_requestData.m_url.hasCredentials())
         return;
 
-    m_url.removeCredentials();
+    m_requestData.m_url.removeCredentials();
     m_platformRequestUpdated = false;
 }
 
@@ -191,17 +191,17 @@ ResourceRequestCachePolicy ResourceRequestBase::cachePolicy() const
 {
     updateResourceRequest(); 
     
-    return m_cachePolicy;
+    return m_requestData.m_cachePolicy;
 }
 
 void ResourceRequestBase::setCachePolicy(ResourceRequestCachePolicy cachePolicy)
 {
     updateResourceRequest(); 
 
-    if (m_cachePolicy == cachePolicy)
+    if (m_requestData.m_cachePolicy == cachePolicy)
         return;
     
-    m_cachePolicy = cachePolicy;
+    m_requestData.m_cachePolicy = cachePolicy;
     
     m_platformRequestUpdated = false;
 }
@@ -210,17 +210,17 @@ double ResourceRequestBase::timeoutInterval() const
 {
     updateResourceRequest(); 
     
-    return m_timeoutInterval; 
+    return m_requestData.m_timeoutInterval;
 }
 
 void ResourceRequestBase::setTimeoutInterval(double timeoutInterval) 
 {
     updateResourceRequest(); 
     
-    if (m_timeoutInterval == timeoutInterval)
+    if (m_requestData.m_timeoutInterval == timeoutInterval)
         return;
 
-    m_timeoutInterval = timeoutInterval;
+    m_requestData.m_timeoutInterval = timeoutInterval;
     
     m_platformRequestUpdated = false;
 }
@@ -229,17 +229,17 @@ const URL& ResourceRequestBase::firstPartyForCookies() const
 {
     updateResourceRequest(); 
     
-    return m_firstPartyForCookies;
+    return m_requestData.m_firstPartyForCookies;
 }
 
 void ResourceRequestBase::setFirstPartyForCookies(const URL& firstPartyForCookies)
 { 
     updateResourceRequest(); 
 
-    if (m_firstPartyForCookies == firstPartyForCookies)
+    if (m_requestData.m_firstPartyForCookies == firstPartyForCookies)
         return;
 
-    m_firstPartyForCookies = firstPartyForCookies;
+    m_requestData.m_firstPartyForCookies = firstPartyForCookies;
     
     m_platformRequestUpdated = false;
 }
@@ -248,7 +248,7 @@ bool ResourceRequestBase::isSameSite() const
 {
     updateResourceRequest();
 
-    return m_sameSiteDisposition == SameSiteDisposition::SameSite;
+    return m_requestData.m_sameSiteDisposition == SameSiteDisposition::SameSite;
 }
 
 void ResourceRequestBase::setIsSameSite(bool isSameSite)
@@ -256,10 +256,10 @@ void ResourceRequestBase::setIsSameSite(bool isSameSite)
     updateResourceRequest();
 
     SameSiteDisposition newDisposition = isSameSite ? SameSiteDisposition::SameSite : SameSiteDisposition::CrossSite;
-    if (m_sameSiteDisposition == newDisposition)
+    if (m_requestData.m_sameSiteDisposition == newDisposition)
         return;
 
-    m_sameSiteDisposition = newDisposition;
+    m_requestData.m_sameSiteDisposition = newDisposition;
 
     m_platformRequestUpdated = false;
 }
@@ -268,17 +268,17 @@ bool ResourceRequestBase::isTopSite() const
 {
     updateResourceRequest();
 
-    return m_isTopSite;
+    return m_requestData.m_isTopSite;
 }
 
 void ResourceRequestBase::setIsTopSite(bool isTopSite)
 {
     updateResourceRequest();
 
-    if (m_isTopSite == isTopSite)
+    if (m_requestData.m_isTopSite == isTopSite)
         return;
 
-    m_isTopSite = isTopSite;
+    m_requestData.m_isTopSite = isTopSite;
 
     m_platformRequestUpdated = false;
 }
@@ -287,17 +287,17 @@ const String& ResourceRequestBase::httpMethod() const
 {
     updateResourceRequest(); 
     
-    return m_httpMethod; 
+    return m_requestData.m_httpMethod;
 }
 
 void ResourceRequestBase::setHTTPMethod(const String& httpMethod) 
 {
     updateResourceRequest(); 
 
-    if (m_httpMethod == httpMethod)
+    if (m_requestData.m_httpMethod == httpMethod)
         return;
 
-    m_httpMethod = httpMethod;
+    m_requestData.m_httpMethod = httpMethod;
     
     m_platformRequestUpdated = false;
 }
@@ -306,28 +306,28 @@ const HTTPHeaderMap& ResourceRequestBase::httpHeaderFields() const
 {
     updateResourceRequest(); 
 
-    return m_httpHeaderFields; 
+    return m_requestData.m_httpHeaderFields;
 }
 
 String ResourceRequestBase::httpHeaderField(StringView name) const
 {
     updateResourceRequest();
 
-    return m_httpHeaderFields.get(name);
+    return m_requestData.m_httpHeaderFields.get(name);
 }
 
 String ResourceRequestBase::httpHeaderField(HTTPHeaderName name) const
 {
     updateResourceRequest(); 
     
-    return m_httpHeaderFields.get(name);
+    return m_requestData.m_httpHeaderFields.get(name);
 }
 
 void ResourceRequestBase::setHTTPHeaderField(const String& name, const String& value)
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.set(name, value);
+    m_requestData.m_httpHeaderFields.set(name, value);
     
     m_platformRequestUpdated = false;
 }
@@ -336,7 +336,7 @@ void ResourceRequestBase::setHTTPHeaderField(HTTPHeaderName name, const String& 
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.set(name, value);
+    m_requestData.m_httpHeaderFields.set(name, value);
 
     m_platformRequestUpdated = false;
 }
@@ -345,7 +345,7 @@ void ResourceRequestBase::clearHTTPAuthorization()
 {
     updateResourceRequest(); 
 
-    if (!m_httpHeaderFields.remove(HTTPHeaderName::Authorization))
+    if (!m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::Authorization))
         return;
 
     m_platformRequestUpdated = false;
@@ -365,7 +365,7 @@ void ResourceRequestBase::clearHTTPContentType()
 {
     updateResourceRequest(); 
 
-    m_httpHeaderFields.remove(HTTPHeaderName::ContentType);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::ContentType);
 
     m_platformRequestUpdated = false;
 }
@@ -374,7 +374,7 @@ void ResourceRequestBase::clearPurpose()
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.remove(HTTPHeaderName::Purpose);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::Purpose);
 
     m_platformRequestUpdated = false;
 }
@@ -386,7 +386,7 @@ String ResourceRequestBase::httpReferrer() const
 
 bool ResourceRequestBase::hasHTTPReferrer() const
 {
-    return m_httpHeaderFields.contains(HTTPHeaderName::Referer);
+    return m_requestData.m_httpHeaderFields.contains(HTTPHeaderName::Referer);
 }
 
 void ResourceRequestBase::setHTTPReferrer(const String& httpReferrer)
@@ -414,7 +414,7 @@ void ResourceRequestBase::clearHTTPReferrer()
 {
     updateResourceRequest(); 
 
-    m_httpHeaderFields.remove(HTTPHeaderName::Referer);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::Referer);
 
     m_platformRequestUpdated = false;
 }
@@ -431,21 +431,21 @@ void ResourceRequestBase::setHTTPOrigin(const String& httpOrigin)
 
 bool ResourceRequestBase::hasHTTPOrigin() const
 {
-    return m_httpHeaderFields.contains(HTTPHeaderName::Origin);
+    return m_requestData.m_httpHeaderFields.contains(HTTPHeaderName::Origin);
 }
 
 void ResourceRequestBase::clearHTTPOrigin()
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.remove(HTTPHeaderName::Origin);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::Origin);
 
     m_platformRequestUpdated = false;
 }
 
 bool ResourceRequestBase::hasHTTPHeader(HTTPHeaderName name) const
 {
-    return m_httpHeaderFields.contains(name);
+    return m_requestData.m_httpHeaderFields.contains(name);
 }
 
 String ResourceRequestBase::httpUserAgent() const
@@ -462,7 +462,7 @@ void ResourceRequestBase::clearHTTPUserAgent()
 {
     updateResourceRequest(); 
 
-    m_httpHeaderFields.remove(HTTPHeaderName::UserAgent);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::UserAgent);
 
     m_platformRequestUpdated = false;
 }
@@ -471,7 +471,7 @@ void ResourceRequestBase::clearHTTPAcceptEncoding()
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.remove(HTTPHeaderName::AcceptEncoding);
+    m_requestData.m_httpHeaderFields.remove(HTTPHeaderName::AcceptEncoding);
 
     m_platformRequestUpdated = false;
 }
@@ -480,14 +480,14 @@ void ResourceRequestBase::setResponseContentDispositionEncodingFallbackArray(con
 {
     updateResourceRequest(); 
     
-    m_responseContentDispositionEncodingFallbackArray.clear();
-    m_responseContentDispositionEncodingFallbackArray.reserveInitialCapacity(!encoding1.isNull() + !encoding2.isNull() + !encoding3.isNull());
+    m_requestData.m_responseContentDispositionEncodingFallbackArray.clear();
+    m_requestData.m_responseContentDispositionEncodingFallbackArray.reserveInitialCapacity(!encoding1.isNull() + !encoding2.isNull() + !encoding3.isNull());
     if (!encoding1.isNull())
-        m_responseContentDispositionEncodingFallbackArray.uncheckedAppend(encoding1);
+        m_requestData.m_responseContentDispositionEncodingFallbackArray.uncheckedAppend(encoding1);
     if (!encoding2.isNull())
-        m_responseContentDispositionEncodingFallbackArray.uncheckedAppend(encoding2);
+        m_requestData.m_responseContentDispositionEncodingFallbackArray.uncheckedAppend(encoding2);
     if (!encoding3.isNull())
-        m_responseContentDispositionEncodingFallbackArray.uncheckedAppend(encoding3);
+        m_requestData.m_responseContentDispositionEncodingFallbackArray.uncheckedAppend(encoding3);
     
     m_platformRequestUpdated = false;
 }
@@ -526,17 +526,17 @@ bool ResourceRequestBase::allowCookies() const
 {
     updateResourceRequest(); 
     
-    return m_allowCookies;
+    return m_requestData.m_allowCookies;
 }
 
 void ResourceRequestBase::setAllowCookies(bool allowCookies)
 {
     updateResourceRequest(); 
 
-    if (m_allowCookies == allowCookies)
+    if (m_requestData.m_allowCookies == allowCookies)
         return;
 
-    m_allowCookies = allowCookies;
+    m_requestData.m_allowCookies = allowCookies;
     
     m_platformRequestUpdated = false;
 }
@@ -545,17 +545,17 @@ ResourceLoadPriority ResourceRequestBase::priority() const
 {
     updateResourceRequest();
 
-    return m_priority;
+    return m_requestData.m_priority;
 }
 
 void ResourceRequestBase::setPriority(ResourceLoadPriority priority)
 {
     updateResourceRequest();
 
-    if (m_priority == priority)
+    if (m_requestData.m_priority == priority)
         return;
 
-    m_priority = priority;
+    m_requestData.m_priority = priority;
 
     m_platformRequestUpdated = false;
 }
@@ -564,7 +564,7 @@ void ResourceRequestBase::addHTTPHeaderFieldIfNotPresent(HTTPHeaderName name, co
 {
     updateResourceRequest();
 
-    if (!m_httpHeaderFields.addIfNotPresent(name, value))
+    if (!m_requestData.m_httpHeaderFields.addIfNotPresent(name, value))
         return;
 
     m_platformRequestUpdated = false;
@@ -574,7 +574,7 @@ void ResourceRequestBase::addHTTPHeaderField(HTTPHeaderName name, const String& 
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.add(name, value);
+    m_requestData.m_httpHeaderFields.add(name, value);
 
     m_platformRequestUpdated = false;
 }
@@ -583,21 +583,21 @@ void ResourceRequestBase::addHTTPHeaderField(const String& name, const String& v
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.add(name, value);
+    m_requestData.m_httpHeaderFields.add(name, value);
 
     m_platformRequestUpdated = false;
 }
 
 bool ResourceRequestBase::hasHTTPHeaderField(HTTPHeaderName headerName) const
 {
-    return m_httpHeaderFields.contains(headerName);
+    return m_requestData.m_httpHeaderFields.contains(headerName);
 }
 
 void ResourceRequestBase::setHTTPHeaderFields(HTTPHeaderMap headerFields)
 {
     updateResourceRequest();
 
-    m_httpHeaderFields = WTFMove(headerFields);
+    m_requestData.m_httpHeaderFields = WTFMove(headerFields);
 
     m_platformRequestUpdated = false;
 }
@@ -606,7 +606,7 @@ void ResourceRequestBase::removeHTTPHeaderField(const String& name)
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.remove(name);
+    m_requestData.m_httpHeaderFields.remove(name);
 
     m_platformRequestUpdated = false;
 }
@@ -615,7 +615,7 @@ void ResourceRequestBase::removeHTTPHeaderField(HTTPHeaderName name)
 {
     updateResourceRequest();
 
-    m_httpHeaderFields.remove(name);
+    m_requestData.m_httpHeaderFields.remove(name);
 
     m_platformRequestUpdated = false;
 }
@@ -624,10 +624,10 @@ void ResourceRequestBase::setIsAppInitiated(bool isAppInitiated)
 {
     updateResourceRequest();
 
-    if (m_isAppInitiated == isAppInitiated)
+    if (m_requestData.m_isAppInitiated == isAppInitiated)
         return;
 
-    m_isAppInitiated = isAppInitiated;
+    m_requestData.m_isAppInitiated = isAppInitiated;
 
     m_platformRequestUpdated = false;
 };
@@ -639,9 +639,9 @@ bool ResourceRequestBase::isSystemPreview() const
     return m_systemPreviewInfo.has_value();
 }
 
-SystemPreviewInfo ResourceRequestBase::systemPreviewInfo() const
+std::optional<SystemPreviewInfo> ResourceRequestBase::systemPreviewInfo() const
 {
-    return valueOrDefault(m_systemPreviewInfo);
+    return m_systemPreviewInfo;
 }
 
 void ResourceRequestBase::setSystemPreviewInfo(const SystemPreviewInfo& info)
@@ -710,7 +710,7 @@ bool ResourceRequestBase::isConditional() const
     updateResourceRequest();
 
     for (auto headerName : conditionalHeaderNames) {
-        if (m_httpHeaderFields.contains(headerName))
+        if (m_requestData.m_httpHeaderFields.contains(headerName))
             return true;
     }
 
@@ -722,7 +722,7 @@ void ResourceRequestBase::makeUnconditional()
     updateResourceRequest();
 
     for (auto headerName : conditionalHeaderNames)
-        m_httpHeaderFields.remove(headerName);
+        m_requestData.m_httpHeaderFields.remove(headerName);
 }
 
 double ResourceRequestBase::defaultTimeoutInterval()

--- a/Source/WebCore/platform/network/cf/ResourceHandleCFURLConnectionDelegateWithOperationQueue.cpp
+++ b/Source/WebCore/platform/network/cf/ResourceHandleCFURLConnectionDelegateWithOperationQueue.cpp
@@ -190,7 +190,7 @@ void ResourceHandleCFURLConnectionDelegateWithOperationQueue::didReceiveResponse
         int statusCode = msg ? CFHTTPMessageGetResponseStatusCode(msg) : 0;
 
         if (statusCode != 304) {
-            bool isMainResourceLoad = m_handle->firstRequest().requester() == ResourceRequest::Requester::Main;
+            bool isMainResourceLoad = m_handle->firstRequest().requester() == ResourceRequestRequester::Main;
         }
 
         if (_CFURLRequestCopyProtocolPropertyForKey(m_handle->firstRequest().cfURLRequest(DoNotUpdateHTTPBody), CFSTR("ForceHTMLMIMEType")))

--- a/Source/WebCore/platform/network/curl/ResourceRequest.h
+++ b/Source/WebCore/platform/network/curl/ResourceRequest.h
@@ -61,6 +61,14 @@ public:
     {
     }
 
+    ResourceRequest(ResourceRequestBase&& base)
+        : ResourceRequestBase(WTFMove(base))
+    {
+    }
+
+    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestBase::RequestData&&);
+    WEBCORE_EXPORT ResourceRequestBase::RequestData getRequestDataToSerialize() const;
+
     WEBCORE_EXPORT void updateFromDelegatePreservingOldProperties(const ResourceRequest&);
 
     // Needed for compatibility.
@@ -69,9 +77,6 @@ public:
     // The following two stubs are for compatibility with CFNetwork, and are not used.
     static bool httpPipeliningEnabled() { return false; }
     static void setHTTPPipeliningEnabled(bool) { }
-
-    template<class Encoder> void encodeWithPlatformData(Encoder&) const;
-    template<class Decoder> WARN_UNUSED_RETURN bool decodeWithPlatformData(Decoder&);
 
 private:
     friend class ResourceRequestBase;
@@ -85,20 +90,5 @@ private:
 
     static bool s_httpPipeliningEnabled;
 };
-
-template<class Encoder>
-void ResourceRequest::encodeWithPlatformData(Encoder& encoder) const
-{
-    encodeBase(encoder);
-}
-
-template<class Decoder>
-bool ResourceRequest::decodeWithPlatformData(Decoder& decoder)
-{
-    if (!decodeBase(decoder))
-        return false;
-
-    return true;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/ResourceRequestCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceRequestCurl.cpp
@@ -52,6 +52,16 @@ void ResourceRequest::updateFromDelegatePreservingOldProperties(const ResourceRe
         setInspectorInitiatorNodeIdentifier(*oldInspectorInitiatorNodeIdentifier);
 }
 
+ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestBase::RequestData&& requestData)
+{
+    return ResourceRequest(WTFMove(requestData));
+}
+
+ResourceRequestBase::RequestData ResourceRequest::getRequestDataToSerialize() const
+{
+    return m_requestData;
+}
+
 }
 
 #endif

--- a/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
+++ b/Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm
@@ -254,7 +254,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         // Avoid MIME type sniffing if the response comes back as 304 Not Modified.
         int statusCode = [r respondsToSelector:@selector(statusCode)] ? [(id)r statusCode] : 0;
         if (statusCode != 304) {
-            bool isMainResourceLoad = m_handle->firstRequest().requester() == ResourceRequest::Requester::Main;
+            bool isMainResourceLoad = m_handle->firstRequest().requester() == ResourceRequestRequester::Main;
             adjustMIMETypeIfNecessary([r _CFURLResponse], isMainResourceLoad);
         }
 

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -105,7 +105,7 @@ std::optional<Exception> WorkerScriptLoader::loadSynchronously(ScriptExecutionCo
 
     // Only used for importScripts that prescribes NoCors mode.
     ASSERT(mode == FetchOptions::Mode::NoCors);
-    request->setRequester(ResourceRequest::Requester::ImportScripts);
+    request->setRequester(ResourceRequestRequester::ImportScripts);
 
     ThreadableLoaderOptions options;
     options.credentials = FetchOptions::Credentials::Include;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -601,7 +601,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
         m_uploadListenerFlag = true;
 
     ResourceRequest request(m_url);
-    request.setRequester(ResourceRequest::Requester::XHR);
+    request.setRequester(ResourceRequestRequester::XHR);
     request.setInitiatorIdentifier(scriptExecutionContext()->resourceRequestIdentifier());
     request.setHTTPMethod(m_method);
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -302,7 +302,7 @@ bool NetworkLoadChecker::isAllowedByContentSecurityPolicy(const ResourceRequest&
     case FetchOptions::Destination::Sharedworker:
         return contentSecurityPolicy->allowWorkerFromSource(request.url(), redirectResponseReceived, preRedirectURL);
     case FetchOptions::Destination::Script:
-        if (request.requester() == ResourceRequest::Requester::ImportScripts && !contentSecurityPolicy->allowScriptFromSource(request.url(), redirectResponseReceived, preRedirectURL))
+        if (request.requester() == ResourceRequestRequester::ImportScripts && !contentSecurityPolicy->allowScriptFromSource(request.url(), redirectResponseReceived, preRedirectURL))
             return false;
         // FIXME: Check CSP for non-importScripts() initiated loads.
         return true;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -406,15 +406,15 @@ ResourceLoadInfo NetworkResourceLoader::resourceLoadInfo()
         return false;
     };
 
-    auto resourceType = [] (WebCore::ResourceRequestBase::Requester requester, WebCore::FetchOptions::Destination destination) {
+    auto resourceType = [] (WebCore::ResourceRequestRequester requester, WebCore::FetchOptions::Destination destination) {
         switch (requester) {
-        case WebCore::ResourceRequestBase::Requester::XHR:
+        case WebCore::ResourceRequestRequester::XHR:
             return ResourceLoadInfo::Type::XMLHTTPRequest;
-        case WebCore::ResourceRequestBase::Requester::Fetch:
+        case WebCore::ResourceRequestRequester::Fetch:
             return ResourceLoadInfo::Type::Fetch;
-        case WebCore::ResourceRequestBase::Requester::Ping:
+        case WebCore::ResourceRequestRequester::Ping:
             return ResourceLoadInfo::Type::Ping;
-        case WebCore::ResourceRequestBase::Requester::Beacon:
+        case WebCore::ResourceRequestRequester::Beacon:
             return ResourceLoadInfo::Type::Beacon;
         default:
             break;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -140,7 +140,7 @@ public:
         
     void convertToDownload(DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
 
-    bool isMainResource() const { return m_parameters.request.requester() == WebCore::ResourceRequest::Requester::Main; }
+    bool isMainResource() const { return m_parameters.request.requester() == WebCore::ResourceRequestRequester::Main; }
     bool isMainFrameLoad() const { return isMainResource() && m_parameters.frameAncestorOrigins.isEmpty(); }
     bool isCrossOriginPrefetch() const;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -93,7 +93,7 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
     SWFETCH_RELEASE_LOG("ServiceWorkerFetchTask: (serverConnectionIdentifier=%" PRIu64 ", serviceWorkerRegistrationIdentifier=%" PRIu64 ", serviceWorkerIdentifier=%" PRIu64 ", %d)", m_serverConnectionIdentifier.toUInt64(), m_serviceWorkerRegistrationIdentifier.toUInt64(), m_serviceWorkerIdentifier.toUInt64(), isWorkerReady);
 
     // We only do the timeout logic for main document navigations because it is not Web-compatible to do so for subresources.
-    if (loader.parameters().request.requester() == WebCore::ResourceRequest::Requester::Main) {
+    if (loader.parameters().request.requester() == WebCore::ResourceRequestRequester::Main) {
         m_timeoutTimer = makeUnique<Timer>(*this, &ServiceWorkerFetchTask::timeoutTimerFired);
         m_timeoutTimer->startOneShot(loader.connectionToWebProcess().networkProcess().serviceWorkerFetchTimeout());
     }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -192,7 +192,7 @@ void WebSWServerConnection::controlClient(const NetworkResourceLoadParameters& p
 std::unique_ptr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(NetworkResourceLoader& loader, const ResourceRequest& request)
 {
     if (loader.parameters().serviceWorkersMode == ServiceWorkersMode::None) {
-        if (loader.parameters().request.requester() == ResourceRequest::Requester::Fetch && isNavigationRequest(loader.parameters().options.destination)) {
+        if (loader.parameters().request.requester() == ResourceRequestRequester::Fetch && isNavigationRequest(loader.parameters().options.destination)) {
             if (auto task = ServiceWorkerFetchTask::fromNavigationPreloader(*this, loader, request, session()))
                 return task;
         }

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
@@ -555,7 +555,7 @@ Storage::Record Cache::encode(const RecordInformation& recordInformation, const 
     encoder << recordInformation.insertionTime;
     encoder << recordInformation.size;
     encoder << record.requestHeadersGuard;
-    record.request.encodeWithoutPlatformData(encoder);
+    encoder << record.request;
     record.options.encodePersistent(encoder);
     encoder << record.referrer;
 
@@ -584,8 +584,9 @@ static std::optional<WebCore::DOMCacheEngine::Record> decodeDOMCacheRecord(WTF::
     if (!requestHeadersGuard)
         return std::nullopt;
     
-    ResourceRequest request;
-    if (!request.decodeWithoutPlatformData(decoder))
+    std::optional<ResourceRequest> request;
+    decoder >> request;
+    if (!request)
         return std::nullopt;
     
     FetchOptions options;
@@ -618,7 +619,7 @@ static std::optional<WebCore::DOMCacheEngine::Record> decodeDOMCacheRecord(WTF::
         0,
         0,
         WTFMove(*requestHeadersGuard),
-        WTFMove(request),
+        WTFMove(*request),
         WTFMove(options),
         WTFMove(*referrer),
         WTFMove(*responseHeadersGuard),

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -283,7 +283,7 @@ static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalR
             return StoreDecision::NoDueToHTTPStatusCode;
     }
 
-    bool isMainResource = originalRequest.requester() == WebCore::ResourceRequest::Requester::Main;
+    bool isMainResource = originalRequest.requester() == WebCore::ResourceRequestRequester::Main;
     bool storeUnconditionallyForHistoryNavigation = isMainResource || originalRequest.priority() == WebCore::ResourceLoadPriority::VeryHigh;
     if (!storeUnconditionallyForHistoryNavigation) {
         auto now = WallTime::now();
@@ -303,8 +303,8 @@ static StoreDecision makeStoreDecision(const WebCore::ResourceRequest& originalR
     // FIXME: We should introduce a separate media cache partition that doesn't affect other resources.
     // FIXME: We should also make sure make the MSE paths are copy-free so we can use mapped buffers from disk effectively.
     auto requester = originalRequest.requester();
-    bool isDefinitelyStreamingMedia = requester == WebCore::ResourceRequest::Requester::Media;
-    bool isLikelyStreamingMedia = requester == WebCore::ResourceRequest::Requester::XHR && isMediaMIMEType(response.mimeType());
+    bool isDefinitelyStreamingMedia = requester == WebCore::ResourceRequestRequester::Media;
+    bool isLikelyStreamingMedia = requester == WebCore::ResourceRequestRequester::XHR && isMediaMIMEType(response.mimeType());
     if (isLikelyStreamingMedia || isDefinitelyStreamingMedia)
         return StoreDecision::NoDueToStreamingMedia;
 
@@ -317,7 +317,7 @@ static bool inline canRequestUseSpeculativeRevalidation(const WebCore::ResourceR
     if (request.isConditional())
         return false;
 
-    if (request.requester() == WebCore::ResourceRequest::Requester::XHR || request.requester() == WebCore::ResourceRequest::Requester::Fetch)
+    if (request.requester() == WebCore::ResourceRequestRequester::XHR || request.requester() == WebCore::ResourceRequestRequester::Fetch)
         return false;
 
     switch (request.cachePolicy()) {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -95,7 +95,7 @@ Storage::Record Entry::encodeAsStorageRecord() const
     uint8_t privateRelayed = m_privateRelayed == PrivateRelayed::Yes;
     encoder << static_cast<uint8_t>((isRedirect << 0) | (privateRelayed << 1));
     if (isRedirect)
-        m_redirectRequest->encodeWithoutPlatformData(encoder);
+        encoder << m_redirectRequest;
 
     encoder << m_maxAgeCap;
     
@@ -145,8 +145,11 @@ std::unique_ptr<Entry> Entry::decodeStorageRecord(const Storage::Record& storage
     
     if (isRedirect) {
         entry->m_redirectRequest.emplace();
-        if (!entry->m_redirectRequest->decodeWithoutPlatformData(decoder))
+        std::optional<std::optional<WebCore::ResourceRequest>> resourceRequest;
+        decoder >> resourceRequest;
+        if (!resourceRequest)
             return nullptr;
+        entry->m_redirectRequest = WTFMove(*resourceRequest);
     }
 
     std::optional<std::optional<Seconds>> maxAgeCap;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -354,7 +354,7 @@ void SpeculativeLoadManager::registerLoad(const GlobalFrameID& frameID, const Re
     if (!shouldRegisterLoad(request))
         return;
 
-    auto isMainResource = request.requester() == ResourceRequest::Requester::Main;
+    auto isMainResource = request.requester() == ResourceRequestRequester::Main;
     if (isMainResource) {
         // Mark previous load in this frame as completed if necessary.
         if (auto* pendingFrameLoad = m_pendingFrameLoads.get(frameID))

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -953,7 +953,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // Avoid MIME type sniffing if the response comes back as 304 Not Modified.
         int statusCode = [response isKindOfClass:NSHTTPURLResponse.class] ? [(NSHTTPURLResponse *)response statusCode] : 0;
         if (statusCode != 304) {
-            bool isMainResourceLoad = networkDataTask->firstRequest().requester() == WebCore::ResourceRequest::Requester::Main;
+            bool isMainResourceLoad = networkDataTask->firstRequest().requester() == WebCore::ResourceRequestRequester::Main;
             WebCore::adjustMIMETypeIfNecessary(response._CFURLResponse, isMainResourceLoad);
         }
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -255,6 +255,7 @@ def serialized_identifiers():
         'WebCore::BroadcastChannelIdentifier',
         'WebCore::DOMCacheIdentifier',
         'WebCore::DisplayList::ItemBufferIdentifier',
+        'WebCore::ElementIdentifier',
         'WebCore::FetchIdentifier',
         'WebCore::FileSystemHandleIdentifier',
         'WebCore::FileSystemSyncAccessHandleIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -115,11 +115,11 @@ std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subn
 
     return {
         Namespace::Subnamespace::StructName {
-            WTFMove(*firstMemberName),
+            WTFMove(*firstMemberName)
 #if ENABLE(SECOND_MEMBER)
-            WTFMove(*secondMemberName),
+            , WTFMove(*secondMemberName)
 #endif
-            WTFMove(*nullableTestMember)
+            , WTFMove(*nullableTestMember)
         }
     };
 }
@@ -167,10 +167,10 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
 
     return {
         Namespace::OtherClass {
-            WTFMove(*isNull),
-            WTFMove(*a),
-            WTFMove(*b),
-            WTFMove(*dataDetectorResults)
+            WTFMove(*isNull)
+            , WTFMove(*a)
+            , WTFMove(*b)
+            , WTFMove(*dataDetectorResults)
         }
     };
 }
@@ -216,9 +216,9 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
 
     return {
         Namespace::ReturnRefClass::create(
-            WTFMove(*functionCallmember1),
-            WTFMove(*functionCallmember2),
-            WTFMove(*uniqueMember)
+            WTFMove(*functionCallmember1)
+            , WTFMove(*functionCallmember2)
+            , WTFMove(*uniqueMember)
         )
     };
 }
@@ -379,8 +379,8 @@ std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decod
             WithoutNamespace {
                 WTFMove(*a)
             }
-            ,
-            WTFMove(*b)
+            
+            , WTFMove(*b)
         }
     };
 }
@@ -419,11 +419,11 @@ std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::Inheritance
                 WithoutNamespace {
                     WTFMove(*a)
                 }
-                ,
-                WTFMove(*b)
+                
+                , WTFMove(*b)
             }
-            ,
-            WTFMove(*c)
+            
+            , WTFMove(*c)
         }
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -71,6 +71,7 @@
 #include <WebCore/BroadcastChannelIdentifier.h>
 #include <WebCore/DOMCacheIdentifier.h>
 #include <WebCore/DisplayList.h>
+#include <WebCore/ElementIdentifier.h>
 #include <WebCore/FetchIdentifier.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
@@ -371,6 +372,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebCore::BroadcastChannelIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::DOMCacheIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::DisplayList::ItemBufferIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebCore::ElementIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::FetchIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::FileSystemHandleIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebCore::FileSystemSyncAccessHandleIdentifier));
@@ -442,6 +444,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::BroadcastChannelIdentifier"_s,
         "WebCore::DOMCacheIdentifier"_s,
         "WebCore::DisplayList::ItemBufferIdentifier"_s,
+        "WebCore::ElementIdentifier"_s,
         "WebCore::FetchIdentifier"_s,
         "WebCore::FileSystemHandleIdentifier"_s,
         "WebCore::FileSystemSyncAccessHandleIdentifier"_s,

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -28,3 +28,12 @@ header: <WebCore/DictionaryPopupInfo.h>
     RetainPtr<NSDictionary> options;
     RetainPtr<NSAttributedString> attributedString;
 };
+
+#if PLATFORM(COCOA)
+header: <WebCore/ResourceRequest.h>
+[CustomHeader=True] struct WebCore::ResourceRequestPlatformData {
+    RetainPtr<NSURLRequest> m_urlRequest;
+    std::optional<bool> m_isAppInitiated;
+    std::optional<WebCore::ResourceRequestRequester> m_requester
+};
+#endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -742,64 +742,6 @@ bool ArgumentCoder<Cursor>::decode(Decoder& decoder, Cursor& cursor)
     return true;
 }
 
-void ArgumentCoder<ResourceRequest>::encode(Encoder& encoder, const ResourceRequest& resourceRequest)
-{
-    if (resourceRequest.encodingRequiresPlatformData()) {
-        encoder << true;
-        encodePlatformData(encoder, resourceRequest);
-    } else {
-        encoder << false;
-        resourceRequest.encodeWithoutPlatformData(encoder);
-    }
-
-    encoder << resourceRequest.cachePartition();
-    encoder << resourceRequest.hiddenFromInspector();
-
-#if USE(SYSTEM_PREVIEW)
-    if (resourceRequest.isSystemPreview()) {
-        encoder << true;
-        encoder << resourceRequest.systemPreviewInfo();
-    } else
-        encoder << false;
-#endif
-}
-
-bool ArgumentCoder<ResourceRequest>::decode(Decoder& decoder, ResourceRequest& resourceRequest)
-{
-    bool hasPlatformData;
-    if (!decoder.decode(hasPlatformData))
-        return false;
-
-    bool decodeSuccess = hasPlatformData ? decodePlatformData(decoder, resourceRequest) : resourceRequest.decodeWithoutPlatformData(decoder);
-    if (!decodeSuccess)
-        return false;
-
-    String cachePartition;
-    if (!decoder.decode(cachePartition))
-        return false;
-    resourceRequest.setCachePartition(cachePartition);
-
-    bool isHiddenFromInspector;
-    if (!decoder.decode(isHiddenFromInspector))
-        return false;
-    resourceRequest.setHiddenFromInspector(isHiddenFromInspector);
-
-#if USE(SYSTEM_PREVIEW)
-    bool isSystemPreview;
-    if (!decoder.decode(isSystemPreview))
-        return false;
-
-    if (isSystemPreview) {
-        SystemPreviewInfo systemPreviewInfo;
-        if (!decoder.decode(systemPreviewInfo))
-            return false;
-        resourceRequest.setSystemPreviewInfo(systemPreviewInfo);
-    }
-#endif
-
-    return true;
-}
-
 void ArgumentCoder<ResourceError>::encode(Encoder& encoder, const ResourceError& resourceError)
 {
     encoder << resourceError.type();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -319,13 +319,6 @@ template<> struct ArgumentCoder<WebCore::DecomposedGlyphs> {
     static std::optional<Ref<WebCore::DecomposedGlyphs>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<WebCore::ResourceRequest> {
-    static void encode(Encoder&, const WebCore::ResourceRequest&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ResourceRequest&);
-    static void encodePlatformData(Encoder&, const WebCore::ResourceRequest&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::ResourceRequest&);
-};
-
 template<> struct ArgumentCoder<WebCore::ResourceError> {
     static void encode(Encoder&, const WebCore::ResourceError&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ResourceError&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1144,3 +1144,91 @@ header: <WebCore/DisplayListItems.h>
     uint8_t colorData().resolved().blue
     uint8_t colorData().resolved().alpha
 }
+
+header: <WebCore/HTTPHeaderMap.h>
+[Nested, CustomHeader] struct WebCore::HTTPHeaderMap::CommonHeader {
+    WebCore::HTTPHeaderName key;
+    String value;
+};
+
+header: <WebCore/HTTPHeaderMap.h>
+[Nested, CustomHeader] struct WebCore::HTTPHeaderMap::UncommonHeader {
+    String key;
+    String value;
+};
+
+class WebCore::HTTPHeaderMap {
+    Vector<WebCore::HTTPHeaderMap::CommonHeader, 0, CrashOnOverflow, 6> commonHeaders();
+    Vector<WebCore::HTTPHeaderMap::UncommonHeader, 0, CrashOnOverflow, 0> uncommonHeaders();
+}
+
+struct WebCore::ElementContext {
+    WebCore::FloatRect boundingRect;
+    WebCore::PageIdentifier webPageIdentifier;
+    WebCore::ScriptExecutionContextIdentifier documentIdentifier;
+    WebCore::ElementIdentifier elementIdentifier;
+};
+
+header: <WebCore/FrameLoaderTypes.h>
+[CustomHeader] struct WebCore::SystemPreviewInfo {
+    WebCore::ElementContext element;
+    WebCore::IntRect previewRect;
+    bool isPreview;
+};
+
+header: <WebCore/ResourceRequest.h>
+[CustomHeader, Nested] class WebCore::ResourceRequest::RequestData {
+    URL m_url;
+    double m_timeoutInterval;
+    URL m_firstPartyForCookies;
+    String m_httpMethod;
+    WebCore::HTTPHeaderMap m_httpHeaderFields;
+    Vector<String> m_responseContentDispositionEncodingFallbackArray;
+    WebCore::ResourceRequestCachePolicy m_cachePolicy;
+    WebCore::ResourceRequestBase::SameSiteDisposition m_sameSiteDisposition;
+    WebCore::ResourceLoadPriority m_priority;
+    WebCore::ResourceRequestRequester m_requester;
+    bool m_allowCookies;
+    bool m_isTopSite;
+    bool m_isAppInitiated;
+};
+
+#if USE(SOUP)
+header: <WebCore/ResourceRequest.h>
+[CustomHeader=True] struct WebCore::ResourceRequestPlatformData {
+    WebCore::ResourceRequest::RequestData requestData;
+    std::optional<String> flattenedHTTPBody;
+    bool acceptEncoding;
+    uint16_t redirectCount;
+};
+#endif
+
+#if PLATFORM(COCOA) && USE(SYSTEM_PREVIEW)
+[CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
+    std::variant<WebCore::ResourceRequest::RequestData, WebCore::ResourceRequestPlatformData> getRequestDataToSerialize();
+    String cachePartition();
+    bool hiddenFromInspector();
+    std::optional<WebCore::SystemPreviewInfo> systemPreviewInfo();
+};
+#endif
+
+#if PLATFORM(COCOA) && !USE(SYSTEM_PREVIEW)
+[CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
+    std::variant<WebCore::ResourceRequest::RequestData, WebCore::ResourceRequestPlatformData> getRequestDataToSerialize();
+    String cachePartition();
+    bool hiddenFromInspector();
+};
+#endif
+
+#if USE(CURL)
+[CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
+    WebCore::ResourceRequest::RequestData getRequestDataToSerialize();
+};
+#endif
+
+#if !USE(CURL) && !PLATFORM(COCOA)
+header: <WebCore/ResourceRequest.h>
+[CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
+    std::variant<WebCore::ResourceRequest::RequestData, WebCore::ResourceRequestPlatformData> getRequestDataToSerialize();
+};
+#endif

--- a/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
+++ b/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
@@ -40,16 +40,6 @@ namespace IPC {
 
 using namespace WebCore;
 
-void ArgumentCoder<ResourceRequest>::encodePlatformData(Encoder& encoder, const ResourceRequest& resourceRequest)
-{
-    resourceRequest.encodeWithPlatformData(encoder);
-}
-
-bool ArgumentCoder<ResourceRequest>::decodePlatformData(Decoder& decoder, ResourceRequest& resourceRequest)
-{
-    return resourceRequest.decodeWithPlatformData(decoder);
-}
-
 template<typename Encoder>
 void ArgumentCoder<CertificateInfo>::encode(Encoder& encoder, const CertificateInfo& certificateInfo)
 {

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -43,16 +43,6 @@
 namespace IPC {
 using namespace WebCore;
 
-void ArgumentCoder<ResourceRequest>::encodePlatformData(Encoder& encoder, const ResourceRequest& resourceRequest)
-{
-    resourceRequest.encodeWithPlatformData(encoder);
-}
-
-bool ArgumentCoder<ResourceRequest>::decodePlatformData(Decoder& decoder, ResourceRequest& resourceRequest)
-{
-    return resourceRequest.decodeWithPlatformData(decoder);
-}
-
 template<typename Encoder>
 void ArgumentCoder<CertificateInfo>::encode(Encoder& encoder, const CertificateInfo& certificateInfo)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitResponsePolicyDecision.cpp
@@ -184,7 +184,7 @@ gboolean webkit_response_policy_decision_is_main_frame_main_resource(WebKitRespo
     if (!decision->priv->navigationResponse->frame().isMainFrame())
         return FALSE;
 
-    return decision->priv->navigationResponse->request().requester() == ResourceRequest::Requester::Main;
+    return decision->priv->navigationResponse->request().requester() == ResourceRequestRequester::Main;
 }
 
 WebKitPolicyDecision* webkitResponsePolicyDecisionCreate(Ref<API::NavigationResponse>&& response, Ref<WebKit::WebFramePolicyListenerProxy>&& listener)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -244,7 +244,7 @@ WebKitWebResource* webkitWebResourceCreate(WebFrameProxy& frame, const WebCore::
     WebKitWebResource* resource = WEBKIT_WEB_RESOURCE(g_object_new(WEBKIT_TYPE_WEB_RESOURCE, NULL));
     resource->priv->frame = &frame;
     resource->priv->uri = request.url().string().utf8();
-    resource->priv->isMainResource = frame.isMainFrame() && request.requester() == WebCore::ResourceRequest::Requester::Main;
+    resource->priv->isMainResource = frame.isMainFrame() && request.requester() == WebCore::ResourceRequestRequester::Main;
     return resource;
 }
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -96,7 +96,7 @@ public:
 
 #if USE(SYSTEM_PREVIEW)
     bool isSystemPreviewDownload() const { return request().isSystemPreview(); }
-    WebCore::SystemPreviewInfo systemPreviewDownloadInfo() const { return request().systemPreviewInfo(); }
+    WebCore::SystemPreviewInfo systemPreviewDownloadInfo() const { RELEASE_ASSERT(request().systemPreviewInfo().has_value()); return *request().systemPreviewInfo(); }
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -636,7 +636,7 @@ static bool shouldClearReferrerOnHTTPSToHTTPRedirect(Frame* frame)
 WebLoaderStrategy::SyncLoadResult WebLoaderStrategy::loadDataURLSynchronously(const ResourceRequest& request)
 {
     auto mode = DataURLDecoder::Mode::Legacy;
-    if (request.requester() == ResourceRequest::Requester::Fetch)
+    if (request.requester() == ResourceRequestRequester::Fetch)
         mode = DataURLDecoder::Mode::ForgivingBase64;
 
     SyncLoadResult result;

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -247,7 +247,7 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
         serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(isAppInitiated);
     });
 
-    auto client = WebServiceWorkerFetchTaskClient::create(m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request.requester() == ResourceRequest::Requester::Main);
+    auto client = WebServiceWorkerFetchTaskClient::create(m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request.requester() == ResourceRequestRequester::Main);
 
     request.setHTTPBody(formData.takeData());
     serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTFMove(client), WTFMove(request), WTFMove(referrer), WTFMove(options), isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));


### PR DESCRIPTION
#### 8983399c2041f3be0c275e117a76524f8b45fcbc
<pre>
Port ResourceRequest and related to the new CoreIPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=247135">https://bugs.webkit.org/show_bug.cgi?id=247135</a>
rdar://101640392

Port ResourceRequest and related classes to the new CoreIPC serialization
format. This change pulls out the core ResourceRequestData (which we persist)
and defines a new &quot;platform specific&quot; requestData type which can be serialized
in place of the core data for CoreIPC when needed.

Reviewed by Alex Christensen.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::sendBeacon):
* Source/WebCore/Modules/fetch/FetchRequest.h:
(WebCore::FetchRequest::FetchRequest):
* Source/WebCore/dom/ElementContext.h:
(WebCore::ElementContext::isSameElement const):
(WebCore::operator==):
(WebCore::ElementContext::encode const): Deleted.
(WebCore::ElementContext::decode): Deleted.
* Source/WebCore/inspector/agents/InspectorDOMDebuggerAgent.cpp:
(WebCore::InspectorDOMDebuggerAgent::willSendRequest):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::willSendRequest):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::inspectorResourceType):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource):
* Source/WebCore/loader/FrameLoaderTypes.h:
(WebCore::SystemPreviewInfo::encode const): Deleted.
(WebCore::SystemPreviewInfo::decode): Deleted.
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::requestResource):
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::sendPing):
* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::toResourceType):
* Source/WebCore/loader/ResourceLoadInfo.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::loadDataURL):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::connect):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::encode):
(WTF::Persistence::Coder&lt;WebCore::ResourceRequest&gt;::decode):
* Source/WebCore/platform/WebCorePersistentCoders.h:
* Source/WebCore/platform/network/HTTPHeaderMap.cpp:
* Source/WebCore/platform/network/HTTPHeaderMap.h:
(WebCore::HTTPHeaderMap::CommonHeader::isolatedCopy):
(WebCore::HTTPHeaderMap::UncommonHeader::isolatedCopy):
(WebCore::HTTPHeaderMap::CommonHeader::encode const): Deleted.
(WebCore::HTTPHeaderMap::CommonHeader::decode): Deleted.
(WebCore::HTTPHeaderMap::UncommonHeader::encode const): Deleted.
(WebCore::HTTPHeaderMap::UncommonHeader::decode): Deleted.
(WebCore::HTTPHeaderMap::encode const): Deleted.
(WebCore::HTTPHeaderMap::decode): Deleted.
* Source/WebCore/platform/network/ResourceLoadPriority.h:
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::setAsIsolatedCopy):
(WebCore::ResourceRequestBase::isEmpty const):
(WebCore::ResourceRequestBase::isNull const):
(WebCore::ResourceRequestBase::url const):
(WebCore::ResourceRequestBase::setURL):
(WebCore::ResourceRequestBase::redirectAsGETIfNeeded):
(WebCore::ResourceRequestBase::redirectedRequest const):
(WebCore::ResourceRequestBase::removeCredentials):
(WebCore::ResourceRequestBase::cachePolicy const):
(WebCore::ResourceRequestBase::setCachePolicy):
(WebCore::ResourceRequestBase::timeoutInterval const):
(WebCore::ResourceRequestBase::setTimeoutInterval):
(WebCore::ResourceRequestBase::firstPartyForCookies const):
(WebCore::ResourceRequestBase::setFirstPartyForCookies):
(WebCore::ResourceRequestBase::isSameSite const):
(WebCore::ResourceRequestBase::setIsSameSite):
(WebCore::ResourceRequestBase::isTopSite const):
(WebCore::ResourceRequestBase::setIsTopSite):
(WebCore::ResourceRequestBase::httpMethod const):
(WebCore::ResourceRequestBase::setHTTPMethod):
(WebCore::ResourceRequestBase::httpHeaderFields const):
(WebCore::ResourceRequestBase::httpHeaderField const):
(WebCore::ResourceRequestBase::setHTTPHeaderField):
(WebCore::ResourceRequestBase::clearHTTPAuthorization):
(WebCore::ResourceRequestBase::clearHTTPContentType):
(WebCore::ResourceRequestBase::clearPurpose):
(WebCore::ResourceRequestBase::hasHTTPReferrer const):
(WebCore::ResourceRequestBase::clearHTTPReferrer):
(WebCore::ResourceRequestBase::hasHTTPOrigin const):
(WebCore::ResourceRequestBase::clearHTTPOrigin):
(WebCore::ResourceRequestBase::hasHTTPHeader const):
(WebCore::ResourceRequestBase::clearHTTPUserAgent):
(WebCore::ResourceRequestBase::clearHTTPAcceptEncoding):
(WebCore::ResourceRequestBase::setResponseContentDispositionEncodingFallbackArray):
(WebCore::ResourceRequestBase::allowCookies const):
(WebCore::ResourceRequestBase::setAllowCookies):
(WebCore::ResourceRequestBase::priority const):
(WebCore::ResourceRequestBase::setPriority):
(WebCore::ResourceRequestBase::addHTTPHeaderFieldIfNotPresent):
(WebCore::ResourceRequestBase::addHTTPHeaderField):
(WebCore::ResourceRequestBase::hasHTTPHeaderField const):
(WebCore::ResourceRequestBase::setHTTPHeaderFields):
(WebCore::ResourceRequestBase::removeHTTPHeaderField):
(WebCore::ResourceRequestBase::isConditional const):
(WebCore::ResourceRequestBase::makeUnconditional):
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
(WebCore::ResourceRequestBase::ResourceRequestBase):
(WebCore::ResourceRequestBase::isSameSiteUnspecified const):
(WebCore::ResourceRequestBase::sameSiteDisposition const):
(WebCore::ResourceRequestBase::setSameSiteDisposition):
(WebCore::ResourceRequestBase::responseContentDispositionEncodingFallbackArray const):
(WebCore::ResourceRequestBase::setResponseContentDispositionEncodingFallbackArray):
(WebCore::ResourceRequestBase::platformRequestUpdated const):
(WebCore::ResourceRequestBase::requester const):
(WebCore::ResourceRequestBase::setRequester):
(WebCore::ResourceRequestBase::m_isAppInitiated):
(WebCore::ResourceRequestBase::encodeBase const): Deleted.
(WebCore::ResourceRequestBase::decodeBase): Deleted.
(WebCore::ResourceRequestBase::encodeWithoutPlatformData const): Deleted.
(WebCore::ResourceRequestBase::decodeWithoutPlatformData): Deleted.
* Source/WebCore/platform/network/cf/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
* Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp:
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::ResourceRequest::getRequestDataToSerialize const):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::ResourceRequest):
(WebCore::ResourceRequest::fromResourceRequestData):
(WebCore::ResourceRequest::getResourceRequestPlatformData const):
(WebCore::ResourceRequest::doUpdateResourceRequest):
(WebCore::ResourceRequest::doUpdatePlatformRequest):
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebCore/platform/network/curl/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
(WebCore::fromResourceRequestData):
(WebCore::ResourceRequest::encodeWithPlatformData const): Deleted.
(WebCore::ResourceRequest::decodeWithPlatformData): Deleted.
* Source/WebCore/platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm:
(-[WebCoreResourceHandleAsOperationQueueDelegate connection:didReceiveResponse:]):
* Source/WebCore/platform/network/soup/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
(WebCore::fromResourceRequestData):
(WebCore::ResourceRequest::encodeWithPlatformData const): Deleted.
(WebCore::ResourceRequest::decodeWithPlatformData): Deleted.
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadSynchronously):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::resourceLoadInfo):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::createFetchTask):
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp:
(WebKit::CacheStorage::Cache::encode):
(WebKit::CacheStorage::decodeDOMCacheRecord):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeStoreDecision):
(WebKit::NetworkCache::canRequestUseSpeculativeRevalidation):
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::encodeAsStorageRecord const):
(WebKit::NetworkCache::Entry::decodeStorageRecord):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::registerLoad):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
* Source/WebKit/Scripts/generate-serializers.py:
(construct_type):
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::ResourceRequest&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::ResourceRequest&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ResourceRequest&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ResourceRequest&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadDataURLSynchronously):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::startFetch):

Canonical link: <a href="https://commits.webkit.org/256413@main">https://commits.webkit.org/256413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fec6fe803747e792e73bb4a6d0b69a5a057fbb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105253 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165554 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5006 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33690 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101101 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3674 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82293 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30731 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39424 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37122 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20302 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41118 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2124 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39553 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->