### PR TITLE
[GTK][WPE] Improve detection of the web view main resource

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2109,6 +2109,8 @@ void DocumentLoader::startLoadingMainResource()
     ASSERT(timing().startTime());
 
     willSendRequest(ResourceRequest(m_request), ResourceResponse(), [this, protectedThis = WTFMove(protectedThis)] (ResourceRequest&& request) mutable {
+        request.setRequester(ResourceRequest::Requester::Main);
+
         m_request = request;
         // FIXME: Implement local URL interception by getting the service worker of the parent.
 
@@ -2118,7 +2120,6 @@ void DocumentLoader::startLoadingMainResource()
             return;
         }
 
-        request.setRequester(ResourceRequest::Requester::Main);
         // If this is a reload the cache layer might have made the previous request conditional. DocumentLoader can't handle 304 responses itself.
         request.makeUnconditional();
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp
@@ -56,8 +56,7 @@ private:
             if (!webRequest)
                 return;
 
-            GRefPtr<WebKitURIRequest> request = adoptGRef(webkitURIRequestCreateForResourceRequest(webRequest->resourceRequest()));
-            webkitWebViewResourceLoadStarted(webView, *frame, resourceIdentifier->value(), request.get());
+            webkitWebViewResourceLoadStarted(webView, *frame, resourceIdentifier->value(), webRequest->resourceRequest());
         } else if (g_str_equal(messageName, "DidSendRequestForResource")) {
             API::UInt64* resourceIdentifier = static_cast<API::UInt64*>(message.get(String::fromUTF8("Identifier")));
             if (!resourceIdentifier)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -233,12 +233,12 @@ static void webkitWebResourceUpdateURI(WebKitWebResource* resource, const CStrin
     g_object_notify_by_pspec(G_OBJECT(resource), sObjProperties[PROP_URI]);
 }
 
-WebKitWebResource* webkitWebResourceCreate(WebFrameProxy& frame, WebKitURIRequest* request, bool isMainResource)
+WebKitWebResource* webkitWebResourceCreate(WebFrameProxy& frame, const WebCore::ResourceRequest& request)
 {
     WebKitWebResource* resource = WEBKIT_WEB_RESOURCE(g_object_new(WEBKIT_TYPE_WEB_RESOURCE, NULL));
     resource->priv->frame = &frame;
-    resource->priv->uri = webkit_uri_request_get_uri(request);
-    resource->priv->isMainResource = isMainResource;
+    resource->priv->uri = request.url().string().utf8();
+    resource->priv->isMainResource = frame.isMainFrame() && request.requester() == WebCore::ResourceRequest::Requester::Main;
     return resource;
 }
 
@@ -279,6 +279,11 @@ void webkitWebResourceFailedWithTLSErrors(WebKitWebResource* resource, GTlsCerti
 WebFrameProxy* webkitWebResourceGetFrame(WebKitWebResource* resource)
 {
     return resource->priv->frame.get();
+}
+
+bool webkitWebResourceIsMainResource(WebKitWebResource* resource)
+{
+    return resource->priv->isMainResource;
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResourcePrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResourcePrivate.h
@@ -20,8 +20,9 @@
 #pragma once
 
 #include "WebKitWebResource.h"
+#include <WebCore/ResourceRequest.h>
 
-WebKitWebResource* webkitWebResourceCreate(WebKit::WebFrameProxy&, WebKitURIRequest*, bool isMainResource);
+WebKitWebResource* webkitWebResourceCreate(WebKit::WebFrameProxy&, const WebCore::ResourceRequest&);
 void webkitWebResourceSentRequest(WebKitWebResource*, WebKitURIRequest*, WebKitURIResponse*);
 void webkitWebResourceSetResponse(WebKitWebResource*, WebKitURIResponse*);
 void webkitWebResourceNotifyProgress(WebKitWebResource*, guint64 bytesReceived);
@@ -29,3 +30,4 @@ void webkitWebResourceFinished(WebKitWebResource*);
 void webkitWebResourceFailed(WebKitWebResource*, GError*);
 void webkitWebResourceFailedWithTLSErrors(WebKitWebResource*, GTlsCertificateFlags, GTlsCertificate*);
 WebKit::WebFrameProxy* webkitWebResourceGetFrame(WebKitWebResource*);
+bool webkitWebResourceIsMainResource(WebKitWebResource*);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -2751,15 +2751,14 @@ void webkitWebViewPrintFrame(WebKitWebView* webView, WebFrameProxy* frame)
 }
 #endif
 
-void webkitWebViewResourceLoadStarted(WebKitWebView* webView, WebFrameProxy& frame, uint64_t resourceIdentifier, WebKitURIRequest* request)
+void webkitWebViewResourceLoadStarted(WebKitWebView* webView, WebFrameProxy& frame, uint64_t resourceIdentifier, const ResourceRequest& request)
 {
-    WebKitWebViewPrivate* priv = webView->priv;
-    bool isMainResource = frame.isMainFrame() && !priv->mainResource;
-    WebKitWebResource* resource = webkitWebResourceCreate(frame, request, isMainResource);
-    if (isMainResource)
-        priv->mainResource = resource;
-    priv->loadingResourcesMap.set(resourceIdentifier, adoptGRef(resource));
-    g_signal_emit(webView, signals[RESOURCE_LOAD_STARTED], 0, resource, request);
+    GRefPtr<WebKitWebResource> resource = adoptGRef(webkitWebResourceCreate(frame, request));
+    if (webkitWebResourceIsMainResource(resource.get()))
+        webView->priv->mainResource = resource;
+    webView->priv->loadingResourcesMap.set(resourceIdentifier, resource);
+    GRefPtr<WebKitURIRequest> uriRequest = adoptGRef(webkitURIRequestCreateForResourceRequest(request));
+    g_signal_emit(webView, signals[RESOURCE_LOAD_STARTED], 0, resource.get(), uriRequest.get());
 }
 
 WebKitWebResource* webkitWebViewGetLoadingWebResource(WebKitWebView* webView, uint64_t resourceIdentifier)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -39,6 +39,7 @@
 #include <WebCore/CompositionUnderline.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/LinkIcon.h>
+#include <WebCore/ResourceRequest.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/text/CString.h>
 
@@ -72,7 +73,7 @@ void webkitWebViewMakePolicyDecision(WebKitWebView*, WebKitPolicyDecisionType, W
 void webkitWebViewMouseTargetChanged(WebKitWebView*, const WebKit::WebHitTestResultData&, OptionSet<WebKit::WebEventModifier>);
 void webkitWebViewHandleDownloadRequest(WebKitWebView*, WebKit::DownloadProxy*);
 void webkitWebViewPrintFrame(WebKitWebView*, WebKit::WebFrameProxy*);
-void webkitWebViewResourceLoadStarted(WebKitWebView*, WebKit::WebFrameProxy&, uint64_t resourceIdentifier, WebKitURIRequest*);
+void webkitWebViewResourceLoadStarted(WebKitWebView*, WebKit::WebFrameProxy&, uint64_t resourceIdentifier, const WebCore::ResourceRequest&);
 void webkitWebViewRunFileChooserRequest(WebKitWebView*, WebKitFileChooserRequest*);
 WebKitWebResource* webkitWebViewGetLoadingWebResource(WebKitWebView*, uint64_t resourceIdentifier);
 #if PLATFORM(GTK)


### PR DESCRIPTION
#### a3c1630617d29865df618e6fc017d958c1477b1d
<pre>
[GTK][WPE] Improve detection of the web view main resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=247177">https://bugs.webkit.org/show_bug.cgi?id=247177</a>

Reviewed by Michael Catanzaro.

We currently assume that the first resource loaded for a web view in the
main frame is the main resource, but we can check the request requester
instead.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource): Set the requester before copying the request.
* Source/WebKit/UIProcess/API/glib/WebKitInjectedBundleClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp:
(webkitWebResourceCreate):
(webkitWebResourceIsMainResource):
* Source/WebKit/UIProcess/API/glib/WebKitWebResourcePrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewResourceLoadStarted):
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:

Canonical link: <a href="https://commits.webkit.org/256142@main">https://commits.webkit.org/256142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf5ed1fd3de9fd2cab45744ee5d4205d2677af4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104270 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164539 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3873 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/31999 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100226 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2785 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81015 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29813 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38402 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18084 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19359 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4239 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42013 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38592 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->