### PR TITLE
[webkitbugspy] Support radar users with no username

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.8.3',
+    version='0.8.4',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 3)
+version = Version(0, 8, 4)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -148,9 +148,11 @@ class Tracker(GenericTracker):
             elif name:
                 found = self.library.AppleDirectoryQuery.user_entry_for_attribute_value('cn', name)
             if not found:
-                raise RuntimeError("Failed to find '{}'".format(User(
-                    name, username, [email],
-                )))
+                return self.users.create(
+                    name=name,
+                    username=None,
+                    emails=[email],
+                )
             name = '{} {}'.format(found.first_name(), found.last_name())
             username = found.dsid()
             email = found.email()

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -60,6 +60,10 @@ class TestRadar(unittest.TestCase):
                 User.Encoder().default(tracker.user(name='Felix Filer')),
                 dict(name='Felix Filer', username=809, emails=['ffiler@example.com']),
             )
+            self.assertEqual(
+                User.Encoder().default(tracker.user(name='Olivia Outsider', email='ooutsider@example.com')),
+                dict(name='Olivia Outsider', emails=['ooutsider@example.com']),
+            )
 
     def test_link(self):
         with mocks.Radar(users=mocks.USERS):


### PR DESCRIPTION
#### 3fca3f4cf3f6abe28945ee3634a4ba8e61e491d9
<pre>
[webkitbugspy] Support radar users with no username
<a href="https://bugs.webkit.org/show_bug.cgi?id=247145">https://bugs.webkit.org/show_bug.cgi?id=247145</a>
rdar://101645349

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump verison.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.user):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadar.test_users):

Canonical link: <a href="https://commits.webkit.org/256105@main">https://commits.webkit.org/256105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fca479e679bc22448b905efecaaa45796c13b760

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/94711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/3868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/98706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/3936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/32057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/100377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/3936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/87024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/98296 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/3936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2009 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/42191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->