### PR TITLE
Regression(iOS 16.1) Use of Shared Workers cause Web Content process crash in non-default-browser WKWebViews

### DIFF
--- a/LayoutTests/http/tests/navigation/resources/shared-worker-script.js
+++ b/LayoutTests/http/tests/navigation/resources/shared-worker-script.js
@@ -18,9 +18,14 @@ self.onconnect = function(e) {
             port.postMessage(state);
             return;
         }
+        if (event.data === 'ping') {
+            port.postMessage('pong');
+            return;
+        }
         if (event.data.action === 'setState') {
             state = event.data.state;
             port.postMessage('ok');
+            return;
         }
     };
 }

--- a/LayoutTests/http/tests/workers/shared/shared-worker-with-service-workers-disabled-expected.txt
+++ b/LayoutTests/http/tests/workers/shared/shared-worker-with-service-workers-disabled-expected.txt
@@ -1,0 +1,10 @@
+Make sure that shared workers are functional even when service workers are disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS message is "pong"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/workers/shared/shared-worker-with-service-workers-disabled.html
+++ b/LayoutTests/http/tests/workers/shared/shared-worker-with-service-workers-disabled.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ ServiceWorkersEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description('Make sure that shared workers are functional even when service workers are disabled.');
+window.jsTestIsAsync = true;
+
+window.addEventListener('load', function() {
+    worker = new SharedWorker('../../navigation/resources/shared-worker-script.js');
+    worker.port.onmessage = (event) => {
+        message = event.data;
+        shouldBeEqualToString("message", "pong");
+        finishJSTest();
+    }
+    worker.port.postMessage("ping");
+}, false);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -84,6 +84,7 @@ imported/w3c/web-platform-tests/screen-orientation [ Skip ]
 
 # Shared workers are only implemented for WebKit2.
 http/tests/navigation/page-cache-shared-worker.html [ Skip ]
+http/tests/workers/shared [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-allowed.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-classic.http.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -180,6 +180,7 @@ imported/w3c/web-platform-tests/webcodecs [ Skip ]
 
 # Shared workers are only implemented for WebKit2.
 http/tests/navigation/page-cache-shared-worker.html [ Skip ]
+http/tests/workers/shared [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-allowed.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/sharedworker-classic.http.html [ Skip ]

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -141,6 +141,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     m_source = source;
     m_destination = fetchOptions.destination;
     m_isCOEPEnabled = scriptExecutionContext.settingsValues().crossOriginEmbedderPolicyEnabled;
+    m_clientIdentifier = clientIdentifier;
 
     ASSERT(scriptRequest.httpMethod() == "GET"_s);
 
@@ -163,7 +164,7 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     if ((m_destination == FetchOptions::Destination::Worker || m_destination == FetchOptions::Destination::Sharedworker) && is<Document>(scriptExecutionContext) && downcast<Document>(scriptExecutionContext).settings().serviceWorkersEnabled()) {
         m_topOriginForServiceWorkerRegistration = SecurityOriginData { scriptExecutionContext.topOrigin().data() };
         ASSERT(clientIdentifier);
-        options.clientIdentifier = m_clientIdentifier = clientIdentifier;
+        options.clientIdentifier = clientIdentifier;
         // In case of blob URLs, we reuse the document controlling service worker.
         if (request->url().protocolIsBlob() && scriptExecutionContext.activeServiceWorker())
             setControllingServiceWorker(ServiceWorkerData { scriptExecutionContext.activeServiceWorker()->data() });


### PR DESCRIPTION
#### a665aab7969fcec713fd40d8f97368e86f6b37b2
<pre>
Regression(iOS 16.1) Use of Shared Workers cause Web Content process crash in non-default-browser WKWebViews
<a href="https://bugs.webkit.org/show_bug.cgi?id=247147">https://bugs.webkit.org/show_bug.cgi?id=247147</a>
rdar://101562445

Reviewed by Geoffrey Garen.

253592@main made the initialization of WorkerScriptLoader::m_clientIdentifier
conditional on service workers being enabled. However, this wasn&apos;t correct
since shared workers rely on this data member too.

This clientIdentifier gets sent over IPC at some point and fails decoding
when not initialized, leading to the WebProcess getting killed.

* LayoutTests/http/tests/navigation/resources/shared-worker-script.js:
(self.onconnect):
* LayoutTests/http/tests/navigation/shared-worker-with-service-workers-disabled-expected.txt: Added.
* LayoutTests/http/tests/navigation/shared-worker-with-service-workers-disabled.html: Added.
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::loadAsynchronously):

Canonical link: <a href="https://commits.webkit.org/256099@main">https://commits.webkit.org/256099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8053fee664aa908a8d030d120fef072a3757c0a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104250 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164522 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3852 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31978 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100213 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2771 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80994 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29794 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84696 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38382 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18082 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36236 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19357 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40140 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/41998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2004 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38590 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->