### PR TITLE
Style checker has issue with test implementation files with no primary headers

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3598,6 +3598,10 @@ def _classify_include(filename, include, is_system, include_state):
     target_base = FileInfo(filename).base_name()
     include_base = FileInfo(include).base_name()
 
+    # Test .cpp, .mm, .c files do not have primary header files.
+    if any(target_base.endswith(suffix) for suffix in ['Test', 'Tests']):
+        return _OTHER_HEADER
+
     # If we haven't encountered a primary header, then be lenient in checking.
     if not include_state.visited_primary_section():
         if target_base.find(include_base) != -1:

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -3636,6 +3636,20 @@ class OrderOfIncludesTest(CppStyleTestBase):
                                          '#include "bar.h"\n',
                                          '')
 
+        # .. for tests even if the base name of an include is the prefix of the includee base name.
+        self.assert_language_rules_check('FooTest.cpp',
+                                         '#include "config.h"\n'
+                                         '\n'
+                                         '#include "Foo.h"\n',
+                                         '')
+
+        # .. for tests even if the base name of an include is contained in the includee base name.
+        self.assert_language_rules_check('FooTests.cpp',
+                                         '#include "config.h"\n'
+                                         '\n'
+                                         '#include "Test.h"\n',
+                                         '')
+
         # Pretend that header files exist.
         os.path.isfile = lambda filename: True
 


### PR DESCRIPTION
#### 2419e966a284c22a483f6f9bdc02141bed8e0c29
<pre>
Style checker has issue with test implementation files with no primary headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=185057">https://bugs.webkit.org/show_bug.cgi?id=185057</a>
rdar://problem/101670878

Reviewed by Jonathan Bedard.

Fix the cpp style checker to account for test .cpp files. These
files do not have a primary header file. The style checker would
make many mistakes flagging a wrong include as primary include.
For file ConnectionTests.cpp:
  - It would think &quot;Connection.h&quot; would be a primary include.
  - It would think &quot;Test.h&quot; would be a primary include.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(_classify_include):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:

Canonical link: <a href="https://commits.webkit.org/256128@main">https://commits.webkit.org/256128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c75fa28b59a3ed3c25f2936cd4a5bfd147122ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104276 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164545 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3879 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32005 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100230 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100321 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81020 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29823 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/98240 "Passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38408 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18092 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36260 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4232 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42015 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38603 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->