### PR TITLE
[GTK][WPE] Use a single global JavaScript context to serialize/deserialize script values

### DIFF
--- a/Source/WebKit/Shared/API/APISerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.h
@@ -32,6 +32,12 @@
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/RefPtr.h>
 
+#if USE(GLIB)
+typedef struct _GVariant GVariant;
+typedef struct _JSCContext JSCContext;
+typedef struct _JSCValue JSCValue;
+#endif
+
 namespace API {
 
 class SerializedScriptValue : public API::ObjectImpl<API::Object::Type::SerializedScriptValue> {
@@ -65,6 +71,8 @@ public:
 #endif
 
 #if USE(GLIB)
+    static JSCContext* sharedJSCContext();
+    static GRefPtr<JSCValue> deserialize(WebCore::SerializedScriptValue&);
     static RefPtr<SerializedScriptValue> createFromGVariant(GVariant*);
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.cpp
@@ -34,8 +34,7 @@
 struct _WebKitJavascriptResult {
     explicit _WebKitJavascriptResult(WebCore::SerializedScriptValue& serializedScriptValue)
     {
-        auto* jsContext = SharedJavascriptContext::singleton().getOrCreateContext();
-        jsValue = jscContextGetOrCreateValue(jsContext, serializedScriptValue.deserialize(jscContextGetJSContext(jsContext), nullptr));
+        jsValue = API::SerializedScriptValue::deserialize(serializedScriptValue);
     }
 
     GRefPtr<JSCValue> jsValue;

--- a/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResultPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitJavascriptResultPrivate.h
@@ -21,40 +21,5 @@
 
 #include <WebCore/SerializedScriptValue.h>
 #include "WebKitJavascriptResult.h"
-#include <wtf/NeverDestroyed.h>
-#include <wtf/RunLoop.h>
-#include <wtf/glib/GRefPtr.h>
-
-class SharedJavascriptContext {
-public:
-    static SharedJavascriptContext& singleton()
-    {
-        static NeverDestroyed<SharedJavascriptContext> context;
-        return context;
-    }
-
-    SharedJavascriptContext()
-        : m_timer(RunLoop::main(), this, &SharedJavascriptContext::releaseContext)
-    {
-    }
-
-    JSCContext* getOrCreateContext()
-    {
-        if (!m_context) {
-            m_context = adoptGRef(jsc_context_new());
-            m_timer.startOneShot(1_s);
-        }
-        return m_context.get();
-    }
-
-private:
-    void releaseContext()
-    {
-        m_context = nullptr;
-    }
-
-    GRefPtr<JSCContext> m_context;
-    RunLoop::Timer<SharedJavascriptContext> m_timer;
-};
 
 WebKitJavascriptResult* webkitJavascriptResultCreate(WebCore::SerializedScriptValue&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3937,7 +3937,7 @@ JSGlobalContextRef webkit_web_view_get_javascript_global_context(WebKitWebView* 
     // We keep a reference to the js context in the view only when this method is called
     // for backwards compatibility.
     if (!webView->priv->jsContext)
-        webView->priv->jsContext = SharedJavascriptContext::singleton().getOrCreateContext();
+        webView->priv->jsContext = API::SerializedScriptValue::sharedJSCContext();
     return jscContextGetJSContext(webView->priv->jsContext.get());
 }
 #endif


### PR DESCRIPTION
#### 4041ec7696c53b8f7e64d3046d4f7ae3d180cf35
<pre>
[GTK][WPE] Use a single global JavaScript context to serialize/deserialize script values
<a href="https://bugs.webkit.org/show_bug.cgi?id=247180">https://bugs.webkit.org/show_bug.cgi?id=247180</a>

Reviewed by Michael Catanzaro.

Remove the global context used by WebKitJavascriptResult and use
API::SerializedScriptValue instead.

* Source/WebKit/Shared/API/APISerializedScriptValue.h:
* Source/WebKit/UIProcess/API/glib/APISerializedScriptValueGLib.cpp:
(API::SharedJSContext::SharedJSContext):
(API::SerializedScriptValue::sharedJSCContext):
(API::SerializedScriptValue::deserialize):
(API::coreValueFromGVariant):
* Source/WebKit/UIProcess/API/glib/WebKitJavascriptResult.cpp:
(_WebKitJavascriptResult::_WebKitJavascriptResult):
* Source/WebKit/UIProcess/API/glib/WebKitJavascriptResultPrivate.h:
(SharedJavascriptContext::singleton): Deleted.
(SharedJavascriptContext::SharedJavascriptContext): Deleted.
(SharedJavascriptContext::getOrCreateContext): Deleted.
(SharedJavascriptContext::releaseContext): Deleted.
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_get_javascript_global_context):

Canonical link: <a href="https://commits.webkit.org/256143@main">https://commits.webkit.org/256143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01b0aa07638016e2e6e8223fe61ba9585f27eb08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104284 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3887 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32011 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100233 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2792 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81028 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29822 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72710 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38416 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18091 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36265 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19369 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4238 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42018 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/close/sending-messages.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38602 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->