### PR TITLE
[WPE] Support the stable xdg_shell protocol in WindowViewBackend

### DIFF
--- a/Tools/wpe/backends/PlatformWPE.cmake
+++ b/Tools/wpe/backends/PlatformWPE.cmake
@@ -4,11 +4,13 @@ find_package(WaylandProtocols 1.12 REQUIRED)
 find_package(WPEBackend_fdo 1.3.0 REQUIRED)
 
 list(APPEND WPEToolingBackends_PUBLIC_HEADERS
+    ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
     ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-unstable-v6-client-protocol.h
     fdo/WindowViewBackend.h
 )
 
 list(APPEND WPEToolingBackends_SOURCES
+    ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-protocol.c
     ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-unstable-v6-protocol.c
 
     atk/ViewBackendAtk.cpp
@@ -42,6 +44,19 @@ list(APPEND WPEToolingBackends_LIBRARIES
 
 list(APPEND WPEToolingBackends_DEFINITIONS USE_GLIB=1)
 list(APPEND WPEToolingBackends_PRIVATE_DEFINITIONS ${LIBEPOXY_DEFINITIONS})
+
+add_custom_command(
+    OUTPUT ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-protocol.c
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml
+    DEPENDS ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} code ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-protocol.c
+    VERBATIM)
+
+add_custom_command(
+    OUTPUT ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
+    MAIN_DEPENDENCY ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml
+    COMMAND ${WAYLAND_SCANNER} client-header ${WAYLAND_PROTOCOLS_DATADIR}/stable/xdg-shell/xdg-shell.xml ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-client-protocol.h
+    VERBATIM)
 
 add_custom_command(
     OUTPUT ${WPEToolingBackends_DERIVED_SOURCES_DIR}/xdg-shell-unstable-v6-protocol.c

--- a/Tools/wpe/backends/fdo/WindowViewBackend.h
+++ b/Tools/wpe/backends/fdo/WindowViewBackend.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ViewBackend.h"
+#include "xdg-shell-client-protocol.h"
 #include "xdg-shell-unstable-v6-client-protocol.h"
 #include <glib.h>
 #include <unordered_map>
@@ -66,14 +67,11 @@ private:
 #endif
 
     static const struct wl_registry_listener s_registryListener;
-    static const struct zxdg_shell_v6_listener s_xdgWmBaseListener;
     static const struct wl_pointer_listener s_pointerListener;
     static const struct wl_keyboard_listener s_keyboardListener;
     static const struct wl_touch_listener s_touchListener;
     static const struct wl_seat_listener s_seatListener;
     static const struct wl_callback_listener s_frameListener;
-    static const struct zxdg_surface_v6_listener s_xdgSurfaceListener;
-    static const struct zxdg_toplevel_v6_listener s_xdgToplevelListener;
 
 #if WPE_CHECK_VERSION(1, 11, 1)
     static bool onDOMFullscreenRequest(void* data, bool fullscreen);
@@ -134,12 +132,9 @@ private:
 
     struct wl_display* m_display { nullptr };
     struct wl_compositor* m_compositor { nullptr };
-    struct zxdg_shell_v6* m_xdg { nullptr };
     struct wl_seat* m_seat { nullptr };
     GSource* m_eventSource { nullptr };
     struct wl_surface* m_surface { nullptr };
-    struct zxdg_surface_v6* m_xdgSurface { nullptr };
-    struct zxdg_toplevel_v6* m_xdgToplevel { nullptr };
     struct wl_egl_window* m_eglWindow { nullptr };
     EGLContext m_eglContext { nullptr };
     EGLConfig m_eglConfig;
@@ -152,6 +147,26 @@ private:
 #if WPE_CHECK_VERSION(1, 11, 1)
     bool m_waiting_fullscreen_notify { false };
 #endif
+
+    struct XDGStable {
+        static const struct xdg_wm_base_listener s_wmListener;
+        static const struct xdg_surface_listener s_surfaceListener;
+        static const struct xdg_toplevel_listener s_toplevelListener;
+
+        struct xdg_wm_base* wm { nullptr };
+        struct xdg_surface* surface { nullptr };
+        struct xdg_toplevel* toplevel { nullptr };
+    } m_xdg;
+
+    struct XDGUnstable {
+        static const struct zxdg_shell_v6_listener s_shellListener;
+        static const struct zxdg_surface_v6_listener s_surfaceListener;
+        static const struct zxdg_toplevel_v6_listener s_toplevelListener;
+
+        struct zxdg_shell_v6* shell { nullptr };
+        struct zxdg_surface_v6* surface { nullptr };
+        struct zxdg_toplevel_v6* toplevel { nullptr };
+    } m_zxdg;
 };
 
 } // WPEToolingBackends


### PR DESCRIPTION
#### 2dc61a55832a0a6e75c963cd3805ab645c5dad7c
<pre>
[WPE] Support the stable xdg_shell protocol in WindowViewBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=247176">https://bugs.webkit.org/show_bug.cgi?id=247176</a>

Reviewed by Carlos Garcia Campos.

Have WPE&apos;s WindowViewBackend support the stable xdg_shell protocol, implementing
it alongside the support for the unstable variant of that protocol. The stable
variant is preferred, if available.

The relevant protocol files are generated and included in the build. The shell
objects and listeners are reorganized into two separate structs. The differences
between the two variants are not big, main problem is just the different set
of types and functions being used.

* Tools/wpe/backends/PlatformWPE.cmake:
* Tools/wpe/backends/fdo/WindowViewBackend.cpp:
(WPEToolingBackends::WindowViewBackend::onDOMFullscreenRequest):
(WPEToolingBackends::WindowViewBackend::WindowViewBackend):
(WPEToolingBackends::WindowViewBackend::~WindowViewBackend):
* Tools/wpe/backends/fdo/WindowViewBackend.h:

Canonical link: <a href="https://commits.webkit.org/256092@main">https://commits.webkit.org/256092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f381731e7d02a1361c0f93e69882b8869994c602

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104279 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164548 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3882 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32007 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86963 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100324 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81023 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29820 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84716 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72708 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38411 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36262 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19367 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4206 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40169 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38600 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->