### PR TITLE
[css-contain-intrinsic-size] Apply the value of css contain-intrinsic-size to <select>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032-expected.txt
@@ -1,24 +1,12 @@
 
 
-FAIL .test 1 assert_equals:
-<select class="test ciw-none cih-none" data-expected-client-width="34" data-expected-client-height="16"></select>
-clientHeight expected 16 but got 12
-FAIL .test 2 assert_equals:
-<select class="test ciw-none cih-0" data-expected-client-width="34" data-expected-client-height="0"></select>
-clientHeight expected 0 but got 12
+PASS .test 1
+PASS .test 2
 PASS .test 3
-FAIL .test 4 assert_equals:
-<select class="test ciw-0 cih-none" data-expected-client-width="0" data-expected-client-height="16"></select>
-clientHeight expected 16 but got 12
-FAIL .test 5 assert_equals:
-<select class="test ciw-0 cih-0" data-expected-client-width="0" data-expected-client-height="0"></select>
-clientHeight expected 0 but got 12
+PASS .test 4
+PASS .test 5
 PASS .test 6
-FAIL .test 7 assert_equals:
-<select class="test ciw-100 cih-none" data-expected-client-width="100" data-expected-client-height="16"></select>
-clientHeight expected 16 but got 12
-FAIL .test 8 assert_equals:
-<select class="test ciw-100 cih-0" data-expected-client-width="100" data-expected-client-height="0"></select>
-clientHeight expected 0 but got 12
+PASS .test 7
+PASS .test 8
 PASS .test 9
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -432,6 +432,8 @@ override;
     void updateLogicalHeight();
     virtual LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const;
 
+    void overrideLogicalHeightForSizeContainment();
+
     void cacheIntrinsicContentLogicalHeightForFlexItem(LayoutUnit) const;
     
     // This function will compute the logical border-box height, without laying

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -519,7 +519,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
 
     // Let the theme also have a crack at adjusting the style.
     if (style.hasAppearance())
-        RenderTheme::singleton().adjustStyle(style, m_element, userAgentAppearanceStyle);
+        adjustThemeStyle(style, userAgentAppearanceStyle);
 
     // If we have first-letter pseudo style, do not share this style.
     if (style.hasPseudoStyle(PseudoId::FirstLetter))
@@ -723,6 +723,32 @@ void Adjuster::adjustAnimatedStyle(RenderStyle& style, OptionSet<AnimationImpact
     
     if (style.hasAutoUsedZIndex() && impact.contains(AnimationImpact::ForcesStackingContext))
         style.setUsedZIndex(0);
+}
+
+void Adjuster::adjustThemeStyle(RenderStyle& style, const RenderStyle* userAgentAppearanceStyle) const
+{
+    ASSERT(style.hasAppearance());
+    auto isOldWidthAuto = style.width().isAuto();
+    auto isOldMinWidthAuto = style.minWidth().isAuto();
+    auto isOldHeightAuto = style.height().isAuto();
+    auto isOldMinHeightAuto = style.minHeight().isAuto();
+
+    RenderTheme::singleton().adjustStyle(style, m_element, userAgentAppearanceStyle);
+
+    if (style.containsSize()) {
+        if (style.containIntrinsicWidthType() != ContainIntrinsicSizeType::None) {
+            if (isOldWidthAuto)
+                style.setWidth(Length(LengthType::Auto));
+            if (isOldMinWidthAuto)
+                style.setMinWidth(Length(LengthType::Auto));
+        }
+        if (style.containIntrinsicHeightType() != ContainIntrinsicSizeType::None) {
+            if (isOldHeightAuto)
+                style.setHeight(Length(LengthType::Auto));
+            if (isOldMinHeightAuto)
+                style.setMinHeight(Length(LengthType::Auto));
+        }
+    }
 }
 
 void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -71,6 +71,9 @@ public:
 private:
     void adjustDisplayContentsStyle(RenderStyle&) const;
     void adjustForSiteSpecificQuirks(RenderStyle&) const;
+
+    void adjustThemeStyle(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
+
     static OptionSet<EventListenerRegionType> computeEventListenerRegionTypes(const Document&, const RenderStyle&, const EventTarget&, OptionSet<EventListenerRegionType>);
 
     const Document& m_document;


### PR DESCRIPTION
#### b7276669eb690bb0effc20c9a3c2daac0f5d53b5
<pre>
[css-contain-intrinsic-size] Apply the value of css contain-intrinsic-size to &lt;select&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=246338">https://bugs.webkit.org/show_bug.cgi?id=246338</a>

Reviewed by Alan Baradlay.

Per [1], the intrinsic size is determined as if the element had no content.
When RenderMenuList without content, it should still display the appearance
of theme. So if it is a size containment, it should have size of theme appearance.
While calculating height, we should keep the height from theme style.

Per [2], contain-intrinsic-* properties specify an explicit intrinsic inner size.
For RenderMenuList, the explicit intrinsic inner size includes the content size and
the theme size. So while calculating height, we should override the intrinsic size.

When adjusting the style for themes, it might set a fixed value to properties, like width,
height, min-width and min-height. This would make contain-intrinsic-* properties not
effective. To fix this, the values of these properties need to restore to the auto value.

[1] <a href="https://www.w3.org/TR/css-contain-2/#containment-size">https://www.w3.org/TR/css-contain-2/#containment-size</a>
[2] <a href="https://www.w3.org/TR/css-sizing-4/#intrinsic-size-override">https://www.w3.org/TR/css-sizing-4/#intrinsic-size-override</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::overrideLogicalHeightForSizeContainment): Override the height and handle RenderMenuList.
(WebCore::RenderBox::updateLogicalHeight):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustThemeStyle const): If there is contain-intrinsic-size and the css size properties are
changed from auto to a fixed value, we should restore them, so that contain-intrinsic-size would be effective.
* Source/WebCore/style/StyleAdjuster.h:

Canonical link: <a href="https://commits.webkit.org/257704@main">https://commits.webkit.org/257704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d55b1297a5f706d526675d0d11d4cb1cdc20ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108963 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169221 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86079 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106890 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/7078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90592 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34037 "An unexpected error occured. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; layout-tests (exception); Running set-build-summary") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21949 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23463 "Passed tests") | | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45853 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8692 "Build is being retried. Recent messages:configuring build; Cleaned up git repository; 'python3 Tools/Scripts/git-webkit ...'; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5291 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4412 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->