### PR TITLE
Make sure frame creation message gets processed before DecidePolicyForNavigationActionSync

### DIFF
--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -349,16 +349,11 @@ void WebFrameProxy::disconnect()
 
 void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID)
 {
-    // The DecidePolicyForNavigationActionSync IPC is synchronous and may therefore get processed before the DidCreateSubframe one.
-    // When this happens, decidePolicyForNavigationActionSync() calls didCreateSubframe() and we need to ignore the DidCreateSubframe
-    // IPC when it later gets processed.
-    if (WebFrameProxy::webFrame(frameID))
-        return;
-
-    MESSAGE_CHECK(m_process, m_page);
     MESSAGE_CHECK(m_process, WebFrameProxy::canCreateFrame(frameID));
     MESSAGE_CHECK(m_process, frameID.processIdentifier() == m_process->coreProcessIdentifier());
-
+    if (!m_page)
+        return;
+    
     auto child = WebFrameProxy::create(*m_page, m_process, m_webPageID, frameID);
     child->m_parentFrame = *this;
     m_childFrames.add(WTFMove(child));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4735,12 +4735,6 @@ void WebPageProxy::preferencesDidChange()
 
 void WebPageProxy::didCreateMainFrame(FrameIdentifier frameID)
 {
-    // The DecidePolicyForNavigationActionSync IPC is synchronous and may therefore get processed before the DidCreateMainFrame one.
-    // When this happens, decidePolicyForNavigationActionSync() calls didCreateMainFrame() and we need to ignore the DidCreateMainFrame
-    // IPC when it later gets processed.
-    if (m_mainFrame && m_mainFrame->frameID() == frameID)
-        return;
-
     PageClientProtector protector(pageClient());
 
     MESSAGE_CHECK(m_process, !m_mainFrame);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -115,7 +115,7 @@ void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame)
     WebProcess::singleton().addMessageReceiver(Messages::WebFrame::messageReceiverName(), m_frameID.object(), *this);
     WebProcess::singleton().addWebFrame(frameID(), this);
 
-    page.send(Messages::WebPageProxy::DidCreateMainFrame(frameID()));
+    page.send(Messages::WebPageProxy::DidCreateMainFrame(frameID()), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 
     m_coreFrame = coreFrame;
     m_coreFrame->tree().setName(nullAtom());
@@ -132,7 +132,7 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
     frame->m_frameID = coreFrame->frameID();
     WebProcess::singleton().addMessageReceiver(Messages::WebFrame::messageReceiverName(), frame->m_frameID.object(), frame.get());
     WebProcess::singleton().addWebFrame(coreFrame->frameID(), frame.ptr());
-    parent.send(Messages::WebFrameProxy::DidCreateSubframe(coreFrame->frameID()));
+    parent.send(Messages::WebFrameProxy::DidCreateSubframe(coreFrame->frameID()), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 
     coreFrame->tree().setName(frameName);
     ASSERT(ownerElement.document().frame());


### PR DESCRIPTION
#### f2d3ba4747c159c3b95ae675c890ece0cdf9fe4a
<pre>
Make sure frame creation message gets processed before DecidePolicyForNavigationActionSync
<a href="https://bugs.webkit.org/show_bug.cgi?id=247213">https://bugs.webkit.org/show_bug.cgi?id=247213</a>
rdar://101692692

Reviewed by Chris Dumez.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCreateSubframe):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCreateMainFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::initWithCoreMainFrame):
(WebKit::WebFrame::createSubframe):

Canonical link: <a href="https://commits.webkit.org/256172@main">https://commits.webkit.org/256172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93602b8b01c724943dccf47d9c98b28f26ebac5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104557 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4185 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32283 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100474 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100621 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81433 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30008 "Found 3 new test failures: svg/dom/viewspec-parser-5.html, svg/dom/viewspec-parser-6.html, svg/dom/viewspec-parser-7.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72897 "Found 2 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.ParentFrame (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38692 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36521 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40448 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2044 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38848 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->