### PR TITLE
Implement input validation for CSSColorValues

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/resources/testhelper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/resources/testhelper.js
@@ -31,6 +31,9 @@ function assert_color_channel_approx_equals(a, b) {
         assert_approx_equals(a[i].value, b[i].value, epsilonForUnitType(a.unit));
       }
       break;
+    case 'CSSKeywordValue':
+        assert_equals(a.value, b.value);
+        break;
     default:
       assert_equals(a.unit, b.unit);
       assert_approx_equals(a.value, b.value, epsilonForUnitType(a.unit));

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHSL-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHSL-expected.txt
@@ -1,23 +1,26 @@
 
+PASS Constructing a CSSHSL with a number for the hue works as intended.
+PASS CSSHSL.h can be updated with a a number.
 PASS Constructing a CSSHSL with degrees for the hue works as intended.
 PASS CSSHSL.h can be updated with a degrees.
 PASS Constructing a CSSHSL with radians for the hue works as intended.
 PASS CSSHSL.h can be updated with a radians.
 PASS Constructing a CSSHSL with gradians for the hue works as intended.
 PASS CSSHSL.h can be updated with a gradians.
-FAIL Constructing a CSSHSL with a number for hue throws a type error. assert_throws_js: function "() => new CSSHSL(hue, 0, 0)" did not throw
-FAIL Constructing a CSSHSL with css pixels for hue throws a type error. assert_throws_js: function "() => new CSSHSL(hue, 0, 0)" did not throw
-FAIL Constructing a CSSHSL with undefined for hue throws a type error. assert_throws_js: function "() => new CSSHSL(hue, 0, 0)" did not throw
-FAIL CSSHSL can be constructed from three numbers and will get an alpha of 100%. assert_equals: expected "CSSUnitValue" but got "Number"
-FAIL CSSHSL can be constructed from four numbers. assert_equals: expected "CSSUnitValue" but got "Number"
-FAIL Constructing a CSSHSL with CSS.number for s, l or alpha throws a TypeError assert_throws_js: function "() => new CSSHSL(CSS.deg(0), CSS.number(1), 0, 0)" did not throw
-FAIL Updating a CSSHSL with CSS.number for s throws a TypeError assert_throws_js: function "() => result[attr] = CSS.number(1)" did not throw
-FAIL CSSHSL.s can be updated to a number. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Constructing a CSSHSL with undefined for the hue works as intended.
+PASS CSSHSL.h can be updated with a undefined.
+PASS Constructing a CSSHSL with css pixels for hue throws a SyntaxError.
+PASS Constructing a CSSHSL with css em for hue throws a SyntaxError.
+PASS CSSHSL can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSHSL can be constructed from four numbers.
+PASS Constructing a CSSHSL with CSS.number for s, l or alpha throws a TypeError
+PASS Updating a CSSHSL with CSS.number for s throws a SyntaxError
+PASS CSSHSL.s can be updated to a number.
 PASS CSSHSL.s can be updated with a CSS percent.
-FAIL Updating a CSSHSL with CSS.number for l throws a TypeError assert_throws_js: function "() => result[attr] = CSS.number(1)" did not throw
-FAIL CSSHSL.l can be updated to a number. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Updating a CSSHSL with CSS.number for l throws a SyntaxError
+PASS CSSHSL.l can be updated to a number.
 PASS CSSHSL.l can be updated with a CSS percent.
-FAIL Updating a CSSHSL with CSS.number for alpha throws a TypeError assert_throws_js: function "() => result[attr] = CSS.number(1)" did not throw
-FAIL CSSHSL.alpha can be updated to a number. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Updating a CSSHSL with CSS.number for alpha throws a SyntaxError
+PASS CSSHSL.alpha can be updated to a number.
 PASS CSSHSL.alpha can be updated with a CSS percent.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHSL.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHSL.html
@@ -8,35 +8,38 @@
 <script>
 'use strict';
 
+const gUndefinedKeyword = new CSSKeywordValue("undefined");
+
 const gValidHueInputs = [
-  {hue: CSS.deg(180), desc: 'degrees'},
-  {hue: CSS.rad(1), desc: 'radians'},
-  {hue: CSS.grad(81), desc: 'gradians'},
+  {hue: 180, desc: "a number", expected: CSS.deg(180)},
+  {hue: CSS.deg(180), desc: 'degrees', expected: CSS.deg(180)},
+  {hue: CSS.rad(1), desc: 'radians', expected: CSS.rad(1)},
+  {hue: CSS.grad(81), desc: 'gradians', expected: CSS.grad(81)},
+  {hue: undefined, desc: "undefined", expected: gUndefinedKeyword},
 ];
 
 const gInvalidHueInputs = [
-  {hue: 180, desc: "a number"},
   {hue: CSS.px(1), desc: "css pixels"},
-  {hue: undefined, desc: "undefined"},
+  {hue: CSS.em(1), desc: "css em"},
 ]
 
-for (const {hue, desc} of gValidHueInputs) {
+for (const {hue, desc, expected} of gValidHueInputs) {
   test(() => {
     const result = new CSSHSL(hue, 0.5, 0.5);
-    assert_color_channel_approx_equals(result.h, hue);
+    assert_color_channel_approx_equals(result.h, expected);
   }, `Constructing a CSSHSL with ${desc} for the hue works as intended.`);
 
   test(() => {
     const result = new CSSHSL(CSS.deg(0), 0.5, 0.5);
     result.h = hue;
-    assert_color_channel_approx_equals(result.h, hue);
+    assert_color_channel_approx_equals(result.h, expected);
   }, `CSSHSL.h can be updated with a ${desc}.`);
 }
 
 for (const {hue, desc} of gInvalidHueInputs) {
   test(() => {
-    assert_throws_js(TypeError, () => new CSSHSL(hue, 0, 0));
-  }, `Constructing a CSSHSL with ${desc} for hue throws a type error.`);
+    assert_throws_dom("SyntaxError", () => new CSSHSL(hue, 0, 0));
+  }, `Constructing a CSSHSL with ${desc} for hue throws a SyntaxError.`);
 }
 
 test(() => {
@@ -56,16 +59,16 @@ test(() => {
 }, 'CSSHSL can be constructed from four numbers.');
 
 test(() => {
-  assert_throws_js(TypeError, () => new CSSHSL(CSS.deg(0), CSS.number(1), 0, 0));
-  assert_throws_js(TypeError, () => new CSSHSL(CSS.deg(0), 0, CSS.number(1), 0));
-  assert_throws_js(TypeError, () => new CSSHSL(CSS.deg(0), 0, 0, CSS.number(1)));
+  assert_throws_dom("SyntaxError", () => new CSSHSL(CSS.deg(0), CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSHSL(CSS.deg(0), 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSHSL(CSS.deg(0), 0, 0, CSS.number(1)));
 }, `Constructing a CSSHSL with CSS.number for s, l or alpha throws a TypeError`);
 
 for (const attr of ['s', 'l', 'alpha']) {
   test(() => {
     const result = new CSSHSL(CSS.deg(0), 0, 0);
-    assert_throws_js(TypeError, () => result[attr] = CSS.number(1));
-  }, `Updating a CSSHSL with CSS.number for ${attr} throws a TypeError`);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSHSL with CSS.number for ${attr} throws a SyntaxError`);
 
   test(() => {
     const result = new CSSHSL(CSS.deg(0), 0, 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHWB-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHWB-expected.txt
@@ -5,19 +5,19 @@ PASS Constructing a CSSHWB with radians for the hue works as intended.
 PASS CSSHWB.h can be updated with a radians.
 PASS Constructing a CSSHWB with gradians for the hue works as intended.
 PASS CSSHWB.h can be updated with a gradians.
-PASS Constructing a CSSHWB with a number for hue throws a type error.
-FAIL Constructing a CSSHWB with css pixels for hue throws a type error. assert_throws_js: function "() => new CSSHWB(hue, 0, 0)" did not throw
-PASS Constructing a CSSHWB with undefined for hue throws a type error.
-FAIL CSSHWB can be constructed from three numbers and will get an alpha of 100%. assert_equals: expected "CSSUnitValue" but got "Number"
-FAIL CSSHWB can be constructed from four numbers. assert_equals: expected "CSSUnitValue" but got "Number"
-FAIL Constructing a CSSHWB with CSS.number for s, l or alpha throws a TypeError assert_throws_js: function "() => new CSSHWB(CSS.deg(0), CSS.number(1), 0, 0)" did not throw
-FAIL Updating a CSSHWB with CSS.number for w throws a TypeError assert_throws_js: function "() => result[attr] = CSS.number(1)" did not throw
-FAIL CSSHWB.w can be updated to a number. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Constructing a CSSHWB with a number for hue throws a TypeError.
+PASS Constructing a CSSHWB with undefined for hue throws a TypeError.
+PASS Constructing a CSSHWB with css pixels for hue throws a SyntaxError.
+PASS CSSHWB can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSHWB can be constructed from four numbers.
+PASS Constructing a CSSHWB with CSS.number for s, l or alpha throws a SyntaxError
+PASS Updating a CSSHWB with CSS.number for w throws a SyntaxError
+PASS CSSHWB.w can be updated to a number.
 PASS CSSHWB.w can be updated with a CSS percent.
-FAIL Updating a CSSHWB with CSS.number for b throws a TypeError assert_throws_js: function "() => result[attr] = CSS.number(1)" did not throw
-FAIL CSSHWB.b can be updated to a number. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Updating a CSSHWB with CSS.number for b throws a SyntaxError
+PASS CSSHWB.b can be updated to a number.
 PASS CSSHWB.b can be updated with a CSS percent.
-FAIL Updating a CSSHWB with CSS.number for alpha throws a TypeError assert_throws_js: function "() => result[attr] = CSS.number(1)" did not throw
-FAIL CSSHWB.alpha can be updated to a number. assert_equals: expected "CSSUnitValue" but got "Number"
+PASS Updating a CSSHWB with CSS.number for alpha throws a SyntaxError
+PASS CSSHWB.alpha can be updated to a number.
 PASS CSSHWB.alpha can be updated with a CSS percent.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHWB.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHWB.html
@@ -14,10 +14,13 @@ const gValidHueInputs = [
   {hue: CSS.grad(81), desc: 'gradians'},
 ];
 
-const gInvalidHueInputs = [
+const gInvalidHueInputsNotNumericValue = [
   {hue: 180, desc: "a number"},
-  {hue: CSS.px(1), desc: "css pixels"},
   {hue: undefined, desc: "undefined"},
+]
+
+const gInvalidHueInputsNumericValue = [
+  {hue: CSS.px(1), desc: "css pixels"},
 ]
 
 for (const {hue, desc} of gValidHueInputs) {
@@ -33,10 +36,16 @@ for (const {hue, desc} of gValidHueInputs) {
   }, `CSSHWB.h can be updated with a ${desc}.`);
 }
 
-for (const {hue, desc} of gInvalidHueInputs) {
+for (const {hue, desc} of gInvalidHueInputsNotNumericValue) {
   test(() => {
     assert_throws_js(TypeError, () => new CSSHWB(hue, 0, 0));
-  }, `Constructing a CSSHWB with ${desc} for hue throws a type error.`);
+  }, `Constructing a CSSHWB with ${desc} for hue throws a TypeError.`);
+}
+
+for (const {hue, desc} of gInvalidHueInputsNumericValue) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSHWB(hue, 0, 0));
+  }, `Constructing a CSSHWB with ${desc} for hue throws a SyntaxError.`);
 }
 
 test(() => {
@@ -56,16 +65,16 @@ test(() => {
 }, 'CSSHWB can be constructed from four numbers.');
 
 test(() => {
-  assert_throws_js(TypeError, () => new CSSHWB(CSS.deg(0), CSS.number(1), 0, 0));
-  assert_throws_js(TypeError, () => new CSSHWB(CSS.deg(0), 0, CSS.number(1), 0));
-  assert_throws_js(TypeError, () => new CSSHWB(CSS.deg(0), 0, 0, CSS.number(1)));
-}, `Constructing a CSSHWB with CSS.number for s, l or alpha throws a TypeError`);
+  assert_throws_dom("SyntaxError", () => new CSSHWB(CSS.deg(0), CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSHWB(CSS.deg(0), 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSHWB(CSS.deg(0), 0, 0, CSS.number(1)));
+}, `Constructing a CSSHWB with CSS.number for s, l or alpha throws a SyntaxError`);
 
 for (const attr of ['w', 'b', 'alpha']) {
   test(() => {
     const result = new CSSHWB(CSS.deg(0), 0, 0);
-    assert_throws_js(TypeError, () => result[attr] = CSS.number(1));
-  }, `Updating a CSSHWB with CSS.number for ${attr} throws a TypeError`);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSHWB with CSS.number for ${attr} throws a SyntaxError`);
 
   test(() => {
     const result = new CSSHWB(CSS.deg(0), 0, 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLCH-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLCH-expected.txt
@@ -1,0 +1,20 @@
+
+PASS Constructing a CSSLCH with percent for the lightness works as intended.
+PASS CSSLCH.l can be updated with a percent.
+PASS Constructing a CSSLCH with number for the lightness works as intended.
+PASS CSSLCH.l can be updated with a number.
+PASS Constructing a CSSLCH with css pixels for lightness throws a SyntaxError.
+PASS Constructing a CSSLCH with degrees for lightness throws a SyntaxError.
+PASS CSSLCH can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSLCH can be constructed from four numbers.
+PASS Constructing a CSSLCH with CSS.number for l, c, h or alpha throws a SyntaxError
+PASS Updating a CSSLCH with CSS.number for l throws a SyntaxError
+PASS CSSLCH.l can be updated to a number.
+PASS CSSLCH.l can be updated with a CSS percent.
+PASS Updating a CSSLCH with CSS.number for c throws a SyntaxError
+PASS CSSLCH.c can be updated to a number.
+PASS CSSLCH.c can be updated with a CSS percent.
+PASS Updating a CSSLCH with CSS.number for alpha throws a SyntaxError
+PASS CSSLCH.alpha can be updated to a number.
+PASS CSSLCH.alpha can be updated with a CSS percent.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLCH.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLCH.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSLCH tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSLCH(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSLCH with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSLCH.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSLCH(lightness, 0, 0));
+  }, `Constructing a CSSLCH with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSLCH(CSS.percent(27), 0.7, 8);
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.deg(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSLCH can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSLCH(0.2, 0.7, CSS.rad(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.rad(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSLCH can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSLCH(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSLCH(0, CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSLCH(0, 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSLCH(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSLCH with CSS.number for l, c, h or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'c', 'alpha']) {
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSLCH with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLCH.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSLCH(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLCH.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLab-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLab-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Constructing a CSSLab with percent for the lightness works as intended.
+PASS CSSLab.l can be updated with a percent.
+PASS Constructing a CSSLab with number for the lightness works as intended.
+PASS CSSLab.l can be updated with a number.
+PASS Constructing a CSSLab with css pixels for lightness throws a SyntaxError.
+PASS Constructing a CSSLab with degrees for lightness throws a SyntaxError.
+PASS CSSLab can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSLab can be constructed from four numbers.
+PASS Constructing a CSSLab with CSS.number for l or alpha throws a SyntaxError
+PASS Updating a CSSLab with CSS.number for l throws a SyntaxError
+PASS CSSLab.l can be updated to a number.
+PASS CSSLab.l can be updated with a CSS percent.
+PASS Updating a CSSLab with CSS.number for alpha throws a SyntaxError
+PASS CSSLab.alpha can be updated to a number.
+PASS CSSLab.alpha can be updated with a CSS percent.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLab.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLab.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSLab tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSLab(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSLab with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSLab.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSLab(lightness, 0, 0));
+  }, `Constructing a CSSLab with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSLab(CSS.percent(27), 7, CSS.number(8));
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSLab can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSLab(0.2, 7, CSS.number(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSLab can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSLab(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSLab(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSLab with CSS.number for l or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'alpha']) {
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSLab with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLab.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSLab(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSLab.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLCH-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLCH-expected.txt
@@ -1,0 +1,20 @@
+
+PASS Constructing a CSSOKLCH with percent for the lightness works as intended.
+PASS CSSOKLCH.l can be updated with a percent.
+PASS Constructing a CSSOKLCH with number for the lightness works as intended.
+PASS CSSOKLCH.l can be updated with a number.
+PASS Constructing a CSSOKLCH with css pixels for lightness throws a SyntaxError.
+PASS Constructing a CSSOKLCH with degrees for lightness throws a SyntaxError.
+PASS CSSOKLCH can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSOKLCH can be constructed from four numbers.
+PASS Constructing a CSSOKLCH with CSS.number for l, c, h or alpha throws a SyntaxError
+PASS Updating a CSSOKLCH with CSS.number for l throws a SyntaxError
+PASS CSSOKLCH.l can be updated to a number.
+PASS CSSOKLCH.l can be updated with a CSS percent.
+PASS Updating a CSSOKLCH with CSS.number for c throws a SyntaxError
+PASS CSSOKLCH.c can be updated to a number.
+PASS CSSOKLCH.c can be updated with a CSS percent.
+PASS Updating a CSSOKLCH with CSS.number for alpha throws a SyntaxError
+PASS CSSOKLCH.alpha can be updated to a number.
+PASS CSSOKLCH.alpha can be updated with a CSS percent.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLCH.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLCH.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOKLCH tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSOKLCH(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSOKLCH with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSOKLCH.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSOKLCH(lightness, 0, 0));
+  }, `Constructing a CSSOKLCH with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSOKLCH(CSS.percent(27), 0.7, 8);
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.deg(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSOKLCH can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSOKLCH(0.2, 0.7, CSS.rad(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.c, CSS.percent(70));
+  assert_color_channel_approx_equals(result.h, CSS.rad(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSOKLCH can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(0, CSS.number(1), 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(0, 0, CSS.number(1), 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLCH(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSOKLCH with CSS.number for l, c, h or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'c', 'alpha']) {
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSOKLCH with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLCH.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSOKLCH(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLCH.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLab-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLab-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Constructing a CSSOKLab with percent for the lightness works as intended.
+PASS CSSOKLab.l can be updated with a percent.
+PASS Constructing a CSSOKLab with number for the lightness works as intended.
+PASS CSSOKLab.l can be updated with a number.
+PASS Constructing a CSSOKLab with css pixels for lightness throws a SyntaxError.
+PASS Constructing a CSSOKLab with degrees for lightness throws a SyntaxError.
+PASS CSSOKLab can be constructed from three numbers and will get an alpha of 100%.
+PASS CSSOKLab can be constructed from four numbers.
+PASS Constructing a CSSOKLab with CSS.number for l or alpha throws a SyntaxError
+PASS Updating a CSSOKLab with CSS.number for l throws a SyntaxError
+PASS CSSOKLab.l can be updated to a number.
+PASS CSSOKLab.l can be updated with a CSS percent.
+PASS Updating a CSSOKLab with CSS.number for alpha throws a SyntaxError
+PASS CSSOKLab.alpha can be updated to a number.
+PASS CSSOKLab.alpha can be updated with a CSS percent.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLab.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLab.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOKLab tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-typed-om-1/#csshwb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/testhelper.js"></script>
+<script>
+'use strict';
+
+const gValidLightnessInputs = [
+  {lightness: CSS.percent(50), desc: 'percent', expected: CSS.percent(50)},
+  {lightness: 0.5, desc: 'number', expected: CSS.percent(50)},
+];
+
+const gInvalidLightnessInputs = [
+  {lightness: CSS.px(1), desc: "css pixels"},
+  {lightness: CSS.deg(180), desc: "degrees"},
+]
+
+for (const {lightness, desc, expected} of gValidLightnessInputs) {
+  test(() => {
+    const result = new CSSOKLab(lightness, 0.5, 0.5);
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `Constructing a CSSOKLab with ${desc} for the lightness works as intended.`);
+
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0.5, 0.5);
+    result.l = lightness;
+    assert_color_channel_approx_equals(result.l, expected);
+  }, `CSSOKLab.l can be updated with a ${desc}.`);
+}
+
+for (const {lightness, desc} of gInvalidLightnessInputs) {
+  test(() => {
+    assert_throws_dom("SyntaxError", () => new CSSOKLab(lightness, 0, 0));
+  }, `Constructing a CSSOKLab with ${desc} for lightness throws a SyntaxError.`);
+}
+
+test(() => {
+  const result = new CSSOKLab(CSS.percent(27), 7, CSS.number(8));
+  assert_color_channel_approx_equals(result.l, CSS.percent(27));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(100));
+}, 'CSSOKLab can be constructed from three numbers and will get an alpha of 100%.');
+
+test(() => {
+  const result = new CSSOKLab(0.2, 7, CSS.number(8), CSS.percent(0.4));
+  assert_color_channel_approx_equals(result.l, CSS.percent(20));
+  assert_color_channel_approx_equals(result.a, CSS.number(7));
+  assert_color_channel_approx_equals(result.b, CSS.number(8));
+  assert_color_channel_approx_equals(result.alpha, CSS.percent(0.4));
+}, 'CSSOKLab can be constructed from four numbers.');
+
+test(() => {
+  assert_throws_dom("SyntaxError", () => new CSSOKLab(CSS.number(1), 0, 0, 0));
+  assert_throws_dom("SyntaxError", () => new CSSOKLab(0, 0, 0, CSS.number(1)));
+}, `Constructing a CSSOKLab with CSS.number for l or alpha throws a SyntaxError`);
+
+for (const attr of ['l', 'alpha']) {
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0, 0);
+    assert_throws_dom("SyntaxError", () => result[attr] = CSS.number(1));
+  }, `Updating a CSSOKLab with CSS.number for ${attr} throws a SyntaxError`);
+
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0, 0);
+    result[attr] = 0.5;
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLab.' + attr + ' can be updated to a number.');
+
+  test(() => {
+    const result = new CSSOKLab(CSS.percent(0), 0, 0);
+    result[attr] = CSS.percent(50);
+    assert_color_channel_approx_equals(result[attr], CSS.percent(50));
+  }, 'CSSOKLab.' + attr + ' can be updated with a CSS percent.');
+}
+</script>

--- a/Source/WebCore/css/typedom/color/CSSColorValue.h
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.h
@@ -37,7 +37,9 @@ using CSSKeywordish = std::variant<String, RefPtr<CSSKeywordValue>>;
 using CSSColorPercent = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
 using RectifiedCSSColorPercent = std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;
 using CSSColorNumber = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+using RectifiedCSSColorNumber = std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;
 using CSSColorAngle = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
+using RectifiedCSSColorAngle = std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;
 
 class CSSColorValue : public CSSStyleValue {
 public:
@@ -46,7 +48,12 @@ public:
     static std::variant<RefPtr<CSSColorValue>, RefPtr<CSSStyleValue>> parse(const String&);
 
     static ExceptionOr<RectifiedCSSColorPercent> rectifyCSSColorPercent(CSSColorPercent&&);
+    static ExceptionOr<RectifiedCSSColorAngle> rectifyCSSColorAngle(CSSColorAngle&&);
+    static ExceptionOr<RectifiedCSSColorNumber> rectifyCSSColorNumber(CSSColorNumber&&);
     static CSSColorPercent toCSSColorPercent(const RectifiedCSSColorPercent&);
+    static CSSColorPercent toCSSColorPercent(const CSSNumberish&);
+    static CSSColorAngle toCSSColorAngle(const RectifiedCSSColorAngle&);
+    static CSSColorNumber toCSSColorNumber(const RectifiedCSSColorNumber&);
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSHSL.cpp
+++ b/Source/WebCore/css/typedom/color/CSSHSL.cpp
@@ -26,18 +26,93 @@
 #include "config.h"
 #include "CSSHSL.h"
 
+#include "Exception.h"
+#include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSHSL);
 
-CSSHSL::CSSHSL(CSSColorAngle hue, CSSColorPercent saturation, CSSColorPercent lightness, CSSColorPercent alpha)
+ExceptionOr<Ref<CSSHSL>> CSSHSL::create(CSSColorAngle&& hue, CSSColorPercent&& saturation, CSSColorPercent&& lightness, CSSColorPercent&& alpha)
+{
+    auto rectifiedHue = rectifyCSSColorAngle(WTFMove(hue));
+    if (rectifiedHue.hasException())
+        return rectifiedHue.releaseException();
+    auto rectifiedSaturation = rectifyCSSColorPercent(WTFMove(saturation));
+    if (rectifiedSaturation.hasException())
+        return rectifiedSaturation.releaseException();
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    return adoptRef(*new CSSHSL(rectifiedHue.releaseReturnValue(), rectifiedSaturation.releaseReturnValue(), rectifiedLightness.releaseReturnValue(), rectifiedAlpha.releaseReturnValue()));
+}
+
+CSSHSL::CSSHSL(RectifiedCSSColorAngle&& hue, RectifiedCSSColorPercent&& saturation, RectifiedCSSColorPercent&& lightness, RectifiedCSSColorPercent&& alpha)
     : m_hue(WTFMove(hue))
     , m_saturation(WTFMove(saturation))
     , m_lightness(WTFMove(lightness))
     , m_alpha(WTFMove(alpha))
 {
+}
+
+CSSColorAngle CSSHSL::h() const
+{
+    return toCSSColorAngle(m_hue);
+}
+
+ExceptionOr<void> CSSHSL::setH(CSSColorAngle&& hue)
+{
+    auto rectifiedHue = rectifyCSSColorAngle(WTFMove(hue));
+    if (rectifiedHue.hasException())
+        return rectifiedHue.releaseException();
+    m_hue = rectifiedHue.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSHSL::s() const
+{
+    return toCSSColorPercent(m_saturation);
+}
+
+ExceptionOr<void> CSSHSL::setS(CSSColorPercent&& saturation)
+{
+    auto rectifiedSaturation = rectifyCSSColorPercent(WTFMove(saturation));
+    if (rectifiedSaturation.hasException())
+        return rectifiedSaturation.releaseException();
+    m_saturation = rectifiedSaturation.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSHSL::l() const
+{
+    return toCSSColorPercent(m_lightness);
+}
+
+ExceptionOr<void> CSSHSL::setL(CSSColorPercent&& lightness)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    m_lightness = rectifiedLightness.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSHSL::alpha() const
+{
+    return toCSSColorPercent(m_alpha);
+}
+
+ExceptionOr<void> CSSHSL::setAlpha(CSSColorPercent&& alpha)
+{
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    m_alpha = rectifiedAlpha.releaseReturnValue();
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSHSL.h
+++ b/Source/WebCore/css/typedom/color/CSSHSL.h
@@ -29,27 +29,27 @@
 
 namespace WebCore {
 
-class CSSHSL : public CSSColorValue {
+class CSSHSL final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSHSL);
 public:
-    template<typename... Args> static Ref<CSSHSL> create(Args&&... args) { return adoptRef(*new CSSHSL(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSHSL>> create(CSSColorAngle&& hue, CSSColorPercent&& saturation, CSSColorPercent&& lightness, CSSColorPercent&& alpha);
 
-    const CSSColorAngle& h() const { return m_hue; }
-    void setH(CSSColorAngle hue) { m_hue = WTFMove(hue); }
-    const CSSColorPercent& s() const { return m_saturation; }
-    void setS(CSSColorPercent saturation) { m_saturation = WTFMove(saturation); }
-    const CSSColorPercent& l() const { return m_lightness; }
-    void setL(CSSColorPercent lightness) { m_lightness = WTFMove(lightness); }
-    const CSSColorPercent& alpha() const { return m_alpha; }
-    void setAlpha(CSSColorPercent alpha) { m_alpha = WTFMove(alpha); }
+    CSSColorAngle h() const;
+    ExceptionOr<void> setH(CSSColorAngle&&);
+    CSSColorPercent s() const;
+    ExceptionOr<void> setS(CSSColorPercent&&);
+    CSSColorPercent l() const;
+    ExceptionOr<void> setL(CSSColorPercent&&);
+    CSSColorPercent alpha() const;
+    ExceptionOr<void> setAlpha(CSSColorPercent&&);
 
 private:
-    CSSHSL(CSSColorAngle, CSSColorPercent, CSSColorPercent, CSSColorPercent);
+    CSSHSL(RectifiedCSSColorAngle&&, RectifiedCSSColorPercent&&, RectifiedCSSColorPercent&&, RectifiedCSSColorPercent&&);
 
-    CSSColorAngle m_hue;
-    CSSColorPercent m_saturation;
-    CSSColorPercent m_lightness;
-    CSSColorPercent m_alpha;
+    RectifiedCSSColorAngle m_hue;
+    RectifiedCSSColorPercent m_saturation;
+    RectifiedCSSColorPercent m_lightness;
+    RectifiedCSSColorPercent m_alpha;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSHWB.h
+++ b/Source/WebCore/css/typedom/color/CSSHWB.h
@@ -29,27 +29,27 @@
 
 namespace WebCore {
 
-class CSSHWB : public CSSColorValue {
+class CSSHWB final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSHWB);
 public:
-    template<typename... Args> static Ref<CSSHWB> create(Args&&... args) { return adoptRef(*new CSSHWB(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSHWB>> create(Ref<CSSNumericValue>&& hue, CSSNumberish&& whiteness, CSSNumberish&& blackness, CSSNumberish&& alpha);
 
-    const Ref<CSSNumericValue>& h() const { return m_hue; }
-    void setH(Ref<CSSNumericValue> hue) { m_hue = WTFMove(hue); }
-    const CSSNumberish& w() const { return m_whiteness; }
-    void setW(CSSNumberish whiteness) { m_whiteness = WTFMove(whiteness); }
-    const CSSNumberish& b() const { return m_blackness; }
-    void setB(CSSNumberish blackness) { m_blackness = WTFMove(blackness); }
-    const CSSNumberish& alpha() const { return m_alpha; }
-    void setAlpha(CSSNumberish alpha) { m_alpha = WTFMove(alpha); }
+    CSSNumericValue& h() const;
+    ExceptionOr<void> setH(Ref<CSSNumericValue>&&);
+    CSSNumberish w() const;
+    ExceptionOr<void> setW(CSSNumberish&&);
+    CSSNumberish b() const;
+    ExceptionOr<void> setB(CSSNumberish&&);
+    CSSNumberish alpha() const;
+    ExceptionOr<void> setAlpha(CSSNumberish&&);
 
 private:
-    CSSHWB(Ref<CSSNumericValue>, CSSNumberish, CSSNumberish, CSSNumberish);
+    CSSHWB(Ref<CSSNumericValue>&& hue, Ref<CSSNumericValue>&& whiteness, Ref<CSSNumericValue>&& m_blackness, Ref<CSSNumericValue>&& alpha);
 
     Ref<CSSNumericValue> m_hue;
-    CSSNumberish m_whiteness;
-    CSSNumberish m_blackness;
-    CSSNumberish m_alpha;
+    Ref<CSSNumericValue> m_whiteness;
+    Ref<CSSNumericValue> m_blackness;
+    Ref<CSSNumericValue> m_alpha;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSLCH.cpp
+++ b/Source/WebCore/css/typedom/color/CSSLCH.cpp
@@ -26,18 +26,94 @@
 #include "config.h"
 #include "CSSLCH.h"
 
+#include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSLCH);
 
-CSSLCH::CSSLCH(CSSColorPercent lightness, CSSColorPercent chroma, CSSColorAngle hue, CSSColorPercent alpha)
+ExceptionOr<Ref<CSSLCH>> CSSLCH::create(CSSColorPercent&& lightness, CSSColorPercent&& chroma, CSSColorAngle&& hue, CSSColorPercent&& alpha)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    auto rectifiedChroma = rectifyCSSColorPercent(WTFMove(chroma));
+    if (rectifiedChroma.hasException())
+        return rectifiedChroma.releaseException();
+    auto rectifiedHue = rectifyCSSColorAngle(WTFMove(hue));
+    if (rectifiedHue.hasException())
+        return rectifiedHue.releaseException();
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+
+    return adoptRef(*new CSSLCH(rectifiedLightness.releaseReturnValue(), rectifiedChroma.releaseReturnValue(), rectifiedHue.releaseReturnValue(), rectifiedAlpha.releaseReturnValue()));
+
+}
+
+CSSLCH::CSSLCH(RectifiedCSSColorPercent&& lightness, RectifiedCSSColorPercent&& chroma, RectifiedCSSColorAngle&& hue, RectifiedCSSColorPercent&& alpha)
     : m_lightness(WTFMove(lightness))
     , m_chroma(WTFMove(chroma))
     , m_hue(WTFMove(hue))
     , m_alpha(WTFMove(alpha))
 {
+}
+
+CSSColorPercent CSSLCH::l() const
+{
+    return toCSSColorAngle(m_lightness);
+}
+
+ExceptionOr<void> CSSLCH::setL(CSSColorPercent&& lightness)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    m_lightness = rectifiedLightness.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSLCH::c() const
+{
+    return toCSSColorAngle(m_chroma);
+}
+
+ExceptionOr<void> CSSLCH::setC(CSSColorPercent&& chroma)
+{
+    auto rectifiedChroma = rectifyCSSColorPercent(WTFMove(chroma));
+    if (rectifiedChroma.hasException())
+        return rectifiedChroma.releaseException();
+    m_chroma = rectifiedChroma.releaseReturnValue();
+    return { };
+}
+
+CSSColorAngle CSSLCH::h() const
+{
+    return toCSSColorAngle(m_hue);
+}
+
+ExceptionOr<void> CSSLCH::setH(CSSColorAngle&& hue)
+{
+    auto rectifiedHue = rectifyCSSColorAngle(WTFMove(hue));
+    if (rectifiedHue.hasException())
+        return rectifiedHue.releaseException();
+    m_hue = rectifiedHue.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSLCH::alpha() const
+{
+    return toCSSColorPercent(m_alpha);
+}
+
+ExceptionOr<void> CSSLCH::setAlpha(CSSColorPercent&& alpha)
+{
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    m_alpha = rectifiedAlpha.releaseReturnValue();
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSLCH.h
+++ b/Source/WebCore/css/typedom/color/CSSLCH.h
@@ -29,27 +29,27 @@
 
 namespace WebCore {
 
-class CSSLCH : public CSSColorValue {
+class CSSLCH final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSLCH);
 public:
-    template<typename... Args> static Ref<CSSLCH> create(Args&&... args) { return adoptRef(*new CSSLCH(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSLCH>> create(CSSColorPercent&& lightness, CSSColorPercent&& chroma, CSSColorAngle&& hue, CSSColorPercent&& alpha);
 
-    const CSSColorPercent& l() const { return m_lightness; }
-    void setL(CSSColorPercent lightness) { m_lightness = WTFMove(lightness); }
-    const CSSColorPercent& c() const { return m_chroma; }
-    void setC(CSSColorPercent chroma) { m_chroma = WTFMove(chroma); }
-    const CSSColorAngle& h() const { return m_hue; }
-    void setH(CSSColorAngle hue) { m_hue = WTFMove(hue); }
-    const CSSColorPercent& alpha() const { return m_alpha; }
-    void setAlpha(CSSColorPercent alpha) { m_alpha = WTFMove(alpha); }
+    CSSColorPercent l() const;
+    ExceptionOr<void> setL(CSSColorPercent&&);
+    CSSColorPercent c() const;
+    ExceptionOr<void> setC(CSSColorPercent&&);
+    CSSColorAngle h() const;
+    ExceptionOr<void> setH(CSSColorAngle&&);
+    CSSColorPercent alpha() const;
+    ExceptionOr<void> setAlpha(CSSColorPercent&&);
 
 private:
-    CSSLCH(CSSColorPercent, CSSColorPercent c, CSSColorAngle h, CSSColorPercent alpha);
+    CSSLCH(RectifiedCSSColorPercent&& lightness, RectifiedCSSColorPercent&& chroma, RectifiedCSSColorAngle&& hue, RectifiedCSSColorPercent&& alpha);
 
-    CSSColorPercent m_lightness;
-    CSSColorPercent m_chroma;
-    CSSColorAngle m_hue;
-    CSSColorPercent m_alpha;
+    RectifiedCSSColorPercent m_lightness;
+    RectifiedCSSColorPercent m_chroma;
+    RectifiedCSSColorAngle m_hue;
+    RectifiedCSSColorPercent m_alpha;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSLab.cpp
+++ b/Source/WebCore/css/typedom/color/CSSLab.cpp
@@ -26,18 +26,93 @@
 #include "config.h"
 #include "CSSLab.h"
 
+#include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSLab);
 
-CSSLab::CSSLab(CSSColorPercent lightness, CSSColorNumber a, CSSColorNumber b, CSSColorPercent alpha)
+ExceptionOr<Ref<CSSLab>> CSSLab::create(CSSColorPercent&& lightness, CSSColorNumber&& a, CSSColorNumber&& b, CSSColorPercent&& alpha)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    auto rectifiedA = rectifyCSSColorNumber(WTFMove(a));
+    if (rectifiedA.hasException())
+        return rectifiedA.releaseException();
+    auto rectifiedB = rectifyCSSColorNumber(WTFMove(b));
+    if (rectifiedB.hasException())
+        return rectifiedB.releaseException();
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+
+    return adoptRef(*new CSSLab(rectifiedLightness.releaseReturnValue(), rectifiedA.releaseReturnValue(), rectifiedB.releaseReturnValue(), rectifiedAlpha.releaseReturnValue()));
+}
+
+CSSLab::CSSLab(RectifiedCSSColorPercent&& lightness, RectifiedCSSColorNumber&& a, RectifiedCSSColorNumber&& b, RectifiedCSSColorPercent&& alpha)
     : m_lightness(WTFMove(lightness))
     , m_a(WTFMove(a))
     , m_b(WTFMove(b))
     , m_alpha(WTFMove(alpha))
 {
+}
+
+CSSColorPercent CSSLab::l() const
+{
+    return toCSSColorPercent(m_lightness);
+}
+
+ExceptionOr<void> CSSLab::setL(CSSColorPercent&& lightness)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    m_lightness = rectifiedLightness.releaseReturnValue();
+    return { };
+}
+
+CSSColorNumber CSSLab::a() const
+{
+    return toCSSColorNumber(m_a);
+}
+
+ExceptionOr<void> CSSLab::setA(CSSColorNumber&& a)
+{
+    auto rectifiedA = rectifyCSSColorNumber(WTFMove(a));
+    if (rectifiedA.hasException())
+        return rectifiedA.releaseException();
+    m_a = rectifiedA.releaseReturnValue();
+    return { };
+}
+
+CSSColorNumber CSSLab::b() const
+{
+    return toCSSColorNumber(m_b);
+}
+
+ExceptionOr<void> CSSLab::setB(CSSColorNumber&& b)
+{
+    auto rectifiedB = rectifyCSSColorNumber(WTFMove(b));
+    if (rectifiedB.hasException())
+        return rectifiedB.releaseException();
+    m_b = rectifiedB.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSLab::alpha() const
+{
+    return toCSSColorPercent(m_alpha);
+}
+
+ExceptionOr<void> CSSLab::setAlpha(CSSColorPercent&& alpha)
+{
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    m_alpha = rectifiedAlpha.releaseReturnValue();
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSLab.h
+++ b/Source/WebCore/css/typedom/color/CSSLab.h
@@ -29,27 +29,27 @@
 
 namespace WebCore {
 
-class CSSLab : public CSSColorValue {
+class CSSLab final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSLab);
 public:
-    template<typename... Args> static Ref<CSSLab> create(Args&&... args) { return adoptRef(*new CSSLab(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSLab>> create(CSSColorPercent&& lightness, CSSColorNumber&& a, CSSColorNumber&& b, CSSColorPercent&& alpha);
 
-    const CSSColorPercent& l() const { return m_lightness; }
-    void setL(CSSColorPercent lightness) { m_lightness = WTFMove(lightness); }
-    const CSSColorNumber& a() const { return m_a; }
-    void setA(CSSColorNumber a) { m_a = WTFMove(a); }
-    const CSSColorNumber& b() const { return m_b; }
-    void setB(CSSColorNumber b) { m_b = WTFMove(b); }
-    const CSSColorPercent& alpha() const { return m_alpha; }
-    void setAlpha(CSSColorPercent alpha) { m_alpha = WTFMove(alpha); }
+    CSSColorPercent l() const;
+    ExceptionOr<void> setL(CSSColorPercent&&);
+    CSSColorNumber a() const;
+    ExceptionOr<void> setA(CSSColorNumber&&);
+    CSSColorNumber b() const;
+    ExceptionOr<void> setB(CSSColorNumber&&);
+    CSSColorPercent alpha() const;
+    ExceptionOr<void> setAlpha(CSSColorPercent&&);
 
 private:
-    CSSLab(CSSColorPercent, CSSColorNumber, CSSColorNumber, CSSColorPercent);
+    CSSLab(RectifiedCSSColorPercent&&, RectifiedCSSColorNumber&&, RectifiedCSSColorNumber&&, RectifiedCSSColorPercent&&);
 
-    CSSColorPercent m_lightness;
-    CSSColorNumber m_a;
-    CSSColorNumber m_b;
-    CSSColorPercent m_alpha;
+    RectifiedCSSColorPercent m_lightness;
+    RectifiedCSSColorNumber m_a;
+    RectifiedCSSColorNumber m_b;
+    RectifiedCSSColorPercent m_alpha;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSOKLCH.cpp
+++ b/Source/WebCore/css/typedom/color/CSSOKLCH.cpp
@@ -26,18 +26,94 @@
 #include "config.h"
 #include "CSSOKLCH.h"
 
+#include "Exception.h"
+#include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSOKLCH);
 
-CSSOKLCH::CSSOKLCH(CSSColorPercent lightness, CSSColorPercent chroma, CSSColorAngle hue, CSSColorPercent alpha)
+ExceptionOr<Ref<CSSOKLCH>> CSSOKLCH::create(CSSColorPercent&& lightness, CSSColorPercent&& chroma, CSSColorAngle&& hue, CSSColorPercent&& alpha)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    auto rectifiedChroma = rectifyCSSColorPercent(WTFMove(chroma));
+    if (rectifiedChroma.hasException())
+        return rectifiedChroma.releaseException();
+    auto rectifiedHue = rectifyCSSColorAngle(WTFMove(hue));
+    if (rectifiedHue.hasException())
+        return rectifiedHue.releaseException();
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+
+    return adoptRef(*new CSSOKLCH(rectifiedLightness.releaseReturnValue(), rectifiedChroma.releaseReturnValue(), rectifiedHue.releaseReturnValue(), rectifiedAlpha.releaseReturnValue()));
+}
+
+CSSOKLCH::CSSOKLCH(RectifiedCSSColorPercent&& lightness, RectifiedCSSColorPercent&& chroma, RectifiedCSSColorAngle&& hue, RectifiedCSSColorPercent&& alpha)
     : m_lightness(WTFMove(lightness))
     , m_chroma(WTFMove(chroma))
     , m_hue(WTFMove(hue))
     , m_alpha(WTFMove(alpha))
 {
+}
+
+CSSColorPercent CSSOKLCH::l() const
+{
+    return toCSSColorPercent(m_lightness);
+}
+
+ExceptionOr<void> CSSOKLCH::setL(CSSColorPercent&& lightness)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    m_lightness = rectifiedLightness.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSOKLCH::c() const
+{
+    return toCSSColorPercent(m_chroma);
+}
+
+ExceptionOr<void> CSSOKLCH::setC(CSSColorPercent&& chroma)
+{
+    auto rectifiedChroma = rectifyCSSColorPercent(WTFMove(chroma));
+    if (rectifiedChroma.hasException())
+        return rectifiedChroma.releaseException();
+    m_chroma = rectifiedChroma.releaseReturnValue();
+    return { };
+}
+
+CSSColorAngle CSSOKLCH::h() const
+{
+    return toCSSColorAngle(m_hue);
+}
+
+ExceptionOr<void> CSSOKLCH::setH(CSSColorAngle&& hue)
+{
+    auto rectifiedHue = rectifyCSSColorAngle(WTFMove(hue));
+    if (rectifiedHue.hasException())
+        return rectifiedHue.releaseException();
+    m_hue = rectifiedHue.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSOKLCH::alpha() const
+{
+    return toCSSColorPercent(m_alpha);
+}
+
+ExceptionOr<void> CSSOKLCH::setAlpha(CSSColorPercent&& alpha)
+{
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    m_alpha = rectifiedAlpha.releaseReturnValue();
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSOKLCH.h
+++ b/Source/WebCore/css/typedom/color/CSSOKLCH.h
@@ -29,27 +29,27 @@
 
 namespace WebCore {
 
-class CSSOKLCH : public CSSColorValue {
+class CSSOKLCH final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSOKLCH);
 public:
-    template<typename... Args> static Ref<CSSOKLCH> create(Args&&... args) { return adoptRef(*new CSSOKLCH(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSOKLCH>> create(CSSColorPercent&& lightness, CSSColorPercent&& chroma, CSSColorAngle&& hue, CSSColorPercent&& alpha);
 
-    const CSSColorPercent& l() const { return m_lightness; }
-    void setL(CSSColorPercent lightness) { m_lightness = WTFMove(lightness); }
-    const CSSColorPercent& c() const { return m_chroma; }
-    void setC(CSSColorPercent chroma) { m_chroma = WTFMove(chroma); }
-    const CSSColorAngle& h() const { return m_hue; }
-    void setH(CSSColorAngle hue) { m_hue = WTFMove(hue); }
-    const CSSColorPercent& alpha() const { return m_alpha; }
-    void setAlpha(CSSColorPercent alpha) { m_alpha = WTFMove(alpha); }
+    CSSColorPercent l() const;
+    ExceptionOr<void> setL(CSSColorPercent&&);
+    CSSColorPercent c() const;
+    ExceptionOr<void> setC(CSSColorPercent&&);
+    CSSColorAngle h() const;
+    ExceptionOr<void> setH(CSSColorAngle&&);
+    CSSColorPercent alpha() const;
+    ExceptionOr<void> setAlpha(CSSColorPercent&&);
 
 private:
-    CSSOKLCH(CSSColorPercent l, CSSColorPercent c, CSSColorAngle h, CSSColorPercent alpha);
+    CSSOKLCH(RectifiedCSSColorPercent&& lightness, RectifiedCSSColorPercent&& chroma, RectifiedCSSColorAngle&& hue, RectifiedCSSColorPercent&& alpha);
 
-    CSSColorPercent m_lightness;
-    CSSColorPercent m_chroma;
-    CSSColorAngle m_hue;
-    CSSColorPercent m_alpha;
+    RectifiedCSSColorPercent m_lightness;
+    RectifiedCSSColorPercent m_chroma;
+    RectifiedCSSColorAngle m_hue;
+    RectifiedCSSColorPercent m_alpha;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSOKLab.cpp
+++ b/Source/WebCore/css/typedom/color/CSSOKLab.cpp
@@ -26,18 +26,93 @@
 #include "config.h"
 #include "CSSOKLab.h"
 
+#include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSOKLab);
 
-CSSOKLab::CSSOKLab(CSSColorPercent lightness, CSSColorNumber a, CSSColorNumber b, CSSColorPercent alpha)
+ExceptionOr<Ref<CSSOKLab>> CSSOKLab::create(CSSColorPercent&& lightness, CSSColorNumber&& a, CSSColorNumber&& b, CSSColorPercent&& alpha)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    auto rectifiedA = rectifyCSSColorNumber(WTFMove(a));
+    if (rectifiedA.hasException())
+        return rectifiedA.releaseException();
+    auto rectifiedB = rectifyCSSColorNumber(WTFMove(b));
+    if (rectifiedB.hasException())
+        return rectifiedB.releaseException();
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+
+    return adoptRef(*new CSSOKLab(rectifiedLightness.releaseReturnValue(), rectifiedA.releaseReturnValue(), rectifiedB.releaseReturnValue(), rectifiedAlpha.releaseReturnValue()));
+}
+
+CSSOKLab::CSSOKLab(RectifiedCSSColorPercent&& lightness, RectifiedCSSColorNumber&& a, RectifiedCSSColorNumber&& b, RectifiedCSSColorPercent&& alpha)
     : m_lightness(WTFMove(lightness))
     , m_a(WTFMove(a))
     , m_b(WTFMove(b))
     , m_alpha(WTFMove(alpha))
 {
+}
+
+CSSColorPercent CSSOKLab::l() const
+{
+    return toCSSColorPercent(m_lightness);
+}
+
+ExceptionOr<void> CSSOKLab::setL(CSSColorPercent&& lightness)
+{
+    auto rectifiedLightness = rectifyCSSColorPercent(WTFMove(lightness));
+    if (rectifiedLightness.hasException())
+        return rectifiedLightness.releaseException();
+    m_lightness = rectifiedLightness.releaseReturnValue();
+    return { };
+}
+
+CSSColorNumber CSSOKLab::a() const
+{
+    return toCSSColorNumber(m_a);
+}
+
+ExceptionOr<void> CSSOKLab::setA(CSSColorNumber&& a)
+{
+    auto rectifiedA = rectifyCSSColorNumber(WTFMove(a));
+    if (rectifiedA.hasException())
+        return rectifiedA.releaseException();
+    m_a = rectifiedA.releaseReturnValue();
+    return { };
+}
+
+CSSColorNumber CSSOKLab::b() const
+{
+    return toCSSColorNumber(m_b);
+}
+
+ExceptionOr<void> CSSOKLab::setB(CSSColorNumber&& b)
+{
+    auto rectifiedB = rectifyCSSColorNumber(WTFMove(b));
+    if (rectifiedB.hasException())
+        return rectifiedB.releaseException();
+    m_b = rectifiedB.releaseReturnValue();
+    return { };
+}
+
+CSSColorPercent CSSOKLab::alpha() const
+{
+    return toCSSColorPercent(m_alpha);
+}
+
+ExceptionOr<void> CSSOKLab::setAlpha(CSSColorPercent&& alpha)
+{
+    auto rectifiedAlpha = rectifyCSSColorPercent(WTFMove(alpha));
+    if (rectifiedAlpha.hasException())
+        return rectifiedAlpha.releaseException();
+    m_alpha = rectifiedAlpha.releaseReturnValue();
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSOKLab.h
+++ b/Source/WebCore/css/typedom/color/CSSOKLab.h
@@ -29,27 +29,27 @@
 
 namespace WebCore {
 
-class CSSOKLab : public CSSColorValue {
+class CSSOKLab final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSOKLab);
 public:
-    template<typename... Args> static Ref<CSSOKLab> create(Args&&... args) { return adoptRef(*new CSSOKLab(std::forward<Args>(args)...)); }
+    static ExceptionOr<Ref<CSSOKLab>> create(CSSColorPercent&& lightness, CSSColorNumber&& a, CSSColorNumber&& b, CSSColorPercent&& alpha);
 
-    const CSSColorPercent& l() const { return m_lightness; }
-    void setL(CSSColorPercent lightness) { m_lightness = WTFMove(lightness); }
-    const CSSColorNumber& a() const { return m_a; }
-    void setA(CSSColorNumber a) { m_a = WTFMove(a); }
-    const CSSColorNumber& b() const { return m_b; }
-    void setB(CSSColorNumber b) { m_b = WTFMove(b); }
-    const CSSColorPercent& alpha() const { return m_alpha; }
-    void setAlpha(CSSColorPercent alpha) { m_alpha = WTFMove(alpha); }
+    CSSColorPercent l() const;
+    ExceptionOr<void> setL(CSSColorPercent&&);
+    CSSColorNumber a() const;
+    ExceptionOr<void> setA(CSSColorNumber&&);
+    CSSColorNumber b() const;
+    ExceptionOr<void> setB(CSSColorNumber&&);
+    CSSColorPercent alpha() const;
+    ExceptionOr<void> setAlpha(CSSColorPercent&&);
 
 private:
-    CSSOKLab(CSSColorPercent, CSSColorNumber, CSSColorNumber, CSSColorPercent alpha);
+    CSSOKLab(RectifiedCSSColorPercent&&, RectifiedCSSColorNumber&&, RectifiedCSSColorNumber&&, RectifiedCSSColorPercent&& alpha);
 
-    CSSColorPercent m_lightness;
-    CSSColorNumber m_a;
-    CSSColorNumber m_b;
-    CSSColorPercent m_alpha;
+    RectifiedCSSColorPercent m_lightness;
+    RectifiedCSSColorNumber m_a;
+    RectifiedCSSColorNumber m_b;
+    RectifiedCSSColorPercent m_alpha;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSRGB.h
+++ b/Source/WebCore/css/typedom/color/CSSRGB.h
@@ -33,7 +33,7 @@ namespace WebCore {
 using CSSColorRGBComp = std::variant<double, RefPtr<CSSNumericValue>, String, RefPtr<CSSKeywordValue>>;
 using RectifiedCSSColorRGBComp = std::variant<RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>>;
 
-class CSSRGB : public CSSColorValue {
+class CSSRGB final : public CSSColorValue {
     WTF_MAKE_ISO_ALLOCATED(CSSRGB);
 public:
     static ExceptionOr<Ref<CSSRGB>> create(CSSColorRGBComp&&, CSSColorRGBComp&&, CSSColorRGBComp&&, CSSColorPercent&&);


### PR DESCRIPTION
#### 4e3531dd8b179697e87ed54b0a601b4f4118629b
<pre>
Implement input validation for CSSColorValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=247167">https://bugs.webkit.org/show_bug.cgi?id=247167</a>

Reviewed by Antti Koivisto.

Implement input validation for CSSColorValues:
- <a href="https://drafts.css-houdini.org/css-typed-om/#csshsl">https://drafts.css-houdini.org/css-typed-om/#csshsl</a>
- <a href="https://drafts.css-houdini.org/css-typed-om/#csshwb">https://drafts.css-houdini.org/css-typed-om/#csshwb</a>
- <a href="https://drafts.css-houdini.org/css-typed-om/#csslab">https://drafts.css-houdini.org/css-typed-om/#csslab</a>
- <a href="https://drafts.css-houdini.org/css-typed-om/#csslch">https://drafts.css-houdini.org/css-typed-om/#csslch</a>
- <a href="https://drafts.css-houdini.org/css-typed-om/#cssoklab">https://drafts.css-houdini.org/css-typed-om/#cssoklab</a>
- <a href="https://drafts.css-houdini.org/css-typed-om/#cssoklch">https://drafts.css-houdini.org/css-typed-om/#cssoklch</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/resources/testhelper.js:
(assert_color_channel_approx_equals):
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHSL-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHSL.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHWB-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssHWB.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLCH-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLCH.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLab-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssLab.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLCH-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLCH.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLab-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssOKLab.html: Added.
* Source/WebCore/css/typedom/color/CSSColorValue.cpp:
(WebCore::CSSColorValue::rectifyCSSColorAngle):
(WebCore::CSSColorValue::rectifyCSSColorNumber):
(WebCore::CSSColorValue::toCSSColorPercent):
(WebCore::CSSColorValue::toCSSColorAngle):
(WebCore::CSSColorValue::toCSSColorNumber):
* Source/WebCore/css/typedom/color/CSSColorValue.h:
* Source/WebCore/css/typedom/color/CSSHSL.cpp:
(WebCore::CSSHSL::create):
(WebCore::CSSHSL::CSSHSL):
(WebCore::CSSHSL::h const):
(WebCore::CSSHSL::setH):
(WebCore::CSSHSL::s const):
(WebCore::CSSHSL::setS):
(WebCore::CSSHSL::l const):
(WebCore::CSSHSL::setL):
(WebCore::CSSHSL::alpha const):
(WebCore::CSSHSL::setAlpha):
* Source/WebCore/css/typedom/color/CSSHSL.h:
(WebCore::CSSHSL::create): Deleted.
(WebCore::CSSHSL::h const): Deleted.
(WebCore::CSSHSL::setH): Deleted.
(WebCore::CSSHSL::s const): Deleted.
(WebCore::CSSHSL::setS): Deleted.
(WebCore::CSSHSL::l const): Deleted.
(WebCore::CSSHSL::setL): Deleted.
(WebCore::CSSHSL::alpha const): Deleted.
(WebCore::CSSHSL::setAlpha): Deleted.
* Source/WebCore/css/typedom/color/CSSHWB.cpp:
(WebCore::CSSHWB::create):
(WebCore::CSSHWB::CSSHWB):
(WebCore::CSSHWB::h const):
(WebCore::CSSHWB::setH):
(WebCore::CSSHWB::w const):
(WebCore::CSSHWB::setW):
(WebCore::CSSHWB::b const):
(WebCore::CSSHWB::setB):
(WebCore::CSSHWB::alpha const):
(WebCore::CSSHWB::setAlpha):
* Source/WebCore/css/typedom/color/CSSHWB.h:
(WebCore::CSSHWB::create): Deleted.
(WebCore::CSSHWB::h const): Deleted.
(WebCore::CSSHWB::setH): Deleted.
(WebCore::CSSHWB::w const): Deleted.
(WebCore::CSSHWB::setW): Deleted.
(WebCore::CSSHWB::b const): Deleted.
(WebCore::CSSHWB::setB): Deleted.
(WebCore::CSSHWB::alpha const): Deleted.
(WebCore::CSSHWB::setAlpha): Deleted.
* Source/WebCore/css/typedom/color/CSSLCH.cpp:
(WebCore::CSSLCH::create):
(WebCore::CSSLCH::CSSLCH):
(WebCore::CSSLCH::l const):
(WebCore::CSSLCH::setL):
(WebCore::CSSLCH::c const):
(WebCore::CSSLCH::setC):
(WebCore::CSSLCH::h const):
(WebCore::CSSLCH::setH):
(WebCore::CSSLCH::alpha const):
(WebCore::CSSLCH::setAlpha):
* Source/WebCore/css/typedom/color/CSSLCH.h:
(WebCore::CSSLCH::create): Deleted.
(WebCore::CSSLCH::l const): Deleted.
(WebCore::CSSLCH::setL): Deleted.
(WebCore::CSSLCH::c const): Deleted.
(WebCore::CSSLCH::setC): Deleted.
(WebCore::CSSLCH::h const): Deleted.
(WebCore::CSSLCH::setH): Deleted.
(WebCore::CSSLCH::alpha const): Deleted.
(WebCore::CSSLCH::setAlpha): Deleted.
* Source/WebCore/css/typedom/color/CSSLab.cpp:
(WebCore::CSSLab::create):
(WebCore::CSSLab::CSSLab):
(WebCore::CSSLab::l const):
(WebCore::CSSLab::setL):
(WebCore::CSSLab::a const):
(WebCore::CSSLab::setA):
(WebCore::CSSLab::b const):
(WebCore::CSSLab::setB):
(WebCore::CSSLab::alpha const):
(WebCore::CSSLab::setAlpha):
* Source/WebCore/css/typedom/color/CSSLab.h:
(WebCore::CSSLab::create): Deleted.
(WebCore::CSSLab::l const): Deleted.
(WebCore::CSSLab::setL): Deleted.
(WebCore::CSSLab::a const): Deleted.
(WebCore::CSSLab::setA): Deleted.
(WebCore::CSSLab::b const): Deleted.
(WebCore::CSSLab::setB): Deleted.
(WebCore::CSSLab::alpha const): Deleted.
(WebCore::CSSLab::setAlpha): Deleted.
* Source/WebCore/css/typedom/color/CSSOKLCH.cpp:
(WebCore::CSSOKLCH::create):
(WebCore::CSSOKLCH::CSSOKLCH):
(WebCore::CSSOKLCH::l const):
(WebCore::CSSOKLCH::setL):
(WebCore::CSSOKLCH::c const):
(WebCore::CSSOKLCH::setC):
(WebCore::CSSOKLCH::h const):
(WebCore::CSSOKLCH::setH):
(WebCore::CSSOKLCH::alpha const):
(WebCore::CSSOKLCH::setAlpha):
* Source/WebCore/css/typedom/color/CSSOKLCH.h:
(WebCore::CSSOKLCH::create): Deleted.
(WebCore::CSSOKLCH::l const): Deleted.
(WebCore::CSSOKLCH::setL): Deleted.
(WebCore::CSSOKLCH::c const): Deleted.
(WebCore::CSSOKLCH::setC): Deleted.
(WebCore::CSSOKLCH::h const): Deleted.
(WebCore::CSSOKLCH::setH): Deleted.
(WebCore::CSSOKLCH::alpha const): Deleted.
(WebCore::CSSOKLCH::setAlpha): Deleted.
* Source/WebCore/css/typedom/color/CSSOKLab.cpp:
(WebCore::CSSOKLab::create):
(WebCore::CSSOKLab::CSSOKLab):
(WebCore::CSSOKLab::l const):
(WebCore::CSSOKLab::setL):
(WebCore::CSSOKLab::a const):
(WebCore::CSSOKLab::setA):
(WebCore::CSSOKLab::b const):
(WebCore::CSSOKLab::setB):
(WebCore::CSSOKLab::alpha const):
(WebCore::CSSOKLab::setAlpha):
* Source/WebCore/css/typedom/color/CSSOKLab.h:
(WebCore::CSSOKLab::create): Deleted.
(WebCore::CSSOKLab::l const): Deleted.
(WebCore::CSSOKLab::setL): Deleted.
(WebCore::CSSOKLab::a const): Deleted.
(WebCore::CSSOKLab::setA): Deleted.
(WebCore::CSSOKLab::b const): Deleted.
(WebCore::CSSOKLab::setB): Deleted.
(WebCore::CSSOKLab::alpha const): Deleted.
(WebCore::CSSOKLab::setAlpha): Deleted.
* Source/WebCore/css/typedom/color/CSSRGB.h:

Canonical link: <a href="https://commits.webkit.org/256229@main">https://commits.webkit.org/256229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbfcb9bcf28247a3b3f38e6fc8f50a8d3d703668

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94686 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104308 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164575 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3912 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32267 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100249 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2814 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81627 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29834 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84299 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72722 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38440 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18113 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19392 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2069 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42167 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38625 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->