### PR TITLE
[JSC] Fix WebAssembly.Tag.getArg's thrown error type

### DIFF
--- a/JSTests/wasm/stress/create-tag-from.js
+++ b/JSTests/wasm/stress/create-tag-from.js
@@ -17,6 +17,6 @@ assert.eq(exception.getArg(tag, 0), 1);
 assert.eq(exception.getArg(tag, 1), 2.5);
 assert.eq(exception.getArg(tag, 2), parameters);
 
-assert.throws(() => exception.getArg(tag, 3), TypeError, "WebAssembly.Exception.getArg(): Index out of range");
+assert.throws(() => exception.getArg(tag, 3), RangeError, "WebAssembly.Exception.getArg(): Index out of range");
 
 assert.eq(WebAssembly.Exception.prototype.__proto__, Object.prototype)

--- a/JSTests/wasm/v8/exceptions-api.js
+++ b/JSTests/wasm/v8/exceptions-api.js
@@ -202,7 +202,7 @@ function TestGetArgHelper(types_str, types, values) {
       /First argument must be a WebAssembly.Tag/);
   //assertThrows(() => exception.getArg(tag, undefined), TypeError,
       ///Index must be convertible to a valid number/);
-  assertThrows(() => exception.getArg(tag, 0xFFFFFFFF), TypeError,
+  assertThrows(() => exception.getArg(tag, 0xFFFFFFFF), RangeError,
       /Index out of range/);
   let wrong_tag = new WebAssembly.Tag({parameters: ['i32']});
   assertThrows(() => exception.getArg(wrong_tag, 0), TypeError,

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/compile_worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/compile_worker.js
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2016 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/create_multiple_memory.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/create_multiple_memory.worker.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js
@@ -20,7 +20,7 @@ test(() => {
 test(() => {
   const tag = new WebAssembly.Tag({ parameters: [] });
   const exn = new WebAssembly.Exception(tag, []);
-  assert_throws_js(TypeError, () => exn.getArg(tag, 1));
+  assert_throws_js(RangeError, () => exn.getArg(tag, 1));
 }, "Index out of bounds");
 
 test(() => {

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/resources/load_wasm.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/resources/load_wasm.js
@@ -1,4 +1,4 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
+// Copyright 2016 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any-expected.txt
@@ -1,3 +1,7 @@
+Blocked access to external URL http://www.localhost:8800/wasm/incrementer.wasm
+CONSOLE MESSAGE: Fetch API cannot load http://www.localhost:8800/wasm/incrementer.wasm due to access control checks.
+Blocked access to external URL http://www.localhost:8800/wasm/incrementer.wasm
+CONSOLE MESSAGE: Fetch API cannot load http://www.localhost:8800/wasm/incrementer.wasm due to access control checks.
 
 PASS Opaque response: compileStreaming
 PASS Opaque redirect response: compileStreaming

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any.js
@@ -2,7 +2,7 @@
 
 for (const method of ["compileStreaming", "instantiateStreaming"]) {
   promise_test(t => {
-    const url = "http://{{hosts[alt][]}}:{{ports[http][0]}}/wasm/incrementer.wasm";
+    const url = "http://{{domains[www]}}:{{ports[http][0]}}/wasm/incrementer.wasm";
     const response = fetch(url, { "mode": "no-cors" });
     return promise_rejects_js(t, TypeError, WebAssembly[method](response));
   }, `Opaque response: ${method}`);

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any-expected.txt
@@ -1,5 +1,3 @@
-Blocked access to external URL http://www.localhost:8800/wasm/incrementer.wasm
-Blocked access to external URL http://www.localhost:8800/wasm/incrementer.wasm
 
 PASS Opaque response: compileStreaming
 PASS Opaque redirect response: compileStreaming

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any.worker-expected.txt
@@ -1,5 +1,3 @@
-Blocked access to external URL http://www.localhost:8800/wasm/incrementer.wasm
-Blocked access to external URL http://www.localhost:8800/wasm/incrementer.wasm
 
 PASS Opaque response: compileStreaming
 PASS Opaque redirect response: compileStreaming

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp
@@ -91,13 +91,6 @@ ALWAYS_INLINE static JSWebAssemblyException* getException(JSGlobalObject* global
     return nullptr;
 }
 
-ALWAYS_INLINE static JSWebAssemblyTag* getTag(JSValue tagValue)
-{
-    if (!tagValue.isCell())
-        return nullptr;
-    return jsDynamicCast<JSWebAssemblyTag*>(tagValue.asCell());
-}
-
 JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -106,9 +99,6 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg, (JSGlobalObject* g
     const auto& formatMessage = [&](const auto& message) {
         return makeString("WebAssembly.Exception.getArg(): ", message);
     };
-    const auto& typeError = [&](const auto& message) {
-        return throwVMTypeError(globalObject, throwScope, formatMessage(message));
-    };
 
     JSWebAssemblyException* jsException = getException(globalObject, callFrame->thisValue());
     RETURN_IF_EXCEPTION(throwScope, { });
@@ -116,16 +106,18 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncGetArg, (JSGlobalObject* g
     if (UNLIKELY(callFrame->argumentCount() < 2))
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
-    JSWebAssemblyTag* tag = getTag(callFrame->argument(0));
-    if (!tag)
-        return typeError("First argument must be a WebAssembly.Tag");
+    JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));
+    if (UNLIKELY(!tag))
+        return throwVMTypeError(globalObject, throwScope, formatMessage("First argument must be a WebAssembly.Tag"_s));
 
-    if (jsException->tag() != tag->tag())
-        return typeError("First argument does not match the exception tag");
+    uint32_t index = toNonWrappingUint32(globalObject, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(throwScope, { });
 
-    uint32_t index = callFrame->argument(1).toUInt32(globalObject);
-    if (index >= tag->tag().parameterCount())
-        return typeError("Index out of range");
+    if (UNLIKELY(jsException->tag() != tag->tag()))
+        return throwVMTypeError(globalObject, throwScope, formatMessage("First argument does not match the exception tag"_s));
+
+    if (UNLIKELY(index >= tag->tag().parameterCount()))
+        return throwVMRangeError(globalObject, throwScope, formatMessage("Index out of range"_s));
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(jsException->getArg(globalObject, index)));
 }
@@ -141,7 +133,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyExceptionProtoFuncIs, (JSGlobalObject* globa
     if (UNLIKELY(callFrame->argumentCount() < 1))
         return JSValue::encode(throwException(globalObject, throwScope, createNotEnoughArgumentsError(globalObject)));
 
-    JSWebAssemblyTag* tag = getTag(callFrame->argument(0));
+    JSWebAssemblyTag* tag = jsDynamicCast<JSWebAssemblyTag*>(callFrame->argument(0));
     if (!tag)
         return throwVMTypeError(globalObject, throwScope, "WebAssembly.Exception.is(): First argument must be a WebAssembly.Tag"_s);
 


### PR DESCRIPTION
#### b1248207241a66f6361f4a2f035f18cc7caed4ae
<pre>
[JSC] Fix WebAssembly.Tag.getArg&apos;s thrown error type
<a href="https://bugs.webkit.org/show_bug.cgi?id=247223">https://bugs.webkit.org/show_bug.cgi?id=247223</a>
rdar://101705666

Reviewed by Alexey Shvayka.

1. We should use toNonWrappingUint32 to get Uint32 for getArg index
2. We should throw RangeError instead of TypeError for out of bounds getArg

<a href="https://webassembly.github.io/exception-handling/js-api/#dom-exception-getarg">https://webassembly.github.io/exception-handling/js-api/#dom-exception-getarg</a>

* LayoutTests/imported/w3c/web-platform-tests/wasm/compile_worker.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/create_multiple_memory.worker.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/jsapi/exception/getArg.tentative.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/wasm/resources/load_wasm.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any.js:
* LayoutTests/imported/w3c/web-platform-tests/wasm/webapi/origin.sub.any.worker-expected.txt:
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::getTag): Deleted.

Canonical link: <a href="https://commits.webkit.org/256158@main">https://commits.webkit.org/256158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7723621de72408eaa32e0905e89303aa2bfba651

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94938 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/4086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/27844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4171 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/32269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100607 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/87244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/84928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/27844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/86077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/27844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81303 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/27844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28003 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/40435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83976 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2033 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42411 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/27844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18980 "Passed tests") | 
<!--EWS-Status-Bubble-End-->