### PR TITLE
[Nicosia] AsyncScrolling: use accessCommitted instead of accessPending when collecting layers for hit testing

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp
@@ -82,12 +82,12 @@ static bool collectDescendantLayersAtPoint(Vector<RefPtr<CompositionLayer>>& lay
     bool existsOnLayer = false;
     bool existsOnDescendent = false;
 
-    parent->accessPending([&](const CompositionLayer::LayerState& state) {
+    parent->accessCommitted([&](const CompositionLayer::LayerState& state) {
         existsOnLayer = !!state.scrollingNodeID && FloatRect({ }, state.size).contains(point) && state.eventRegion.contains(roundedIntPoint(point));
 
         for (auto child : state.children) {
             FloatPoint transformedPoint(point);
-            child->accessPending([&](const CompositionLayer::LayerState& childState) {
+            child->accessCommitted([&](const CompositionLayer::LayerState& childState) {
                 if (!childState.transform.isInvertible())
                     return;
                 float originX = childState.anchorPoint.x() * childState.size.width();


### PR DESCRIPTION
#### 64b55a4086d73ac3d3b606699e3c851cfa70fd44
<pre>
[Nicosia] AsyncScrolling: use accessCommitted instead of accessPending when collecting layers for hit testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247182">https://bugs.webkit.org/show_bug.cgi?id=247182</a>

Reviewed by Žan Doberšek.

We are currently using accessPending when collecting layers and
accessCommitted when iterating the collected layers.

* Source/WebCore/page/scrolling/nicosia/ScrollingTreeNicosia.cpp:
(WebCore::collectDescendantLayersAtPoint):

Canonical link: <a href="https://commits.webkit.org/256220@main">https://commits.webkit.org/256220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f7314d6fda8181fa7f52a8d525781827ad290f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104287 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164554 "Found 1 new test failure: js/dfg-uint32array.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3890 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32014 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100234 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2793 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81031 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29825 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72713 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38419 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18095 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36268 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19373 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4300 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42021 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38606 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->