### PR TITLE
Fix CSSStyleValue.parse() / parseAll() for shorthand CSS properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parse.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parse.html
@@ -32,6 +32,7 @@ test(() => {
   const result = CSSStyleValue.parse('margin', '1px 2px 3px 4px');
   assert_true(result instanceof CSSStyleValue,
               'Result must be a subclass of CSSStyleValue');
+  assert_equals(result.toString(), '1px 2px 3px 4px');
 }, 'CSSStyleValue.parse() with a valid shorthand property returns a CSSStyleValue');
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-expected.txt
@@ -2,6 +2,6 @@
 PASS CSSStyleValue.parseAll() with a valid property returns a list with a single CSSStyleValue
 PASS CSSStyleValue.parseAll() is not case sensitive
 PASS CSSStyleValue.parseAll() with a valid list-valued property returns a list with a single CSSStyleValue
-FAIL CSSStyleValue.parseAll() with a valid shorthand property returns a CSSStyleValue assert_equals: Result must be a list with one element expected 1 but got 4
+PASS CSSStyleValue.parseAll() with a valid shorthand property returns a CSSStyleValue
 PASS CSSStyleValue.parseAll() with a valid custom property returns a list with a single CSSStyleValue
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll.html
@@ -38,6 +38,7 @@ test(() => {
   assert_equals(result.length, 1, 'Result must be a list with one element');
   assert_true(result[0] instanceof CSSStyleValue,
               'Only element in result must be a subclass of CSSStyleValue');
+  assert_equals(result[0].toString(), '1px 2px 3px 4px');
 }, 'CSSStyleValue.parseAll() with a valid shorthand property returns a CSSStyleValue');
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssStyleValue-string-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssStyleValue-string-expected.txt
@@ -1,4 +1,4 @@
 
 PASS CSSStyleValue parsed from string serializes to given string
-FAIL Shorthand CSSStyleValue parsed from string serializes to given string assert_equals: expected "blue" but got "initial"
+PASS Shorthand CSSStyleValue parsed from string serializes to given string
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -44,13 +44,14 @@ class CSSStyleValueFactory {
 public:
     static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, Document* = nullptr);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
+    static ExceptionOr<RefPtr<CSSStyleValue>> constructStyleValueForShorthandProperty(CSSPropertyID, const Function<RefPtr<CSSValue>(CSSPropertyID)>& propertyValue, Document* = nullptr);
 
 protected:
     CSSStyleValueFactory() = delete;
 
 private:
     static ExceptionOr<RefPtr<CSSValue>> extractCSSValue(const CSSPropertyID&, const String&);
-    static ExceptionOr<void> extractShorthandCSSValues(Vector<Ref<CSSValue>>&, const CSSPropertyID&, const String&);
+    static ExceptionOr<RefPtr<CSSStyleValue>> extractShorthandCSSValues(const CSSPropertyID&, const String&);
     static ExceptionOr<void> extractCustomCSSValues(Vector<Ref<CSSValue>>&, const AtomString&, const String&);
 };
 

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp
@@ -30,6 +30,7 @@
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "CSSStyleValue.h"
+#include "CSSStyleValueFactory.h"
 #include "CSSUnparsedValue.h"
 #include "CSSValueList.h"
 #include "CSSVariableData.h"
@@ -105,29 +106,10 @@ ExceptionOr<bool> MainThreadStylePropertyMapReadOnly::has(ScriptExecutionContext
 
 RefPtr<CSSStyleValue> MainThreadStylePropertyMapReadOnly::shorthandPropertyValue(Document& document, CSSPropertyID propertyID) const
 {
-    auto shorthand = shorthandForProperty(propertyID);
-    Vector<Ref<CSSValue>> values;
-    for (auto& longhand : shorthand) {
-        RefPtr value = propertyValue(longhand);
-        if (!value)
-            return nullptr;
-        if (value->isImplicitInitialValue())
-            continue;
-        // VariableReference set from the shorthand.
-        if (is<CSSPendingSubstitutionValue>(*value))
-            return CSSUnparsedValue::create(downcast<CSSPendingSubstitutionValue>(*value).shorthandValue().data().tokenRange());
-        values.append(value.releaseNonNull());
-    }
-    if (values.isEmpty())
-        return nullptr;
-
-    if (values.size() == 1)
-        return reifyValue(values[0].ptr(), document);
-
-    auto valueList = CSSValueList::createSpaceSeparated();
-    for (auto& value : values)
-        valueList->append(WTFMove(value));
-    return CSSStyleValue::create(WTFMove(valueList));
+    auto result = CSSStyleValueFactory::constructStyleValueForShorthandProperty(propertyID, [this](auto longhandPropertyID) {
+        return propertyValue(longhandPropertyID);
+    }, &document);
+    return result.hasException() ? nullptr : RefPtr<CSSStyleValue> { result.releaseReturnValue() };
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### fd2b5bf98a6eef3c49c4d4cc9647eba431812b00
<pre>
Fix CSSStyleValue.parse() / parseAll() for shorthand CSS properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=247205">https://bugs.webkit.org/show_bug.cgi?id=247205</a>

Reviewed by Antti Koivisto.

Fix CSSStyleValue.parse() / parseAll() for shorthand CSS properties:
- <a href="https://drafts.css-houdini.org/css-typed-om/#dom-cssstylevalue-parse">https://drafts.css-houdini.org/css-typed-om/#dom-cssstylevalue-parse</a>
- <a href="https://drafts.css-houdini.org/css-typed-om/#dom-cssstylevalue-parseall">https://drafts.css-houdini.org/css-typed-om/#dom-cssstylevalue-parseall</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parse.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-objects/parseAll.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-serialization/cssStyleValue-string-expected.txt:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::extractShorthandCSSValues):
(WebCore::CSSStyleValueFactory::parseStyleValue):
* Source/WebCore/css/typedom/CSSStyleValueFactory.h:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.cpp:
(WebCore::MainThreadStylePropertyMapReadOnly::shorthandPropertyValue const):

Canonical link: <a href="https://commits.webkit.org/256228@main">https://commits.webkit.org/256228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fbb312a139f1311f403ac9824873c6ffb356635

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104343 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164606 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/3948 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32345 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100274 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2846 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81430 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29862 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72750 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38474 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18161 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36318 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19441 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42278 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2068 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38672 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->