### PR TITLE
[Modern Media Controls] [macOS] REGRESSION(252362@main): adding `border-radius: inherit` causes negative power perf impact

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/adwaita-layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/adwaita-layout-traits.js
@@ -92,6 +92,11 @@ class AdwaitaLayoutTraits extends LayoutTraits
         return false;
     }
 
+    inheritsBorderRadius()
+    {
+        return false;
+    }
+
     toString()
     {
         const mode = this.isFullscreen ? "Fullscreen" : "Inline";

--- a/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css
@@ -3,7 +3,6 @@
 
 .media-controls.inline.ios:not(.audio) {
     background-color: rgba(0, 0, 0, 0.55);
-    border-radius: inherit;
 }
 
 .media-controls.inline.ios:not(.audio):is(:empty, .shows-start-button, .faded) {

--- a/Source/WebCore/Modules/modern-media-controls/controls/ios-layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/ios-layout-traits.js
@@ -85,6 +85,11 @@ class IOSLayoutTraits extends LayoutTraits
         return false;
     }
 
+    inheritsBorderRadius()
+    {
+        return true;
+    }
+
     toString()
     {
         return `[IOSLayoutTraits]`;

--- a/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js
@@ -102,6 +102,11 @@ class LayoutTraits
     {
         throw "Derived class must implement this function.";
     }
+
+    inheritsBorderRadius()
+    {
+        throw "Derived class must implement this function.";
+    }
 }
 
 LayoutTraits.Mode = {

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js
@@ -92,6 +92,11 @@ class MacOSLayoutTraits extends LayoutTraits
         return true;
     }
 
+    inheritsBorderRadius()
+    {
+        return false;
+    }
+
     toString()
     {
         const mode = this.isFullscreen ? "Fullscreen" : "Inline";

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -57,7 +57,6 @@
     -webkit-cursor-visibility: inherit;
     position: relative;
     will-change: z-index;
-    border-radius: inherit;
 }
 
 .media-controls-container,
@@ -89,6 +88,11 @@
 
 :host(:-webkit-animating-full-screen-transition) .media-controls {
     display: none;
+}
+
+.media-controls-container:has(.media-controls.inherits-border-radius),
+.media-controls.inherits-border-radius {
+    border-radius: inherit;
 }
 
 .media-controls > *,

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
@@ -30,6 +30,9 @@ class MediaControls extends LayoutNode
     {
         super(`<div class="media-controls"></div>`);
 
+        if (layoutTraits?.inheritsBorderRadius())
+            this.element.classList.add("inherits-border-radius");
+
         this._scaleFactor = 1;
 
         this.width = width;
@@ -56,12 +59,12 @@ class MediaControls extends LayoutNode
         this.invalidPlacard = new InvalidPlacard(this);
 
         // FIXME: Adwaita layout doesn't have an icon for pip-placard.
-        if (this.layoutTraits.supportsPiP())
+        if (this.layoutTraits?.supportsPiP())
             this.pipPlacard = new PiPPlacard(this);
         else
             this.pipPlacard = null;
 
-        if (this.layoutTraits.supportsAirPlay()) {
+        if (this.layoutTraits?.supportsAirPlay()) {
             this.airplayButton = new AirplayButton(this);
             this.airplayPlacard = new AirplayPlacard(this);
         } else {

--- a/Source/WebCore/Modules/modern-media-controls/controls/watchos-layout-traits.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/watchos-layout-traits.js
@@ -85,6 +85,11 @@ class WatchOSLayoutTraits extends LayoutTraits
         return false;
     }
 
+    inheritsBorderRadius()
+    {
+        return false;
+    }
+
     toString()
     {
         return `[WatchOSLayoutTraits]`;


### PR DESCRIPTION
#### 2476493a0ed78d8778b5766a92c76f8217b8e228
<pre>
[Modern Media Controls] [macOS] REGRESSION(252362@main): adding `border-radius: inherit` causes negative power perf impact
<a href="https://bugs.webkit.org/show_bug.cgi?id=247152">https://bugs.webkit.org/show_bug.cgi?id=247152</a>
&lt;rdar://problem/100234334&gt;

Reviewed by Eric Carlson.

This is only used on iOS, so adding it to all platforms is unnecessary (and apparently costly).

* Source/WebCore/Modules/modern-media-controls/controls/layout-traits.js:
(LayoutTraits.prototype.inheritsBorderRadius): Added.
* Source/WebCore/Modules/modern-media-controls/controls/adwaita-layout-traits.js:
(AdwaitaLayoutTraits.prototype.inheritsBorderRadius): Added.
* Source/WebCore/Modules/modern-media-controls/controls/ios-layout-traits.js:
(IOSLayoutTraits.prototype.inheritsBorderRadius): Added.
* Source/WebCore/Modules/modern-media-controls/controls/macos-layout-traits.js:
(MacOSLayoutTraits.prototype.inheritsBorderRadius): Added.
* Source/WebCore/Modules/modern-media-controls/controls/watchos-layout-traits.js:
(WatchOSLayoutTraits.prototype.inheritsBorderRadius): Added.
* Source/WebCore/Modules/modern-media-controls/controls/media-controls.js:
(MediaControls):
Add a new `LayoutTraits` method that controls whether `border-radius: inherit` is used.

* Source/WebCore/Modules/modern-media-controls/controls/ios-inline-media-controls.css:
(.media-controls.inline.ios:not(.audio)):
* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(.media-controls-container):
(.media-controls-container:has(.media-controls.inherits-border-radius), .media-controls.inherits-border-radius): Added.
Move the `border-radius: inherit` to only if the CSS class is applied (which is controlled by the above).

Canonical link: <a href="https://commits.webkit.org/256167@main">https://commits.webkit.org/256167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/746141aafd601613177bf59d513a69b9f82f31a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104546 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164809 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4174 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32271 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100465 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38681 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36511 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4252 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40437 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38832 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->