### PR TITLE
[Curl] Add some missing NetworkLoadMetrics information for curl port

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -2138,3 +2138,7 @@ webkit.org/b/188980 fast/css/vertical-align-block-elements.html [ ImageOnlyFailu
 imported/w3c/web-platform-tests/resource-timing/cross-origin-redirects.html [ Pass ]
 imported/w3c/web-platform-tests/resource-timing/cross-origin-start-end-time-with-redirects.html [ Pass ]
 imported/w3c/web-platform-tests/resource-timing/resource_reuse.sub.html [ Pass ]
+imported/w3c/web-platform-tests/resource-timing/resource_TAO_cross_origin_redirect_chain.html [ Pass ]
+imported/w3c/web-platform-tests/resource-timing/resource_timing_same_origin_redirect.html [ Pass ]
+imported/w3c/web-platform-tests/resource-timing/resource_timing_TAO_cross_origin_redirect.html [ Pass ]
+imported/w3c/web-platform-tests/resource-timing/resource-timing-level1.sub.html [ Pass ]

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -756,11 +756,12 @@ NetworkLoadMetrics CurlRequest::networkLoadMetrics()
     if (!networkLoadMetrics)
         return NetworkLoadMetrics();
 
+    networkLoadMetrics->responseBodyDecodedSize = m_totalReceivedSize;
+
     if (m_captureExtraMetrics) {
         m_curlHandle->addExtraNetworkLoadMetrics(*networkLoadMetrics);
         if (auto* additionalMetrics = networkLoadMetrics->additionalNetworkLoadMetricsForWebInspector.get())
             additionalMetrics->requestHeaders = m_requestHeaders;
-        networkLoadMetrics->responseBodyDecodedSize = m_totalReceivedSize;
     }
 
     return WTFMove(*networkLoadMetrics);

--- a/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
+++ b/Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp
@@ -181,9 +181,15 @@ void CurlResourceHandleDelegate::curlDidFailWithError(CurlRequest&, ResourceErro
 
 void CurlResourceHandleDelegate::updateNetworkLoadMetrics(NetworkLoadMetrics& networkLoadMetrics)
 {
+    if (!d()->m_startTime)
+        d()->m_startTime = networkLoadMetrics.fetchStart;
+
     m_handle.checkTAO(m_response);
 
+    networkLoadMetrics.redirectStart = m_handle.startTimeBeforeRedirects();
+    networkLoadMetrics.redirectCount = m_handle.redirectCount();
     networkLoadMetrics.failsTAOCheck = m_handle.failsTAOCheck();
+    networkLoadMetrics.hasCrossOriginRedirect = m_handle.hasCrossOriginRedirect();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
@@ -482,6 +482,12 @@ void ResourceHandle::willSendRequest()
         newRequest.clearHTTPOrigin();
     }
 
+    // Check if the redirected url is allowed to access the redirecting url's timing information.
+    if (!hasCrossOriginRedirect() && !WebCore::SecurityOrigin::create(newRequest.url())->canRequest(delegate()->response().url()))
+        markAsHavingCrossOriginRedirect();
+
+    incrementRedirectCount();
+
     ResourceResponse responseCopy = delegate()->response();
     client()->willSendRequestAsync(this, WTFMove(newRequest), WTFMove(responseCopy), [this, protectedThis = Ref { *this }] (ResourceRequest&& request) {
         continueAfterWillSendRequest(WTFMove(request));

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
@@ -115,7 +115,9 @@ private:
 
     bool m_blockingCookies { false };
 
+    MonotonicTime m_startTime;
     bool m_failsTAOCheck { false };
+    bool m_hasCrossOriginRedirect { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### d65c8d10ac7f37b6e840a3bf34318a0ab3d8f4ad
<pre>
[Curl] Add some missing NetworkLoadMetrics information for curl port
<a href="https://bugs.webkit.org/show_bug.cgi?id=247160">https://bugs.webkit.org/show_bug.cgi?id=247160</a>

Reviewed by Fujii Hironori.

Add some missing NetworkLoadMetrics information for curl port.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::getNetworkLoadMetrics):
(WebCore::CurlHandle::addExtraNetworkLoadMetrics):
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::networkLoadMetrics):
* Source/WebCore/platform/network/curl/CurlResourceHandleDelegate.cpp:
(WebCore::CurlResourceHandleDelegate::updateNetworkLoadMetrics):
* Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp:
(WebCore::ResourceHandle::willSendRequest):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCurl::updateNetworkLoadMetrics):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h:

Canonical link: <a href="https://commits.webkit.org/256133@main">https://commits.webkit.org/256133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4062e140c802932f198fb9b7fa9353522f6c3a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104265 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164534 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3868 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31994 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100223 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2782 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81010 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29810 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72699 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38397 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19355 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4234 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42008 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38588 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->