### PR TITLE
[JSC] uDFG should be able to watch JSGlobalObject WatchpointSets

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2298,7 +2298,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     }
 
                     if (node->arrayMode().isOutOfBounds()) {
-                        if (m_graph.isWatchingArrayPrototypeIsSaneChainWatchpoint(node)) {
+                        if (m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node)) {
                             if (node->arrayMode().type() == Array::Double && node->arrayMode().isOutOfBoundsSaneChain() && !(node->flags() & NodeBytecodeUsesAsOther))
                                 setConstant(node, jsNumber(PNaN));
                             else

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -249,7 +249,7 @@ private:
 
                 // If we're out-of-bounds then we proceed only if the prototype chain
                 // for the allocation is sane (i.e. doesn't have indexed properties).
-                if (m_graph.isWatchingObjectPrototypeIsSaneChainWatchpoint(edge.node()))
+                if (m_graph.isWatchingObjectPrototypeChainIsSaneWatchpoint(edge.node()))
                     break;
                 escape(edge, source);
                 break;
@@ -268,10 +268,10 @@ private:
                 // If we're out-of-bounds then we proceed only if the prototype chain
                 // for the allocation is sane (i.e. doesn't have indexed properties).
                 if (edge->op() == CreateRest) {
-                    if (m_graph.isWatchingArrayPrototypeIsSaneChainWatchpoint(edge.node()))
+                    if (m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(edge.node()))
                         break;
                 } else {
-                    if (m_graph.isWatchingObjectPrototypeIsSaneChainWatchpoint(edge.node()))
+                    if (m_graph.isWatchingObjectPrototypeChainIsSaneWatchpoint(edge.node()))
                         break;
                 }
                 escape(edge, source);

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
@@ -255,7 +255,7 @@ ArrayMode ArrayMode::refine(
         if (node->op() == GetByVal
             && isJSArrayWithOriginalStructure()
             && !graph.hasExitSite(node->origin.semantic, OutOfBounds)
-            && graph.isWatchingArrayPrototypeIsSaneChainWatchpoint(node))
+            && graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node))
             return withSpeculation(Array::InBoundsSaneChain);
         return ArrayMode(Array::Generic, action());
     }

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1706,7 +1706,7 @@ private:
             // that it doesn't contain any indexed properties, and that any holes will result in
             // jsUndefined().
             if (node->child1()->shouldSpeculateArray()
-                && m_graph.isWatchingArrayPrototypeIsSaneChainWatchpoint(node->child1().node())
+                && m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node->child1().node())
                 && m_graph.isWatchingArrayIteratorProtocolWatchpoint(node->child1().node())
                 && m_graph.isWatchingHavingABadTimeWatchpoint(node->child1().node()))
                 fixEdge<ArrayUse>(node->child1());
@@ -3833,7 +3833,7 @@ private:
 
     bool watchSaneChain(Node* node)
     {
-        return m_graph.isWatchingArrayPrototypeIsSaneChainWatchpoint(node);
+        return m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node);
     }
 
     void setSaneChainIfPossible(Node* node, Array::Speculation speculation)

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -793,10 +793,24 @@ public:
     }
 
     template<typename WatchpointSet>
-    bool isWatchingGlobalObjectWatchpoint(JSGlobalObject* globalObject, WatchpointSet& set)
+    bool isWatchingGlobalObjectWatchpoint(JSGlobalObject* globalObject, WatchpointSet& set, LinkerIR::Type type)
     {
-        if (m_plan.isUnlinked())
-            return false;
+        if (m_plan.isUnlinked()) {
+            if (m_codeBlock->globalObject() != globalObject)
+                return false;
+
+            LinkerIR::Value value { nullptr, type };
+            if (m_constantPoolMap.contains(value))
+                return true;
+
+            if (!set.isStillValid()) {
+                auto result = m_constantPoolMap.add(value, m_constantPoolMap.size());
+                ASSERT_UNUSED(result, result.isNewEntry);
+                m_constantPool.append(value);
+            }
+
+            return true;
+        }
 
         if (watchpoints().isWatched(set))
             return true;
@@ -816,112 +830,79 @@ public:
 
     bool isWatchingHavingABadTimeWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         WatchpointSet& set = globalObject->havingABadTimeWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::HavingABadTimeWatchpointSet);
     }
 
     bool isWatchingMasqueradesAsUndefinedWatchpointSet(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         WatchpointSet& set = globalObject->masqueradesAsUndefinedWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::MasqueradesAsUndefinedWatchpointSet);
     }
 
     bool isWatchingArrayIteratorProtocolWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->arrayIteratorProtocolWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::ArrayIteratorProtocolWatchpointSet);
     }
 
     bool isWatchingNumberToStringWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->numberToStringWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::NumberToStringWatchpointSet);
     }
 
     bool isWatchingStructureCacheClearedWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->structureCacheClearedWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StructureCacheClearedWatchpointSet);
     }
 
     bool isWatchingStringSymbolReplaceWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->stringSymbolReplaceWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StringSymbolReplaceWatchpointSet);
     }
 
     bool isWatchingRegExpPrimordialPropertiesWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->regExpPrimordialPropertiesWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::RegExpPrimordialPropertiesWatchpointSet);
     }
 
     bool isWatchingArraySpeciesWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->arraySpeciesWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::ArraySpeciesWatchpointSet);
     }
 
-    bool isWatchingArrayPrototypeIsSaneChainWatchpoint(Node* node)
+    bool isWatchingArrayPrototypeChainIsSaneWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->arrayPrototypeChainIsSaneWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::ArrayPrototypeChainIsSaneWatchpointSet);
     }
 
-    bool isWatchingStringPrototypeIsSaneChainWatchpoint(Node* node)
+    bool isWatchingStringPrototypeChainIsSaneWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->stringPrototypeChainIsSaneWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StringPrototypeChainIsSaneWatchpointSet);
     }
 
-    bool isWatchingObjectPrototypeIsSaneChainWatchpoint(Node* node)
+    bool isWatchingObjectPrototypeChainIsSaneWatchpoint(Node* node)
     {
-        if (m_plan.isUnlinked())
-            return false;
-
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
         InlineWatchpointSet& set = globalObject->objectPrototypeChainIsSaneWatchpointSet();
-        return isWatchingGlobalObjectWatchpoint(globalObject, set);
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::ObjectPrototypeChainIsSaneWatchpointSet);
     }
 
     Profiler::Compilation* compilation() { return m_plan.compilation(); }
@@ -1287,6 +1268,9 @@ public:
     HashMap<GenericHashKey<int64_t>, double*> m_doubleConstantsMap;
     Bag<double> m_doubleConstants;
 #endif
+
+    Vector<LinkerIR::Value> m_constantPool;
+    HashMap<LinkerIR::Value, LinkerIR::Constant, LinkerIR::ValueHash, LinkerIR::ValueTraits> m_constantPoolMap;
     
     OptimizationFixpointState m_fixpointState;
     StructureRegistrationState m_structureRegistrationState;

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -101,6 +101,19 @@ public:
         CellPointer,
         NonCellPointer,
         GlobalObject,
+
+        // WatchpointSet.
+        HavingABadTimeWatchpointSet,
+        MasqueradesAsUndefinedWatchpointSet,
+        ArrayIteratorProtocolWatchpointSet,
+        NumberToStringWatchpointSet,
+        StructureCacheClearedWatchpointSet,
+        StringSymbolReplaceWatchpointSet,
+        RegExpPrimordialPropertiesWatchpointSet,
+        ArraySpeciesWatchpointSet,
+        ArrayPrototypeChainIsSaneWatchpointSet,
+        StringPrototypeChainIsSaneWatchpointSet,
+        ObjectPrototypeChainIsSaneWatchpointSet,
     };
 
     using Value = CompactPointerTuple<void*, Type>;
@@ -155,7 +168,7 @@ public:
     static ptrdiff_t offsetOfExits() { return OBJECT_OFFSETOF(JITData, m_exits); }
     static ptrdiff_t offsetOfIsInvalidated() { return OBJECT_OFFSETOF(JITData, m_isInvalidated); }
 
-    static std::unique_ptr<JITData> create(VM&, CodeBlock*, const JITCode&, ExitVector&& exits);
+    static std::unique_ptr<JITData> tryCreate(VM&, CodeBlock*, const JITCode&, ExitVector&& exits);
 
     void setExitCode(unsigned exitIndex, MacroAssemblerCodeRef<OSRExitPtrTag> code)
     {
@@ -171,12 +184,16 @@ public:
     }
 
     FixedVector<StructureStubInfo>& stubInfos() { return m_stubInfos; }
+    FixedVector<OptimizingCallLinkInfo>& callLinkInfos() { return m_callLinkInfos; }
 
 private:
-    explicit JITData(VM&, CodeBlock*, const JITCode&, ExitVector&&);
+    explicit JITData(const JITCode&, ExitVector&&);
+
+    bool tryInitialize(VM&, CodeBlock*, const JITCode&);
 
     FixedVector<StructureStubInfo> m_stubInfos;
     FixedVector<OptimizingCallLinkInfo> m_callLinkInfos;
+    FixedVector<CodeBlockJettisoningWatchpoint> m_watchpoints;
     ExitVector m_exits;
     uint8_t m_isInvalidated { 0 };
 };
@@ -288,9 +305,12 @@ public:
 #endif // ENABLE(FTL_JIT)
 };
 
-inline std::unique_ptr<JITData> JITData::create(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode, ExitVector&& exits)
+inline std::unique_ptr<JITData> JITData::tryCreate(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode, ExitVector&& exits)
 {
-    return std::unique_ptr<JITData> { new (NotNull, fastMalloc(Base::allocationSize(jitCode.m_linkerIR.size()))) JITData(vm, codeBlock, jitCode, WTFMove(exits)) };
+    auto result = std::unique_ptr<JITData> { new (NotNull, fastMalloc(Base::allocationSize(jitCode.m_linkerIR.size()))) JITData(jitCode, WTFMove(exits)) };
+    if (result->tryInitialize(vm, codeBlock, jitCode))
+        return result;
+    return nullptr;
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -380,7 +380,7 @@ void JITCompiler::link(LinkBuffer& linkBuffer)
     if (m_pcToCodeOriginMapBuilder.didBuildMapping())
         m_jitCode->common.m_pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTFMove(m_pcToCodeOriginMapBuilder), linkBuffer);
 
-    m_jitCode->m_linkerIR = LinkerIR(WTFMove(m_constantPool));
+    m_jitCode->m_linkerIR = LinkerIR(WTFMove(m_graph.m_constantPool));
 }
 
 static void emitStackOverflowCheck(JITCompiler& jit, MacroAssembler::JumpList& stackOverflow)
@@ -802,9 +802,9 @@ void JITCompiler::LinkableConstant::store(CCallHelpers& jit, CCallHelpers::Addre
 LinkerIR::Constant JITCompiler::addToConstantPool(LinkerIR::Type type, void* payload)
 {
     LinkerIR::Value value { payload, type };
-    auto result = m_constantPoolMap.add(value, m_constantPoolMap.size());
+    auto result = m_graph.m_constantPoolMap.add(value, m_graph.m_constantPoolMap.size());
     if (result.isNewEntry)
-        m_constantPool.append(value);
+        m_graph.m_constantPool.append(value);
     return result.iterator->value;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -463,8 +463,6 @@ private:
     Vector<DFG::OSREntryData> m_osrEntry;
     Vector<DFG::OSRExit> m_osrExit;
     Vector<DFG::SpeculationRecovery> m_speculationRecovery;
-    Vector<LinkerIR::Value> m_constantPool;
-    HashMap<LinkerIR::Value, LinkerIR::Constant, LinkerIR::ValueHash, LinkerIR::ValueTraits> m_constantPoolMap;
     SegmentedVector<DFG::UnlinkedStructureStubInfo> m_unlinkedStubInfos;
     SegmentedVector<DFG::UnlinkedCallLinkInfo> m_unlinkedCallLinkInfos;
     

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -64,7 +64,11 @@ bool JITFinalizer::finalize()
     CodeBlock* codeBlock = m_plan.codeBlock();
 
     codeBlock->setJITCode(m_jitCode.copyRef());
-    codeBlock->setDFGJITData(m_plan.finalizeJITData(m_jitCode.get()));
+
+    auto data = m_plan.tryFinalizeJITData(m_jitCode.get());
+    if (UNLIKELY(!data))
+        return false;
+    codeBlock->setDFGJITData(WTFMove(data));
 
 #if ENABLE(FTL_JIT)
     m_jitCode->optimizeAfterWarmUp(codeBlock);

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -692,12 +692,11 @@ void Plan::cleanMustHandleValuesIfNecessary()
     }
 }
 
-std::unique_ptr<JITData> Plan::finalizeJITData(const JITCode& jitCode)
+std::unique_ptr<JITData> Plan::tryFinalizeJITData(const JITCode& jitCode)
 {
     auto osrExitThunk = m_vm->getCTIStub(osrExitGenerationThunkGenerator).retagged<OSRExitPtrTag>();
     auto exits = JITData::ExitVector::createWithSizeAndConstructorArguments(jitCode.m_osrExit.size(), osrExitThunk);
-    auto jitData = JITData::create(*m_vm, m_codeBlock, jitCode, WTFMove(exits));
-    return jitData;
+    return JITData::tryCreate(*m_vm, m_codeBlock, jitCode, WTFMove(exits));
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -103,7 +103,7 @@ public:
     DeferredCompilationCallback* callback() const { return m_callback.get(); }
     void setCallback(Ref<DeferredCompilationCallback>&& callback) { m_callback = WTFMove(callback); }
 
-    std::unique_ptr<JITData> finalizeJITData(const JITCode&);
+    std::unique_ptr<JITData> tryFinalizeJITData(const JITCode&);
 
 private:
     CompilationPath compileInThreadImpl() override;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -3000,7 +3000,7 @@ void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std:
         m_jit.move(TrustedImm32(JSValue::CellTag), resultRegs.tagGPR());
 #endif
 
-        if (m_graph.isWatchingStringPrototypeIsSaneChainWatchpoint(node)) {
+        if (m_graph.isWatchingStringPrototypeChainIsSaneWatchpoint(node)) {
             // FIXME: This could be captured using a Speculation mode that means "out-of-bounds
             // loads return a trivial value". Something like OutOfBoundsSaneChain. This should
             // speculate that we don't take negative out-of-bounds, or better yet, it should rely

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -9160,7 +9160,7 @@ IGNORE_CLANG_WARNINGS_END
             // FIXME: Revisit JSGlobalObject.
             // https://bugs.webkit.org/show_bug.cgi?id=203204
             JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-            if (m_graph.isWatchingStringPrototypeIsSaneChainWatchpoint(m_node)) {
+            if (m_graph.isWatchingStringPrototypeChainIsSaneWatchpoint(m_node)) {
                 // FIXME: This could be captured using a Speculation mode that means
                 // "out-of-bounds loads return a trivial value", something like
                 // OutOfBoundsSaneChain.
@@ -20511,7 +20511,7 @@ IGNORE_CLANG_WARNINGS_END
     void speculateNonNullObject(Edge edge, LValue cell)
     {
         FTL_TYPE_CHECK(jsValueValue(cell), edge, SpecObject, isNotObject(cell));
-        if (m_graph.isWatchingObjectPrototypeIsSaneChainWatchpoint(m_node))
+        if (m_graph.isWatchingObjectPrototypeChainIsSaneWatchpoint(m_node))
             return;
         
         speculate(


### PR DESCRIPTION
#### 085b9807d093d97e6d2df08c98904a85e09465a6
<pre>
[JSC] uDFG should be able to watch JSGlobalObject WatchpointSets
<a href="https://bugs.webkit.org/show_bug.cgi?id=247154">https://bugs.webkit.org/show_bug.cgi?id=247154</a>
rdar://101657085

Reviewed by Mark Lam.

This patch allows uDFG to watch JSGlobalObject WatchpointSets.
We extract this watchpoint insertion as a LinkerIR. And we run this when materializing DFG::JITData,
which should eventually become uDFG&apos;s linking phase. We also fixed a bug where we missed visiting
uDFG CallLinkInfo in CodeBlock.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finalizeJITInlineCaches):
(JSC::CodeBlock::getICStatusMap):
(JSC::CodeBlock::getCallLinkInfoForBytecodeIndex):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::JITData):
(JSC::DFG::attemptToWatch):
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
(JSC::DFG::JITData::tryCreate):
(JSC::DFG::JITData::create): Deleted.
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::link):
(JSC::DFG::JITCompiler::addToConstantPool):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::finalize):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::tryFinalizeJITData):
(JSC::DFG::Plan::finalizeJITData): Deleted.
* Source/JavaScriptCore/dfg/DFGPlan.h:

Canonical link: <a href="https://commits.webkit.org/256111@main">https://commits.webkit.org/256111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2819875e278acdb3476d8eefe341093942fc373d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94733 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/3889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/3957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/32078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100400 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/3957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/87045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/3957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/85904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/81107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/81107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/40240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83776 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2012 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/42212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/18917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->