### PR TITLE
dragenter & dragleave events do not include relatedTarget in the event object

### DIFF
--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -445,7 +445,7 @@ private:
     bool dispatchMouseEvent(const AtomString& eventType, Node* target, int clickCount, const PlatformMouseEvent&, FireMouseOverOut);
 
 #if ENABLE(DRAG_SUPPORT)
-    bool dispatchDragEvent(const AtomString& eventType, Element& target, const PlatformMouseEvent&, DataTransfer&);
+    bool dispatchDragEvent(const AtomString& eventType, Element& target, const Element& relatedTarget, const PlatformMouseEvent&, DataTransfer&);
     DragTargetResponse dispatchDragEnterOrDragOverEvent(const AtomString& eventType, Element& target, const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&& , OptionSet<DragOperation>, bool draggingFiles);
     void invalidateDataTransfer();
 


### PR DESCRIPTION
<pre>
dragenter & dragleave events do not include relatedTarget in the event object
<a href="https://bugs.webkit.org/show_bug.cgi?id=66547">https://bugs.webkit.org/show_bug.cgi?id=66547</a>

Reviewed by NOBODY (OOPS!).

This is to align Webkit with Blink / Chrome and Gecko / Firefox also with Web Specifications.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/611466a4430557a67478d236ac57dc649b6eee99">https://chromium.googlesource.com/chromium/src.git/+/611466a4430557a67478d236ac57dc649b6eee99</a>

Webkit use to set the relatedTarget of boundary
drag events to null. This is not what the spec
says and developers expect.

This commit fix this
by setting the relatedTarget to the element that
the pointer just left/entered (based on the event).

* Source/WebCore/page/EventHandler.h: Update 'dispatchDragEvent' to have "relatedTarget"
* Source/WebCore/page/EventHandler.cpp:
(EventHandler::handlePasteGlobalSelection): Add "relatedTarget"
(EventHandler::dispatchDragEvent): Add logic about "relatedTarget" and updated to return rather than "0" to "relatedTarget"
(EventHandler::DragTargetResponse EventHandler::updateDragAndDrop): Update response to add "dragTarget" and "nullptr"
(EventHandler::DragTargetResponse EventHandler::cancelDragAndDrop): Update response of "nullptr"
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/486642ea0a64f5923880ccf86905789e9baf771a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95595 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4859 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28643 "Hash 486642ea for PR 5929 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105175 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165459 "Hash 486642ea for PR 5929 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99581 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4908 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33608 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87969 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101026 "Hash 486642ea for PR 5929 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101257 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/4908 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82210 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/87969 "Hash 486642ea for PR 5929 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/4908 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/28643 "Hash 486642ea for PR 5929 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/87969 "Hash 486642ea for PR 5929 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39347 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/28643 "Hash 486642ea for PR 5929 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37047 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/28643 "Hash 486642ea for PR 5929 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41044 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/82210 "Hash 486642ea for PR 5929 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43032 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/28643 "Hash 486642ea for PR 5929 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->