### PR TITLE
Fix default angle cases from at-font-face-descriptors.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt
@@ -68,7 +68,7 @@ FAIL font-style(valid): 'auto' keyword inside @font-face: auto assert_not_equals
 PASS font-style(invalid): 'italic' followed by angle: italic 20deg
 PASS font-style(invalid): Extra content after keyword: italic a
 PASS font-style(valid): 'oblique' followed by zero degrees: oblique 0deg
-FAIL font-style(valid): 'oblique' followed by default 20deg angle: oblique 20deg assert_equals: Unexpected resulting value. expected "oblique" but got "oblique 20deg"
+PASS font-style(valid): 'oblique' followed by former default 20deg angle: oblique 20deg
 PASS font-style(valid): 'oblique' followed by maxumum 90 degree angle: oblique 90deg
 PASS font-style(valid): 'oblique' followed by minimum -90 degree angle: oblique -90deg
 PASS font-style(valid): 'oblique' followed by calc with out of range value (should be clamped): oblique calc(91deg)
@@ -82,7 +82,7 @@ PASS font-style(invalid): 'oblique' followed by minus and angle separated by spa
 PASS font-style(invalid): 'oblique' followed by minus and non-number: oblique -a
 PASS font-style(valid): Simple range: oblique 10deg 20deg
 FAIL font-style(valid): Simple range with equal upper and lower bounds: oblique 10deg 10deg assert_equals: Unexpected resulting value. expected "oblique 10deg" but got "oblique 10deg 10deg"
-FAIL font-style(valid): Simple range with  default angle for both bounds: oblique 20deg 20deg assert_equals: Unexpected resulting value. expected "oblique" but got "oblique 20deg 20deg"
+PASS font-style(valid): Simple range with former default angle for both bounds: oblique 20deg 20deg
 PASS font-style(valid): Bounds out of order: oblique 20deg 10deg
 PASS font-style(invalid): Lower bound out of range: oblique -100deg 20deg
 PASS font-style(invalid): Upper bound out of range: oblique 20deg 100deg

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors.html
@@ -147,7 +147,7 @@
             { value: "italic 20deg",            isValid: false, description: "'italic' followed by angle" },
             { value: "italic a",                isValid: false, description: "Extra content after keyword" },
             { value: "oblique 0deg",            isValid: true,  description: "'oblique' followed by zero degrees" },
-            { value: "oblique 20deg",           isValid: true,  expectedValue: "oblique", description: "'oblique' followed by default 20deg angle" },
+            { value: "oblique 20deg",           isValid: true,  description: "'oblique' followed by former default 20deg angle" },
             { value: "oblique 90deg",           isValid: true,  description: "'oblique' followed by maxumum 90 degree angle" },
             { value: "oblique -90deg",          isValid: true,  description: "'oblique' followed by minimum -90 degree angle" },
             { value: "oblique calc(91deg)",     isValid: true,  description: "'oblique' followed by calc with out of range value (should be clamped)" },
@@ -163,7 +163,7 @@
             // Value range
             { value: "oblique 10deg 20deg",         isValid: true,  description: "Simple range" },
             { value: "oblique 10deg 10deg",         isValid: true,  expectedValue: "oblique 10deg", description: "Simple range with equal upper and lower bounds" },
-            { value: "oblique 20deg 20deg",         isValid: true,  expectedValue: "oblique", description: "Simple range with  default angle for both bounds" },
+            { value: "oblique 20deg 20deg",         isValid: true,  description: "Simple range with former default angle for both bounds" },
             { value: "oblique 20deg 10deg",         isValid: true,  expectedValue: "oblique 20deg 10deg", description: "Bounds out of order" },
             { value: "oblique -100deg 20deg",       isValid: false, description: "Lower bound out of range" },
             { value: "oblique 20deg 100deg",        isValid: false, description: "Upper bound out of range" },


### PR DESCRIPTION
#### 3e8ac0a21f3047ebd9add1db025f4c13d287df53
<pre>
Fix default angle cases from at-font-face-descriptors.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=247172">https://bugs.webkit.org/show_bug.cgi?id=247172</a>
rdar://101666575

Reviewed by Darin Adler.

The default angle is now 14deg, not 20deg, but even then, I do not think we should treat the default angle specially in this case, given that it changed. We lose information by serializing to the shorter form (did the author intend to mean 20deg or the current default angle?). For clarity, always putting the angle is better.

See: <a href="https://github.com/w3c/csswg-drafts/issues/2295">https://github.com/w3c/csswg-drafts/issues/2295</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/variations/at-font-face-descriptors.html:

Canonical link: <a href="https://commits.webkit.org/256098@main">https://commits.webkit.org/256098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/296a0b1702fa581bbdf34337eb4813b5e67427df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104259 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164529 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3861 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31987 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100220 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2777 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81003 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29801 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84702 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72695 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38391 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18075 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19349 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40149 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2003 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38581 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->