### PR TITLE
Rendering artifacts when presenting fullscreen video

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -577,7 +577,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
             targetWidth = videoDimensions.width * preferredHeight / videoDimensions.height;
     }
 
-    [_window setFrame:CGRectMake(0, 0, targetWidth, targetHeight)];
+    [_window setFrame:CGRectMake(0, 0, floorf(targetWidth), floorf(targetHeight))];
     [_window setClipsToBounds:YES];
     [_window _setContinuousCornerRadius:kFullScreenWindowCornerRadius];
     [_window setNeedsLayout];
@@ -739,7 +739,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
             [_fullscreenViewController showBanner];
 
 #if HAVE(UIKIT_WEBKIT_INTERNALS)
-            configureViewForEnteringFullscreen(_fullscreenViewController.get().view, kAnimationDuration, [_window frame].size);
+            configureViewControllerForEnteringFullscreen(_fullscreenViewController.get(), kAnimationDuration, [_window frame].size);
 #endif
 
             if (auto* videoFullscreenManager = self._videoFullscreenManager) {
@@ -874,7 +874,7 @@ static constexpr CGFloat kTargetWindowAspectRatio = 1.7778;
         [self _dismissFullscreenViewController];
     };
 #if HAVE(UIKIT_WEBKIT_INTERNALS)
-    configureViewForExitingFullscreen(_fullscreenViewController.get().view, kAnimationDuration, _originalWindowSize, WTFMove(completionHandler));
+    configureViewControllerForExitingFullscreen(_fullscreenViewController.get(), kAnimationDuration, _originalWindowSize, WTFMove(completionHandler));
 #else
     completionHandler();
 #endif


### PR DESCRIPTION
#### 7df587ca6a527c0e64cadc9d421de5298f65ea1c
<pre>
Rendering artifacts when presenting fullscreen video
<a href="https://bugs.webkit.org/show_bug.cgi?id=247155">https://bugs.webkit.org/show_bug.cgi?id=247155</a>
rdar://101352957

Reviewed by Tim Horton.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):

Floor the values in the target size, as the window dimensions need to be integral values.

(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:]):

Canonical link: <a href="https://commits.webkit.org/256251@main">https://commits.webkit.org/256251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a8f3fffdf02079edd757de02f1af3694e3d5ab5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104235 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3835 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31961 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86914 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100201 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2759 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/80977 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29775 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72670 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38365 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18062 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19336 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4321 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40124 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/41987 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42091 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38565 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->