### PR TITLE
Drive macOS RemoteLayerTreeDrawingAreaProxy updates from a DisplayLink

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -676,6 +676,17 @@ HashSet<ScrollingNodeID> ScrollingTree::nodesWithActiveScrollAnimations()
     return m_treeState.nodesWithActiveScrollAnimations;
 }
 
+void ScrollingTree::serviceScrollAnimations(MonotonicTime currentTime)
+{
+    for (auto nodeID : nodesWithActiveScrollAnimations()) {
+        RefPtr targetNode = nodeForID(nodeID);
+        if (!is<ScrollingTreeScrollingNode>(targetNode))
+            continue;
+
+        downcast<ScrollingTreeScrollingNode>(*targetNode).serviceScrollAnimation(currentTime);
+    }
+}
+
 void ScrollingTree::setMainFramePinnedState(RectEdges<bool> edgePinningState)
 {
     Locker locker { m_swipeStateLock };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -229,7 +229,8 @@ public:
 
     void windowScreenDidChange(PlatformDisplayID, std::optional<FramesPerSecond> nominalFramesPerSecond);
     PlatformDisplayID displayID();
-    
+    WEBCORE_EXPORT virtual void displayDidRefresh(PlatformDisplayID) { }
+
     WEBCORE_EXPORT void willProcessWheelEvent();
 
     WEBCORE_EXPORT void addPendingScrollUpdate(ScrollUpdate&&);
@@ -257,6 +258,7 @@ protected:
     bool hasProcessedWheelEventsRecently();
 
     HashSet<ScrollingNodeID> nodesWithActiveScrollAnimations();
+    WEBCORE_EXPORT void serviceScrollAnimations(MonotonicTime) WTF_REQUIRES_LOCK(m_treeLock);
 
     Lock m_treeLock; // Protects the scrolling tree.
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -406,19 +406,6 @@ void ThreadedScrollingTree::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAni
     });
 }
 
-void ThreadedScrollingTree::serviceScrollAnimations(MonotonicTime currentTime)
-{
-    ASSERT(ScrollingThread::isCurrentThread());
-
-    for (auto nodeID : nodesWithActiveScrollAnimations()) {
-        RefPtr targetNode = nodeForID(nodeID);
-        if (!is<ScrollingTreeScrollingNode>(targetNode))
-            continue;
-
-        downcast<ScrollingTreeScrollingNode>(*targetNode).serviceScrollAnimation(currentTime);
-    }
-}
-
 // This code allows the main thread about half a frame to complete its rendering udpate. If the main thread
 // is responsive (i.e. managing to render every frame), then we expect to get a didCompletePlatformRenderingUpdate()
 // within 8ms of willStartRenderingUpdate(). We time this via m_stateCondition, which blocks the scrolling

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -56,7 +56,7 @@ public:
 
     void invalidate() override;
 
-    WEBCORE_EXPORT void displayDidRefresh(PlatformDisplayID);
+    void displayDidRefresh(PlatformDisplayID) override;
 
     void didScheduleRenderingUpdate();
     void willStartRenderingUpdate();
@@ -110,8 +110,6 @@ private:
     void hasNodeWithAnimatedScrollChanged(bool) final;
     
     bool isScrollingSynchronizedWithMainThread() final WTF_REQUIRES_LOCK(m_treeLock);
-
-    void serviceScrollAnimations(MonotonicTime) WTF_REQUIRES_LOCK(m_treeLock);
 
     Seconds frameDuration();
     Seconds maxAllowableRenderingUpdateDurationForSynchronization();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -56,7 +56,8 @@ public:
     TransactionID nextLayerTreeTransactionID() const { return m_pendingLayerTreeTransactionID.next(); }
     TransactionID lastCommittedLayerTreeTransactionID() const { return m_transactionIDForPendingCACommit; }
 
-    void didRefreshDisplay();
+    virtual void didRefreshDisplay();
+    virtual void setDisplayLinkWantsFullSpeedUpdates(bool) { }
     
     bool hasDebugIndicator() const { return !!m_debugIndicatorLayerTreeHost; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -319,6 +319,11 @@ ScrollingTreeScrollingNode* RemoteScrollingCoordinatorProxy::rootNode() const
     return m_scrollingTree->rootNode();
 }
 
+void RemoteScrollingCoordinatorProxy::displayDidRefresh(PlatformDisplayID displayID)
+{
+    m_scrollingTree->displayDidRefresh(displayID);
+}
+
 bool RemoteScrollingCoordinatorProxy::hasScrollableOrZoomedMainFrame() const
 {
     auto* rootNode = m_scrollingTree->rootNode();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -103,6 +103,8 @@ public:
     void setRootNodeIsInUserScroll(bool);
 #endif
 
+    virtual void hasNodeWithAnimatedScrollChanged(bool) { }
+
     String scrollingTreeAsText() const;
 
     OptionSet<WebCore::TouchAction> activeTouchActionsForTouchIdentifier(unsigned touchIdentifier) const;
@@ -111,6 +113,8 @@ public:
     
     void resetStateAfterProcessExited();
     WebCore::ScrollingTreeScrollingNode* rootNode() const;
+
+    virtual void displayDidRefresh(WebCore::PlatformDisplayID);
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     void removeFixedScrollingNodeLayerIDs(const Vector<WebCore::GraphicsLayer::PlatformLayerID>&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -78,9 +78,9 @@
             if (page.preferences().webAnimationsCustomFrameRateEnabled() || !page.preferences().preferPageRenderingUpdatesNear60FPSEnabled()) {
                 auto minimumRefreshInterval = _displayLink.maximumRefreshRate;
                 if (minimumRefreshInterval > 0) {
-                    if (auto displayId = page.displayId()) {
+                    if (auto displayID = page.displayID()) {
                         WebCore::FramesPerSecond frameRate = std::round(1.0 / minimumRefreshInterval);
-                        page.windowScreenDidChange(*displayId, frameRate);
+                        page.windowScreenDidChange(*displayID, frameRate);
                     }
                 }
             }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -29,17 +29,56 @@
 #if PLATFORM(MAC)
 
 #import "RemoteScrollingCoordinatorProxyMac.h"
+#import "WebPageProxy.h"
+#import "WebProcessPool.h"
+#import "WebProcessProxy.h"
 #import <WebCore/ScrollView.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-static const Seconds displayLinkTimerInterval { 1_s / 60 };
+class RemoteLayerTreeDisplayLinkClient final : public DisplayLink::Client {
+public:
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    explicit RemoteLayerTreeDisplayLinkClient(WebPageProxyIdentifier pageID)
+        : m_pageIdentifier(pageID)
+    {
+    }
+
+private:
+    void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
+
+    WebPageProxyIdentifier m_pageIdentifier;
+};
+
+// This is called off the main thread.
+void RemoteLayerTreeDisplayLinkClient::displayLinkFired(WebCore::PlatformDisplayID /* displayID */, WebCore::DisplayUpdate /* displayUpdate */, bool /* wantsFullSpeedUpdates */, bool /* anyObserverWantsCallback */)
+{
+    RunLoop::main().dispatch([pageIdentifier = m_pageIdentifier]() {
+        auto* page = WebProcessProxy::webPage(pageIdentifier);
+        if (!page)
+            return;
+
+        if (auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(page->drawingArea()))
+            drawingArea->didRefreshDisplay();
+    });
+}
 
 RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy& pageProxy, WebProcessProxy& processProxy)
     : RemoteLayerTreeDrawingAreaProxy(pageProxy, processProxy)
-    , m_displayLinkTimer(RunLoop::main(), this, &RemoteLayerTreeDrawingAreaProxyMac::displayLinkTimerFired)
+    , m_displayLinkClient(makeUnique<RemoteLayerTreeDisplayLinkClient>(pageProxy.identifier()))
 {
+}
+
+RemoteLayerTreeDrawingAreaProxyMac::~RemoteLayerTreeDrawingAreaProxyMac()
+{
+    if (auto* displayLink = exisingDisplayLink()) {
+        if (m_fullSpeedUpdateObserverID)
+            displayLink->removeObserver(*m_displayLinkClient, *m_fullSpeedUpdateObserverID);
+        if (m_displayRefreshObserverID)
+            displayLink->removeObserver(*m_displayLinkClient, *m_displayRefreshObserverID);
+    }
 }
 
 DelegatedScrollingMode RemoteLayerTreeDrawingAreaProxyMac::delegatedScrollingMode() const
@@ -52,22 +91,120 @@ std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxy
     return makeUnique<RemoteScrollingCoordinatorProxyMac>(m_webPageProxy);
 }
 
+DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink()
+{
+    if (!m_displayID)
+        return nullptr;
+    
+    return process().processPool().displayLinks().displayLinkForDisplay(*m_displayID);
+}
+
+DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink()
+{
+    ASSERT(m_displayID);
+
+    auto& displayLinks = process().processPool().displayLinks();
+    auto* displayLink = displayLinks.displayLinkForDisplay(*m_displayID);
+    if (!displayLink) {
+        auto newDisplayLink = makeUnique<DisplayLink>(*m_displayID);
+        displayLink = newDisplayLink.get();
+        displayLinks.add(WTFMove(newDisplayLink));
+    }
+    return *displayLink;
+}
+
+void RemoteLayerTreeDrawingAreaProxyMac::removeObserver(std::optional<DisplayLinkObserverID>& observerID)
+{
+    if (!observerID)
+        return;
+
+    if (auto* displayLink = exisingDisplayLink())
+        displayLink->removeObserver(*m_displayLinkClient, *observerID);
+
+    observerID = { };
+}
+
 void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks()
 {
-    if (m_displayLinkTimer.isActive())
+    LOG_WITH_STREAM(DisplayLink, stream << "[UI ] RemoteLayerTreeDrawingAreaProxyMac " << this << " scheduleDisplayLink for display " << m_displayID << " - existing observer " << m_displayRefreshObserverID);
+    if (m_displayRefreshObserverID)
         return;
-    
-    m_displayLinkTimer.startOneShot(displayLinkTimerInterval);
+
+    if (!m_displayID) {
+        WTFLogAlways("RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink(): page has no displayID");
+        return;
+    }
+
+    auto& displayLink = ensureDisplayLink();
+    m_displayRefreshObserverID = DisplayLinkObserverID::generate();
+    displayLink.addObserver(*m_displayLinkClient, *m_displayRefreshObserverID, m_clientPreferredFramesPerSecond);
 }
 
 void RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayRefreshCallbacks()
 {
-    m_displayLinkTimer.stop();
+    LOG_WITH_STREAM(DisplayLink, stream << "[UI ] RemoteLayerTreeDrawingAreaProxyMac " << this << " pauseDisplayLink for display " << m_displayID << " - observer " << m_displayRefreshObserverID);
+    removeObserver(m_displayRefreshObserverID);
 }
 
-void RemoteLayerTreeDrawingAreaProxyMac::displayLinkTimerFired()
+void RemoteLayerTreeDrawingAreaProxyMac::setPreferredFramesPerSecond(WebCore::FramesPerSecond preferredFramesPerSecond)
 {
-    didRefreshDisplay();
+    m_clientPreferredFramesPerSecond = preferredFramesPerSecond;
+
+    if (!m_displayID) {
+        WTFLogAlways("RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink(): page has no displayID");
+        return;
+    }
+
+    auto* displayLink = exisingDisplayLink();
+    if (m_displayRefreshObserverID && displayLink)
+        displayLink->setObserverPreferredFramesPerSecond(*m_displayLinkClient, *m_displayRefreshObserverID, preferredFramesPerSecond);
+}
+
+void RemoteLayerTreeDrawingAreaProxyMac::setDisplayLinkWantsFullSpeedUpdates(bool wantsFullSpeedUpdates)
+{
+    if (!m_displayID)
+        return;
+
+    auto& displayLink = ensureDisplayLink();
+
+    // Use a second observer for full-speed updates (used to drive scroll animations).
+    if (wantsFullSpeedUpdates) {
+        if (m_fullSpeedUpdateObserverID)
+            return;
+
+        m_fullSpeedUpdateObserverID = DisplayLinkObserverID::generate();
+        displayLink.addObserver(*m_displayLinkClient, *m_fullSpeedUpdateObserverID, displayLink.nominalFramesPerSecond());
+    } else if (m_fullSpeedUpdateObserverID)
+        removeObserver(m_fullSpeedUpdateObserverID);
+}
+
+void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFramesPerSecond)
+{
+    if (displayID == m_displayID && m_displayNominalFramesPerSecond == nominalFramesPerSecond)
+        return;
+
+    bool hadFullSpeedOberver = m_fullSpeedUpdateObserverID.has_value();
+    if (hadFullSpeedOberver)
+        removeObserver(m_fullSpeedUpdateObserverID);
+
+    pauseDisplayRefreshCallbacks();
+
+    m_displayID = displayID;
+    m_displayNominalFramesPerSecond = nominalFramesPerSecond;
+
+    scheduleDisplayRefreshCallbacks();
+    if (hadFullSpeedOberver) {
+        m_fullSpeedUpdateObserverID = DisplayLinkObserverID::generate();
+        if (auto* displayLink = exisingDisplayLink())
+            displayLink->addObserver(*m_displayLinkClient, *m_fullSpeedUpdateObserverID, displayLink->nominalFramesPerSecond());
+    }
+}
+
+void RemoteLayerTreeDrawingAreaProxyMac::didRefreshDisplay()
+{
+    // FIXME: Need to pass WebCore::DisplayUpdate here and filter out non-relevant displays.
+    m_webPageProxy.scrollingCoordinatorProxy()->displayDidRefresh(m_displayID.value_or(0));
+    RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay();
 }
 
 void RemoteLayerTreeDrawingAreaProxyMac::didChangeViewExposedRect()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -38,8 +38,9 @@ public:
 private:
     void didReceiveWheelEvent(bool) override;
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
+    void hasNodeWithAnimatedScrollChanged(bool) override;
+    void displayDidRefresh(WebCore::PlatformDisplayID) override;
 };
-
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -28,6 +28,8 @@
 
 #if PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)
 
+#import "RemoteLayerTreeDrawingAreaProxy.h"
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -41,10 +43,25 @@ void RemoteScrollingCoordinatorProxyMac::didReceiveWheelEvent(bool /* wasHandled
     scrollingTree()->applyLayerPositions();
 }
 
+void RemoteScrollingCoordinatorProxyMac::displayDidRefresh(PlatformDisplayID displayID)
+{
+    RemoteScrollingCoordinatorProxy::displayDidRefresh(displayID);
+    scrollingTree()->applyLayerPositions();
+}
+
 bool RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&)
 {
     // Unlike iOS, we handle scrolling requests for the main frame in the same way we handle them for subscrollers.
     return false;
+}
+
+void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool hasAnimatedScrolls)
+{
+    auto* drawingArea = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy().drawingArea());
+    if (!drawingArea)
+        return;
+
+    drawingArea->setDisplayLinkWantsFullSpeedUpdates(hasAnimatedScrolls);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp
@@ -47,10 +47,20 @@ RemoteScrollingTreeMac::RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy& 
 
 RemoteScrollingTreeMac::~RemoteScrollingTreeMac() = default;
 
-
 void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID, PlatformWheelEventPhase)
 {
     // FIXME: Is this needed?
+}
+
+void RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged(bool hasNodeWithAnimatedScroll)
+{
+    m_scrollingCoordinatorProxy.hasNodeWithAnimatedScrollChanged(hasNodeWithAnimatedScroll);
+}
+
+void RemoteScrollingTreeMac::displayDidRefresh(PlatformDisplayID)
+{
+    Locker locker { m_treeLock };
+    serviceScrollAnimations(MonotonicTime::now()); // FIXME: Share timestamp with the rest of the update.
 }
 
 Ref<ScrollingTreeNode> RemoteScrollingTreeMac::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -50,6 +50,8 @@ public:
 
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) final;
+    void hasNodeWithAnimatedScrollChanged(bool) final;
+    void displayDidRefresh(WebCore::PlatformDisplayID) final;
 
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) final;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1131,7 +1131,7 @@ public:
     void accessibilitySettingsDidChange();
 
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond> nominalFramesPerSecond);
-    std::optional<WebCore::PlatformDisplayID> displayId() const { return m_displayID; }
+    std::optional<WebCore::PlatformDisplayID> displayID() const { return m_displayID; }
 
 #if PLATFORM(IOS_FAMILY)
     WebCore::PlatformDisplayID generateDisplayIDFromPageID() const;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -242,6 +242,8 @@ public:
     void handleMemoryPressureWarning(Critical);
 
 #if HAVE(CVDISPLAYLINK)
+    DisplayLinkCollection& displayLinks() { return m_displayLinks; }
+
     std::optional<WebCore::FramesPerSecond> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
 
     void startDisplayLink(WebProcessProxy&, DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);

--- a/Source/WebKit/UIProcess/mac/DisplayLink.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLink.h
@@ -32,9 +32,9 @@
 #include <WebCore/AnimationFrameRate.h>
 #include <WebCore/DisplayUpdate.h>
 #include <WebCore/PlatformScreen.h>
+#include <wtf/CheckedPtr.h>
+#include <wtf/HashMap.h>
 #include <wtf/Lock.h>
-#include <wtf/WeakHashMap.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 


### PR DESCRIPTION
#### 972d19fa6e3366d294c4a2735c8d931d8f41f0d2
<pre>
Drive macOS RemoteLayerTreeDrawingAreaProxy updates from a DisplayLink
<a href="https://bugs.webkit.org/show_bug.cgi?id=247222">https://bugs.webkit.org/show_bug.cgi?id=247222</a>
rdar://101704617

Reviewed by Tim Horton.

Replace the timer-based `displayDidRefresh` updates in RemoteLayerTreeDrawingAreaProxyMac with ones
driven from a DisplayLink.

RemoteLayerTreeDrawingAreaProxyMac owns a RemoteLayerTreeDisplayLinkClient, which receives `displayLinkFired()`
off the main thread; this bounces to the main thread, looking up the target DrawingAreaProxy via a WebPageProxyIdentifier
(to avoid the need to use WeakPtr across threads, or extend object lifetime). RemoteLayerTreeDrawingAreaProxyMac
uses m_displayRefreshObserverID to identify its primary observer, used to drive displayDidRefresh() which ultimately
drives rendering updates.

RemoteLayerTreeDrawingAreaProxyMac has a second observer identified with m_fullSpeedUpdateObserverID which
is only active when the scrolling tree has animations (e.g. rubber-banding); this observer will request
120Hz on capable displays. Future changes will ensure that 120Hz updates get filtered out of the rendering
update pipeline as appropriate. (This avoids use of DisplayLink::{increment,decrement}FullSpeedRequestClientCount
used for web process compositing, which was a mistake.)

RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange() has to respond by unregistering
observers on the DisplayLink for the old display, and re-registering them for the new one.

`serviceScrollAnimations()` is moved from ThreadedScrollingTree to ScrollingTree so we can call
it from RemoteScrollingCoordinatorProxy. RemoteScrollingCoordinatorProxyMac also needs an override
so we actually apply layer positions after the scroll animations run.

`hasNodeWithAnimatedScrollChanged` is hooked up as the signal to start/stop the m_fullSpeedUpdateObserverID.

WebPageProxy::displayId() is renamed to WebPageProxy::displayID().

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::serviceScrollAnimations):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::displayDidRefresh):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::serviceScrollAnimations): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::setDisplayLinkWantsFullSpeedUpdates):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::displayDidRefresh):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::hasNodeWithAnimatedScrollChanged):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDisplayLinkClient::displayLinkFired):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::~RemoteLayerTreeDrawingAreaProxyMac):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::ensureDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::removeObserver):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayRefreshCallbacks):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::setPreferredFramesPerSecond):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::setDisplayLinkWantsFullSpeedUpdates):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLinkTimerFired): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::displayDidRefresh):
(WebKit::RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.cpp:
(WebKit::RemoteScrollingTreeMac::hasNodeWithAnimatedScrollChanged):
(WebKit::RemoteScrollingTreeMac::displayDidRefresh):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/DisplayLink.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/256181@main">https://commits.webkit.org/256181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7f6e373d67e2bc00677621157b718627458b1c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94785 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104391 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164656 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4011 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32119 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100312 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2889 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81139 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29890 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72774 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38528 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19453 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4264 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40286 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38684 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->