### PR TITLE
[Nicosia] Remove Nicosia::CompositionLayer::updateState

### DIFF
--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
@@ -68,7 +68,7 @@ void ScrollingTreeFixedNodeNicosia::applyLayerPositions()
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFixedNode " << scrollingNodeID() << " relatedNodeScrollPositionDidChange: viewportRectAtLastLayout " << m_constraints.viewportRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
     ASSERT(m_layer);
-    m_layer->updateState(
+    m_layer->accessPending(
         [&layerPosition](Nicosia::CompositionLayer::LayerState& state)
         {
             state.position = layerPosition;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
@@ -117,7 +117,7 @@ void ScrollingTreeFrameScrollingNodeNicosia::repositionScrollingLayers()
 
     auto scrollPosition = currentScrollPosition();
 
-    compositionLayer.updateState(
+    compositionLayer.accessPending(
         [&scrollPosition](Nicosia::CompositionLayer::LayerState& state)
         {
             state.position = -scrollPosition;
@@ -135,7 +135,7 @@ void ScrollingTreeFrameScrollingNodeNicosia::repositionRelatedLayers()
     auto applyLayerPosition =
         [](auto& layer, auto&& position)
         {
-            layer.updateState(
+            layer.accessPending(
                 [&position](Nicosia::CompositionLayer::LayerState& state)
                 {
                     state.position = position;
@@ -148,7 +148,7 @@ void ScrollingTreeFrameScrollingNodeNicosia::repositionRelatedLayers()
 
     float topContentInset = this->topContentInset();
     if (m_insetClipLayer && m_rootContentsLayer) {
-        m_insetClipLayer->updateState(
+        m_insetClipLayer->accessPending(
             [&scrollPosition, &topContentInset](Nicosia::CompositionLayer::LayerState& state)
             {
                 state.position = { state.position.x(), FrameView::yPositionForInsetClipLayer(scrollPosition, topContentInset) };

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
@@ -63,7 +63,7 @@ void ScrollingTreeOverflowScrollProxyNodeNicosia::applyLayerPositions()
     FloatPoint scrollOffset = computeLayerPosition();
 
     LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeOverflowScrollProxyNodeNicosia " << scrollingNodeID() << " applyLayerPositions: setting bounds origin to " << scrollOffset);
-    m_layer->updateState(
+    m_layer->accessPending(
         [&scrollOffset](Nicosia::CompositionLayer::LayerState& state)
         {
             state.boundsOrigin = scrollOffset;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp
@@ -69,7 +69,7 @@ void ScrollingTreeOverflowScrollingNodeNicosia::repositionScrollingLayers()
 
     auto scrollOffset = currentScrollOffset();
 
-    compositionLayer.updateState(
+    compositionLayer.accessPending(
         [&scrollOffset](Nicosia::CompositionLayer::LayerState& state)
         {
             state.boundsOrigin = scrollOffset;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
@@ -70,7 +70,7 @@ void ScrollingTreePositionedNodeNicosia::applyLayerPositions()
     layerPosition -= m_constraints.alignmentOffset();
 
     ASSERT(m_layer);
-    m_layer->updateState(
+    m_layer->accessPending(
         [&layerPosition](Nicosia::CompositionLayer::LayerState& state)
         {
             state.position = layerPosition;

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
@@ -72,7 +72,7 @@ void ScrollingTreeStickyNodeNicosia::applyLayerPositions()
     layerPosition -= m_constraints.alignmentOffset();
 
     ASSERT(m_layer);
-    m_layer->updateState(
+    m_layer->accessPending(
         [&layerPosition](Nicosia::CompositionLayer::LayerState& state)
         {
             state.position = layerPosition;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPlatformLayer.h
@@ -209,13 +209,6 @@ public:
     };
 
     template<typename T>
-    void updateState(const T& functor)
-    {
-        Locker locker { PlatformLayer::m_state.lock };
-        functor(m_state.pending);
-    }
-
-    template<typename T>
     void flushState(const T& functor)
     {
         Locker locker { PlatformLayer::m_state.lock };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -943,7 +943,7 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
     }
 
     {
-        m_nicosia.layer->updateState(
+        m_nicosia.layer->accessPending(
             [this](Nicosia::CompositionLayer::LayerState& state)
             {
                 // OR the local delta value into the layer's pending state delta. After that,


### PR DESCRIPTION
#### 693343741daad856141b277fac82603600e66c40
<pre>
[Nicosia] Remove Nicosia::CompositionLayer::updateState
<a href="https://bugs.webkit.org/show_bug.cgi?id=247186">https://bugs.webkit.org/show_bug.cgi?id=247186</a>

Reviewed by Miguel Gomez.

It&apos;s exactly the same as Nicosia::CompositionLayer::accessPending()
which is more explicit and less confusing.

* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp:
(WebCore::ScrollingTreeFixedNodeNicosia::applyLayerPositions):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp:
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::repositionScrollingLayers):
(WebCore::ScrollingTreeFrameScrollingNodeNicosia::repositionRelatedLayers):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp:
(WebCore::ScrollingTreeOverflowScrollProxyNodeNicosia::applyLayerPositions):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollingNodeNicosia.cpp:
(WebCore::ScrollingTreeOverflowScrollingNodeNicosia::repositionScrollingLayers):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp:
(WebCore::ScrollingTreePositionedNodeNicosia::applyLayerPositions):
* Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp:
(WebCore::ScrollingTreeStickyNodeNicosia::applyLayerPositions):
* Source/WebCore/platform/graphics/nicosia/NicosiaPlatformLayer.h:
(Nicosia::CompositionLayer::updateState): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):

Canonical link: <a href="https://commits.webkit.org/256141@main">https://commits.webkit.org/256141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2597e82c57d6c62ca64105446e85f2d88ed4b139

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104293 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164560 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3897 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32033 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/86986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100238 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2803 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81037 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29826 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84286 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72714 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38425 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18101 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36274 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19380 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4237 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42026 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38613 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->