### PR TITLE
Align CSSOMVariableReferenceValue serialization with Blink

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssUnparsedValue-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssUnparsedValue-expected.txt
@@ -1,5 +1,5 @@
 
 PASS CSSUnparsedValue containing strings serializes to its concatenated contents
-FAIL CSSUnparsedValue containing variable references serializes its concatenated contents assert_equals: expected "var(--A,var(--B))var(--C)" but got "var(--A, var(--B))var(--C)"
-FAIL CSSUnparsedValue containing mix of strings and variable references serializes to its concatenated contents assert_equals: expected "foobar var(--A,baz var(--B)lemon)var(--C,ade)" but got "foobar var(--A, baz var(--B)lemon)var(--C, ade)"
+PASS CSSUnparsedValue containing variable references serializes its concatenated contents
+PASS CSSUnparsedValue containing mix of strings and variable references serializes to its concatenated contents
 

--- a/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
+++ b/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
@@ -68,7 +68,7 @@ void CSSOMVariableReferenceValue::serialize(StringBuilder& builder, OptionSet<Se
     builder.append("var(");
     builder.append(m_variable);
     if (m_fallback) {
-        builder.append(", ");
+        builder.append(',');
         m_fallback->serialize(builder, arguments);
     }
     builder.append(')');


### PR DESCRIPTION
#### 91bc6304bed238314f758e732e8f45e4c63c1eec
<pre>
Align CSSOMVariableReferenceValue serialization with Blink
<a href="https://bugs.webkit.org/show_bug.cgi?id=247202">https://bugs.webkit.org/show_bug.cgi?id=247202</a>

Reviewed by Antti Koivisto.

Align CSSOMVariableReferenceValue serialization with Blink and to match what
WPT tests expect.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssUnparsedValue-expected.txt:
* Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp:
(WebCore::CSSOMVariableReferenceValue::serialize const):

Canonical link: <a href="https://commits.webkit.org/256230@main">https://commits.webkit.org/256230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/988f367ab52c089dd2aebdf359fa289f138bdaa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104333 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164597 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3938 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32336 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100267 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2840 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81668 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29858 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72745 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38464 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18129 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19408 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40221 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2067 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38639 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->