### PR TITLE
Add findDoubleNan / findFloatNaN

### DIFF
--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1156,11 +1156,8 @@ bool JSArray::unshiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsi
         // through shifting and then realize we should have been in ArrayStorage mode.
         if (moveCount) {
             if (UNLIKELY(holesMustForwardToPrototype())) {
-                for (unsigned i = oldLength; i-- > startIndex;) {
-                    double v = butterfly->contiguousDouble().at(this, i);
-                    if (UNLIKELY(v != v))
-                        RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
-                }
+                if (UNLIKELY(WTF::findDoubleNaN(butterfly->contiguousDouble().data() + startIndex, moveCount)))
+                    RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
             }
 
             gcSafeMemmove(butterfly->contiguousDouble().data() + startIndex + count, butterfly->contiguousDouble().data() + startIndex, moveCount * sizeof(double));


### PR DESCRIPTION
#### 0d69e5c388431f0dcec6bbaa56e8535bdbf48b5c
<pre>
Add findDoubleNan / findFloatNaN
<a href="https://bugs.webkit.org/show_bug.cgi?id=247225">https://bugs.webkit.org/show_bug.cgi?id=247225</a>
rdar://101708661

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::unshiftCountWithAnyIndexingType):
* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::findFloatNaNAlignedImpl):
(WTF::findDoubleNaNAlignedImpl):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::find16):
(WTF::find64):
(WTF::findFloat):
(WTF::findFloatNaN):
(WTF::findDouble):
(WTF::findDoubleNaN):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d69e5c388431f0dcec6bbaa56e8535bdbf48b5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3945 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27673 "Hash 0d69e5c3 for PR 5932 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104400 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164664 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4019 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32393 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100322 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2897 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81428 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29896 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84820 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/27673 "Hash 0d69e5c3 for PR 5932 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72780 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/85944 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38537 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/27673 "Hash 0d69e5c3 for PR 5932 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81165 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36374 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/27673 "Hash 0d69e5c3 for PR 5932 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/27933 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40295 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42277 "Found 1 new test failure: storage/indexeddb/crash-on-getdatabases.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/83837 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42271 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/27673 "Hash 0d69e5c3 for PR 5932 does not build (failure)") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/18943 "Passed tests") | 
<!--EWS-Status-Bubble-End-->