### PR TITLE
Non-unified build fixes, late October 2022 edition

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorServer.cpp
@@ -30,6 +30,7 @@
 
 #include "RemoteInspectorMessageParser.h"
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace Inspector {
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp
@@ -30,6 +30,7 @@
 
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 
 namespace Inspector {

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -37,6 +37,7 @@
 #include <windows.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashMap.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/win/WCharStringExtras.h>

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -28,6 +28,7 @@
 
 #include "ContextDestructionObserver.h"
 #include "Document.h"
+#include "FormData.h"
 #include "HeaderFieldTokenizer.h"
 #include "RFC8941.h"
 #include "Report.h"

--- a/Source/WebCore/css/CSSFontValue.cpp
+++ b/Source/WebCore/css/CSSFontValue.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "CSSFontValue.h"
 
+#include "CSSFontStyleValue.h"
 #include "CSSValueList.h"
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -75,6 +75,7 @@
 #include "CSSVariableReferenceValue.h"
 #include "DeprecatedCSSOMPrimitiveValue.h"
 #include "DeprecatedCSSOMValueList.h"
+#include "EventTarget.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -40,8 +40,10 @@
 #include "CSSImageValue.h"
 #include "CSSNamedImageValue.h"
 #include "CSSPaintImageValue.h"
+#include "CSSParser.h"
 #include "CSSParserIdioms.h"
 #include "CSSValuePool.h"
+#include "CSSVariableData.h"
 #include "CalculationCategory.h"
 #include "ColorConversion.h"
 #include "ColorInterpolation.h"
@@ -4612,19 +4614,19 @@ const AtomString& genericFontFamily(CSSValueID ident)
 {
     switch (ident) {
     case CSSValueSerif:
-        return serifFamily.get();
+        return WebKitFontFamilyNames::serifFamily.get();
     case CSSValueSansSerif:
-        return sansSerifFamily.get();
+        return WebKitFontFamilyNames::sansSerifFamily.get();
     case CSSValueCursive:
-        return cursiveFamily.get();
+        return WebKitFontFamilyNames::cursiveFamily.get();
     case CSSValueFantasy:
-        return fantasyFamily.get();
+        return WebKitFontFamilyNames::fantasyFamily.get();
     case CSSValueMonospace:
-        return monospaceFamily.get();
+        return WebKitFontFamilyNames::monospaceFamily.get();
     case CSSValueWebkitPictograph:
-        return pictographFamily.get();
+        return WebKitFontFamilyNames::pictographFamily.get();
     case CSSValueSystemUi:
-        return systemUiFamily.get();
+        return WebKitFontFamilyNames::systemUiFamily.get();
     default:
         return emptyAtom();
     }

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSStyleRule.h"
 #include "CSSStyleSheet.h"
+#include "Document.h"
 #include "StyleProperties.h"
 #include "StyleRule.h"
 

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
+#include "Document.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/NodeList.h
+++ b/Source/WebCore/dom/NodeList.h
@@ -31,6 +31,7 @@
 namespace WebCore {
 
 class Node;
+class ScriptExecutionContext;
 
 class NodeList : public ScriptWrappable, public RefCounted<NodeList> {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(NodeList, WEBCORE_EXPORT);

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -34,6 +34,7 @@
 #include "HTMLParserIdioms.h"
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryParser.h"
+#include "MediaQueryParserContext.h"
 #include "RenderStyle.h"
 #include "Settings.h"
 #include "StyleResolveForDocument.h"

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 class DOMURL;
+class ScriptExecutionContext;
 
 class URLSearchParams : public RefCounted<URLSearchParams> {
 public:

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
@@ -27,6 +27,7 @@
 
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
+#include <functional>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/network/win/DownloadBundleWin.cpp
+++ b/Source/WebCore/platform/network/win/DownloadBundleWin.cpp
@@ -29,6 +29,7 @@
 #include <io.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/win/KeyEventWin.cpp
+++ b/Source/WebCore/platform/win/KeyEventWin.cpp
@@ -30,6 +30,7 @@
 #include <windows.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/HexNumber.h>
+#include <wtf/NeverDestroyed.h>
 
 #ifndef MAPVK_VSC_TO_VK_EX
 #define MAPVK_VSC_TO_VK_EX 3

--- a/Source/WebCore/rendering/style/StyleCanvasImage.h
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.h
@@ -32,6 +32,7 @@
 
 namespace WebCore {
 
+class Document;
 class HTMLCanvasElement;
 
 class StyleCanvasImage final : public StyleGeneratedImage, public CanvasObserver {

--- a/Source/WebCore/rendering/style/StyleCursorImage.h
+++ b/Source/WebCore/rendering/style/StyleCursorImage.h
@@ -34,6 +34,8 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 class SVGCursorElement;
 
+enum class LoadedFromOpaqueSource : uint8_t;
+
 class StyleCursorImage final : public StyleMultiImage {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "StyleGeneratedImage.h"
 
+#include "GeneratedImage.h"
 #include "RenderElement.h"
 #include "StyleResolver.h"
 

--- a/Source/WebCore/style/FilterOperationsBuilder.cpp
+++ b/Source/WebCore/style/FilterOperationsBuilder.cpp
@@ -31,6 +31,7 @@
 #include "CSSToLengthConversionData.h"
 #include "ColorFromPrimitiveValue.h"
 #include "Document.h"
+#include "RenderStyle.h"
 #include "TransformFunctions.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/FilterOperationsBuilder.h
+++ b/Source/WebCore/style/FilterOperationsBuilder.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include "FilterOperations.h"
+#include <optional>
+
 namespace WebCore {
 
 class CSSToLengthConversionData;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGComponentTransferFunctionElement.h"
 
+#include "SVGComponentTransferFunctionElementInlines.h"
 #include "SVGFEComponentTransferElement.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebDriver/socket/SessionHostSocket.cpp
+++ b/Source/WebDriver/socket/SessionHostSocket.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "SessionHost.h"
+
+#include <wtf/NeverDestroyed.h>
 #include <wtf/UUID.h>
 
 namespace WebDriver {

--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
@@ -28,6 +28,7 @@
 
 #include "ImageBufferShareableBitmapBackend.h"
 #include "ShareablePixelBuffer.h"
+#include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.h
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "SharedMemory.h"
 #include <WebCore/ImageBufferAllocator.h>
 #include <WebCore/ProcessIdentity.h>
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "QualifiedRenderingResourceIdentifier.h"
+#include "RemoteRenderingBackend.h"
 #include "ScopedActiveMessageReceiveQueue.h"
 #include <WebCore/ImageBuffer.h>
 

--- a/Source/WebKit/Platform/IPC/IPCUtilities.h
+++ b/Source/WebKit/Platform/IPC/IPCUtilities.h
@@ -27,6 +27,10 @@
 
 #define ASSERT_IS_TESTING_IPC() ASSERT(IPC::isTestingIPC(), "Untrusted connection sent invalid data. Should only happen when testing IPC.")
 
+#if OS(WINDOWS)
+#include <windows.h>
+#endif
+
 namespace IPC {
 
 // Function to check when asserting IPC-related failures, so that IPC testing skips the assertions

--- a/Source/WebKit/Shared/win/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/win/WebEventFactory.cpp
@@ -36,6 +36,7 @@
 #include <windowsx.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/HexNumber.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "ArgumentCoders.h"
+#include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/MessagePortChannelProvider.h>
+#include <WebCore/MessageWithMessagePorts.h>
 
 namespace WebKit {
 


### PR DESCRIPTION
#### f4c89112efa5537db0b99d9d7ea7fb4843123670
<pre>
Non-unified build fixes, late October 2022 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=247211">https://bugs.webkit.org/show_bug.cgi?id=247211</a>

Reviewed by Yusuke Suzuki.

* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorServer.cpp:
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp:
* Source/WTF/wtf/win/FileSystemWin.cpp:
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
* Source/WebCore/css/CSSFontValue.cpp:
* Source/WebCore/css/CSSValue.cpp:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.cpp:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
* Source/WebCore/dom/NodeList.h:
* Source/WebCore/html/HTMLMetaElement.cpp:
* Source/WebCore/html/URLSearchParams.h:
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h:
* Source/WebCore/platform/network/win/DownloadBundleWin.cpp:
* Source/WebCore/platform/win/KeyEventWin.cpp:
* Source/WebCore/rendering/style/StyleCanvasImage.h:
* Source/WebCore/rendering/style/StyleCursorImage.h:
* Source/WebCore/rendering/style/StyleGeneratedImage.cpp:
* Source/WebCore/style/FilterOperationsBuilder.cpp:
* Source/WebCore/style/FilterOperationsBuilder.h:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
* Source/WebDriver/socket/SessionHostSocket.cpp:
* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp:
* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/Platform/IPC/IPCUtilities.h:
* Source/WebKit/Shared/win/WebEventFactory.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/256137@main">https://commits.webkit.org/256137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/880a37ee9eab1be987513f12807616b8d30204e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104408 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164672 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4027 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32136 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100330 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100470 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/2902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81178 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29901 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84825 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72786 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85950 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38545 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18184 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81171 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19465 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/27937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4235 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83844 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38696 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18946 "Found 1 new JSC stress test failure: stress/call-apply-exponential-bytecode-size.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->