### PR TITLE
Implement StylePropertyMap::set()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6035,6 +6035,9 @@ svg/W3C-SVG-1.1-SE/color-prop-05-t.svg [ Skip ]
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload.html [ Skip ]
 imported/w3c/web-platform-tests/import-maps/acquiring/modulepreload-link-header.html [ Skip ]
 
+# Crashes since StylePropertyMap::set() was implemented and this test started running.
+webkit.org/b/247212 imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles.html [ Skip ]
+
 # WPT meta name="variant" is not supported. And iframe 'load' event has a bug.
 imported/w3c/web-platform-tests/import-maps/data-driven/resolving.html [ Skip ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-typed-om-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-typed-om-expected.txt
@@ -1,26 +1,26 @@
 
 PASS CSS.cqw function
 PASS Reify value with cqw unit
-FAIL Set value with cqw unit (string) set() is not yet supported
-FAIL Set value with cqw unit (CSS.cqw) set() is not yet supported
+PASS Set value with cqw unit (string)
+PASS Set value with cqw unit (CSS.cqw)
 PASS CSS.cqh function
 PASS Reify value with cqh unit
-FAIL Set value with cqh unit (string) set() is not yet supported
-FAIL Set value with cqh unit (CSS.cqh) set() is not yet supported
+PASS Set value with cqh unit (string)
+PASS Set value with cqh unit (CSS.cqh)
 PASS CSS.cqi function
 PASS Reify value with cqi unit
-FAIL Set value with cqi unit (string) set() is not yet supported
-FAIL Set value with cqi unit (CSS.cqi) set() is not yet supported
+PASS Set value with cqi unit (string)
+PASS Set value with cqi unit (CSS.cqi)
 PASS CSS.cqb function
 PASS Reify value with cqb unit
-FAIL Set value with cqb unit (string) set() is not yet supported
-FAIL Set value with cqb unit (CSS.cqb) set() is not yet supported
+PASS Set value with cqb unit (string)
+PASS Set value with cqb unit (CSS.cqb)
 PASS CSS.cqmin function
 PASS Reify value with cqmin unit
-FAIL Set value with cqmin unit (string) set() is not yet supported
-FAIL Set value with cqmin unit (CSS.cqmin) set() is not yet supported
+PASS Set value with cqmin unit (string)
+PASS Set value with cqmin unit (CSS.cqmin)
 PASS CSS.cqmax function
 PASS Reify value with cqmax unit
-FAIL Set value with cqmax unit (string) set() is not yet supported
-FAIL Set value with cqmax unit (CSS.cqmax) set() is not yet supported
+PASS Set value with cqmax unit (string)
+PASS Set value with cqmax unit (CSS.cqmax)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Computed * is reified as CSSUnparsedValue set() is not yet supported
+PASS Computed * is reified as CSSUnparsedValue
 FAIL Computed <angle> is reified as CSSUnitValue The given initial value does not parse for the given syntax.
 FAIL Computed <color> is reified as CSSStyleValue The given initial value does not parse for the given syntax.
 FAIL Computed <custom-ident> is reified as CSSKeywordValue The given initial value does not parse for the given syntax.
@@ -19,8 +19,8 @@ FAIL First computed value correctly reified in space-separated list assert_false
 FAIL First computed value correctly reified in comma-separated list assert_false: expected false got true
 FAIL All computed values correctly reified in space-separated list The given initial value does not parse for the given syntax.
 FAIL All computed values correctly reified in comma-separated list The given initial value does not parse for the given syntax.
-FAIL Specified * is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified * is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+PASS Specified * is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified * is reified as CSSUnparsedValue from get/getAll [styleMap]
 FAIL Specified foo is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified foo is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <angle> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -31,14 +31,14 @@ FAIL Specified <custom-ident> is reified as CSSUnparsedValue from get/getAll [at
 FAIL Specified <custom-ident> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <image> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <image> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <integer> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified <integer> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
-FAIL Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
-FAIL Specified <length> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified <length> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
-FAIL Specified <number> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified <number> is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
+PASS Specified <integer> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <integer> is reified as CSSUnparsedValue from get/getAll [styleMap]
+PASS Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <length-percentage> is reified as CSSUnparsedValue from get/getAll [styleMap]
+PASS Specified <length> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <length> is reified as CSSUnparsedValue from get/getAll [styleMap]
+PASS Specified <number> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <number> is reified as CSSUnparsedValue from get/getAll [styleMap]
 FAIL Specified <percentage> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <percentage> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <resolution> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -51,12 +51,12 @@ FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [
 FAIL Specified <transform-list> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <url> is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <url> is reified as CSSUnparsedValue from get/getAll [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <length>+ is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified <length>+ is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
-FAIL Specified <length># is reified as CSSUnparsedValue from get/getAll [attributeStyleMap] set() is not yet supported
-FAIL Specified <length># is reified as CSSUnparsedValue from get/getAll [styleMap] set() is not yet supported
-FAIL Specified string "foo" accepted by set() for syntax * [attributeStyleMap] set() is not yet supported
-FAIL Specified string "foo" accepted by set() for syntax * [styleMap] set() is not yet supported
+PASS Specified <length>+ is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <length>+ is reified as CSSUnparsedValue from get/getAll [styleMap]
+PASS Specified <length># is reified as CSSUnparsedValue from get/getAll [attributeStyleMap]
+PASS Specified <length># is reified as CSSUnparsedValue from get/getAll [styleMap]
+PASS Specified string "foo" accepted by set() for syntax * [attributeStyleMap]
+PASS Specified string "foo" accepted by set() for syntax * [styleMap]
 FAIL Specified string "foo" accepted by set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "foo" accepted by set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "10deg" accepted by set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -67,14 +67,14 @@ FAIL Specified string "foo" accepted by set() for syntax <custom-ident> [attribu
 FAIL Specified string "foo" accepted by set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "url("a")" accepted by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "url("a")" accepted by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "1" accepted by set() for syntax <integer> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "1" accepted by set() for syntax <integer> [styleMap] set() is not yet supported
-FAIL Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [styleMap] set() is not yet supported
-FAIL Specified string "10px" accepted by set() for syntax <length> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "10px" accepted by set() for syntax <length> [styleMap] set() is not yet supported
-FAIL Specified string "1" accepted by set() for syntax <number> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "1" accepted by set() for syntax <number> [styleMap] set() is not yet supported
+PASS Specified string "1" accepted by set() for syntax <integer> [attributeStyleMap]
+PASS Specified string "1" accepted by set() for syntax <integer> [styleMap]
+PASS Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [attributeStyleMap]
+PASS Specified string "calc(10% + 10px)" accepted by set() for syntax <length-percentage> [styleMap]
+PASS Specified string "10px" accepted by set() for syntax <length> [attributeStyleMap]
+PASS Specified string "10px" accepted by set() for syntax <length> [styleMap]
+PASS Specified string "1" accepted by set() for syntax <number> [attributeStyleMap]
+PASS Specified string "1" accepted by set() for syntax <number> [styleMap]
 FAIL Specified string "10%" accepted by set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "10%" accepted by set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "10dpi" accepted by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -87,10 +87,10 @@ FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <t
 FAIL Specified string "matrix(0, 0, 0, 0, 0, 0)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "url("a")" accepted by set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "url("a")" accepted by set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "10px 11px" accepted by set() for syntax <length>+ [attributeStyleMap] set() is not yet supported
-FAIL Specified string "10px 11px" accepted by set() for syntax <length>+ [styleMap] set() is not yet supported
-FAIL Specified string "10px, 11px" accepted by set() for syntax <length># [attributeStyleMap] set() is not yet supported
-FAIL Specified string "10px, 11px" accepted by set() for syntax <length># [styleMap] set() is not yet supported
+PASS Specified string "10px 11px" accepted by set() for syntax <length>+ [attributeStyleMap]
+PASS Specified string "10px 11px" accepted by set() for syntax <length>+ [styleMap]
+PASS Specified string "10px, 11px" accepted by set() for syntax <length># [attributeStyleMap]
+PASS Specified string "10px, 11px" accepted by set() for syntax <length># [styleMap]
 FAIL Specified string "bar" accepted by set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "bar" accepted by set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "10px" accepted by set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -101,14 +101,14 @@ FAIL Specified string "10px" accepted by set() for syntax <custom-ident> [attrib
 FAIL Specified string "10px" accepted by set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "a" accepted by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "a" accepted by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "float" accepted by set() for syntax <integer> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "float" accepted by set() for syntax <integer> [styleMap] set() is not yet supported
-FAIL Specified string "red" accepted by set() for syntax <length-percentage> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "red" accepted by set() for syntax <length-percentage> [styleMap] set() is not yet supported
-FAIL Specified string "red" accepted by set() for syntax <length> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "red" accepted by set() for syntax <length> [styleMap] set() is not yet supported
-FAIL Specified string "red" accepted by set() for syntax <number> [attributeStyleMap] set() is not yet supported
-FAIL Specified string "red" accepted by set() for syntax <number> [styleMap] set() is not yet supported
+PASS Specified string "float" accepted by set() for syntax <integer> [attributeStyleMap]
+PASS Specified string "float" accepted by set() for syntax <integer> [styleMap]
+PASS Specified string "red" accepted by set() for syntax <length-percentage> [attributeStyleMap]
+PASS Specified string "red" accepted by set() for syntax <length-percentage> [styleMap]
+PASS Specified string "red" accepted by set() for syntax <length> [attributeStyleMap]
+PASS Specified string "red" accepted by set() for syntax <length> [styleMap]
+PASS Specified string "red" accepted by set() for syntax <number> [attributeStyleMap]
+PASS Specified string "red" accepted by set() for syntax <number> [styleMap]
 FAIL Specified string "var(--x)" accepted by set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "var(--x)" accepted by set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "blue" accepted by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -121,12 +121,12 @@ FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [at
 FAIL Specified string "bar(1)" accepted by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "a" accepted by set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified string "a" accepted by set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified string "a b" accepted by set() for syntax <length>+ [attributeStyleMap] set() is not yet supported
-FAIL Specified string "a b" accepted by set() for syntax <length>+ [styleMap] set() is not yet supported
-FAIL Specified string "a, b" accepted by set() for syntax <length># [attributeStyleMap] set() is not yet supported
-FAIL Specified string "a, b" accepted by set() for syntax <length># [styleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax * [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax * [styleMap] set() is not yet supported
+PASS Specified string "a b" accepted by set() for syntax <length>+ [attributeStyleMap]
+PASS Specified string "a b" accepted by set() for syntax <length>+ [styleMap]
+PASS Specified string "a, b" accepted by set() for syntax <length># [attributeStyleMap]
+PASS Specified string "a, b" accepted by set() for syntax <length># [styleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax * [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax * [styleMap]
 FAIL CSSUnparsedValue is accepted via set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -137,14 +137,14 @@ FAIL CSSUnparsedValue is accepted via set() for syntax <custom-ident> [attribute
 FAIL CSSUnparsedValue is accepted via set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnparsedValue is accepted via set() for syntax <integer> [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <integer> [styleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length-percentage> [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length-percentage> [styleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length> [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length> [styleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <number> [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <number> [styleMap] set() is not yet supported
+PASS CSSUnparsedValue is accepted via set() for syntax <integer> [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <integer> [styleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length-percentage> [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length-percentage> [styleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length> [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length> [styleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <number> [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <number> [styleMap]
 FAIL CSSUnparsedValue is accepted via set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -157,20 +157,12 @@ FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [attribu
 FAIL CSSUnparsedValue is accepted via set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <url> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnparsedValue is accepted via set() for syntax <url> [styleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnparsedValue is accepted via set() for syntax <length>+ [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length>+ [styleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length># [attributeStyleMap] set() is not yet supported
-FAIL CSSUnparsedValue is accepted via set() for syntax <length># [styleMap] set() is not yet supported
-FAIL CSSKeywordValue rejected by set() for syntax * [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSKeywordValue rejected by set() for syntax * [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS CSSUnparsedValue is accepted via set() for syntax <length>+ [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length>+ [styleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length># [attributeStyleMap]
+PASS CSSUnparsedValue is accepted via set() for syntax <length># [styleMap]
+PASS CSSKeywordValue rejected by set() for syntax * [attributeStyleMap]
+PASS CSSKeywordValue rejected by set() for syntax * [styleMap]
 FAIL CSSKeywordValue rejected by set() for syntax foo [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSKeywordValue rejected by set() for syntax foo [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnitValue rejected by set() for syntax <angle> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -179,46 +171,14 @@ FAIL CSSKeywordValue rejected by set() for syntax <custom-ident> [attributeStyle
 FAIL CSSKeywordValue rejected by set() for syntax <custom-ident> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSImageValue rejected by set() for syntax <image> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSImageValue rejected by set() for syntax <image> [styleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnitValue rejected by set() for syntax <integer> [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <integer> [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length-percentage> [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length-percentage> [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length> [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length> [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <number> [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <number> [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS CSSUnitValue rejected by set() for syntax <integer> [attributeStyleMap]
+PASS CSSUnitValue rejected by set() for syntax <integer> [styleMap]
+PASS CSSUnitValue rejected by set() for syntax <length-percentage> [attributeStyleMap]
+PASS CSSUnitValue rejected by set() for syntax <length-percentage> [styleMap]
+PASS CSSUnitValue rejected by set() for syntax <length> [attributeStyleMap]
+PASS CSSUnitValue rejected by set() for syntax <length> [styleMap]
+PASS CSSUnitValue rejected by set() for syntax <number> [attributeStyleMap]
+PASS CSSUnitValue rejected by set() for syntax <number> [styleMap]
 FAIL CSSUnitValue rejected by set() for syntax <percentage> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnitValue rejected by set() for syntax <percentage> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSUnitValue rejected by set() for syntax <resolution> [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -227,26 +187,10 @@ FAIL CSSUnitValue rejected by set() for syntax <time> [attributeStyleMap] The gi
 FAIL CSSUnitValue rejected by set() for syntax <time> [styleMap] The given initial value does not parse for the given syntax.
 FAIL CSSTransformValue rejected by set() for syntax <transform-list> [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL CSSTransformValue rejected by set() for syntax <transform-list> [styleMap] The given initial value does not parse for the given syntax.
-FAIL CSSUnitValue rejected by set() for syntax <length>+ [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length>+ [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length># [attributeStyleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL CSSUnitValue rejected by set() for syntax <length># [styleMap] assert_throws_js: function "() => {
-        map.set(name, value);
-    }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS CSSUnitValue rejected by set() for syntax <length>+ [attributeStyleMap]
+PASS CSSUnitValue rejected by set() for syntax <length>+ [styleMap]
+PASS CSSUnitValue rejected by set() for syntax <length># [attributeStyleMap]
+PASS CSSUnitValue rejected by set() for syntax <length># [styleMap]
 FAIL Appending a string to * is not allowed [attributeStyleMap] assert_throws_js: function "() => {
         map.append(name, value);
     }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
@@ -427,8 +371,8 @@ PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>+
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <length>#
 FAIL Direct CSSStyleValue may not be set [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Direct CSSStyleValue may not be set [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified * is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified * is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+PASS Specified * is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified * is reified CSSUnparsedValue by iterator [styleMap]
 FAIL Specified foo is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified foo is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <angle> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -439,14 +383,14 @@ FAIL Specified <custom-ident> is reified CSSUnparsedValue by iterator [attribute
 FAIL Specified <custom-ident> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <image> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <image> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <integer> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified <integer> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
-FAIL Specified <length-percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified <length-percentage> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
-FAIL Specified <length> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified <length> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
-FAIL Specified <number> is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified <number> is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+PASS Specified <integer> is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <integer> is reified CSSUnparsedValue by iterator [styleMap]
+PASS Specified <length-percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <length-percentage> is reified CSSUnparsedValue by iterator [styleMap]
+PASS Specified <length> is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <length> is reified CSSUnparsedValue by iterator [styleMap]
+PASS Specified <number> is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <number> is reified CSSUnparsedValue by iterator [styleMap]
 FAIL Specified <percentage> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <percentage> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <resolution> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -459,18 +403,18 @@ FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [attribu
 FAIL Specified <transform-list> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <url> is reified CSSUnparsedValue by iterator [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Specified <url> is reified CSSUnparsedValue by iterator [styleMap] The given initial value does not parse for the given syntax.
-FAIL Specified <length>+ is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified <length>+ is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
-FAIL Specified <length># is reified CSSUnparsedValue by iterator [attributeStyleMap] set() is not yet supported
-FAIL Specified <length># is reified CSSUnparsedValue by iterator [styleMap] set() is not yet supported
+PASS Specified <length>+ is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <length>+ is reified CSSUnparsedValue by iterator [styleMap]
+PASS Specified <length># is reified CSSUnparsedValue by iterator [attributeStyleMap]
+PASS Specified <length># is reified CSSUnparsedValue by iterator [styleMap]
 FAIL Registered property with initial value show up on iteration of computedStyleMap assert_true: expected true got false
-FAIL Computed * is reified as CSSUnparsedValue by iterator set() is not yet supported
+FAIL Computed * is reified as CSSUnparsedValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <angle> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
 FAIL Computed <custom-ident> is reified as CSSKeywordValue by iterator The given initial value does not parse for the given syntax.
 FAIL Computed <image> is reified as CSSImageValue by iterator The given initial value does not parse for the given syntax.
-FAIL Computed <integer> is reified as CSSUnitValue by iterator set() is not yet supported
-FAIL Computed <length> is reified as CSSUnitValue by iterator set() is not yet supported
-FAIL Computed <number> is reified as CSSUnitValue by iterator set() is not yet supported
+FAIL Computed <integer> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
+FAIL Computed <length> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
+FAIL Computed <number> is reified as CSSUnitValue by iterator undefined is not an object (evaluating 'result.length')
 FAIL Computed <percentage> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
 FAIL Computed <resolution> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.
 FAIL Computed <time> is reified as CSSUnitValue by iterator The given initial value does not parse for the given syntax.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/unit-cycles-expected.txt
@@ -1,5 +1,20 @@
-CONSOLE MESSAGE: NotSupportedError: set() is not yet supported
 
-Harness Error (FAIL), message = NotSupportedError: set() is not yet supported
-
+FAIL Non-font-dependent variables can be used in font-size assert_equals: expected "42px" but got "16px"
+FAIL Lengths with em units may not be referenced from font-size assert_equals: expected "" but got "32px"
+FAIL Lengths with ex units may not be referenced from font-size assert_equals: expected "" but got "14.359375px"
+FAIL Lengths with ch units may not be referenced from font-size assert_equals: expected "" but got "16px"
+FAIL Lengths with rem units may be referenced from font-size on non-root element assert_equals: expected "32px" but got "16px"
+FAIL Lengths with rem units may not be referenced from font-size on root element assert_equals: expected "" but got "32px"
+PASS Fallback may not use font-relative units
+PASS Fallback not triggered while inside em unit cycle
+PASS Fallback not triggered while inside ex unit cycle
+PASS Fallback not triggered while inside ch unit cycle
+PASS Fallback not triggered while inside rem unit cycle on root element
+FAIL Lengths with em units are detected via var references assert_equals: expected "" but got "160px"
+FAIL Lengths with ex units are detected via var references assert_equals: expected "" but got "71.796875px"
+FAIL Lengths with ch units are detected via var references assert_equals: expected "" but got "80px"
+FAIL Lengths with rem units are detected via var references assert_equals: expected "" but got "160px"
+FAIL Inherited lengths with em units may be used assert_equals: expected "64px" but got "16px"
+FAIL Inherited lengths with ex units may be used assert_equals: expected "28.71875px" but got "16px"
+FAIL Inherited lengths with ch units may be used assert_equals: expected "32px" but got "16px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/declared-styleMap-accepts-inherit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/declared-styleMap-accepts-inherit-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Declared styleMap objects accept 'inherit' as a value set() is not yet supported
+PASS Declared styleMap objects accept 'inherit' as a value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/set-var-reference-thcrash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/set-var-reference-thcrash-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Do not crash when referencing a variable with CSSVariableReferenceValue set() is not yet supported
+PASS Do not crash when referencing a variable with CSSVariableReferenceValue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative-expected.txt
@@ -5,5 +5,5 @@ PASS Declared StylePropertyMap does not contain inline styles
 FAIL Declared StylePropertyMap contains custom property declarations assert_equals: expected " auto" but got "auto"
 PASS Declared StylePropertyMap does not contain properties with invalid values
 PASS Declared StylePropertyMap contains properties with their last valid value
-FAIL Declared StylePropertyMap is live set() is not yet supported
+PASS Declared StylePropertyMap is live
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set-shorthand-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL Setting a shorthand with an invalid CSSStyleValue on css rule throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a shorthand with an invalid String on css rule throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a shorthand with a CSSStyleValue updates css rule set() is not yet supported
-FAIL Setting a shorthand with a string updates css rule set() is not yet supported
+PASS Setting a shorthand with an invalid CSSStyleValue on css rule throws TypeError
+PASS Setting a shorthand with an invalid String on css rule throws TypeError
+PASS Setting a shorthand with a CSSStyleValue updates css rule
+PASS Setting a shorthand with a string updates css rule
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set.tentative-expected.txt
@@ -1,38 +1,16 @@
 
-FAIL Setting a StylePropertyMap with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with an null property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with a descriptor throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with an invalid String throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a non list-valued property with multiple arguments throws TypeError assert_throws_js: function "() => styleMap.set('width', CSS.px(10), CSS.px(10))" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a non list-valued property with list-valued string throws TypeError assert_throws_js: function "() => styleMap.set('width', '1s, 2s')" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError assert_throws_js: function "() => {
-    styleMap.set('transition-duration', '1s', new CSSUnparsedValue([]));
-  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a list-valued property with a var ref() and other values throws TypeError assert_throws_js: function "() => {
-    styleMap.set('transition-duration', '1s', 'var(--A)');
-  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a property with CSSStyleValue or String updates its value set() is not yet supported
-FAIL Setting a list-valued property with CSSStyleValue or String updates its values set() is not yet supported
-FAIL Setting a list-valued property with a list-valued string updates its value set() is not yet supported
-FAIL Setting a custom property with CSSStyleValue or String updates its value set() is not yet supported
-FAIL StylePropertyMap.set is case-insensitive set() is not yet supported
+PASS Setting a StylePropertyMap with an unsupported property name throws TypeError
+PASS Setting a StylePropertyMap with an null property name throws TypeError
+PASS Setting a StylePropertyMap with a descriptor throws TypeError
+PASS Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError
+PASS Setting a StylePropertyMap with an invalid String throws TypeError
+PASS Setting a non list-valued property with multiple arguments throws TypeError
+PASS Setting a non list-valued property with list-valued string throws TypeError
+PASS Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError
+PASS Setting a list-valued property with a var ref() and other values throws TypeError
+PASS Setting a property with CSSStyleValue or String updates its value
+PASS Setting a list-valued property with CSSStyleValue or String updates its values
+PASS Setting a list-valued property with a list-valued string updates its value
+PASS Setting a custom property with CSSStyleValue or String updates its value
+PASS StylePropertyMap.set is case-insensitive
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set-shorthand-expected.txt
@@ -1,10 +1,6 @@
 
-FAIL Setting a shorthand with an invalid CSSStyleValue on inline style throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a shorthand with an invalid String on inline style throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a shorthand with a CSSStyleValue updates inline style set() is not yet supported
-FAIL Setting a shorthand with a string updates inline style set() is not yet supported
+PASS Setting a shorthand with an invalid CSSStyleValue on inline style throws TypeError
+PASS Setting a shorthand with an invalid String on inline style throws TypeError
+PASS Setting a shorthand with a CSSStyleValue updates inline style
+PASS Setting a shorthand with a string updates inline style
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set.tentative-expected.txt
@@ -1,38 +1,16 @@
 
-FAIL Setting a StylePropertyMap with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with an null property name throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with a descriptor throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a StylePropertyMap with an invalid String throws TypeError assert_throws_js: function "() => styleMap.set(property, ...values)" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a non list-valued property with multiple arguments throws TypeError assert_throws_js: function "() => styleMap.set('width', CSS.px(10), CSS.px(10))" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a non list-valued property with list-valued string throws TypeError assert_throws_js: function "() => styleMap.set('width', '1s, 2s')" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError assert_throws_js: function "() => {
-    styleMap.set('transition-duration', '1s', new CSSUnparsedValue([]));
-  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a list-valued property with a var ref() and other values throws TypeError assert_throws_js: function "() => {
-    styleMap.set('transition-duration', '1s', 'var(--A)');
-  }" threw object "NotSupportedError: set() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Setting a property with CSSStyleValue or String updates its value set() is not yet supported
-FAIL Setting a list-valued property with CSSStyleValue or String updates its values set() is not yet supported
-FAIL Setting a list-valued property with a list-valued string updates its value set() is not yet supported
-FAIL Setting a custom property with CSSStyleValue or String updates its value set() is not yet supported
-FAIL StylePropertyMap.set is case-insensitive set() is not yet supported
+PASS Setting a StylePropertyMap with an unsupported property name throws TypeError
+PASS Setting a StylePropertyMap with an null property name throws TypeError
+PASS Setting a StylePropertyMap with a descriptor throws TypeError
+PASS Setting a StylePropertyMap with an invalid CSSStyleValue throws TypeError
+PASS Setting a StylePropertyMap with an invalid String throws TypeError
+PASS Setting a non list-valued property with multiple arguments throws TypeError
+PASS Setting a non list-valued property with list-valued string throws TypeError
+PASS Setting a list-valued property with a CSSUnparsedValue and other values throws TypeError
+PASS Setting a list-valued property with a var ref() and other values throws TypeError
+PASS Setting a property with CSSStyleValue or String updates its value
+PASS Setting a list-valued property with CSSStyleValue or String updates its values
+PASS Setting a list-valued property with a list-valued string updates its value
+PASS Setting a custom property with CSSStyleValue or String updates its value
+PASS StylePropertyMap.set is case-insensitive
 

--- a/Source/WebCore/css/CSSProperty.cpp
+++ b/Source/WebCore/css/CSSProperty.cpp
@@ -51,4 +51,20 @@ void CSSProperty::wrapValueInCommaSeparatedList()
     m_value = WTFMove(list);
 }
 
+Ref<CSSValueList> CSSProperty::createListForProperty(CSSPropertyID propertyID)
+{
+    switch (listValuedPropertySeparator(propertyID)) {
+    case ' ':
+        return CSSValueList::createSpaceSeparated();
+    case ',':
+        return CSSValueList::createCommaSeparated();
+    case '/':
+        return CSSValueList::createSlashSeparated();
+    default:
+        break;
+    }
+    ASSERT_NOT_REACHED();
+    return CSSValueList::createCommaSeparated();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+class CSSValueList;
+
 struct StylePropertyMetadata {
     StylePropertyMetadata(CSSPropertyID propertyID, bool isSetFromShorthand, int indexInShorthandsVector, bool important, bool implicit, bool inherited)
         : m_propertyID(propertyID)
@@ -89,6 +91,7 @@ public:
     static bool isColorProperty(CSSPropertyID);
     static UChar listValuedPropertySeparator(CSSPropertyID);
     static bool isListValuedProperty(CSSPropertyID propertyID) { return !!listValuedPropertySeparator(propertyID); }
+    static Ref<CSSValueList> createListForProperty(CSSPropertyID);
 
     const StylePropertyMetadata& metadata() const { return m_metadata; }
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1523,7 +1523,7 @@ bool StyleProperties::isPropertyImplicit(CSSPropertyID propertyID) const
     return propertyAt(foundPropertyIndex).isImplicit();
 }
 
-bool MutableStyleProperties::setProperty(CSSPropertyID propertyID, const String& value, bool important, CSSParserContext parserContext)
+bool MutableStyleProperties::setProperty(CSSPropertyID propertyID, const String& value, bool important, CSSParserContext parserContext, bool* didFailParsing)
 {
     if (!isExposed(propertyID, &parserContext.propertySettings) && !isInternal(propertyID)) {
         // Allow internal properties as we use them to handle certain DOM-exposed values
@@ -1541,13 +1541,16 @@ bool MutableStyleProperties::setProperty(CSSPropertyID propertyID, const String&
 
     // When replacing an existing property value, this moves the property to the end of the list.
     // Firefox preserves the position, and MSIE moves the property to the beginning.
-    return CSSParser::parseValue(*this, propertyID, value, important, parserContext) == CSSParser::ParseResult::Changed;
+    auto parseResult = CSSParser::parseValue(*this, propertyID, value, important, parserContext);
+    if (didFailParsing)
+        *didFailParsing = parseResult == CSSParser::ParseResult::Error;
+    return parseResult == CSSParser::ParseResult::Changed;
 }
 
-bool MutableStyleProperties::setProperty(CSSPropertyID propertyID, const String& value, bool important)
+bool MutableStyleProperties::setProperty(CSSPropertyID propertyID, const String& value, bool important, bool* didFailParsing)
 {
     CSSParserContext parserContext(cssParserMode());
-    return setProperty(propertyID, value, important, parserContext);
+    return setProperty(propertyID, value, important, parserContext, didFailParsing);
 }
 
 bool MutableStyleProperties::setCustomProperty(const Document* document, const String& propertyName, const String& value, bool important, CSSParserContext parserContext)

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -228,8 +228,8 @@ public:
     bool addParsedProperty(const CSSProperty&);
 
     // These expand shorthand properties into multiple properties.
-    bool setProperty(CSSPropertyID, const String& value, bool important, CSSParserContext);
-    bool setProperty(CSSPropertyID, const String& value, bool important = false);
+    bool setProperty(CSSPropertyID, const String& value, bool important, CSSParserContext, bool* didFailParsing = nullptr);
+    bool setProperty(CSSPropertyID, const String& value, bool important = false, bool* didFailParsing = nullptr);
     void setProperty(CSSPropertyID, RefPtr<CSSValue>&&, bool important = false);
 
     // These do not. FIXME: This is too messy, we can do better.

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -420,6 +420,11 @@ RefPtr<CSSCalcValue> CSSCalcValue::create(const CalculationValue& value, const R
     return result;
 }
 
+RefPtr<CSSCalcValue> CSSCalcValue::create(Ref<CSSCalcExpressionNode>&& node, bool allowsNegativePercentage)
+{
+    return adoptRef(*new CSSCalcValue(WTFMove(node), allowsNegativePercentage));
+}
+
 TextStream& operator<<(TextStream& ts, const CSSCalcValue& value)
 {
     value.dump(ts);

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -53,6 +53,7 @@ public:
     static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange, const CSSCalcSymbolTable&, bool allowsNegativePercentage = false);
     static RefPtr<CSSCalcValue> create(CSSValueID function, const CSSParserTokenRange&, CalculationCategory destinationCategory, ValueRange);
     static RefPtr<CSSCalcValue> create(const CalculationValue&, const RenderStyle&);
+    static RefPtr<CSSCalcValue> create(Ref<CSSCalcExpressionNode>&&, bool allowsNegativePercentage = false);
     ~CSSCalcValue();
 
     CalculationCategory category() const;

--- a/Source/WebCore/css/typedom/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.cpp
@@ -31,6 +31,8 @@
 #include "CSSKeywordValue.h"
 
 #include "CSSMarkup.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSPropertyParser.h"
 #include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -70,6 +72,14 @@ void CSSKeywordValue::serialize(StringBuilder& builder, OptionSet<SerializationA
 {
     // https://drafts.css-houdini.org/css-typed-om/#keywordvalue-serialization
     serializeIdentifier(m_value, builder);
+}
+
+RefPtr<CSSValue> CSSKeywordValue::toCSSValue() const
+{
+    auto keyword = cssValueKeywordID(m_value);
+    if (keyword == CSSValueInvalid)
+        return nullptr;
+    return CSSPrimitiveValue::createIdentifier(keyword);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSKeywordValue.h
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.h
@@ -47,6 +47,8 @@ public:
     
     static Ref<CSSKeywordValue> rectifyKeywordish(CSSKeywordish&&);
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const final;
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.h
+++ b/Source/WebCore/css/typedom/CSSNumericValue.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class CSSCalcExpressionNode;
 class CSSNumericValue;
 class CSSUnitValue;
 class CSSMathSum;
@@ -71,6 +72,8 @@ public:
     using SumValue = Vector<Addend>;
     virtual std::optional<SumValue> toSumValue() const = 0;
     virtual bool equals(const CSSNumericValue&) const = 0;
+
+    virtual RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const = 0;
 
 protected:
     ExceptionOr<Ref<CSSNumericValue>> addInternal(Vector<Ref<CSSNumericValue>>&&);

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.cpp
@@ -54,4 +54,10 @@ Document* CSSStyleImageValue::document() const
     return m_document.get();
 }
 
+
+RefPtr<CSSValue> CSSStyleImageValue::toCSSValue() const
+{
+    return m_cssValue.copyRef();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.h
@@ -52,6 +52,8 @@ public:
     
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSStyleImageValue; }
     
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSStyleImageValue(Ref<CSSImageValue>&&, Document*);
 

--- a/Source/WebCore/css/typedom/CSSStyleValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleValue.h
@@ -122,6 +122,8 @@ IGNORE_GCC_WARNINGS_END
     static Ref<CSSStyleValue> create(RefPtr<CSSValue>&&, String&& = String());
     static Ref<CSSStyleValue> create();
 
+    virtual RefPtr<CSSValue> toCSSValue() const { return m_propertyValue; }
+
 protected:
     CSSStyleValue(RefPtr<CSSValue>&&, String&& = String());
     CSSStyleValue() = default;

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -114,68 +114,57 @@ ExceptionOr<RefPtr<CSSStyleValue>> CSSStyleValueFactory::extractShorthandCSSValu
     });
 }
 
-ExceptionOr<void> CSSStyleValueFactory::extractCustomCSSValues(Vector<Ref<CSSValue>>& cssValues, const AtomString& customPropertyName, const String& cssText)
+ExceptionOr<Ref<CSSUnparsedValue>> CSSStyleValueFactory::extractCustomCSSValues(const String& cssText)
 {
     if (cssText.isEmpty())
         return Exception { TypeError, "Value cannot be parsed"_s };
 
-    auto styleDeclaration = MutableStyleProperties::create();
-    
-    constexpr bool important = true;
-    CSSParser::ParseResult parseResult = CSSParser::parseCustomPropertyValue(styleDeclaration, customPropertyName, cssText, important, strictCSSParserContext());
-    
-    if (parseResult == CSSParser::ParseResult::Error)
-        return Exception { TypeError, makeString(cssText, " cannot be parsed.")};
-    
-    if (auto customValue = styleDeclaration->getPropertyCSSValue(CSSPropertyCustom))
-        cssValues.append(customValue.releaseNonNull());
-    
-    return { };
+    CSSTokenizer tokenizer(cssText);
+    return { CSSUnparsedValue::create(tokenizer.tokenRange()) };
 }
 
+// https://www.w3.org/TR/css-typed-om-1/#cssstylevalue
 ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValueFactory::parseStyleValue(const AtomString& cssProperty, const String& cssText, bool parseMultiple)
 {
-    // https://www.w3.org/TR/css-typed-om-1/#cssstylevalue
-    
-    Vector<Ref<CSSValue>> cssValues;
-    
     // Extract the CSSValue from cssText given cssProperty
     if (isCustomPropertyName(cssProperty)) {
-        auto result = extractCustomCSSValues(cssValues, cssProperty, cssText);
+        auto result = extractCustomCSSValues(cssText);
         if (result.hasException())
             return result.releaseException();
-    } else {
-        auto property = cssProperty.convertToASCIILowercase();
-        
-        auto propertyID = cssPropertyID(property);
+        return Vector { Ref<CSSStyleValue> { result.releaseReturnValue() } };
+    }
 
-        if (propertyID == CSSPropertyInvalid)
-            return Exception { TypeError, "Property String is not a valid CSS property."_s };
-        
-        if (isShorthandCSSProperty(propertyID)) {
-            auto result = extractShorthandCSSValues(propertyID, cssText);
-            if (result.hasException())
-                return result.releaseException();
-            auto cssValue = result.releaseReturnValue();
-            if (!cssValue)
-                return Vector<Ref<CSSStyleValue>> { };
-            return Vector { cssValue.releaseNonNull() };
-        }
+    auto property = cssProperty.convertToASCIILowercase();
+    auto propertyID = cssPropertyID(property);
 
-        auto result = extractCSSValue(propertyID, cssText);
+    if (propertyID == CSSPropertyInvalid)
+        return Exception { TypeError, "Property String is not a valid CSS property."_s };
+
+    if (isShorthandCSSProperty(propertyID)) {
+        auto result = extractShorthandCSSValues(propertyID, cssText);
         if (result.hasException())
             return result.releaseException();
-        if (auto cssValue = result.releaseReturnValue()) {
-            // https://drafts.css-houdini.org/css-typed-om/#subdivide-into-iterations
-            if (CSSProperty::isListValuedProperty(propertyID)) {
-                if (auto* valueList = dynamicDowncast<CSSValueList>(*cssValue)) {
-                    for (size_t i = 0, length = valueList->length(); i < length; ++i)
-                        cssValues.append(*valueList->item(i));
-                }
+        auto cssValue = result.releaseReturnValue();
+        if (!cssValue)
+            return Vector<Ref<CSSStyleValue>> { };
+        return Vector { cssValue.releaseNonNull() };
+    }
+
+    auto result = extractCSSValue(propertyID, cssText);
+    if (result.hasException())
+        return result.releaseException();
+
+    Vector<Ref<CSSValue>> cssValues;
+    if (auto cssValue = result.releaseReturnValue()) {
+        // https://drafts.css-houdini.org/css-typed-om/#subdivide-into-iterations
+        if (CSSProperty::isListValuedProperty(propertyID)) {
+            if (auto* valueList = dynamicDowncast<CSSValueList>(*cssValue)) {
+                for (size_t i = 0, length = valueList->length(); i < length; ++i)
+                    cssValues.append(*valueList->item(i));
             }
-            if (cssValues.isEmpty())
-                cssValues.append(cssValue.releaseNonNull());
         }
+        if (cssValues.isEmpty())
+            cssValues.append(cssValue.releaseNonNull());
     }
 
     Vector<Ref<CSSStyleValue>> results;
@@ -326,5 +315,24 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Ref<CSSValue> c
     
     return CSSStyleValue::create(WTFMove(cssValue));
 }
+
+Vector<Ref<CSSStyleValue>> CSSStyleValueFactory::vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values)
+{
+    Vector<Ref<CSSStyleValue>> styleValues;
+    for (auto&& value : WTFMove(values)) {
+        switchOn(WTFMove(value), [&](RefPtr<CSSStyleValue>&& styleValue) {
+            ASSERT(styleValue);
+            styleValues.append(styleValue.releaseNonNull());
+        }, [&](String&& string) {
+            constexpr bool parseMultiple = true;
+            auto result = CSSStyleValueFactory::parseStyleValue(property, string, parseMultiple);
+            if (result.hasException())
+                return;
+            styleValues.appendVector(result.releaseReturnValue());
+        });
+    }
+    return styleValues;
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 template<typename T> class ExceptionOr;
 struct CSSParserContext;
+class CSSUnparsedValue;
 class Document;
 class StylePropertyShorthand;
 
@@ -45,6 +46,7 @@ public:
     static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, Document* = nullptr);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
     static ExceptionOr<RefPtr<CSSStyleValue>> constructStyleValueForShorthandProperty(CSSPropertyID, const Function<RefPtr<CSSValue>(CSSPropertyID)>& propertyValue, Document* = nullptr);
+    static Vector<Ref<CSSStyleValue>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
 
 protected:
     CSSStyleValueFactory() = delete;
@@ -52,7 +54,7 @@ protected:
 private:
     static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(const CSSPropertyID&, const String&);
     static ExceptionOr<RefPtr<CSSStyleValue>> extractShorthandCSSValues(const CSSPropertyID&, const String&);
-    static ExceptionOr<void> extractCustomCSSValues(Vector<Ref<CSSValue>>&, const AtomString&, const String&);
+    static ExceptionOr<Ref<CSSUnparsedValue>> extractCustomCSSValues(const String&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "CSSUnitValue.h"
 
+#include "CSSCalcPrimitiveValueNode.h"
 #include "CSSParserToken.h"
 #include "CSSPrimitiveValue.h"
 #include <wtf/IsoMallocInlines.h>
@@ -178,6 +179,16 @@ bool CSSUnitValue::equals(const CSSNumericValue& other) const
     if (!otherUnitValue)
         return false;
     return m_value == otherUnitValue->m_value && m_unit == otherUnitValue->m_unit;
+}
+
+RefPtr<CSSValue> CSSUnitValue::toCSSValue() const
+{
+    return CSSPrimitiveValue::create(m_value, m_unit);
+}
+
+RefPtr<CSSCalcExpressionNode> CSSUnitValue::toCalcExpressionNode() const
+{
+    return CSSCalcPrimitiveValueNode::create(CSSPrimitiveValue::create(m_value, m_unit));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSUnitValue.h
+++ b/Source/WebCore/css/typedom/CSSUnitValue.h
@@ -51,6 +51,9 @@ public:
     RefPtr<CSSUnitValue> convertTo(CSSUnitType) const;
     static CSSUnitType parseUnit(const String& unit);
 
+    RefPtr<CSSValue> toCSSValue() const final;
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSUnitValue(double, CSSUnitType);
 

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.cpp
@@ -33,6 +33,8 @@
 #include "CSSOMVariableReferenceValue.h"
 #include "CSSParserToken.h"
 #include "CSSParserTokenRange.h"
+#include "CSSTokenizer.h"
+#include "CSSVariableReferenceValue.h"
 #include "ExceptionOr.h"
 #include <variant>
 #include <wtf/IsoMallocInlines.h>
@@ -144,6 +146,12 @@ ExceptionOr<CSSUnparsedSegment> CSSUnparsedValue::setItem(size_t index, CSSUnpar
     else
         m_segments[index] = WTFMove(val);
     return CSSUnparsedSegment { m_segments[index] };
+}
+
+RefPtr<CSSValue> CSSUnparsedValue::toCSSValue() const
+{
+    CSSTokenizer tokenizer(toString());
+    return CSSVariableReferenceValue::create(tokenizer.tokenRange(), strictCSSParserContext());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.h
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.h
@@ -50,6 +50,8 @@ public:
 
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSUnparsedValue; }
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     explicit CSSUnparsedValue(Vector<CSSUnparsedSegment>&& segments);
     

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -51,6 +51,9 @@ private:
     RefPtr<CSSValue> customPropertyValue(const AtomString&) const final;
     void removeProperty(CSSPropertyID) final;
     void removeCustomProperty(const AtomString&) final;
+    bool setShorthandProperty(CSSPropertyID, const String&) final;
+    bool setProperty(CSSPropertyID, Ref<CSSValue>&&) final;
+    bool setCustomProperty(Document&, const AtomString&, Ref<CSSVariableReferenceValue>&&) final;
 
     WeakPtr<CSSStyleRule> m_ownerRule;
 };

--- a/Source/WebCore/css/typedom/StylePropertyMap.h
+++ b/Source/WebCore/css/typedom/StylePropertyMap.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+class CSSVariableReferenceValue;
+
 class StylePropertyMap : public MainThreadStylePropertyMapReadOnly {
 public:
     ExceptionOr<void> set(Document&, const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
@@ -41,6 +43,12 @@ public:
 protected:
     virtual void removeProperty(CSSPropertyID) = 0;
     virtual void removeCustomProperty(const AtomString&) = 0;
+    virtual bool setShorthandProperty(CSSPropertyID, const String&) = 0;
+    virtual bool setProperty(CSSPropertyID, Ref<CSSValue>&&) = 0;
+    virtual bool setCustomProperty(Document&, const AtomString&, Ref<CSSVariableReferenceValue>&&) = 0;
+
+private:
+    RefPtr<CSSStyleValue> shorthandPropertyValue(Document&, CSSPropertyID) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSColorValue.cpp
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.cpp
@@ -141,4 +141,10 @@ CSSColorNumber CSSColorValue::toCSSColorNumber(const RectifiedCSSColorNumber& nu
     });
 }
 
+RefPtr<CSSValue> CSSColorValue::toCSSValue() const
+{
+    // FIXME: Implement this.
+    return nullptr;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/color/CSSColorValue.h
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.h
@@ -54,6 +54,8 @@ public:
     static CSSColorPercent toCSSColorPercent(const CSSNumberish&);
     static CSSColorAngle toCSSColorAngle(const RectifiedCSSColorAngle&);
     static CSSColorNumber toCSSColorNumber(const RectifiedCSSColorNumber&);
+
+    RefPtr<CSSValue> toCSSValue() const final;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSMathClamp.h"
 
+#include "CSSCalcOperationNode.h"
 #include "CSSNumericValue.h"
 #include "ExceptionOr.h"
 #include <wtf/IsoMallocInlines.h>
@@ -101,6 +102,18 @@ bool CSSMathClamp::equals(const CSSNumericValue& other) const
     return m_lower->equals(otherClamp->m_lower)
         && m_value->equals(otherClamp->m_value)
         && m_upper->equals(otherClamp->m_upper);
+}
+
+RefPtr<CSSCalcExpressionNode> CSSMathClamp::toCalcExpressionNode() const
+{
+    Vector<Ref<CSSCalcExpressionNode>> values;
+    for (auto& value : { m_lower, m_value, m_upper }) {
+        auto valueNode = value->toCalcExpressionNode();
+        if (!valueNode)
+            return nullptr;
+        values.append(valueNode.releaseNonNull());
+    }
+    return CSSCalcOperationNode::createMinOrMaxOrClamp(CalcOperator::Clamp, WTFMove(values), CalculationCategory::Length);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathClamp.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathClamp.h
@@ -37,6 +37,8 @@ public:
     const CSSNumericValue& value() const { return m_value.get(); }
     const CSSNumericValue& upper() const { return m_upper.get(); }
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Clamp; }
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSMathClamp; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathInvert.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathInvert.cpp
@@ -26,8 +26,9 @@
 #include "config.h"
 #include "CSSMathInvert.h"
 
+#include "CSSCalcInvertNode.h"
 #include "CSSNumericValue.h"
-
+#include "CSSPrimitiveValue.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -110,6 +111,13 @@ bool CSSMathInvert::equals(const CSSNumericValue& other) const
     if (!otherInvert)
         return false;
     return m_value->equals(otherInvert->value());
+}
+
+RefPtr<CSSCalcExpressionNode> CSSMathInvert::toCalcExpressionNode() const
+{
+    if (auto value = m_value->toCalcExpressionNode())
+        return CSSCalcInvertNode::create(value.releaseNonNull());
+    return nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathInvert.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathInvert.h
@@ -36,6 +36,8 @@ public:
     CSSNumericValue& value() { return m_value.get(); }
     const CSSNumericValue& value() const { return m_value.get(); }
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Invert; }
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSMathInvert; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathMax.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMax.cpp
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "CSSMathMax.h"
 
+#include "CSSCalcOperationNode.h"
 #include "CSSNumericArray.h"
-
 #include "ExceptionOr.h"
 #include <wtf/Algorithms.h>
 #include <wtf/FixedVector.h>
@@ -97,6 +97,19 @@ auto CSSMathMax::toSumValue() const -> std::optional<SumValue>
             currentMax = WTFMove(currentValue);
     }
     return currentMax;
+}
+
+RefPtr<CSSCalcExpressionNode> CSSMathMax::toCalcExpressionNode() const
+{
+    Vector<Ref<CSSCalcExpressionNode>> values;
+    values.reserveInitialCapacity(m_values->length());
+    for (auto& value : m_values->array()) {
+        if (auto valueNode = value->toCalcExpressionNode())
+            values.append(valueNode.releaseNonNull());
+    }
+    if (values.isEmpty())
+        return nullptr;
+    return CSSCalcOperationNode::createMinOrMaxOrClamp(CalcOperator::Max, WTFMove(values), CalculationCategory::Length);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathMax.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMax.h
@@ -39,6 +39,8 @@ public:
     static ExceptionOr<Ref<CSSMathMax>> create(Vector<Ref<CSSNumericValue>>&&);
     const CSSNumericArray& values() const;
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Max; }
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSMathMax; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathMin.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMin.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSMathMin.h"
 
+#include "CSSCalcOperationNode.h"
 #include "CSSNumericArray.h"
 #include "ExceptionOr.h"
 #include <wtf/FixedVector.h>
@@ -95,6 +96,19 @@ auto CSSMathMin::toSumValue() const -> std::optional<SumValue>
             currentMax = WTFMove(currentValue);
     }
     return currentMax;
+}
+
+RefPtr<CSSCalcExpressionNode> CSSMathMin::toCalcExpressionNode() const
+{
+    Vector<Ref<CSSCalcExpressionNode>> values;
+    values.reserveInitialCapacity(m_values->length());
+    for (auto& value : m_values->array()) {
+        if (auto valueNode = value->toCalcExpressionNode())
+            values.append(valueNode.releaseNonNull());
+    }
+    if (values.isEmpty())
+        return nullptr;
+    return CSSCalcOperationNode::createMinOrMaxOrClamp(CalcOperator::Min, WTFMove(values), CalculationCategory::Length);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathMin.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMin.h
@@ -39,6 +39,8 @@ public:
     static ExceptionOr<Ref<CSSMathMin>> create(Vector<Ref<CSSNumericValue>>&&);
     const CSSNumericArray& values() const;
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Min; }
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSMathMin; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathNegate.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathNegate.cpp
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "CSSMathNegate.h"
 
+#include "CSSCalcNegateNode.h"
 #include "CSSNumericValue.h"
-
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -82,7 +82,13 @@ bool CSSMathNegate::equals(const CSSNumericValue& other) const
     if (!otherNegate)
         return false;
     return m_value->equals(otherNegate->value());
+}
 
+RefPtr<CSSCalcExpressionNode> CSSMathNegate::toCalcExpressionNode() const
+{
+    if (auto value = m_value->toCalcExpressionNode())
+        return CSSCalcNegateNode::create(value.releaseNonNull());
+    return nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathNegate.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathNegate.h
@@ -39,6 +39,8 @@ public:
     CSSNumericValue& value() { return m_value.get(); }
     const CSSNumericValue& value() const { return m_value.get(); }
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Negate; }
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSMathNegate; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSMathProduct.h"
 
+#include "CSSCalcOperationNode.h"
 #include "CSSMathInvert.h"
 #include "CSSNumericArray.h"
 #include "ExceptionOr.h"
@@ -112,6 +113,19 @@ auto CSSMathProduct::toSumValue() const -> std::optional<SumValue>
         values = WTFMove(temp);
     }
     return { WTFMove(values) };
+}
+
+RefPtr<CSSCalcExpressionNode> CSSMathProduct::toCalcExpressionNode() const
+{
+    Vector<Ref<CSSCalcExpressionNode>> values;
+    values.reserveInitialCapacity(m_values->length());
+    for (auto& item : m_values->array()) {
+        auto value = item->toCalcExpressionNode();
+        if (!value)
+            return nullptr;
+        values.uncheckedAppend(value.releaseNonNull());
+    }
+    return CSSCalcOperationNode::createProduct(WTFMove(values));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathProduct.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathProduct.h
@@ -39,6 +39,8 @@ public:
     static ExceptionOr<Ref<CSSMathProduct>> create(Vector<Ref<CSSNumericValue>>);
     const CSSNumericArray& values() const { return m_values.get(); }
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Product; }
     CSSStyleValueType getType() const final { return CSSStyleValueType::CSSMathProduct; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathSum.cpp
+++ b/Source/WebCore/css/typedom/numeric/CSSMathSum.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSMathSum.h"
 
+#include "CSSCalcOperationNode.h"
 #include "CSSMathNegate.h"
 #include "CSSNumericArray.h"
 #include "ExceptionOr.h"
@@ -129,6 +130,19 @@ auto CSSMathSum::toSumValue() const -> std::optional<SumValue>
     }
     
     return { WTFMove(values) };
+}
+
+RefPtr<CSSCalcExpressionNode> CSSMathSum::toCalcExpressionNode() const
+{
+    Vector<Ref<CSSCalcExpressionNode>> values;
+    values.reserveInitialCapacity(m_values->length());
+    for (auto& item : m_values->array()) {
+        auto value = item->toCalcExpressionNode();
+        if (!value)
+            return nullptr;
+        values.uncheckedAppend(value.releaseNonNull());
+    }
+    return CSSCalcOperationNode::createSum(WTFMove(values));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathSum.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathSum.h
@@ -40,6 +40,8 @@ public:
     static ExceptionOr<Ref<CSSMathSum>> create(Vector<Ref<CSSNumericValue>>);
     const CSSNumericArray& values() const { return m_values.get(); }
 
+    RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const final;
+
 private:
     CSSMathOperator getOperator() const final { return CSSMathOperator::Sum; }
     CSSStyleValueType getType() const override { return CSSStyleValueType::CSSMathSum; }

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.h
@@ -25,9 +25,11 @@
 
 #pragma once
 
+#include "CSSCalcExpressionNode.h"
 #include "CSSMathOperator.h"
 #include "CSSNumericArray.h"
 #include "CSSNumericValue.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSStyleValue.h"
 
 namespace WebCore {
@@ -59,7 +61,14 @@ public:
         }
 
         return true;
+    }
 
+    RefPtr<CSSValue> toCSSValue() const final
+    {
+        auto node = toCalcExpressionNode();
+        if (!node)
+            return nullptr;
+        return CSSPrimitiveValue::create(node->doubleValue(node->primitiveType()), node->primitiveType());
     }
 };
 

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp
@@ -32,6 +32,7 @@
 
 #include "CSSFunctionValue.h"
 #include "CSSNumericFactory.h"
+#include "CSSPrimitiveValue.h"
 #include "CSSStyleValueFactory.h"
 #include "CSSUnitValue.h"
 #include "DOMMatrix.h"
@@ -174,6 +175,26 @@ DOMMatrix& CSSMatrixComponent::matrix()
 void CSSMatrixComponent::setMatrix(Ref<DOMMatrix>&& matrix)
 {
     m_matrix = WTFMove(matrix);
+}
+
+RefPtr<CSSValue> CSSMatrixComponent::toCSSValue() const
+{
+    auto result = CSSFunctionValue::create(is2D() ? CSSValueMatrix : CSSValueMatrix3d);
+    if (is2D()) {
+        double values[] = { m_matrix->a(), m_matrix->b(), m_matrix->c(), m_matrix->d(), m_matrix->e(), m_matrix->f() };
+        for (double value : values)
+            result->append(CSSPrimitiveValue::create(value, CSSUnitType::CSS_NUMBER));
+    } else {
+        double values[] = {
+            m_matrix->m11(), m_matrix->m12(), m_matrix->m13(), m_matrix->m14(),
+            m_matrix->m21(), m_matrix->m22(), m_matrix->m23(), m_matrix->m24(),
+            m_matrix->m31(), m_matrix->m32(), m_matrix->m33(), m_matrix->m34(),
+            m_matrix->m41(), m_matrix->m42(), m_matrix->m43(), m_matrix->m44()
+        };
+        for (double value : values)
+            result->append(CSSPrimitiveValue::create(value, CSSUnitType::CSS_NUMBER));
+    }
+    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
@@ -48,6 +48,9 @@ public:
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;
     
     CSSTransformType getType() const final { return CSSTransformType::MatrixComponent; }
+
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSMatrixComponent(Ref<DOMMatrixReadOnly>&&, Is2D);
     Ref<DOMMatrix> m_matrix;

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.cpp
@@ -158,4 +158,22 @@ ExceptionOr<Ref<DOMMatrix>> CSSPerspective::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), DOMMatrixReadOnly::Is2D::No) };
 }
 
+RefPtr<CSSValue> CSSPerspective::toCSSValue() const
+{
+    RefPtr<CSSValue> length;
+    switchOn(m_length, [&](const RefPtr<CSSNumericValue>& numericValue) {
+        length = numericValue->toCSSValue();
+    }, [&](const String&) {
+        // FIXME: Implement this.
+    }, [&](const RefPtr<CSSKeywordValue>& keywordValue) {
+        length = keywordValue->toCSSValue();
+    });
+    if (!length)
+        return nullptr;
+
+    auto result = CSSFunctionValue::create(CSSValuePerspective);
+    result->append(length.releaseNonNull());
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.h
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.h
@@ -49,6 +49,8 @@ public:
     
     CSSTransformType getType() const final { return CSSTransformType::Perspective; }
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSPerspective(CSSPerspectiveValue);
 

--- a/Source/WebCore/css/typedom/transform/CSSRotate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.cpp
@@ -202,4 +202,30 @@ ExceptionOr<Ref<DOMMatrix>> CSSRotate::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), is2D() ? DOMMatrixReadOnly::Is2D::Yes : DOMMatrixReadOnly::Is2D::No) };
 }
 
+RefPtr<CSSValue> CSSRotate::toCSSValue() const
+{
+    auto result = CSSFunctionValue::create(is2D() ? CSSValueRotate : CSSValueRotate3d);
+    if (!is2D()) {
+        auto x = m_x->toCSSValue();
+        if (!x)
+            return nullptr;
+        auto y = m_y->toCSSValue();
+        if (!y)
+            return nullptr;
+        auto z = m_z->toCSSValue();
+        if (!z)
+            return nullptr;
+
+        result->append(x.releaseNonNull());
+        result->append(y.releaseNonNull());
+        result->append(z.releaseNonNull());
+    }
+
+    auto angle = m_angle->toCSSValue();
+    if (!angle)
+        return nullptr;
+    result->append(angle.releaseNonNull());
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSRotate.h
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.h
@@ -55,6 +55,8 @@ public:
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;
     
     CSSTransformType getType() const final { return CSSTransformType::Rotate; }
+
+    RefPtr<CSSValue> toCSSValue() const final;
     
 private:
     CSSRotate(CSSTransformComponent::Is2D, Ref<CSSNumericValue>, Ref<CSSNumericValue>, Ref<CSSNumericValue>, Ref<CSSNumericValue>);

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -164,4 +164,23 @@ ExceptionOr<Ref<DOMMatrix>> CSSScale::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), is2D() ? DOMMatrixReadOnly::Is2D::Yes : DOMMatrixReadOnly::Is2D::No) };
 }
 
+RefPtr<CSSValue> CSSScale::toCSSValue() const
+{
+    auto x = m_x->toCSSValue();
+    auto y = m_y->toCSSValue();
+    if (!x || !y)
+        return nullptr;
+
+    auto result = CSSFunctionValue::create(is2D() ? CSSValueScale : CSSValueScale3d);
+    result->append(x.releaseNonNull());
+    result->append(y.releaseNonNull());
+    if (!is2D()) {
+        auto z = m_z->toCSSValue();
+        if (!z)
+            return nullptr;
+        result->append(z.releaseNonNull());
+    }
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSScale.h
+++ b/Source/WebCore/css/typedom/transform/CSSScale.h
@@ -53,6 +53,8 @@ public:
 
     CSSTransformType getType() const final { return CSSTransformType::Scale; }
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSScale(CSSTransformComponent::Is2D, Ref<CSSNumericValue>, Ref<CSSNumericValue>, Ref<CSSNumericValue>);
 

--- a/Source/WebCore/css/typedom/transform/CSSSkew.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.cpp
@@ -133,4 +133,18 @@ ExceptionOr<Ref<DOMMatrix>> CSSSkew::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), DOMMatrixReadOnly::Is2D::Yes) };
 }
 
+RefPtr<CSSValue> CSSSkew::toCSSValue() const
+{
+    auto ax = m_ax->toCSSValue();
+    auto ay = m_ay->toCSSValue();
+    if (!ax || !ay)
+        return nullptr;
+
+    auto result = CSSFunctionValue::create(CSSValueSkew);
+    result->append(ax.releaseNonNull());
+    if (!is<CSSUnitValue>(m_ay.get()) || downcast<CSSUnitValue>(m_ay.get()).value())
+        result->append(ay.releaseNonNull());
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSSkew.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.h
@@ -52,6 +52,8 @@ public:
 
     CSSTransformType getType() const final { return CSSTransformType::Skew; }
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSSkew(Ref<CSSNumericValue> ax, Ref<CSSNumericValue> ay);
 

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.cpp
@@ -107,4 +107,14 @@ ExceptionOr<Ref<DOMMatrix>> CSSSkewX::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), DOMMatrixReadOnly::Is2D::Yes) };
 }
 
+RefPtr<CSSValue> CSSSkewX::toCSSValue() const
+{
+    auto ax = m_ax->toCSSValue();
+    if (!ax)
+        return nullptr;
+    auto result = CSSFunctionValue::create(CSSValueSkewX);
+    result->append(ax.releaseNonNull());
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.h
@@ -49,6 +49,8 @@ public:
 
     CSSTransformType getType() const final { return CSSTransformType::SkewX; }
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSSkewX(Ref<CSSNumericValue> ax);
     

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.cpp
@@ -107,4 +107,14 @@ ExceptionOr<Ref<DOMMatrix>> CSSSkewY::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), DOMMatrixReadOnly::Is2D::Yes) };
 }
 
+RefPtr<CSSValue> CSSSkewY::toCSSValue() const
+{
+    auto ay = m_ay->toCSSValue();
+    if (!ay)
+        return nullptr;
+    auto result = CSSFunctionValue::create(CSSValueSkewY);
+    result->append(ay.releaseNonNull());
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.h
@@ -49,6 +49,8 @@ public:
 
     CSSTransformType getType() const final { return CSSTransformType::SkewY; }
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSSkewY(Ref<CSSNumericValue> ay);
     

--- a/Source/WebCore/css/typedom/transform/CSSTransformComponent.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformComponent.h
@@ -59,6 +59,8 @@ public:
     virtual ~CSSTransformComponent() = default;
     virtual CSSTransformType getType() const = 0;
 
+    virtual RefPtr<CSSValue> toCSSValue() const = 0;
+
 private:
     Is2D m_is2D;
 };

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -179,4 +179,14 @@ void CSSTransformValue::serialize(StringBuilder& builder, OptionSet<Serializatio
     }
 }
 
+RefPtr<CSSValue> CSSTransformValue::toCSSValue() const
+{
+    auto cssValueList = CSSValueList::createSpaceSeparated();
+    for (auto& component : m_components) {
+        if (auto cssComponent = component->toCSSValue())
+            cssValueList->append(cssComponent.releaseNonNull());
+    }
+    return cssValueList;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -51,6 +51,9 @@ public:
     ExceptionOr<Ref<DOMMatrix>> toMatrix();
     
     CSSStyleValueType getType() const override { return CSSStyleValueType::CSSTransformValue; }
+
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSTransformValue(Vector<RefPtr<CSSTransformComponent>>&&);
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const final;

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.cpp
@@ -170,4 +170,26 @@ ExceptionOr<Ref<DOMMatrix>> CSSTranslate::toMatrix()
     return { DOMMatrix::create(WTFMove(matrix), is2D() ? DOMMatrixReadOnly::Is2D::Yes : DOMMatrixReadOnly::Is2D::No) };
 }
 
+RefPtr<CSSValue> CSSTranslate::toCSSValue() const
+{
+    auto x = m_x->toCSSValue();
+    if (!x)
+        return nullptr;
+
+    auto y = m_y->toCSSValue();
+    if (!y)
+        return nullptr;
+
+    auto result = CSSFunctionValue::create(is2D() ? CSSValueTranslate : CSSValueTranslate3d);
+    result->append(x.releaseNonNull());
+    result->append(y.releaseNonNull());
+    if (!is2D()) {
+        auto z = m_z->toCSSValue();
+        if (!z)
+            return nullptr;
+        result->append(z.releaseNonNull());
+    }
+    return result;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.h
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.h
@@ -51,6 +51,8 @@ public:
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;
 
+    RefPtr<CSSValue> toCSSValue() const final;
+
 private:
     CSSTranslate(CSSTransformComponent::Is2D, Ref<CSSNumericValue>, Ref<CSSNumericValue>, Ref<CSSNumericValue>);
 

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -50,7 +50,10 @@ public:
     bool setInlineStyleProperty(CSSPropertyID, CSSValueID identifier, bool important = false);
     bool setInlineStyleProperty(CSSPropertyID, CSSPropertyID identifier, bool important = false);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, double value, CSSUnitType, bool important = false);
-    WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, const String& value, bool important = false);
+    WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, const String& value, bool important = false, bool* didFailParsing = nullptr);
+    bool setInlineStyleCustomProperty(const AtomString& property, const String& value, bool important = false);
+    bool setInlineStyleCustomProperty(Ref<CSSValue>&&, bool important = false);
+    bool setInlineStyleProperty(CSSPropertyID, Ref<CSSValue>&&, bool important = false);
     bool removeInlineStyleProperty(CSSPropertyID);
     bool removeInlineStyleCustomProperty(const AtomString&);
     void removeAllInlineStyleProperties();


### PR DESCRIPTION
#### 9d69bb363e5ef9f79361d9e411815894b946e18b
<pre>
Implement StylePropertyMap::set()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247199">https://bugs.webkit.org/show_bug.cgi?id=247199</a>

Reviewed by Antti Koivisto.

Implement StylePropertyMap::set():
- <a href="https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-set">https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-set</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/declared-styleMap-accepts-inherit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/set-var-reference-thcrash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/declared.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/set.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/set.tentative-expected.txt:
* Source/WebCore/css/CSSProperty.cpp:
(WebCore::CSSProperty::createListForProperty):
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::MutableStyleProperties::setProperty):
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::CSSCalcValue::create):
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/typedom/CSSKeywordValue.cpp:
(WebCore::CSSKeywordValue::toCSSValue const):
* Source/WebCore/css/typedom/CSSKeywordValue.h:
* Source/WebCore/css/typedom/CSSNumericValue.h:
* Source/WebCore/css/typedom/CSSStyleImageValue.cpp:
(WebCore::CSSStyleImageValue::toCSSValue const):
* Source/WebCore/css/typedom/CSSStyleImageValue.h:
* Source/WebCore/css/typedom/CSSStyleValue.h:
(WebCore::CSSStyleValue::toCSSValue const):
(WebCore::CSSStyleValue::associatedProperty const):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::vectorFromStyleValuesOrStrings):
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::CSSUnitValue::toCSSValue const):
(WebCore::CSSUnitValue::toCalcExpressionNode const):
* Source/WebCore/css/typedom/CSSUnitValue.h:
* Source/WebCore/css/typedom/CSSUnparsedValue.cpp:
(WebCore::CSSUnparsedValue::toCSSValue const):
* Source/WebCore/css/typedom/CSSUnparsedValue.h:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
(WebCore::DeclaredStylePropertyMap::setShorthandProperty):
(WebCore::DeclaredStylePropertyMap::setProperty):
(WebCore::DeclaredStylePropertyMap::setCustomProperty):
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.h:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::cssValueFromStyleValues):
(WebCore::StylePropertyMap::set):
* Source/WebCore/css/typedom/StylePropertyMap.h:
* Source/WebCore/css/typedom/color/CSSColorValue.cpp:
(WebCore::CSSColorValue::toCSSValue const):
* Source/WebCore/css/typedom/color/CSSColorValue.h:
* Source/WebCore/css/typedom/numeric/CSSMathClamp.cpp:
(WebCore::CSSMathClamp::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathClamp.h:
* Source/WebCore/css/typedom/numeric/CSSMathInvert.cpp:
(WebCore::CSSMathInvert::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathInvert.h:
* Source/WebCore/css/typedom/numeric/CSSMathMax.cpp:
(WebCore::CSSMathMax::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathMax.h:
* Source/WebCore/css/typedom/numeric/CSSMathMin.cpp:
(WebCore::CSSMathMin::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathMin.h:
* Source/WebCore/css/typedom/numeric/CSSMathNegate.cpp:
(WebCore::CSSMathNegate::equals const):
(WebCore::CSSMathNegate::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathNegate.h:
* Source/WebCore/css/typedom/numeric/CSSMathProduct.cpp:
(WebCore::CSSMathProduct::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathProduct.h:
* Source/WebCore/css/typedom/numeric/CSSMathSum.cpp:
(WebCore::CSSMathSum::toCalcExpressionNode const):
* Source/WebCore/css/typedom/numeric/CSSMathSum.h:
* Source/WebCore/css/typedom/numeric/CSSMathValue.h:
(WebCore::CSSMathValue::equalsImpl const):
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.cpp:
(WebCore::CSSMatrixComponent::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.h:
* Source/WebCore/css/typedom/transform/CSSPerspective.cpp:
(WebCore::CSSPerspective::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSPerspective.h:
* Source/WebCore/css/typedom/transform/CSSRotate.cpp:
(WebCore::CSSRotate::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSRotate.h:
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::CSSScale::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSScale.h:
* Source/WebCore/css/typedom/transform/CSSSkew.cpp:
(WebCore::CSSSkew::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSSkew.h:
* Source/WebCore/css/typedom/transform/CSSSkewX.cpp:
(WebCore::CSSSkewX::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSSkewX.h:
* Source/WebCore/css/typedom/transform/CSSSkewY.cpp:
(WebCore::CSSSkewY::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSSkewY.h:
* Source/WebCore/css/typedom/transform/CSSTransformComponent.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/css/typedom/transform/CSSTranslate.cpp:
(WebCore::CSSTranslate::toCSSValue const):
* Source/WebCore/css/typedom/transform/CSSTranslate.h:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::setInlineStyleProperty):
(WebCore::StyledElement::setInlineStyleCustomProperty):
* Source/WebCore/dom/StyledElement.h:

Canonical link: <a href="https://commits.webkit.org/256258@main">https://commits.webkit.org/256258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f37938423315eeeab8adefff6f338fe2e8bb0690

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4312 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104762 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165018 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4411 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33169 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100658 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3212 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81712 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30187 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85116 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86951 "Build was cancelled. Recent messages:Configured build (cancelled)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73086 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38894 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36713 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19789 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40649 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2083 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39030 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->