### PR TITLE
Manage CacheStorage by origin

### DIFF
--- a/LayoutTests/http/tests/cache-storage/cache-clearing-origin.https.html
+++ b/LayoutTests/http/tests/cache-storage/cache-clearing-origin.https.html
@@ -36,10 +36,7 @@ promise_test(() => {
 
             representation = JSON.parse(await internals.cacheStorageEngineRepresentation()).origins;
             test(() => {
-                representation.sort(compareClientOrigins);
-                assert_equals(representation[0].origin.topOrigin, "https://127.0.0.1:8443", "top origin of cache 1");
-                assert_equals(representation[0].origin.clientOrigin, "https://localhost:8443", "client origin of cache 1");
-                assert_array_equals(representation[0].caches.persistent, []);
+                assert_equals(representation.length, 0);
             }, "Validating cache representation after clearing");
             resolve();
         });

--- a/LayoutTests/http/tests/cache-storage/cache-origins.https.html
+++ b/LayoutTests/http/tests/cache-storage/cache-origins.https.html
@@ -21,12 +21,7 @@
         testRunner.clearDOMCache('https://127.0.0.1:8443');
         var representation = JSON.parse(await internals.cacheStorageEngineRepresentation()).origins;
         test(() => {
-            assert_equals(representation[0].origin.topOrigin, "https://127.0.0.1:8443", "top origin of cache 1");
-            assert_equals(representation[1].origin.topOrigin, "https://127.0.0.1:8443", "top origin of cache 2");
-            assert_equals(representation[0].origin.clientOrigin, "https://127.0.0.1:8443", "client origin of cache 1");
-            assert_equals(representation[1].origin.clientOrigin, "https://localhost:8443", "client origin of cache 2");
-            assert_array_equals(representation[0].caches.persistent, []);
-            assert_array_equals(representation[1].caches.persistent, []);
+            assert_equals(representation.length, 0);
         }, "Verifying that clearing caches for an origin will clear both top origin and client origin caches.");
     }
 

--- a/LayoutTests/http/tests/cache-storage/cache-representation.https.html
+++ b/LayoutTests/http/tests/cache-storage/cache-representation.https.html
@@ -13,6 +13,10 @@
     function checkCaches(hasPersistent, hasRemoved, name, value) {
         test(() => {
             var results = JSON.parse(value).origins;
+            if (!hasPersistent && !hasRemoved) {
+                assert_equals(results.length, 0);
+                return;
+            }
             assert_equals(results.length, 1);
             var caches = results[0].caches;
             assert_equals(!!caches["persistent"].length, hasPersistent, "persistent");

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -573,6 +573,22 @@ std::optional<Vector<uint8_t>> readEntireFile(const String& path)
     return contents;
 }
 
+int overwriteEntireFile(const String& path, Span<uint8_t> span)
+{
+    auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::ReadWrite);
+    auto closeFile = makeScopeExit([&] {
+        FileSystem::closeFile(fileHandle);
+    });
+
+    if (!FileSystem::isHandleValid(fileHandle))
+        return -1;
+
+    if (!FileSystem::truncateFile(fileHandle, 0))
+        return -1;
+
+    return FileSystem::writeToFile(fileHandle, span.data(), span.size());
+}
+
 void deleteAllFilesModifiedSince(const String& directory, WallTime time)
 {
     // This function may delete directory folder.

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -160,6 +160,7 @@ using Salt = std::array<uint8_t, 8>;
 WTF_EXPORT_PRIVATE std::optional<Salt> readOrMakeSalt(const String& path);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readEntireFile(PlatformFileHandle);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readEntireFile(const String& path);
+WTF_EXPORT_PRIVATE int overwriteEntireFile(const String& path, Span<uint8_t>);
 
 // Prefix is what the filename should be prefixed with, not the full path.
 WTF_EXPORT_PRIVATE String openTemporaryFile(StringView prefix, PlatformFileHandle&, StringView suffix = { });

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -84,6 +84,24 @@ ResourceResponseBase::ResourceResponseBase(std::optional<ResourceResponseBase::R
 {
 }
 
+ResourceResponseBase::CrossThreadData ResourceResponseBase::CrossThreadData::copy() const
+{
+    ResourceResponseBase::CrossThreadData result;
+    result.url = url;
+    result.mimeType = mimeType;
+    result.expectedContentLength = expectedContentLength;
+    result.textEncodingName = textEncodingName;
+    result.httpStatusCode = httpStatusCode;
+    result.httpVersion = httpVersion;
+    result.httpHeaderFields = httpHeaderFields;
+    result.networkLoadMetrics = networkLoadMetrics;
+    result.type = type;
+    result.tainting = tainting;
+    result.isRedirected = isRedirected;
+    result.isRangeRequested = isRangeRequested;
+    return result;
+}
+
 ResourceResponseBase::CrossThreadData ResourceResponseBase::crossThreadData() const
 {
     CrossThreadData data;

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -75,6 +75,8 @@ public:
         CrossThreadData& operator=(const CrossThreadData&) = delete;
         CrossThreadData() = default;
         CrossThreadData(CrossThreadData&&) = default;
+        CrossThreadData& operator=(CrossThreadData&&) = default;
+        WEBCORE_EXPORT CrossThreadData copy() const;
 
         URL url;
         String mimeType;
@@ -114,8 +116,8 @@ public:
         bool m_isRangeRequested;
     };
 
-    CrossThreadData crossThreadData() const;
-    static ResourceResponse fromCrossThreadData(CrossThreadData&&);
+    WEBCORE_EXPORT CrossThreadData crossThreadData() const;
+    WEBCORE_EXPORT static ResourceResponse fromCrossThreadData(CrossThreadData&&);
 
     bool isNull() const { return m_isNull; }
     WEBCORE_EXPORT bool isInHTTPFamily() const;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1510,12 +1510,6 @@ void NetworkProcess::fetchWebsiteData(PAL::SessionID sessionID, OptionSet<Websit
             callbackAggregator->m_websiteData.entries.append({ securityOrigin, WebsiteDataType::Credentials, 0 });
     }
 
-    if (websiteDataTypes.contains(WebsiteDataType::DOMCache) && session) {
-        CacheStorage::Engine::fetchEntries(*session, fetchOptions.contains(WebsiteDataFetchOption::ComputeSizes), [callbackAggregator](auto entries) mutable {
-            callbackAggregator->m_websiteData.entries.appendVector(entries);
-        });
-    }
-
 #if PLATFORM(COCOA) || USE(SOUP)
     if (websiteDataTypes.contains(WebsiteDataType::HSTSCache))
         callbackAggregator->m_websiteData.hostNamesWithHSTSCache = hostNamesWithHSTSCache(sessionID);
@@ -1588,9 +1582,6 @@ void NetworkProcess::deleteWebsiteData(PAL::SessionID sessionID, OptionSet<Websi
             session->credentialStorage().clearCredentials();
         WebCore::CredentialStorage::clearSessionCredentials();
     }
-
-    if (websiteDataTypes.contains(WebsiteDataType::DOMCache) && session)
-        CacheStorage::Engine::clearAllCaches(*session, [clearTasksHandler] { });
 
 #if ENABLE(SERVICE_WORKER)
     bool clearServiceWorkers = websiteDataTypes.contains(WebsiteDataType::DOMCache) || websiteDataTypes.contains(WebsiteDataType::ServiceWorkerRegistrations);
@@ -1691,11 +1682,6 @@ void NetworkProcess::deleteWebsiteDataForOrigins(PAL::SessionID sessionID, Optio
             session->clearPrivateClickMeasurementForRegistrableDomain(RegistrableDomain::uncheckedCreateFromHost(originData.host), [clearTasksHandler] { });
     }
 
-    if (websiteDataTypes.contains(WebsiteDataType::DOMCache) && session) {
-        for (auto& originData : originDatas)
-            CacheStorage::Engine::clearCachesForOrigin(*session, SecurityOriginData { originData }, [clearTasksHandler] { });
-    }
-
 #if ENABLE(SERVICE_WORKER)
     bool clearServiceWorkers = websiteDataTypes.contains(WebsiteDataType::DOMCache) || websiteDataTypes.contains(WebsiteDataType::ServiceWorkerRegistrations);
     if (clearServiceWorkers && !sessionID.isEphemeral() && session) {
@@ -1760,17 +1746,6 @@ static Vector<String> filterForRegistrableDomains(const Vector<RegistrableDomain
     Vector<String> result;
     for (const auto& value : foundValues) {
         if (registrableDomains.contains(RegistrableDomain::uncheckedCreateFromHost(value)))
-            result.append(value);
-    }
-    
-    return result;
-}
-
-static Vector<WebsiteData::Entry> filterForRegistrableDomains(const Vector<RegistrableDomain>& registrableDomains, const Vector<WebsiteData::Entry>& foundValues)
-{
-    Vector<WebsiteData::Entry> result;
-    for (const auto& value : foundValues) {
-        if (registrableDomains.contains(RegistrableDomain::uncheckedCreateFromHost(value.origin.host)))
             result.append(value);
     }
     
@@ -1885,21 +1860,6 @@ void NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains(PAL::Sess
         auto origins = WebCore::CredentialStorage::originsWithSessionCredentials();
         auto originsToDelete = filterForRegistrableDomains(origins, domainsToDeleteAllScriptWrittenStorageFor, callbackAggregator->m_domains);
         WebCore::CredentialStorage::removeSessionCredentialsWithOrigins(originsToDelete);
-    }
-    
-    if (websiteDataTypes.contains(WebsiteDataType::DOMCache) && session) {
-        CacheStorage::Engine::fetchEntries(*session, fetchOptions.contains(WebsiteDataFetchOption::ComputeSizes), [domainsToDeleteAllScriptWrittenStorageFor, session = WeakPtr { session }, callbackAggregator](auto entries) mutable {
-            
-            auto entriesToDelete = filterForRegistrableDomains(domainsToDeleteAllScriptWrittenStorageFor, entries);
-
-            for (const auto& entry : entriesToDelete)
-                callbackAggregator->m_domains.add(RegistrableDomain::uncheckedCreateFromHost(entry.origin.host));
-
-            if (session) {
-                for (auto& entry : entriesToDelete)
-                    CacheStorage::Engine::clearCachesForOrigin(*session, SecurityOriginData { entry.origin }, [callbackAggregator] { });
-            }
-        });
     }
     
 #if ENABLE(SERVICE_WORKER)
@@ -2034,12 +1994,6 @@ void NetworkProcess::registrableDomainsWithWebsiteData(PAL::SessionID sessionID,
             for (auto& securityOrigin : securityOrigins)
                 callbackAggregator->m_websiteData.entries.append({ securityOrigin, WebsiteDataType::Credentials, 0 });
         }
-    }
-    
-    if (websiteDataTypes.contains(WebsiteDataType::DOMCache) && session) {
-        CacheStorage::Engine::fetchEntries(*session, fetchOptions.contains(WebsiteDataFetchOption::ComputeSizes), [callbackAggregator](auto entries) mutable {
-            callbackAggregator->m_websiteData.entries.appendVector(entries);
-        });
     }
     
 #if ENABLE(SERVICE_WORKER)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -124,10 +124,6 @@ class Cache;
 enum class CacheOption : uint8_t;
 }
 
-namespace CacheStorage {
-class Engine;
-}
-
 class NetworkProcess : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>
 {
     WTF_MAKE_NONCOPYABLE(NetworkProcess);

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp
@@ -1,0 +1,375 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CacheStorageCache.h"
+
+#include "CacheStorageDiskStore.h"
+#include "CacheStorageManager.h"
+#include "CacheStorageMemoryStore.h"
+#include <WebCore/CacheQueryOptions.h>
+#include <WebCore/CrossOriginAccessControl.h>
+#include <WebCore/ResourceError.h>
+#include <wtf/Scope.h>
+
+namespace WebKit {
+
+static String computeKeyURL(const URL& url)
+{
+    URL keyURL { url };
+    keyURL.removeQueryAndFragmentIdentifier();
+    return keyURL.string();
+}
+
+static uint64_t nextRecordIdentifier()
+{
+    static std::atomic<uint64_t> currentRecordIdentifier;
+    return ++currentRecordIdentifier;
+}
+
+static Ref<CacheStorageStore> createStore(const String& uniqueName, const String& path, Ref<WorkQueue>&& queue)
+{
+    if (path.isEmpty())
+        return CacheStorageMemoryStore::create();
+    return CacheStorageDiskStore::create(uniqueName, path, WTFMove(queue));
+}
+
+CacheStorageCache::CacheStorageCache(CacheStorageManager& manager, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&& queue)
+    : m_manager(manager)
+    , m_identifier(WebCore::DOMCacheIdentifier::generateThreadSafe())
+    , m_name(name)
+    , m_uniqueName(uniqueName)
+    , m_store(createStore(uniqueName, path, WTFMove(queue)))
+{
+}
+
+CacheStorageManager* CacheStorageCache::manager()
+{
+    return m_manager.get();
+}
+
+void CacheStorageCache::getSize(CompletionHandler<void(uint64_t)>&& callback)
+{
+    if (m_isInitialized) {
+        uint64_t size = 0;
+        for (auto& urlRecords : m_records.values()) {
+            for (auto& record : urlRecords)
+                size += record.size;
+        }
+        return callback(size);
+    }
+
+    m_store->readAllRecords([callback = WTFMove(callback)](auto&& records) mutable {
+        uint64_t size = 0;
+        for (auto& record : records)
+            size += record.info.size;
+
+        callback(size);
+    });
+}
+
+void CacheStorageCache::open(WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
+{
+    if (m_isInitialized)
+        return callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { m_identifier, false });
+
+    m_store->readAllRecords([this, weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto records) mutable {
+        if (!weakThis)
+            return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+
+        std::sort(records.begin(), records.end(), [](auto& a, auto& b) {
+            return a.info.insertionTime < b.info.insertionTime;
+        });
+
+        for (auto& record : records) {
+            record.info.identifier = nextRecordIdentifier();
+            m_records.ensure(computeKeyURL(record.info.url), [] {
+                return Vector<CacheStorageRecordInformation> { };
+            }).iterator->value.append(record.info);
+        }
+
+        m_isInitialized = true;
+        callback(WebCore::DOMCacheEngine::CacheIdentifierOperationResult { m_identifier, false });
+    });
+}
+
+static CacheStorageRecord toCacheStorageRecord(WebCore::DOMCacheEngine::Record&& record, FileSystem::Salt salt, const String& uniqueName)
+{
+    NetworkCache::Key key { "record"_s, uniqueName, { }, createVersion4UUIDString(), salt };
+    CacheStorageRecordInformation recordInfo { WTFMove(key), MonotonicTime::now().secondsSinceEpoch().milliseconds(), record.identifier, 0 , record.responseBodySize, record.request.url(), false, { } };
+    recordInfo.updateVaryHeaders(record.request, record.response.httpHeaderField(WebCore::HTTPHeaderName::Vary));
+
+    return CacheStorageRecord { WTFMove(recordInfo), record.requestHeadersGuard, WTFMove(record.request), record.options, WTFMove(record.referrer), record.responseHeadersGuard, record.response.crossThreadData(), record.responseBodySize, WTFMove(record.responseBody) };
+}
+
+void CacheStorageCache::retrieveRecords(WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
+{
+    ASSERT(m_isInitialized);
+
+    Vector<CacheStorageRecordInformation> targetRecordInfos;
+    auto url = options.request.url();
+    if (url.isNull()) {
+        for (auto& urlRecords : m_records.values()) {
+            auto newTargetRecordInfos = WTF::map(urlRecords, [&](const auto& record) {
+                return record;
+            });
+            targetRecordInfos.appendVector(WTFMove(newTargetRecordInfos));
+        }
+    } else {
+        if (!options.ignoreMethod && options.request.httpMethod() != "GET"_s)
+            return callback({ });
+
+        auto iterator = m_records.find(computeKeyURL(url));
+        if (iterator == m_records.end())
+            return callback({ });
+
+        WebCore::CacheQueryOptions queryOptions { options.ignoreSearch, options.ignoreMethod, options.ignoreVary };
+        for (auto& record : iterator->value) {
+            if (WebCore::DOMCacheEngine::queryCacheMatch(options.request, record.url, record.hasVaryStar, record.varyHeaders, queryOptions))
+                targetRecordInfos.append(record);
+        }
+    }
+
+    if (targetRecordInfos.isEmpty())
+        return callback({ });
+    
+    m_store->readRecords(targetRecordInfos, [options = WTFMove(options), callback = WTFMove(callback)](auto&& cacheStorageRecords) mutable {
+        Vector<WebCore::DOMCacheEngine::Record> result;
+        result.reserveInitialCapacity(cacheStorageRecords.size());
+        for (auto& cacheStorageRecord : cacheStorageRecords) {
+            if (!cacheStorageRecord)
+                continue;
+    
+            WebCore::DOMCacheEngine::Record record { cacheStorageRecord->info.identifier, 0, cacheStorageRecord->requestHeadersGuard, cacheStorageRecord->request, cacheStorageRecord->options, cacheStorageRecord->referrer, cacheStorageRecord->responseHeadersGuard, { }, nullptr, 0 };
+            if (options.shouldProvideResponse) {
+                record.response = WebCore::ResourceResponse::fromCrossThreadData(WTFMove(cacheStorageRecord->responseData));
+                record.responseBody = WTFMove(cacheStorageRecord->responseBody);
+                record.responseBodySize = cacheStorageRecord->responseBodySize;
+            }
+
+            if (record.response.type() == WebCore::ResourceResponse::Type::Opaque) {
+                if (WebCore::validateCrossOriginResourcePolicy(options.crossOriginEmbedderPolicy.value, options.sourceOrigin, record.request.url(), record.response, WebCore::ForNavigation::No))
+                    return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::CORP));
+            }
+
+            result.uncheckedAppend(WTFMove(record));
+        }
+
+        std::sort(result.begin(), result.end(), [&](auto& a, auto& b) {
+            return a.identifier < b.identifier;
+        });
+
+        callback(WTFMove(result));
+    });
+}
+
+void CacheStorageCache::removeRecords(WebCore::ResourceRequest&& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+{
+    ASSERT(m_isInitialized);
+    
+    if (!options.ignoreMethod && request.httpMethod() != "GET"_s)
+        return callback({ });
+
+    auto iterator = m_records.find(computeKeyURL(request.url()));
+    if (iterator == m_records.end())
+        return callback({ });
+
+    auto& urlRecords = iterator->value;
+    Vector<uint64_t> targetRecordIdentifiers;
+    Vector<CacheStorageRecordInformation> targetRecordInfos;
+    uint64_t sizeDecreased = 0;
+    urlRecords.removeAllMatching([&](auto& record) {
+        if (!WebCore::DOMCacheEngine::queryCacheMatch(request, record.url, record.hasVaryStar, record.varyHeaders, options))
+            return false;
+
+        targetRecordIdentifiers.append(record.identifier);
+        targetRecordInfos.append(record);
+        sizeDecreased += record.size;
+        return true;
+    });
+
+    if (m_manager && sizeDecreased)
+        m_manager->sizeDecreased(sizeDecreased);
+
+    m_store->deleteRecords(targetRecordInfos, [targetIdentifiers = WTFMove(targetRecordIdentifiers), callback = WTFMove(callback)](bool succeeded) mutable {
+        if (!succeeded)
+            return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::WriteDisk));
+
+        callback(WTFMove(targetIdentifiers));
+    });
+}
+
+CacheStorageRecordInformation* CacheStorageCache::findExistingRecord(const WebCore::ResourceRequest& request, std::optional<uint64_t> identifier)
+{
+    auto iterator = m_records.find(computeKeyURL(request.url()));
+    if (iterator == m_records.end())
+        return nullptr;
+
+    WebCore::CacheQueryOptions options;
+    auto index = iterator->value.findIf([&] (auto& record) {
+        bool hasMatchedIdentifier = !identifier || identifier == record.identifier;
+        return hasMatchedIdentifier && WebCore::DOMCacheEngine::queryCacheMatch(request, record.url, record.hasVaryStar, record.varyHeaders, options);
+    });
+    if (index == notFound)
+        return nullptr;
+
+    return &iterator->value[index];
+}
+
+void CacheStorageCache::putRecords(Vector<WebCore::DOMCacheEngine::Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+{
+    ASSERT(m_isInitialized);
+
+    if (!m_manager)
+        return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+
+    int64_t spaceRequested = 0;
+    auto cacheStorageRecords = WTF::map(records, [&](auto&& record) {
+        spaceRequested += record.responseBodySize;
+        if (auto* existingRecord = findExistingRecord(record.request))
+            spaceRequested -= existingRecord->size;
+        return toCacheStorageRecord(WTFMove(record), m_manager->salt(), m_uniqueName);
+    });
+
+    // The request still needs to go through quota check to keep ordering.
+    if (spaceRequested < 0)
+        spaceRequested = 0;
+
+    m_manager->requestSpace(spaceRequested, [this, weakThis = WeakPtr { *this }, records = WTFMove(cacheStorageRecords), callback = WTFMove(callback)](bool granted) mutable {
+        if (!weakThis)
+            return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+
+        if (!granted)
+            return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::QuotaExceeded));
+
+        putRecordsAfterQuotaCheck(WTFMove(records), WTFMove(callback));
+    });
+}
+
+void CacheStorageCache::putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+{
+    ASSERT(m_isInitialized);
+
+    Vector<CacheStorageRecordInformation> targetRecordInfos;
+    for (auto& record : records) {
+        if (auto* existingRecord = findExistingRecord(record.request)) {
+            record.info.identifier = existingRecord->identifier;
+            targetRecordInfos.append(*existingRecord);
+        }
+    }
+
+    auto readRecordsCallback = [this, weakThis = WeakPtr { *this }, records = WTFMove(records), callback = WTFMove(callback)](auto existingCacheStorageRecords) mutable {
+        if (!weakThis)
+            return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::Internal));
+
+        putRecordsInStore(WTFMove(records), WTFMove(existingCacheStorageRecords), WTFMove(callback));
+    };
+
+    m_store->readRecords(targetRecordInfos, WTFMove(readRecordsCallback));
+}
+
+void CacheStorageCache::putRecordsInStore(Vector<CacheStorageRecord>&& records, Vector<std::optional<CacheStorageRecord>>&& existingRecords, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+{
+    Vector<uint64_t> targetIdentifiers;
+    uint64_t sizeIncreased = 0, sizeDecreased = 0;
+    for (auto& record : records) {
+        if (!record.info.identifier) {
+            record.info.identifier = nextRecordIdentifier();
+            sizeIncreased += record.info.size;
+            m_records.ensure(computeKeyURL(record.info.url), [] {
+                return Vector<CacheStorageRecordInformation> { };
+            }).iterator->value.append(record.info);
+        } else {
+            auto index = existingRecords.findIf([&](auto& existingRecord) {
+                return existingRecord && existingRecord->info.identifier == record.info.identifier;
+            });
+            // Ensure record still exists.
+            if (index == notFound) {
+                record.info.identifier = 0;
+                continue;
+            }
+
+            auto& existingRecord = existingRecords[index];
+            // Ensure identifier still exists.
+            auto* existingRecordInfo = findExistingRecord(record.request, record.info.identifier);
+            if (!existingRecordInfo) {
+                record.info.identifier = 0;
+                continue;
+            }
+
+            record.info.key = existingRecordInfo->key;
+            record.info.insertionTime = existingRecordInfo->insertionTime;
+            record.info.url = existingRecordInfo->url;
+            record.requestHeadersGuard = existingRecord->requestHeadersGuard;
+            record.request = WTFMove(existingRecord->request);
+            record.options = WTFMove(existingRecord->options);
+            record.referrer = WTFMove(existingRecord->referrer);
+            record.info.updateVaryHeaders(record.request, record.responseData.httpHeaderFields.get(WebCore::HTTPHeaderName::Vary));
+            sizeIncreased += record.info.size;
+            sizeDecreased += existingRecordInfo->size;
+            existingRecordInfo->size = record.info.size;
+        }
+
+        targetIdentifiers.append(record.info.identifier);
+    }
+
+    records.removeAllMatching([&](auto& record) {
+        return !record.info.identifier;
+    });
+
+    if (m_manager) {
+        if (sizeIncreased > sizeDecreased)
+            m_manager->sizeIncreased(sizeIncreased - sizeDecreased);
+        else if (sizeDecreased > sizeIncreased)
+            m_manager->sizeDecreased(sizeDecreased - sizeIncreased);
+    }
+
+    m_store->writeRecords(WTFMove(records), [targetIdentifiers = WTFMove(targetIdentifiers), callback = WTFMove(callback)](bool succeeded) mutable {
+        if (!succeeded)
+            return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::WriteDisk));
+
+        callback(WTFMove(targetIdentifiers));
+    });
+}
+
+void CacheStorageCache::removeAllRecords()
+{
+    Vector<CacheStorageRecordInformation> targetRecordInfos;
+    for (auto& urlRecords : m_records.values()) {
+        for (auto& record : urlRecords)
+            targetRecordInfos.append(record);
+    }
+
+    m_records.clear();
+    m_store->deleteRecords(targetRecordInfos, [](auto) { });
+}
+
+void CacheStorageCache::close()
+{
+    m_records.clear();
+    m_isInitialized = false;
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CacheStorageRecord.h"
+#include "NetworkCacheKey.h"
+#include <WebCore/RetrieveRecordsOptions.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebKit {
+
+class CacheStorageStore;
+class CacheStorageManager;
+
+class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
+    WebCore::DOMCacheIdentifier identifier() const { return m_identifier; }
+    const String& name() const { return m_name; }
+    const String& uniqueName() const { return m_uniqueName; }
+    CacheStorageManager* manager();
+
+    void getSize(CompletionHandler<void(uint64_t)>&&);
+    void open(WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
+    void retrieveRecords(WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&);
+    void removeRecords(WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void putRecords(Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void removeAllRecords();
+    void close();
+
+private:
+    CacheStorageRecordInformation* findExistingRecord(const WebCore::ResourceRequest&, std::optional<uint64_t> = std::nullopt);
+    void putRecordsAfterQuotaCheck(Vector<CacheStorageRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void putRecordsInStore(Vector<CacheStorageRecord>&&, Vector<std::optional<CacheStorageRecord>>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+
+    WeakPtr<CacheStorageManager> m_manager;
+    bool m_isInitialized { false };
+    WebCore::DOMCacheIdentifier m_identifier;
+    String m_name;
+    String m_uniqueName;
+    HashMap<String, Vector<CacheStorageRecordInformation>> m_records;
+    Ref<CacheStorageStore> m_store;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CacheStorageDiskStore.h"
+
+#include "CacheStorageRecord.h"
+#include "Logging.h"
+#include "NetworkCacheCoders.h"
+#include <wtf/PageBlock.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Scope.h>
+#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/persistence/PersistentDecoder.h>
+#include <wtf/persistence/PersistentEncoder.h>
+
+namespace WebKit {
+
+static constexpr auto saltFileName = "salt"_s;
+static constexpr auto versionDirectoryPrefix = "Version "_s;
+static constexpr auto recordsDirectoryName = "Records"_s;
+static constexpr auto blobsDirectoryName = "Blobs"_s;
+static constexpr auto blobSuffix = "-blob"_s;
+static const unsigned currentVersion = 16;
+
+static bool shouldStoreBodyAsBlob(const Vector<uint8_t>& bodyData)
+{
+    return bodyData.size() > WTF::pageSize();
+}
+
+static SHA1::Digest computeSHA1(Span<const uint8_t> span, FileSystem::Salt salt)
+{
+    SHA1 sha1;
+    sha1.addBytes(salt.data(), salt.size());
+    sha1.addBytes(span.data(), span.size());
+    SHA1::Digest digest;
+    sha1.computeHash(digest);
+    return digest;
+}
+
+struct RecordMetaData {
+    RecordMetaData() { }
+    explicit RecordMetaData(const NetworkCache::Key& key)
+        : cacheStorageVersion(currentVersion)
+        , key(key)
+    { }
+
+    unsigned cacheStorageVersion;
+    NetworkCache::Key key;
+    WallTime timeStamp;
+    SHA1::Digest headerHash;
+    uint64_t headerSize { 0 };
+    SHA1::Digest bodyHash;
+    uint64_t bodySize { 0 };
+    bool isBodyInline { false };
+    uint64_t headerOffset { 0 };
+};
+
+struct RecordHeader {
+    double insertionTime { 0 };
+    uint64_t size { 0 };
+    WebCore::FetchHeaders::Guard requestHeadersGuard { WebCore::FetchHeaders::Guard::None };
+    WebCore::ResourceRequest request;
+    WebCore::FetchOptions options;
+    String referrer;
+    WebCore::FetchHeaders::Guard responseHeadersGuard { WebCore::FetchHeaders::Guard::None };
+    WebCore::ResourceResponse response;
+    uint64_t responseBodySize { 0 };
+};
+
+Ref<CacheStorageDiskStore> CacheStorageDiskStore::create(const String& cacheName, const String& path, Ref<WorkQueue>&& queue)
+{
+    return adoptRef(*new CacheStorageDiskStore(cacheName, path, WTFMove(queue)));
+}
+
+CacheStorageDiskStore::CacheStorageDiskStore(const String& cacheName, const String& path, Ref<WorkQueue>&& queue)
+    : m_cacheName(cacheName)
+    , m_path(path)
+    , m_salt(valueOrDefault(FileSystem::readOrMakeSalt(saltFilePath())))
+    , m_callbackQueue(WTFMove(queue))
+    , m_ioQueue(WorkQueue::create("com.apple.WebKit.CacheStorageCache"))
+{
+    ASSERT(!m_cacheName.isEmpty());
+    ASSERT(!m_path.isEmpty());
+}
+
+String CacheStorageDiskStore::versionDirectoryPath() const
+{
+    return FileSystem::pathByAppendingComponent(m_path, makeString(versionDirectoryPrefix, currentVersion));
+}
+
+String CacheStorageDiskStore::saltFilePath() const
+{
+    return FileSystem::pathByAppendingComponent(versionDirectoryPath(), saltFileName);
+}
+
+String CacheStorageDiskStore::recordsDirectoryPath() const
+{
+    return FileSystem::pathByAppendingComponent(versionDirectoryPath(), recordsDirectoryName);
+}
+
+String CacheStorageDiskStore::recordFilePath(const NetworkCache::Key& key) const
+{
+    return FileSystem::pathByAppendingComponents(recordsDirectoryPath(), { key.partitionHashAsString(), key.type(), key.hashAsString() });
+}
+
+String CacheStorageDiskStore::recordBlobFilePath(const String& recordPath) const
+{
+    return recordPath + blobSuffix;
+}
+
+String CacheStorageDiskStore::blobsDirectoryPath() const
+{
+    return FileSystem::pathByAppendingComponent(versionDirectoryPath(), blobsDirectoryName);
+}
+
+String CacheStorageDiskStore::blobFilePath(const String& blobFileName) const
+{
+    return FileSystem::pathByAppendingComponent(blobsDirectoryPath(), blobFileName);
+}
+
+static std::optional<RecordMetaData> decodeRecordMetaData(Span<const uint8_t> fileData)
+{
+    WTF::Persistence::Decoder decoder(fileData);
+    RecordMetaData metaData;
+    std::optional<unsigned> cacheStorageVersion;
+    decoder >> cacheStorageVersion;
+    if (!cacheStorageVersion)
+        return std::nullopt;
+    metaData.cacheStorageVersion = WTFMove(*cacheStorageVersion);
+
+    std::optional<NetworkCache::Key> key;
+    decoder >> key;
+    if (!key)
+        return std::nullopt;
+    metaData.key = WTFMove(*key);
+
+    std::optional<WallTime> timeStamp;
+    decoder >> timeStamp;
+    if (!timeStamp)
+        return std::nullopt;
+    metaData.timeStamp = WTFMove(*timeStamp);
+
+    std::optional<SHA1::Digest> headerHash;
+    decoder >> headerHash;
+    if (!headerHash)
+        return std::nullopt;
+    metaData.headerHash = WTFMove(*headerHash);
+
+    std::optional<uint64_t> headerSize;
+    decoder >> headerSize;
+    if (!headerSize)
+        return std::nullopt;
+    metaData.headerSize = WTFMove(*headerSize);
+
+    std::optional<SHA1::Digest> bodyHash;
+    decoder >> bodyHash;
+    if (!bodyHash)
+        return std::nullopt;
+    metaData.bodyHash = WTFMove(*bodyHash);
+
+    std::optional<uint64_t> bodySize;
+    decoder >> bodySize;
+    if (!bodySize)
+        return std::nullopt;
+    metaData.bodySize = WTFMove(*bodySize);
+
+    std::optional<bool> isBodyInline;
+    decoder >> isBodyInline;
+    if (!isBodyInline)
+        return std::nullopt;
+    metaData.isBodyInline = WTFMove(*isBodyInline);
+
+    if (!decoder.verifyChecksum())
+        return std::nullopt;
+
+    metaData.headerOffset = decoder.currentOffset();
+    return metaData;
+}
+
+static std::optional<RecordHeader> decodeRecordHeader(Span<const uint8_t> headerData)
+{
+    WTF::Persistence::Decoder decoder(headerData);
+    std::optional<double> insertionTime;
+    decoder >> insertionTime;
+    if (!insertionTime)
+        return std::nullopt;
+
+    std::optional<uint64_t> size;
+    decoder >> size;
+    if (!size)
+        return std::nullopt;
+
+    std::optional<WebCore::FetchHeaders::Guard> requestHeadersGuard;
+    decoder >> requestHeadersGuard;
+    if (!requestHeadersGuard)
+        return std::nullopt;
+
+    std::optional<WebCore::ResourceRequest> request;
+    decoder >> request;
+    if (!request)
+        return std::nullopt;
+
+    WebCore::FetchOptions options;
+    if (!WebCore::FetchOptions::decodePersistent(decoder, options))
+        return std::nullopt;
+
+    std::optional<String> referrer;
+    decoder >> referrer;
+    if (!referrer)
+        return std::nullopt;
+
+    std::optional<WebCore::FetchHeaders::Guard> responseHeadersGuard;
+    decoder >> responseHeadersGuard;
+    if (!responseHeadersGuard)
+        return std::nullopt;
+
+    WebCore::ResourceResponse response;
+    if (!WebCore::ResourceResponse::decode(decoder, response))
+        return std::nullopt;
+
+    std::optional<uint64_t> responseBodySize;
+    decoder >> responseBodySize;
+    if (!responseBodySize)
+        return std::nullopt;
+
+    if (!decoder.verifyChecksum())
+        return std::nullopt;
+
+    return RecordHeader {
+        *insertionTime,
+        *size,
+        *requestHeadersGuard,
+        *request,
+        WTFMove(options),
+        WTFMove(*referrer),
+        *responseHeadersGuard,
+        WTFMove(response),
+        WTFMove(*responseBodySize)
+    };
+}
+
+std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(const Vector<uint8_t>& buffer, const Vector<uint8_t>& blobBuffer)
+{
+    if (buffer.isEmpty())
+        return std::nullopt;
+
+    auto fileData = Span { buffer.data(), buffer.size() };
+    auto metaData = decodeRecordMetaData(fileData);
+    if (!metaData)
+        return std::nullopt;
+
+    if (metaData->cacheStorageVersion != currentVersion || metaData->timeStamp > WallTime::now())
+        return std::nullopt;
+
+    auto headerData = fileData.subspan(metaData->headerOffset, metaData->headerSize);
+    if (metaData->headerHash != computeSHA1(headerData, m_salt))
+        return std::nullopt;
+
+    auto header = decodeRecordHeader(headerData);
+    if (!header)
+        return std::nullopt;
+
+    std::optional<WebCore::DOMCacheEngine::ResponseBody> responseBody;
+    if (metaData->isBodyInline) {
+        size_t bodyOffset = metaData->headerOffset + metaData->headerSize;
+        if (bodyOffset + metaData->bodySize != fileData.size())
+            return std::nullopt;
+
+        auto bodyData = fileData.subspan(bodyOffset);
+        if (metaData->bodyHash != computeSHA1(bodyData, m_salt))
+            return std::nullopt;
+
+        responseBody = WebCore::SharedBuffer::create(bodyData.data(), bodyData.size());
+    } else {
+        if (blobBuffer.isEmpty())
+            return std::nullopt;
+
+        auto sharedBuffer = WebCore::SharedBuffer::create(blobBuffer.data(), blobBuffer.size());
+        auto bodyData = Span { sharedBuffer->data(), sharedBuffer->size() };
+        if (metaData->bodyHash != computeSHA1(bodyData, m_salt))
+            return std::nullopt;
+
+        responseBody = sharedBuffer;
+    }
+
+    if (!responseBody)
+        return std::nullopt;
+
+    CacheStorageRecordInformation info { metaData->key, header->insertionTime, 0, 0, header->responseBodySize, header->request.url(), false, { } };
+    info.updateVaryHeaders(header->request, header->response.httpHeaderField(WebCore::HTTPHeaderName::Vary));
+    return CacheStorageRecord { info, header->requestHeadersGuard, header->request, header->options, header->referrer, header->responseHeadersGuard, header->response.crossThreadData(), header->responseBodySize, WTFMove(*responseBody) };
+}
+
+void CacheStorageDiskStore::readAllRecords(ReadAllRecordsCallback&& callback)
+{
+    auto didReadRecordFiles = [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](auto fileDatas, auto blobDatas) mutable {
+        ASSERT(fileDatas.size() == blobDatas.size());
+        Vector<CacheStorageRecord> result;
+        for (size_t index = 0; index < fileDatas.size(); ++index) {
+            if (auto record = readRecordFromFileData(fileDatas[index], blobDatas[index]))
+                result.append(WTFMove(*record));
+            else
+                RELEASE_LOG(CacheStorage, "%p - CacheStorageDiskStore::readAllRecords fails to decode record from file", this);
+        }
+        callback(WTFMove(result));
+    };
+
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordsDirectory = recordsDirectoryPath().isolatedCopy(), cacheName = m_cacheName.isolatedCopy(), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
+        Vector<Vector<uint8_t>> fileDatas;
+        Vector<Vector<uint8_t>> blobDatas;
+        auto partitionNames = FileSystem::listDirectory(recordsDirectory);
+        for (auto& partitionName : partitionNames) {
+            auto partitionDirectoryPath = FileSystem::pathByAppendingComponent(recordsDirectory, partitionName);
+            auto cacheDirectory = FileSystem::pathByAppendingComponent(partitionDirectoryPath, m_cacheName);
+            for (auto& recordName : FileSystem::listDirectory(cacheDirectory)) {
+                if (recordName.endsWith(blobSuffix))
+                    continue;
+
+                auto recordFile = FileSystem::pathByAppendingComponent(cacheDirectory, recordName);
+                auto fileData = FileSystem::readEntireFile(recordFile);
+                if (fileData) {
+                    fileDatas.append(WTFMove(*fileData));
+                    auto recordBlobFile = recordBlobFilePath(recordFile);
+                    blobDatas.append(valueOrDefault(FileSystem::readEntireFile(recordBlobFile)));
+                }
+            }
+        }
+
+        m_callbackQueue->dispatch([fileDatas = crossThreadCopy(WTFMove(fileDatas)), blobDatas = crossThreadCopy(WTFMove(blobDatas)), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
+            didReadRecordFiles(WTFMove(fileDatas), WTFMove(blobDatas));
+        });
+    });
+}
+
+void CacheStorageDiskStore::readRecords(const Vector<CacheStorageRecordInformation>& recordInfos, ReadRecordsCallback&& callback)
+{
+    auto recordFiles = WTF::map(recordInfos, [this](const auto& recordInfo) {
+        return recordFilePath(recordInfo.key);
+    });
+
+    auto didReadRecordFiles = [this, protectedThis = Ref { *this }, recordInfos, callback = WTFMove(callback)](auto fileDatas, auto blobDatas) mutable {
+        ASSERT(recordInfos.size() == fileDatas.size());
+        ASSERT(recordInfos.size() == blobDatas.size());
+
+        Vector<std::optional<CacheStorageRecord>> result;
+        for (size_t index = 0; index < recordInfos.size(); ++index) {
+            auto record = readRecordFromFileData(fileDatas[index], blobDatas[index]);
+            if (record) {
+                auto recordInfo = recordInfos[index];
+                if (recordInfo.insertionTime != record->info.insertionTime || recordInfo.size != record->info.size || recordInfo.url != record->info.url)
+                    record = std::nullopt;
+                else if (recordFilePath(recordInfo.key) != recordFilePath(record->info.key))
+                    record = std::nullopt;
+                else {
+                    record->info.identifier = recordInfo.identifier;
+                    record->info.updateResponseCounter = recordInfo.updateResponseCounter;
+                }
+            } else
+                RELEASE_LOG(CacheStorage, "%p - CacheStorageDiskStore::readRecords fails to decode record from file", this);
+
+            result.append(WTFMove(record));
+        }
+        callback(WTFMove(result));
+    };
+
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
+        Vector<Vector<uint8_t>> fileDatas;
+        Vector<Vector<uint8_t>> blobDatas;
+        for (auto& recordFile : recordFiles) {
+            auto fileData = valueOrDefault(FileSystem::readEntireFile(recordFile));
+            auto blobData = fileData.isEmpty()? Vector<uint8_t> { } : valueOrDefault(FileSystem::readEntireFile(recordBlobFilePath(recordFile)));
+            fileDatas.append(WTFMove(fileData));
+            blobDatas.append(WTFMove(blobData));
+        }
+
+        m_callbackQueue->dispatch([fileDatas = crossThreadCopy(WTFMove(fileDatas)), blobDatas = crossThreadCopy(WTFMove(blobDatas)), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
+            didReadRecordFiles(WTFMove(fileDatas), WTFMove(blobDatas));
+        });
+    });
+}
+
+void CacheStorageDiskStore::deleteRecords(const Vector<CacheStorageRecordInformation>& recordInfos, WriteRecordsCallback&& callback)
+{
+    auto recordFiles = WTF::map(recordInfos, [&](auto recordInfo) {
+        return recordFilePath(recordInfo.key);
+    });
+
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = WTFMove(recordFiles), callback = WTFMove(callback)]() mutable {
+        bool result = true;
+        for (auto recordFile : recordFiles) {
+            FileSystem::deleteFile(recordBlobFilePath(recordFile));
+            FileSystem::deleteFile(recordFile);
+            // FIXME: we should probably stop writing and revert changes when result becomes false.
+            if (FileSystem::fileExists(recordFile))
+                result = false;
+        }
+
+        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), result, callback = WTFMove(callback)]() mutable {
+            callback(WTFMove(result));
+        });
+    });
+}
+
+static Vector<uint8_t> encodeRecordHeader(CacheStorageRecord&& record)
+{
+    WTF::Persistence::Encoder encoder;
+    encoder << record.info.insertionTime;
+    encoder << record.info.size;
+    encoder << record.requestHeadersGuard;
+    encoder << record.request;
+    record.options.encodePersistent(encoder);
+    encoder << record.referrer;
+    encoder << record.responseHeadersGuard;
+    encoder << WebCore::ResourceResponse::fromCrossThreadData(WTFMove(record.responseData));
+    encoder << record.responseBodySize;
+    encoder.encodeChecksum();
+
+    return { encoder.buffer(), encoder.bufferSize() };
+}
+
+static Vector<uint8_t> encodeRecordBody(const CacheStorageRecord& record)
+{
+    return WTF::switchOn(record.responseBody, [](const Ref<WebCore::FormData>& formData) {
+        // FIXME: Store form data body.
+        return Vector<uint8_t> { };
+    }, [&](const Ref<WebCore::SharedBuffer>& buffer) {
+        return Vector<uint8_t> { buffer->data(), buffer->size() };
+    }, [](const std::nullptr_t&) {
+        return Vector<uint8_t> { };
+    });
+}
+
+static Vector<uint8_t> encodeRecord(const NetworkCache::Key& key, const Vector<uint8_t>& headerData, bool isBodyInline, const Vector<uint8_t>& bodyData, const SHA1::Digest& bodyHash, FileSystem::Salt salt)
+{
+    WTF::Persistence::Encoder encoder;
+    encoder << currentVersion;
+    encoder << key;
+    encoder << WallTime { };
+    encoder << computeSHA1(headerData.span(), salt);
+    encoder << (uint64_t)headerData.size();
+    encoder << bodyHash;
+    encoder << (uint64_t)bodyData.size();
+    encoder << isBodyInline;
+    encoder.encodeChecksum();
+
+    auto metaData = Vector<uint8_t> { encoder.buffer(), encoder.bufferSize() };
+    Vector<uint8_t> result;
+    result.appendVector(metaData);
+    result.appendVector(headerData);
+
+    StringBuilder sb;
+    for (auto& data : bodyData) {
+        sb.append(data);
+        sb.append(",");
+    }
+    
+    if (isBodyInline)
+        result.appendVector(bodyData);
+
+    return result;
+}
+
+void CacheStorageDiskStore::writeRecords(Vector<CacheStorageRecord>&& records, WriteRecordsCallback&& callback)
+{
+    Vector<String> recordFiles;
+    Vector<Vector<uint8_t>> recordDatas;
+    Vector<Vector<uint8_t>> recordBlobDatas;
+    for (auto&& record : records) {
+        recordFiles.append(recordFilePath(record.info.key));
+        auto bodyData = encodeRecordBody(record);
+        auto bodyHash = computeSHA1(bodyData.span(), m_salt);
+        bool shouldCreateBlob = shouldStoreBodyAsBlob(bodyData);
+        auto headerData = encodeRecordHeader(WTFMove(record));
+        auto recordData = encodeRecord(record.info.key, headerData, !shouldCreateBlob, bodyData, bodyHash, m_salt);
+        recordDatas.append(WTFMove(recordData));
+        if (!shouldCreateBlob)
+            bodyData = { };
+        recordBlobDatas.append(WTFMove(bodyData));
+    }
+
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = WTFMove(recordFiles), recordDatas = WTFMove(recordDatas), recordBlobDatas = WTFMove(recordBlobDatas), callback = WTFMove(callback)]() mutable {
+        bool result = true;
+        // FIXME: we should probably stop writing and revert changes when result becomes false.
+        for (size_t index = 0; index < recordFiles.size(); ++index) {
+            auto recordFile = recordFiles[index];
+            auto recordData = recordDatas[index];
+            auto recordBlobData = recordBlobDatas[index];
+            FileSystem::makeAllDirectories(FileSystem::parentPath(recordFile));
+            if (!recordBlobData.isEmpty())  {
+                if (FileSystem::overwriteEntireFile(recordBlobFilePath(recordFile), Span { recordBlobData.data(), recordBlobData.size() }) == -1) {
+                    result = false;
+                    continue;
+                }
+            }
+            if (FileSystem::overwriteEntireFile(recordFile, Span { recordData.data(), recordData.size() }) == -1)
+                result = false;
+        }
+
+        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), result, callback = WTFMove(callback)]() mutable {
+            callback(WTFMove(result));
+        });
+    });
+}
+
+} // namespace WebKit
+

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CacheStorageStore.h"
+#include "NetworkCacheKey.h"
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class CacheStorageDiskStore final : public CacheStorageStore {
+public:
+    static Ref<CacheStorageDiskStore> create(const String& cacheName, const String& path, Ref<WorkQueue>&&);
+
+private:
+    CacheStorageDiskStore(const String& cacheName, const String& path, Ref<WorkQueue>&&);
+
+    // CacheStorageStore
+    void readAllRecords(ReadAllRecordsCallback&&) final;
+    void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) final;
+    void deleteRecords(const Vector<CacheStorageRecordInformation>&, WriteRecordsCallback&&) final;
+    void writeRecords(Vector<CacheStorageRecord>&&, WriteRecordsCallback&&) final;
+
+    String versionDirectoryPath() const;
+    String saltFilePath() const;
+    String recordsDirectoryPath() const;
+    String recordFilePath(const NetworkCache::Key&) const;
+    String recordBlobFilePath(const String&) const;
+    String blobsDirectoryPath() const;
+    String blobFilePath(const String&) const;
+    std::optional<CacheStorageRecord> readRecordFromFileData(const Vector<uint8_t>&, const Vector<uint8_t>&);
+
+    String m_cacheName;
+    String m_path;
+    FileSystem::Salt m_salt;
+    Ref<WorkQueue> m_callbackQueue;
+    Ref<WorkQueue> m_ioQueue;
+};
+
+}
+

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -1,0 +1,504 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CacheStorageManager.h"
+
+#include "CacheStorageCache.h"
+#include "CacheStorageRegistry.h"
+#include "StorageUtilities.h"
+#include <WebCore/ClientOrigin.h>
+#include <wtf/CallbackAggregator.h>
+#include <wtf/Scope.h>
+#include <wtf/persistence/PersistentEncoder.h>
+#include <wtf/text/StringToIntegerConversion.h>
+
+namespace WebKit {
+
+static constexpr auto cachesListFileName = "cacheslist"_s;
+static constexpr auto sizeFileName = "estimatedsize"_s;
+static constexpr auto originFileName = "origin"_s;
+
+static uint64_t nextUpdateNumber()
+{
+    static std::atomic<uint64_t> currentUpdateNumber;
+    return ++currentUpdateNumber;
+}
+
+static std::optional<Vector<std::pair<String, String>>> readCachesList(const String& cachesListDirectoryPath)
+{
+    Vector<std::pair<String, String>> result;
+    if (cachesListDirectoryPath.isEmpty())
+        return result;
+
+    auto cachesListFilePath = FileSystem::pathByAppendingComponent(cachesListDirectoryPath, cachesListFileName);
+    if (!FileSystem::fileExists(cachesListFilePath))
+        return result;
+
+    auto cachesListHandle = FileSystem::openFile(cachesListFilePath, FileSystem::FileOpenMode::ReadWrite);
+    if (!FileSystem::isHandleValid(cachesListHandle))
+        return std::nullopt;
+    auto closeFileOnExit = makeScopeExit([&cachesListHandle]() mutable {
+        FileSystem::closeFile(cachesListHandle);
+    });
+
+    auto cachesList = FileSystem::readEntireFile(cachesListHandle);
+    if (!cachesList)
+        return std::nullopt;
+
+    WTF::Persistence::Decoder decoder({ cachesList->data(), cachesList->size() });
+    std::optional<uint64_t> count;
+    decoder >> count;
+    if (!count)
+        return std::nullopt;
+
+    result.reserveInitialCapacity(*count);
+    for (size_t index = 0; index < *count; ++index) {
+        std::optional<String> name;
+        decoder >> name;
+        if (!name)
+            return std::nullopt;
+
+        std::optional<String> uniqueName;
+        decoder >> uniqueName;
+        if (!uniqueName)
+            return std::nullopt;
+
+        result.uncheckedAppend({ WTFMove(*name), WTFMove(*uniqueName) });
+    }
+
+    return result;
+}
+
+static bool writeCachesList(const String& cachesListDirectoryPath, const Vector<std::unique_ptr<CacheStorageCache>>& caches, std::optional<size_t> skippedCachesIndex = std::nullopt)
+{
+    if (cachesListDirectoryPath.isEmpty())
+        return true;
+
+    auto cachesListFilePath = FileSystem::pathByAppendingComponent(cachesListDirectoryPath, cachesListFileName);
+    if (caches.isEmpty()) {
+        FileSystem::deleteFile(cachesListFilePath);
+        return true;
+    }
+
+    FileSystem::makeAllDirectories(FileSystem::parentPath(cachesListFilePath));
+    auto cachesListHandle = FileSystem::openFile(cachesListFilePath, FileSystem::FileOpenMode::ReadWrite);
+    if (!FileSystem::isHandleValid(cachesListHandle))
+        return false;
+    auto closeFileOnExit = makeScopeExit([&cachesListHandle]() mutable {
+        FileSystem::closeFile(cachesListHandle);
+    });
+
+    if (!FileSystem::truncateFile(cachesListHandle, 0))
+        return false;
+
+    WTF::Persistence::Encoder encoder;
+    uint64_t count = caches.size();
+    if (skippedCachesIndex && *skippedCachesIndex < caches.size())
+        --count;
+    encoder << count;
+    for (size_t index = 0; index < caches.size(); ++index) {
+        if (skippedCachesIndex && index == *skippedCachesIndex)
+            continue;
+        encoder << caches[index]->name();
+        encoder << caches[index]->uniqueName();
+    }
+    FileSystem::writeToFile(cachesListHandle, encoder.buffer(), encoder.bufferSize());
+    return true;
+}
+
+static std::optional<uint64_t> readSizeFile(const String& sizeDirectoryPath)
+{
+    if (sizeDirectoryPath.isEmpty())
+        return std::nullopt;
+
+    auto sizeFilePath = FileSystem::pathByAppendingComponent(sizeDirectoryPath, sizeFileName);
+    if (!FileSystem::fileExists(sizeFilePath))
+        return std::nullopt;
+
+    auto buffer = FileSystem::readEntireFile(sizeFilePath);
+    if (!buffer)
+        return std::nullopt;
+
+    return parseInteger<uint64_t>({ buffer->data(), static_cast<unsigned>(buffer->size()) });
+}
+
+static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)
+{
+    if (sizeDirectoryPath.isEmpty())
+        return true;
+
+    auto sizeFilePath = FileSystem::pathByAppendingComponent(sizeDirectoryPath, sizeFileName);
+    auto value = String::number(size).utf8();
+    return FileSystem::overwriteEntireFile(sizeFilePath, Span { reinterpret_cast<uint8_t*>(const_cast<char*>(value.data())), value.length() }) != -1;
+}
+
+FileSystem::Salt CacheStorageManager::cacheStorageSalt(const String& rootDirectory)
+{
+    if (rootDirectory.isEmpty())
+        return { };
+
+    String saltPath = FileSystem::pathByAppendingComponent(rootDirectory, "salt"_s);
+    auto optionalSalt = FileSystem::readOrMakeSalt(saltPath);
+    if (optionalSalt) {
+        StringBuilder sb;
+        for (auto number : *optionalSalt) {
+            sb.append(number);
+            sb.append(',');
+        }
+    }
+    return valueOrDefault(optionalSalt);
+}
+
+String CacheStorageManager::cacheStorageOriginDirectory(const String& rootDirectory, FileSystem::Salt salt, const WebCore::ClientOrigin& origin)
+{
+    if (rootDirectory.isEmpty())
+        return emptyString();
+
+    NetworkCache::Key key(origin.topOrigin.toString(), origin.clientOrigin.toString(), { }, { }, salt);
+    return FileSystem::pathByAppendingComponent(rootDirectory, key.hashAsString());
+}
+
+HashSet<WebCore::ClientOrigin> CacheStorageManager::originsOfCacheStorageData(const String& rootDirectory)
+{
+    HashSet<WebCore::ClientOrigin> result;
+    for (auto& originName : FileSystem::listDirectory(rootDirectory)) {
+        auto originFile = FileSystem::pathByAppendingComponents(rootDirectory, { originName, originFileName });
+        if (auto origin = readOriginFromFile(originFile))
+            result.add(*origin);
+    }
+
+    return result;
+}
+
+static uint64_t getDirectorySize(const String& originDirectory)
+{
+    uint64_t directorySize = 0;
+    Deque<String> paths;
+    paths.append(originDirectory);
+    while (!paths.isEmpty()) {
+        auto path = paths.takeFirst();
+        if (FileSystem::fileType(path) == FileSystem::FileType::Directory) {
+            auto fileNames = FileSystem::listDirectory(path);
+            for (auto& fileName : fileNames) {
+                // Files in /Blobs directory are hard link.
+                if (fileName == "Blobs"_s)
+                    continue;
+                paths.append(FileSystem::pathByAppendingComponent(path, fileName));
+            }
+            continue;
+        }
+        directorySize += FileSystem::fileSize(path).value_or(0);
+    }
+    return directorySize;
+}
+
+uint64_t CacheStorageManager::cacheStorageSize(const String& originDirectory)
+{
+    if (auto sizeFromFile = readSizeFile(originDirectory))
+        return *sizeFromFile;
+
+    return getDirectorySize(originDirectory);
+}
+
+bool CacheStorageManager::hasCacheList(const String& cacheStorageDirectory)
+{
+    return FileSystem::fileExists(FileSystem::pathByAppendingComponent(cacheStorageDirectory, cachesListFileName));
+}
+
+void CacheStorageManager::makeDirty()
+{
+    m_updateCounter = nextUpdateNumber();
+}
+
+CacheStorageManager::CacheStorageManager(const String& path, FileSystem::Salt salt, CacheStorageRegistry& registry, const WebCore::ClientOrigin& origin, QuotaCheckFunction&& quotaCheckFunction, Ref<WorkQueue>&& queue)
+    : m_updateCounter(nextUpdateNumber())
+    , m_path(path)
+    , m_salt(salt)
+    , m_registry(registry)
+    , m_quotaCheckFunction(WTFMove(quotaCheckFunction))
+    , m_queue(WTFMove(queue))
+{
+    if (!m_path.isEmpty()) {
+        auto originFile = FileSystem::pathByAppendingComponent(m_path, originFileName);
+        writeOriginToFile(originFile, origin);
+    }
+}
+
+CacheStorageManager::~CacheStorageManager()
+{
+    for (auto& request : m_pendingSpaceRequests)
+        request.second(false);
+
+    for (auto& cache : m_caches)
+        m_registry.unregisterCache(cache->identifier());
+
+    for (auto& identifier : m_removedCaches.keys())
+        m_registry.unregisterCache(identifier);
+}
+
+bool CacheStorageManager::initializeCaches()
+{
+    if (m_isInitialized)
+        return true;
+
+    auto cachesList = readCachesList(m_path);
+    if (!cachesList)
+        return false;
+
+    m_isInitialized = true;
+    for (auto& [name, uniqueName] : *cachesList) {
+        auto cache = makeUnique<CacheStorageCache>(*this, name, uniqueName, m_path, m_queue.copyRef());
+        m_registry.registerCache(cache->identifier(), *cache.get());
+        m_caches.append(WTFMove(cache));
+    }
+
+    return true;
+}
+
+void CacheStorageManager::openCache(const String& name, WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
+{
+    if (!initializeCaches())
+        return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::ReadDisk));
+
+    auto index = m_caches.findIf([&](auto& cache) {
+        return cache->name() == name;
+    });
+    if (index != notFound)
+        return m_caches[index]->open(WTFMove(callback));
+
+    m_caches.append(makeUnique<CacheStorageCache>(*this, name, createVersion4UUIDString(), m_path, m_queue.copyRef()));
+    bool written = writeCachesList(m_path, m_caches);
+    if (!written) {
+        m_caches.removeLast();
+        return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::WriteDisk));
+    }
+
+    makeDirty();
+    auto& cache = m_caches.last();
+    m_registry.registerCache(cache->identifier(), *cache);
+    cache->open(WTFMove(callback));
+}
+
+void CacheStorageManager::removeCache(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
+{
+    auto index = m_caches.findIf([&](auto& cache) {
+        return cache->identifier() == cacheIdentifier;
+    });
+    if (index == notFound)
+        return callback(false);
+
+    if (!writeCachesList(m_path, m_caches, index))
+        return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::WriteDisk));
+
+    makeDirty();
+    m_removedCaches.set(cacheIdentifier, WTFMove(m_caches[index]));
+    m_caches.remove(index);
+    return callback(true);
+}
+
+void CacheStorageManager::allCaches(uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&& callback)
+{
+    if (!initializeCaches())
+        return callback(makeUnexpected(WebCore::DOMCacheEngine::Error::ReadDisk));
+
+    auto cacheInfos = WTF::map(m_caches, [](const auto& cache) {
+        return WebCore::DOMCacheEngine::CacheInfo { cache->identifier(), cache->name() };
+    });
+    auto callbackAggregator = CallbackAggregator::create([callback = WTFMove(callback), cacheInfos = WTFMove(cacheInfos), updateCounter = m_updateCounter]() mutable {
+        callback(WebCore::DOMCacheEngine::CacheInfos { WTFMove(cacheInfos), updateCounter });
+    });
+    for (auto& cache : m_caches)
+        cache->open([callbackAggregator](auto) { });
+}
+
+void CacheStorageManager::initializeCacheSize(CacheStorageCache& cache)
+{
+    cache.getSize([this, weakThis = WeakPtr { *this }](auto size) mutable {
+        if (!weakThis)
+            return;
+
+        m_pendingSize.first += size;
+        if (!--m_pendingSize.second)
+            finishInitializingSize();
+    });
+}
+
+void CacheStorageManager::finishInitializingSize()
+{
+    m_size = std::exchange(m_pendingSize.first, 0);
+    writeSizeFile(m_path, *m_size);
+
+    while (!m_pendingSpaceRequests.isEmpty()) {
+        auto [size, callback] = m_pendingSpaceRequests.takeFirst();
+        m_quotaCheckFunction(size, WTFMove(callback));
+    }
+}
+
+void CacheStorageManager::requestSpaceAfterInitializingSize(uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (m_size)
+        return m_quotaCheckFunction(spaceRequested, WTFMove(completionHandler));
+
+    m_pendingSpaceRequests.append({ spaceRequested, WTFMove(completionHandler) });
+    if (m_pendingSpaceRequests.size() > 1)
+        return;
+
+    m_pendingSize = { 0, m_caches.size() + m_removedCaches.size() };
+    for (auto& cache : m_caches)
+        initializeCacheSize(*cache);
+
+    for (auto& cache : m_removedCaches.values())
+        initializeCacheSize(*cache);
+}
+
+void CacheStorageManager::requestSpace(uint64_t size, CompletionHandler<void(bool)>&& completionHandler)
+{
+    requestSpaceAfterInitializingSize(size, WTFMove(completionHandler));
+}
+
+void CacheStorageManager::sizeIncreased(uint64_t amount)
+{
+    if (!m_size || !amount)
+        return;
+
+    m_size = *m_size + amount;
+    writeSizeFile(m_path, *m_size);
+}
+
+void CacheStorageManager::sizeDecreased(uint64_t amount)
+{
+    if (!m_size || !amount)
+        return;
+
+    m_size = *m_size - amount;
+    writeSizeFile(m_path, *m_size);
+}
+
+void CacheStorageManager::reference(IPC::Connection::UniqueID connection, WebCore::DOMCacheIdentifier cacheIdentifier)
+{
+    auto& references = m_cacheRefConnections.ensure(cacheIdentifier, []() {
+        return Vector<IPC::Connection::UniqueID> { };
+    }).iterator->value;
+    references.append(connection);
+}
+
+void CacheStorageManager::dereference(IPC::Connection::UniqueID connection, WebCore::DOMCacheIdentifier cacheIdentifier)
+{
+    auto iter = m_cacheRefConnections.find(cacheIdentifier);
+    if (iter == m_cacheRefConnections.end())
+        return;
+
+    auto& refConnections = iter->value;
+    auto index = refConnections.findIf([&](auto& refConnection) {
+        return refConnection == connection;
+    });
+    if (index == notFound)
+        return;
+
+    refConnections.remove(index);
+    if (!refConnections.isEmpty())
+        return;
+
+    removeUnusedCache(cacheIdentifier);
+}
+
+void CacheStorageManager::connectionClosed(IPC::Connection::UniqueID connection)
+{
+    HashSet<WebCore::DOMCacheIdentifier> unusedCacheIdentifers;
+    for (auto& [identifier, refConnections] : m_cacheRefConnections) {
+        refConnections.removeAllMatching([&](auto refConnection) {
+            return refConnection == connection;
+        });
+        if (refConnections.isEmpty()) {
+            removeUnusedCache(identifier);
+            unusedCacheIdentifers.add(identifier);
+        }
+    }
+
+    for (auto& identifier : unusedCacheIdentifers)
+        m_cacheRefConnections.remove(identifier);
+}
+
+void CacheStorageManager::removeUnusedCache(WebCore::DOMCacheIdentifier cacheIdentifier)
+{
+    auto cache = m_removedCaches.take(cacheIdentifier);
+    if (cache) {
+        cache->removeAllRecords();
+        return;
+    }
+
+    for (auto& cache : m_caches) {
+        if (cache->identifier() == cacheIdentifier) {
+            cache->close();
+            return;
+        }
+    }
+}
+
+bool CacheStorageManager::hasDataInMemory()
+{
+    // Cache data is stored on disk.
+    if (!m_path.isEmpty())
+        return false;
+
+    return !m_caches.isEmpty() || !m_removedCaches.isEmpty();
+}
+
+bool CacheStorageManager::isActive()
+{
+    return !m_cacheRefConnections.isEmpty();
+}
+
+String CacheStorageManager::representationString()
+{
+    StringBuilder builder;
+    builder.append("{ \"persistent\": [");
+
+    bool isFirst = true;
+    for (auto& cache : m_caches) {
+        if (!isFirst)
+            builder.append(", ");
+        isFirst = false;
+        builder.append("\"");
+        builder.append(cache->name());
+        builder.append("\"");
+    }
+
+    builder.append("], \"removed\": [");
+    isFirst = true;
+    for (auto& cache : m_removedCaches.values()) {
+        if (!isFirst)
+            builder.append(", ");
+        isFirst = false;
+        builder.append("\"");
+        builder.append(cache->name());
+        builder.append("\"");
+    }
+    builder.append("]}\n");
+    return builder.toString();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Connection.h"
+#include <WebCore/DOMCacheEngine.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+struct ClientOrigin;
+}
+
+namespace WebKit {
+class CacheStorageCache;
+class CacheStorageRegistry;
+class CacheStorageStore;
+struct CacheStorageRecord;
+struct CacheStorageRecordInformation;
+
+
+class CacheStorageManager : public CanMakeWeakPtr<CacheStorageManager> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static FileSystem::Salt cacheStorageSalt(const String& rootDirectory);
+    static String cacheStorageOriginDirectory(const String& rootDirectory, FileSystem::Salt, const WebCore::ClientOrigin&);
+    static HashSet<WebCore::ClientOrigin> originsOfCacheStorageData(const String& rootDirectory);
+    static uint64_t cacheStorageSize(const String& originDirectory);
+    static bool hasCacheList(const String& cacheListDirectory);
+
+    using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
+    CacheStorageManager(const String& path, FileSystem::Salt, CacheStorageRegistry&, const WebCore::ClientOrigin&, QuotaCheckFunction&&, Ref<WorkQueue>&&);
+    ~CacheStorageManager();
+    void openCache(const String& name, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
+    void removeCache(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
+    void allCaches(uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
+    void reference(IPC::Connection::UniqueID, WebCore::DOMCacheIdentifier);
+    void dereference(IPC::Connection::UniqueID, WebCore::DOMCacheIdentifier);
+
+    void connectionClosed(IPC::Connection::UniqueID);
+    bool hasDataInMemory();
+    bool isActive();
+    String representationString();
+    FileSystem::Salt salt() const { return m_salt; }
+    void requestSpace(uint64_t size, CompletionHandler<void(bool)>&&);
+    void sizeIncreased(uint64_t amount);
+    void sizeDecreased(uint64_t amount);
+
+private:
+    void makeDirty();
+    bool initializeCaches();
+    void removeUnusedCache(WebCore::DOMCacheIdentifier);
+    void initializeCacheSize(CacheStorageCache&);
+    void finishInitializingSize();
+    void requestSpaceAfterInitializingSize(uint64_t size, CompletionHandler<void(bool)>&&);
+
+    bool m_isInitialized { false };
+    uint64_t m_updateCounter;
+    std::optional<uint64_t> m_size;
+    std::pair<uint64_t, size_t> m_pendingSize;
+    String m_path;
+    FileSystem::Salt m_salt;
+    CacheStorageRegistry& m_registry;
+    QuotaCheckFunction m_quotaCheckFunction;
+    Vector<std::unique_ptr<CacheStorageCache>> m_caches;
+    HashMap<WebCore::DOMCacheIdentifier, std::unique_ptr<CacheStorageCache>> m_removedCaches;
+    HashMap<WebCore::DOMCacheIdentifier, Vector<IPC::Connection::UniqueID>> m_cacheRefConnections;
+    Ref<WorkQueue> m_queue;
+    Deque<std::pair<uint64_t, CompletionHandler<void(bool)>>> m_pendingSpaceRequests;
+};
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CacheStorageMemoryStore.h"
+
+#include <WebCore/DOMCacheEngine.h>
+
+namespace WebKit {
+
+Ref<CacheStorageMemoryStore> CacheStorageMemoryStore::create()
+{
+    return adoptRef(*new CacheStorageMemoryStore);
+}
+
+void CacheStorageMemoryStore::readAllRecords(ReadAllRecordsCallback&& callback)
+{
+    callback(WTF::map(m_records.values(), [](const auto& record) {
+        RELEASE_ASSERT(record);
+        return record->copy();
+    }));
+}
+
+void CacheStorageMemoryStore::readRecords(const Vector<CacheStorageRecordInformation>& recordInfos, ReadRecordsCallback&& callback)
+{
+    auto result = WTF::map(recordInfos, [&](auto& recordInfo) -> std::optional<CacheStorageRecord> {
+        auto iterator = m_records.find(recordInfo.identifier);
+        if (iterator == m_records.end())
+            return std::nullopt;
+        return { iterator->value->copy() };
+    });
+    return callback(WTFMove(result));
+}
+
+void CacheStorageMemoryStore::deleteRecords(const Vector<CacheStorageRecordInformation>& recordInfos, WriteRecordsCallback&& callback)
+{
+    for (auto& recordInfo : recordInfos)
+        m_records.remove(recordInfo.identifier);
+
+    callback(true);
+}
+
+void CacheStorageMemoryStore::writeRecords(Vector<CacheStorageRecord>&& records, WriteRecordsCallback&& callback)
+{
+    for (auto&& record : records)
+        m_records.set(record.info.identifier, makeUnique<CacheStorageRecord>(WTFMove(record)));
+
+    callback(true);
+}
+
+}
+

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CacheStorageRecord.h"
+#include "CacheStorageStore.h"
+#include "NetworkCacheKey.h"
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class CacheStorageMemoryStore final : public CacheStorageStore {
+public:
+    static Ref<CacheStorageMemoryStore> create();
+
+private:
+    CacheStorageMemoryStore() = default;
+    // CacheStorageStore
+    void readAllRecords(ReadAllRecordsCallback&&) final;
+    void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) final;
+    void deleteRecords(const Vector<CacheStorageRecordInformation>&, WriteRecordsCallback&&) final;
+    void writeRecords(Vector<CacheStorageRecord>&&, WriteRecordsCallback&&) final;
+
+    HashMap<uint64_t, std::unique_ptr<CacheStorageRecord>> m_records;
+};
+
+}

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include "NetworkCacheKey.h"
+#include <WebCore/DOMCacheEngine.h>
+#include <WebCore/HTTPParsers.h>
+
+namespace WebKit {
+
+struct CacheStorageRecordInformation {
+    void updateVaryHeaders(const WebCore::ResourceRequest& request, const String& varyValue)
+    {
+        if (varyValue.isNull()) {
+            hasVaryStar = false;
+            varyHeaders = { };
+            return;
+        }
+
+        varyValue.split(',', [&](StringView view) {
+            if (!hasVaryStar && WebCore::stripLeadingAndTrailingHTTPSpaces(view) == "*"_s)
+                hasVaryStar = true;
+            varyHeaders.add(view.toString(), request.httpHeaderField(view));
+        });
+
+        if (hasVaryStar)
+            varyHeaders = { };
+    }
+
+    NetworkCache::Key key;
+    double insertionTime { 0 };
+    uint64_t identifier { 0 };
+    uint64_t updateResponseCounter { 0 };
+    uint64_t size { 0 };
+    URL url;
+    bool hasVaryStar { false };
+    HashMap<String, String> varyHeaders;
+};
+
+struct CacheStorageRecord {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    CacheStorageRecord(const CacheStorageRecord&) = delete;
+    CacheStorageRecord& operator=(const CacheStorageRecord&) = delete;
+    CacheStorageRecord() = default;
+    CacheStorageRecord(CacheStorageRecord&&) = default;
+    CacheStorageRecord& operator=(CacheStorageRecord&&) = default;
+    CacheStorageRecord(const CacheStorageRecordInformation& info, WebCore::FetchHeaders::Guard requestHeadersGuard, const WebCore::ResourceRequest& request, WebCore::FetchOptions options, const String& referrer, WebCore::FetchHeaders::Guard responseHeadersGuard, WebCore::ResourceResponse::CrossThreadData&& responseData, uint64_t responseBodySize, WebCore::DOMCacheEngine::ResponseBody&& responseBody)
+        : info(info)
+        , requestHeadersGuard(requestHeadersGuard)
+        , request(request)
+        , options(options)
+        , referrer(referrer)
+        , responseHeadersGuard(responseHeadersGuard)
+        , responseData(WTFMove(responseData))
+        , responseBodySize(responseBodySize)
+        , responseBody(WTFMove(responseBody))
+    {
+    }
+
+    CacheStorageRecord copy() const
+    {
+        return CacheStorageRecord { info, requestHeadersGuard, request, options, referrer, responseHeadersGuard, responseData.copy(), responseBodySize, WebCore::DOMCacheEngine::copyResponseBody(responseBody) };
+    }
+
+    CacheStorageRecordInformation info;
+    WebCore::FetchHeaders::Guard requestHeadersGuard;
+    WebCore::ResourceRequest request;
+    WebCore::FetchOptions options;
+    String referrer;
+    WebCore::FetchHeaders::Guard responseHeadersGuard;
+    WebCore::ResourceResponse::CrossThreadData responseData;
+    uint64_t responseBodySize;
+    WebCore::DOMCacheEngine::ResponseBody responseBody;
+};
+
+}

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CacheStorageRegistry.h"
+
+#include "CacheStorageCache.h"
+
+namespace WebKit {
+
+CacheStorageRegistry::CacheStorageRegistry() = default;
+
+void CacheStorageRegistry::registerCache(WebCore::DOMCacheIdentifier identifier, CacheStorageCache& cache)
+{
+    ASSERT(!m_caches.contains(identifier));
+
+    m_caches.add(identifier, cache);
+}
+
+void CacheStorageRegistry::unregisterCache(WebCore::DOMCacheIdentifier identifier)
+{
+    ASSERT(m_caches.contains(identifier));
+
+    m_caches.remove(identifier);
+}
+
+CacheStorageCache* CacheStorageRegistry::cache(WebCore::DOMCacheIdentifier identifier)
+{
+    return m_caches.get(identifier).get();
+}
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/DOMCacheIdentifier.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+class CacheStorageCache;
+
+class CacheStorageRegistry {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    CacheStorageRegistry();
+    void registerCache(WebCore::DOMCacheIdentifier, CacheStorageCache&);
+    void unregisterCache(WebCore::DOMCacheIdentifier);
+    CacheStorageCache* cache(WebCore::DOMCacheIdentifier);
+
+private:
+    HashMap<WebCore::DOMCacheIdentifier, WeakPtr<CacheStorageCache>> m_caches;
+};
+
+}

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+
+namespace WebKit {
+
+struct CacheStorageRecord;
+struct CacheStorageRecordInformation;
+
+class CacheStorageStore : public RefCounted<CacheStorageStore> {
+public:
+    virtual ~CacheStorageStore() = default;
+    using ReadAllRecordsCallback = CompletionHandler<void(Vector<CacheStorageRecord>&&)>;
+    using ReadRecordsCallback = CompletionHandler<void(Vector<std::optional<CacheStorageRecord>>&&)>;
+    using WriteRecordsCallback = CompletionHandler<void(bool)>;
+    virtual void readAllRecords(ReadAllRecordsCallback&&) = 0;
+    virtual void readRecords(const Vector<CacheStorageRecordInformation>&, ReadRecordsCallback&&) = 0;
+    virtual void deleteRecords(const Vector<CacheStorageRecordInformation>&, WriteRecordsCallback&&) = 0;
+    virtual void writeRecords(Vector<CacheStorageRecord>&&, WriteRecordsCallback&&) = 0;
+
+protected:
+    CacheStorageStore() = default;
+};
+
+} // namespace WebKit
+

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -36,6 +36,7 @@
 #include "WebsiteData.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/ClientOrigin.h>
+#include <WebCore/DOMCacheEngine.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemSyncAccessHandleIdentifier.h>
 #include <WebCore/IDBResourceIdentifier.h>
@@ -62,6 +63,7 @@ struct IDBGetRecordData;
 struct IDBGetAllRecordsData;
 struct IDBIterateCursorData;
 struct IDBKeyRangeData;
+struct RetrieveRecordsOptions;
 enum class StorageType : uint8_t;
 }
 
@@ -180,6 +182,18 @@ private:
     void iterateCursor(const WebCore::IDBRequestData&, const WebCore::IDBIterateCursorData&);
     void getAllDatabaseNamesAndVersions(IPC::Connection&, const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&);
 
+    // Message handlers for CacheStorage.
+    void cacheStorageOpenCache(const WebCore::ClientOrigin&, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);
+    void cacheStorageRemoveCache(WebCore::DOMCacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&&);
+    void cacheStorageAllCaches(const WebCore::ClientOrigin&, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&&);
+    void cacheStorageReference(IPC::Connection&, WebCore::DOMCacheIdentifier);
+    void cacheStorageDereference(IPC::Connection&, WebCore::DOMCacheIdentifier);
+    void cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::RecordsCallback&&);
+    void cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void cacheStoragePutRecords(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::Record>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
+    void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Error>&&)>&&);
+    void cacheStorageRepresentation(CompletionHandler<void(String&&)>&&);
+
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
 
     PAL::SessionID m_sessionID;
@@ -192,6 +206,7 @@ private:
     std::unique_ptr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;
     std::unique_ptr<IDBStorageRegistry> m_idbStorageRegistry;
+    std::unique_ptr<CacheStorageRegistry> m_cacheStorageRegistry;
     String m_customLocalStoragePath;
     String m_customIDBStoragePath;
     String m_customCacheStoragePath;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -75,4 +75,15 @@
     OpenCursor(WebCore::IDBRequestData requestData, WebCore::IDBCursorInfo info)
     IterateCursor(WebCore::IDBRequestData requestData, struct WebCore::IDBIterateCursorData data)
     GetAllDatabaseNamesAndVersions(WebCore::IDBResourceIdentifier requestIdentifier, struct WebCore::ClientOrigin origin) WantsConnection
+
+    CacheStorageOpenCache(struct WebCore::ClientOrigin origin, String cacheName) -> (WebCore::DOMCacheEngine::CacheIdentifierOrError result)
+    CacheStorageRemoveCache(WebCore::DOMCacheIdentifier cacheIdentifier) -> (WebCore::DOMCacheEngine::RemoveCacheIdentifierOrError result)
+    CacheStorageAllCaches(struct WebCore::ClientOrigin origin, uint64_t updateCounter) -> (WebCore::DOMCacheEngine::CacheInfosOrError result)
+    CacheStorageReference(WebCore::DOMCacheIdentifier cacheIdentifier) WantsConnection
+    CacheStorageDereference(WebCore::DOMCacheIdentifier cacheIdentifier) WantsConnection
+    CacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::RecordsOrError result)
+    CacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
+    CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::Record> record) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
+    CacheStorageClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::DOMCacheEngine::Error> error)
+    CacheStorageRepresentation() -> (String representation)
 }

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -30,8 +30,14 @@
 #include "WebsiteDataType.h"
 #include <wtf/text/WTFString.h>
 
+namespace WebCore {
+struct ClientOrigin;
+}
+
 namespace WebKit {
 
+class CacheStorageManager;
+class CacheStorageRegistry;
 class FileSystemStorageHandleRegistry;
 class FileSystemStorageManager;
 class IDBStorageManager;
@@ -46,7 +52,7 @@ class OriginStorageManager {
 public:
     static String originFileIdentifier();
 
-    OriginStorageManager(uint64_t quota, QuotaManager::IncreaseQuotaFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& cacheStoragePath, bool shouldUseCustomPaths);
+    OriginStorageManager(uint64_t quota, QuotaManager::IncreaseQuotaFunction&&, String&& path, String&& cusotmLocalStoragePath, String&& customIDBStoragePath, String&& customCacheStoragePath, FileSystem::Salt cacheStorageSalt, bool shouldUseCustomPaths);
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
@@ -61,6 +67,10 @@ public:
     SessionStorageManager* existingSessionStorageManager();
     IDBStorageManager& idbStorageManager(IDBStorageRegistry&);
     IDBStorageManager* existingIDBStorageManager();
+    CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
+    CacheStorageManager* existingCacheStorageManager();
+    uint64_t cacheStorageSize();
+    void closeCacheStorageManager();
     String resolvedPath(WebsiteDataType);
     bool isActive();
     bool isEmpty();
@@ -86,6 +96,7 @@ private:
     String m_customLocalStoragePath;
     String m_customIDBStoragePath;
     String m_cacheStoragePath;
+    FileSystem::Salt m_cacheStorageSalt;
     uint64_t m_quota;
     QuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
     RefPtr<QuotaManager> m_quotaManager;

--- a/Source/WebKit/NetworkProcess/storage/StorageUtilities.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageUtilities.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/ClientOrigin.h>
+#include <WebCore/WebCorePersistentCoders.h>
+#include <wtf/FileSystem.h>
+#include <wtf/Scope.h>
+#include <wtf/persistence/PersistentCoders.h>
+
+namespace WebKit {
+
+static inline std::optional<WebCore::ClientOrigin> readOriginFromFile(const String& filePath)
+{
+    ASSERT(!RunLoop::isMain());
+
+    if (filePath.isEmpty() || !FileSystem::fileExists(filePath))
+        return std::nullopt;
+
+    auto originFileHandle = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Read);
+    auto closeFile = makeScopeExit([&] {
+        FileSystem::closeFile(originFileHandle);
+    });
+
+    if (!FileSystem::isHandleValid(originFileHandle))
+        return std::nullopt;
+
+    auto originContent = FileSystem::readEntireFile(originFileHandle);
+    if (!originContent)
+        return std::nullopt;
+
+    WTF::Persistence::Decoder decoder({ originContent->data(), originContent->size() });
+    std::optional<WebCore::ClientOrigin> origin;
+    decoder >> origin;
+    return origin;
+}
+
+static inline bool writeOriginToFile(const String& filePath, const WebCore::ClientOrigin& origin)
+{
+    if (filePath.isEmpty() || FileSystem::fileExists(filePath))
+        return false;
+
+    FileSystem::makeAllDirectories(FileSystem::parentPath(filePath));
+    auto originFileHandle = FileSystem::openFile(filePath, FileSystem::FileOpenMode::ReadWrite);
+    auto closeFile = makeScopeExit([&] {
+        FileSystem::closeFile(originFileHandle);
+    });
+
+    if (!FileSystem::isHandleValid(originFileHandle)) {
+        LOG_ERROR("writeOriginToFile: Failed to open origin file '%s'", filePath.utf8().data());
+        return false;
+    }
+
+    WTF::Persistence::Encoder encoder;
+    encoder << origin;
+    FileSystem::writeToFile(originFileHandle, encoder.buffer(), encoder.bufferSize());
+    return true;
+}
+
+}

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -149,6 +149,11 @@ NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
 
+NetworkProcess/storage/CacheStorageCache.cpp
+NetworkProcess/storage/CacheStorageMemoryStore.cpp
+NetworkProcess/storage/CacheStorageManager.cpp
+NetworkProcess/storage/CacheStorageDiskStore.cpp
+NetworkProcess/storage/CacheStorageRegistry.cpp
 NetworkProcess/storage/FileSystemStorageManager.cpp
 NetworkProcess/storage/FileSystemStorageHandle.cpp
 NetworkProcess/storage/FileSystemStorageHandleRegistry.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1551,6 +1551,8 @@
 		9342589A255B535A0059EEDD /* MediaPermissionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 93425898255B534B0059EEDD /* MediaPermissionUtilities.h */; };
 		93468E6D2714AF88009983E3 /* SharedFileHandleCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93468E6C2714AF88009983E3 /* SharedFileHandleCocoa.cpp */; };
 		934B724419F5B9BE00AE96D6 /* WKActionMenuItemTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 934B724319F5B9BE00AE96D6 /* WKActionMenuItemTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		934CF815294B884C00304F7D /* CacheStorageMemoryStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 934CF811294B884A00304F7D /* CacheStorageMemoryStore.h */; };
+		934CF817294B884C00304F7D /* CacheStorageDiskStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 934CF813294B884B00304F7D /* CacheStorageDiskStore.h */; };
 		9354242C2703BDCB005CA72C /* WebFileSystemStorageConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 9354242A2703BDCB005CA72C /* WebFileSystemStorageConnection.h */; };
 		9356F2DC2152B6B500E6D5DF /* WebSWClientConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 517A53021F4793B200DCDC0A /* WebSWClientConnection.h */; };
 		9356F2DD2152B6F600E6D5DF /* WebSWServerConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BA04E02151ADF4007F455F /* WebSWServerConnection.h */; };
@@ -1559,6 +1561,12 @@
 		9356F2E02152B75200E6D5DF /* WebSWServerToContextConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93BA04DD2151ADF3007F455F /* WebSWServerToContextConnection.cpp */; };
 		9356F2E12152B76600E6D5DF /* WebSWServerConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93BA04E12151ADF4007F455F /* WebSWServerConnection.cpp */; };
 		935B579A26F51933008B48AC /* FileSystemStorageHandleRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 935B579826F51270008B48AC /* FileSystemStorageHandleRegistry.h */; };
+		935BF7FC2936BF1A00B41326 /* CacheStorageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 935BF7F22936BF1700B41326 /* CacheStorageCache.h */; };
+		935BF7FF2936BF1A00B41326 /* CacheStorageStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 935BF7F52936BF1800B41326 /* CacheStorageStore.h */; };
+		935BF8002936BF1A00B41326 /* CacheStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 935BF7F62936BF1800B41326 /* CacheStorageManager.h */; };
+		935BF8042936BF1A00B41326 /* CacheStorageRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = 935BF7FA2936BF1900B41326 /* CacheStorageRecord.h */; };
+		935BF8072936C9FD00B41326 /* CacheStorageRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = 935BF8062936C9FC00B41326 /* CacheStorageRegistry.h */; };
+		935BF80A2936CB8500B41326 /* StorageUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 935BF8092936CB8400B41326 /* StorageUtilities.h */; };
 		935EEB9B1277617C003322B8 /* WKBundleBackForwardListItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 935EEB981277616D003322B8 /* WKBundleBackForwardListItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		935EEB9F127761AC003322B8 /* WKBundleBackForwardList.h in Headers */ = {isa = PBXBuildFile; fileRef = 935EEB961277616D003322B8 /* WKBundleBackForwardList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93735EBB1C92986300336FA7 /* WKPreviewActionItemInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 93735EBA1C92986300336FA7 /* WKPreviewActionItemInternal.h */; };
@@ -6108,10 +6116,23 @@
 		93468E6A2714AF47009983E3 /* SharedFileHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedFileHandle.cpp; sourceTree = "<group>"; };
 		93468E6C2714AF88009983E3 /* SharedFileHandleCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedFileHandleCocoa.cpp; sourceTree = "<group>"; };
 		934B724319F5B9BE00AE96D6 /* WKActionMenuItemTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKActionMenuItemTypes.h; sourceTree = "<group>"; };
+		934CF811294B884A00304F7D /* CacheStorageMemoryStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageMemoryStore.h; sourceTree = "<group>"; };
+		934CF812294B884B00304F7D /* CacheStorageMemoryStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageMemoryStore.cpp; sourceTree = "<group>"; };
+		934CF813294B884B00304F7D /* CacheStorageDiskStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageDiskStore.h; sourceTree = "<group>"; };
+		934CF814294B884B00304F7D /* CacheStorageDiskStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageDiskStore.cpp; sourceTree = "<group>"; };
 		9354242A2703BDCB005CA72C /* WebFileSystemStorageConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebFileSystemStorageConnection.h; sourceTree = "<group>"; };
 		9354242B2703BDCB005CA72C /* WebFileSystemStorageConnection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebFileSystemStorageConnection.cpp; sourceTree = "<group>"; };
 		935B579826F51270008B48AC /* FileSystemStorageHandleRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSystemStorageHandleRegistry.h; sourceTree = "<group>"; };
 		935B579926F5192F008B48AC /* FileSystemStorageHandleRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystemStorageHandleRegistry.cpp; sourceTree = "<group>"; };
+		935BF7F22936BF1700B41326 /* CacheStorageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageCache.h; sourceTree = "<group>"; };
+		935BF7F52936BF1800B41326 /* CacheStorageStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageStore.h; sourceTree = "<group>"; };
+		935BF7F62936BF1800B41326 /* CacheStorageManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageManager.h; sourceTree = "<group>"; };
+		935BF7F92936BF1900B41326 /* CacheStorageManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageManager.cpp; sourceTree = "<group>"; };
+		935BF7FA2936BF1900B41326 /* CacheStorageRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageRecord.h; sourceTree = "<group>"; };
+		935BF7FB2936BF1A00B41326 /* CacheStorageCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageCache.cpp; sourceTree = "<group>"; };
+		935BF8062936C9FC00B41326 /* CacheStorageRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CacheStorageRegistry.h; sourceTree = "<group>"; };
+		935BF8082936CA2F00B41326 /* CacheStorageRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CacheStorageRegistry.cpp; sourceTree = "<group>"; };
+		935BF8092936CB8400B41326 /* StorageUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageUtilities.h; sourceTree = "<group>"; };
 		935EEB951277616D003322B8 /* WKBundleBackForwardList.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKBundleBackForwardList.cpp; sourceTree = "<group>"; };
 		935EEB961277616D003322B8 /* WKBundleBackForwardList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBundleBackForwardList.h; sourceTree = "<group>"; };
 		935EEB971277616D003322B8 /* WKBundleBackForwardListItem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKBundleBackForwardListItem.cpp; sourceTree = "<group>"; };
@@ -11886,6 +11907,18 @@
 		93085DC226E1BB65000EC6A7 /* storage */ = {
 			isa = PBXGroup;
 			children = (
+				935BF7FB2936BF1A00B41326 /* CacheStorageCache.cpp */,
+				935BF7F22936BF1700B41326 /* CacheStorageCache.h */,
+				934CF814294B884B00304F7D /* CacheStorageDiskStore.cpp */,
+				934CF813294B884B00304F7D /* CacheStorageDiskStore.h */,
+				935BF7F92936BF1900B41326 /* CacheStorageManager.cpp */,
+				935BF7F62936BF1800B41326 /* CacheStorageManager.h */,
+				934CF812294B884B00304F7D /* CacheStorageMemoryStore.cpp */,
+				934CF811294B884A00304F7D /* CacheStorageMemoryStore.h */,
+				935BF7FA2936BF1900B41326 /* CacheStorageRecord.h */,
+				935BF8082936CA2F00B41326 /* CacheStorageRegistry.cpp */,
+				935BF8062936C9FC00B41326 /* CacheStorageRegistry.h */,
+				935BF7F52936BF1800B41326 /* CacheStorageStore.h */,
 				931A1BE026F85C320081A7E5 /* FileSystemStorageError.h */,
 				931A075226F06AB4004474CD /* FileSystemStorageHandle.cpp */,
 				931A075326F06AB4004474CD /* FileSystemStorageHandle.h */,
@@ -11918,6 +11951,7 @@
 				93E799D6276121080074008A /* StorageAreaBase.h */,
 				93E799C5276027360074008A /* StorageAreaRegistry.cpp */,
 				93E799C6276027370074008A /* StorageAreaRegistry.h */,
+				935BF8092936CB8400B41326 /* StorageUtilities.h */,
 			);
 			path = storage;
 			sourceTree = "<group>";
@@ -14759,9 +14793,16 @@
 				4F601432155C5AA2001FBDE0 /* BlockingResponseMap.h in Headers */,
 				1A5705111BE410E600874AF1 /* BlockSPI.h in Headers */,
 				BC3065FA1259344E00E71278 /* CacheModel.h in Headers */,
+				935BF7FC2936BF1A00B41326 /* CacheStorageCache.h in Headers */,
+				934CF817294B884C00304F7D /* CacheStorageDiskStore.h in Headers */,
 				41897ED81F415D8A0016FA42 /* CacheStorageEngine.h in Headers */,
 				41FABD2A1F4DE001006A6C97 /* CacheStorageEngineCache.h in Headers */,
 				41897EDA1F415D8A0016FA42 /* CacheStorageEngineConnection.h in Headers */,
+				935BF8002936BF1A00B41326 /* CacheStorageManager.h in Headers */,
+				934CF815294B884C00304F7D /* CacheStorageMemoryStore.h in Headers */,
+				935BF8042936BF1A00B41326 /* CacheStorageRecord.h in Headers */,
+				935BF8072936C9FD00B41326 /* CacheStorageRegistry.h in Headers */,
+				935BF7FF2936BF1A00B41326 /* CacheStorageStore.h in Headers */,
 				2D478B91288F33A600F3B73A /* CGDisplayList.h in Headers */,
 				BCE579A62634836700F5C5E9 /* CGDisplayListImageBufferBackend.h in Headers */,
 				57B4B46020B504AC00D4AD79 /* ClientCertificateAuthenticationXPCConstants.h in Headers */,
@@ -15350,6 +15391,7 @@
 				1A334DEE16DE8F88006A8E38 /* StorageAreaMapMessages.h in Headers */,
 				93E799C7276027460074008A /* StorageAreaRegistry.h in Headers */,
 				465F4E06230B2E95003CEDB7 /* StorageNamespaceIdentifier.h in Headers */,
+				935BF80A2936CB8500B41326 /* StorageUtilities.h in Headers */,
 				7B73123C25CC8525003B2796 /* StreamClientConnection.h in Headers */,
 				7B73123A25CC8525003B2796 /* StreamConnectionBuffer.h in Headers */,
 				7B73124225CC8525003B2796 /* StreamConnectionEncoder.h in Headers */,

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -26,11 +26,10 @@
 #include "config.h"
 #include "WebCacheStorageConnection.h"
 
-#include "CacheStorageEngine.h"
-#include "CacheStorageEngineConnectionMessages.h"
 #include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"
 #include "NetworkProcessMessages.h"
+#include "NetworkStorageManagerMessages.h"
 #include "WebCacheStorageProvider.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebProcess.h"
@@ -64,32 +63,32 @@ void WebCacheStorageConnection::open(const WebCore::ClientOrigin& origin, const 
         }
         callback(WTFMove(result));
     };
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::Open(origin, cacheName), WTFMove(newCallback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageOpenCache(origin, cacheName), WTFMove(newCallback));
 }
 
 void WebCacheStorageConnection::remove(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::Remove(cacheIdentifier), WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageRemoveCache(cacheIdentifier), WTFMove(callback));
 }
 
 void WebCacheStorageConnection::retrieveCaches(const WebCore::ClientOrigin& origin, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::Caches(origin, updateCounter), WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageAllCaches(origin, updateCounter), WTFMove(callback));
 }
 
 void WebCacheStorageConnection::retrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::RetrieveRecordsOptions&& options, WebCore::DOMCacheEngine::RecordsCallback&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::RetrieveRecords(cacheIdentifier, options), WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageRetrieveRecords(cacheIdentifier, options), WTFMove(callback));
 }
 
 void WebCacheStorageConnection::batchDeleteOperation(WebCore::DOMCacheIdentifier cacheIdentifier, const WebCore::ResourceRequest& request, WebCore::CacheQueryOptions&& options, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::DeleteMatchingRecords(cacheIdentifier, request, options), WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageRemoveRecords(cacheIdentifier, request, options), WTFMove(callback));
 }
 
 void WebCacheStorageConnection::batchPutOperation(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<Record>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::PutRecords(cacheIdentifier, records), WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStoragePutRecords(cacheIdentifier, records), WTFMove(callback));
 }
 
 void WebCacheStorageConnection::reference(WebCore::DOMCacheIdentifier cacheIdentifier)
@@ -97,7 +96,7 @@ void WebCacheStorageConnection::reference(WebCore::DOMCacheIdentifier cacheIdent
     if (!m_connectedIdentifiers.contains(cacheIdentifier))
         return;
 
-    connection().send(Messages::CacheStorageEngineConnection::Reference(cacheIdentifier), 0);
+    connection().send(Messages::NetworkStorageManager::CacheStorageReference(cacheIdentifier), 0);
 }
 
 void WebCacheStorageConnection::dereference(WebCore::DOMCacheIdentifier cacheIdentifier)
@@ -105,17 +104,17 @@ void WebCacheStorageConnection::dereference(WebCore::DOMCacheIdentifier cacheIde
     if (!m_connectedIdentifiers.contains(cacheIdentifier))
         return;
 
-    connection().send(Messages::CacheStorageEngineConnection::Dereference(cacheIdentifier), 0);
+    connection().send(Messages::NetworkStorageManager::CacheStorageDereference(cacheIdentifier), 0);
 }
 
 void WebCacheStorageConnection::clearMemoryRepresentation(const WebCore::ClientOrigin& origin, CompletionCallback&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::ClearMemoryRepresentation { origin }, WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageClearMemoryRepresentation { origin }, WTFMove(callback));
 }
 
 void WebCacheStorageConnection::engineRepresentation(CompletionHandler<void(const String&)>&& callback)
 {
-    connection().sendWithAsyncReply(Messages::CacheStorageEngineConnection::EngineRepresentation { }, WTFMove(callback));
+    connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageRepresentation { }, WTFMove(callback));
 }
 
 void WebCacheStorageConnection::updateQuotaBasedOnSpaceUsage(const WebCore::ClientOrigin& origin)


### PR DESCRIPTION
#### 03403b4f8c4e7aa6e10be71dca42f10c0f28bbdd
<pre>
Manage CacheStorage by origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=247207">https://bugs.webkit.org/show_bug.cgi?id=247207</a>
rdar://problem/101968609

Reviewed by Youenn Fablet.

The OriginStorageManager class is designed to manage storage of a paritioned origin, and have exclusive access to origin
storage directory. This patch refactors DOMCache backend to use OriginStorageManager for CacheStorage management.

The old structure is:
NetworkSession - CacheStorage::Engine - CacheStorage::Caches - CacheStorage::Cache
The new structure is:
NetworkSession - NetworkStorageManager - OriginStorageManager - CacheStorageManager - CacheStorageCache

Here are the new classes:
CacheStorageManager: it manages cache storage of a partitioned origin and store caches.
CacheStorageCache: it represents a cache and keeps track of records (by record information) in memory.
CacheStorageStore: it represents backing store of cache; it is implemented by CacheStorageMemoryStore and
CacheStorageDiskStore.
CacheStorageRegistry: it keeps track of all CacheStorageCaches in a session, so NetworkStorageManager can find the
target of a CacheStorage IPC message quickly.

Here are some other changes made to complete the transition:
1. CacheStorage messages are sent to NetworkStorageManager instead of CacheStorage::Engine.
2. NetworkStorageManager handles CachesStorage messages and performs corresponding operations on its own WorkQueue.
Since WorkQueue is not tied to one thread, this patch use ResourceResponse::CrossThreadData instead of ResourceResponse
in CacheStorageRecord.
3. CacheStoragePersistentStore provides a simple file system backend for CacheStorage, instead of using
NetworkCache::Storage.
4. Representation string of CacheStorage will report origins that have CacheStorage data. It used to report origins of
existing CacheStorage::Caches (which manages cache storage of partitioned origin like CacheStorageManager), but having
CacheStorage::Caches does not mean the origin has CacheStorage data or the origin is actively performing CacheStorage
operations, and the state is subjective to change based on implementation (e.g. we might add/delete CacheStorage::Caches
proactively based on its activity). Therefore, let&apos;s use CacheStorage data as the truth, and update test expectations.
5. CacheStorage backend used to have multiple WorkQueues per partition origin, now it has one WorkQueue for all origins
(shared with other types) for message handling, and at most one queue per cache for I/O operation on cache records.

* LayoutTests/http/tests/cache-storage/cache-clearing-origin.https.html:
* LayoutTests/http/tests/cache-storage/cache-origins.https.html:
* LayoutTests/http/tests/cache-storage/cache-representation.https.html:
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::overwriteEntireFile):
* Source/WTF/wtf/FileSystem.h:
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::CrossThreadData::copy const):
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::fetchWebsiteData):
(WebKit::NetworkProcess::deleteWebsiteData):
(WebKit::NetworkProcess::deleteWebsiteDataForOrigins):
(WebKit::NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains):
(WebKit::NetworkProcess::registrableDomainsWithWebsiteData):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp: Added.
(WebKit::computeKeyURL):
(WebKit::nextRecordIdentifier):
(WebKit::createStore):
(WebKit::CacheStorageCache::CacheStorageCache):
(WebKit::CacheStorageCache::manager):
(WebKit::CacheStorageCache::getSize):
(WebKit::CacheStorageCache::open):
(WebKit::toCacheStorageRecord):
(WebKit::CacheStorageCache::retrieveRecords):
(WebKit::CacheStorageCache::removeRecords):
(WebKit::CacheStorageCache::findExistingRecord):
(WebKit::CacheStorageCache::putRecords):
(WebKit::CacheStorageCache::putRecordsAfterQuotaCheck):
(WebKit::CacheStorageCache::putRecordsInStore):
(WebKit::CacheStorageCache::removeAllRecords):
(WebKit::CacheStorageCache::close):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h: Added.
(WebKit::CacheStorageCache::identifier const):
(WebKit::CacheStorageCache::name const):
(WebKit::CacheStorageCache::uniqueName const):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp: Added.
(WebKit::shouldStoreBodyAsBlob):
(WebKit::computeSHA1):
(WebKit::RecordMetaData::RecordMetaData):
(WebKit::CacheStorageDiskStore::create):
(WebKit::CacheStorageDiskStore::CacheStorageDiskStore):
(WebKit::CacheStorageDiskStore::versionDirectoryPath const):
(WebKit::CacheStorageDiskStore::saltFilePath const):
(WebKit::CacheStorageDiskStore::recordsDirectoryPath const):
(WebKit::CacheStorageDiskStore::recordFilePath const):
(WebKit::CacheStorageDiskStore::recordBlobFilePath const):
(WebKit::CacheStorageDiskStore::blobsDirectoryPath const):
(WebKit::CacheStorageDiskStore::blobFilePath const):
(WebKit::decodeRecordMetaData):
(WebKit::decodeRecordHeader):
(WebKit::CacheStorageDiskStore::readRecordFromFileData):
(WebKit::CacheStorageDiskStore::readAllRecords):
(WebKit::CacheStorageDiskStore::readRecords):
(WebKit::CacheStorageDiskStore::deleteRecords):
(WebKit::encodeRecordHeader):
(WebKit::encodeRecordBody):
(WebKit::encodeRecord):
(WebKit::CacheStorageDiskStore::writeRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h: Added.
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp: Added.
(WebKit::nextUpdateNumber):
(WebKit::readCachesList):
(WebKit::writeCachesList):
(WebKit::readSizeFile):
(WebKit::writeSizeFile):
(WebKit::CacheStorageManager::cacheStorageSalt):
(WebKit::CacheStorageManager::cacheStorageOriginDirectory):
(WebKit::CacheStorageManager::originsOfCacheStorageData):
(WebKit::getDirectorySize):
(WebKit::CacheStorageManager::cacheStorageSize):
(WebKit::CacheStorageManager::hasCacheList):
(WebKit::CacheStorageManager::makeDirty):
(WebKit::CacheStorageManager::CacheStorageManager):
(WebKit::CacheStorageManager::~CacheStorageManager):
(WebKit::CacheStorageManager::initializeCaches):
(WebKit::CacheStorageManager::openCache):
(WebKit::CacheStorageManager::removeCache):
(WebKit::CacheStorageManager::allCaches):
(WebKit::CacheStorageManager::initializeCacheSize):
(WebKit::CacheStorageManager::finishInitializingSize):
(WebKit::CacheStorageManager::requestSpaceAfterInitializingSize):
(WebKit::CacheStorageManager::requestSpace):
(WebKit::CacheStorageManager::sizeIncreased):
(WebKit::CacheStorageManager::sizeDecreased):
(WebKit::CacheStorageManager::reference):
(WebKit::CacheStorageManager::dereference):
(WebKit::CacheStorageManager::connectionClosed):
(WebKit::CacheStorageManager::removeUnusedCache):
(WebKit::CacheStorageManager::hasDataInMemory):
(WebKit::CacheStorageManager::isActive):
(WebKit::CacheStorageManager::representationString):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.h: Added.
(WebKit::CacheStorageManager::salt const):
* Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.cpp: Added.
(WebKit::CacheStorageMemoryStore::create):
(WebKit::CacheStorageMemoryStore::readAllRecords):
(WebKit::CacheStorageMemoryStore::readRecords):
(WebKit::CacheStorageMemoryStore::deleteRecords):
(WebKit::CacheStorageMemoryStore::writeRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageMemoryStore.h: Added.
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h: Added.
(WebKit::CacheStorageRecordInformation::updateVaryHeaders):
(WebKit::CacheStorageRecord::CacheStorageRecord):
(WebKit::CacheStorageRecord::copy const):
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.cpp: Added.
(WebKit::CacheStorageRegistry::registerCache):
(WebKit::CacheStorageRegistry::unregisterCache):
(WebKit::CacheStorageRegistry::cache):
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h: Added.
* Source/WebKit/NetworkProcess/storage/CacheStorageStore.h: Added.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::canHandleTypes):
(WebKit::NetworkStorageManager::originStorageManager):
(WebKit::NetworkStorageManager::getAllOrigins):
(WebKit::NetworkStorageManager::cacheStorageOpenCache):
(WebKit::NetworkStorageManager::cacheStorageRemoveCache):
(WebKit::NetworkStorageManager::cacheStorageAllCaches):
(WebKit::NetworkStorageManager::cacheStorageReference):
(WebKit::NetworkStorageManager::cacheStorageDereference):
(WebKit::NetworkStorageManager::cacheStorageRetrieveRecords):
(WebKit::NetworkStorageManager::cacheStorageRemoveRecords):
(WebKit::NetworkStorageManager::cacheStoragePutRecords):
(WebKit::NetworkStorageManager::cacheStorageClearMemoryRepresentation):
(WebKit::NetworkStorageManager::cacheStorageRepresentation):
(WebKit::readOriginFromFile): Deleted.
(WebKit::writeOriginToFile): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::existingCacheStorageManager):
(WebKit::OriginStorageManager::StorageBucket::StorageBucket):
(WebKit::OriginStorageManager::StorageBucket::connectionClosed):
(WebKit::OriginStorageManager::StorageBucket::toStorageType const):
(WebKit::OriginStorageManager::StorageBucket::toStorageIdentifier const):
(WebKit::OriginStorageManager::StorageBucket::cacheStorageManager):
(WebKit::OriginStorageManager::StorageBucket::isActive const):
(WebKit::OriginStorageManager::StorageBucket::isEmpty):
(WebKit::OriginStorageManager::StorageBucket::fetchDataTypesInListFromMemory):
(WebKit::OriginStorageManager::StorageBucket::fetchDataTypesInListFromDisk):
(WebKit::OriginStorageManager::StorageBucket::deleteData):
(WebKit::OriginStorageManager::StorageBucket::deleteCacheStorageData):
(WebKit::OriginStorageManager::StorageBucket::deleteEmptyDirectory):
(WebKit::OriginStorageManager::StorageBucket::resolvedPath):
(WebKit::OriginStorageManager::StorageBucket::closeCacheStorageManager):
(WebKit::createQuotaManager):
(WebKit::OriginStorageManager::OriginStorageManager):
(WebKit::OriginStorageManager::defaultBucket):
(WebKit::OriginStorageManager::existingCacheStorageManager):
(WebKit::OriginStorageManager::cacheStorageManager):
(WebKit::OriginStorageManager::closeCacheStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/storage/StorageUtilities.h: Added.
(WebKit::readOriginFromFile):
(WebKit::writeOriginToFile):
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::open):
(WebKit::WebCacheStorageConnection::remove):
(WebKit::WebCacheStorageConnection::retrieveCaches):
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchDeleteOperation):
(WebKit::WebCacheStorageConnection::batchPutOperation):
(WebKit::WebCacheStorageConnection::reference):
(WebKit::WebCacheStorageConnection::dereference):
(WebKit::WebCacheStorageConnection::clearMemoryRepresentation):
(WebKit::WebCacheStorageConnection::engineRepresentation):

Canonical link: <a href="https://commits.webkit.org/258235@main">https://commits.webkit.org/258235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ffe22b2ab5258c9aa7d53925aa741d77499fb3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101212 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110503 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170784 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1233 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108328 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35147 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78151 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/91665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4007 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24765 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/87784 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/1575 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1191 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29283 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44240 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/90679 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5667 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5811 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20270 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->