### PR TITLE
Allow http/https scheme in WebSocket (and by proxy, relative URLs).

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -237,7 +237,7 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         return Exception { SyntaxError };
     }
 
-    if (!m_url.protocolIs("ws"_s) && !m_url.protocolIs("wss"_s)) {
+    if (!m_url.protocolIs("ws"_s) && !m_url.protocolIs("wss"_s) && !m_url.protocolIs("http"_s) && !m_url.protocolIs("https"_s)) {
         context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Wrong url scheme for WebSocket " + m_url.stringCenterEllipsizedToLength());
         m_state = CLOSED;
         return Exception { SyntaxError };


### PR DESCRIPTION
#### a877dbdb5c93861c9c27b9ff1975b582241b53f5
<pre>
Allow http/https scheme in WebSocket (and by proxy, relative URLs).
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab0a7a32b3dbe7714d56d01ca285b196140dffc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104215 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164487 "Found 1 new test failure: http/tests/websocket/tests/hybi/url-parsing.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3805 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31938 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100184 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100247 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2735 "Found 8 new test failures: http/tests/websocket/tests/hybi/url-parsing.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.worker.html, imported/w3c/web-platform-tests/websockets/constructor/002.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80955 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29762 "Found 8 new test failures: http/tests/websocket/tests/hybi/url-parsing.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.worker.html, imported/w3c/web-platform-tests/websockets/constructor/002.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84228 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72657 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/title-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38341 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18049 "Found 8 new test failures: http/tests/websocket/tests/hybi/url-parsing.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.worker.html, imported/w3c/web-platform-tests/websockets/constructor/002.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36201 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19323 "Found 8 new test failures: http/tests/websocket/tests/hybi/url-parsing.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.worker.html, imported/w3c/web-platform-tests/websockets/constructor/002.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40102 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41967 "Found 8 new test failures: http/tests/websocket/tests/hybi/url-parsing.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.html, imported/w3c/web-platform-tests/websockets/Create-invalid-urls.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.html, imported/w3c/web-platform-tests/websockets/Create-non-absolute-url.any.worker.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.html, imported/w3c/web-platform-tests/websockets/Create-wrong-scheme.any.worker.html, imported/w3c/web-platform-tests/websockets/constructor/002.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38552 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->