### PR TITLE
Fix IPC testing API after 256008@main

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2690,11 +2690,6 @@ JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* 
             jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "syncRequestID"_s), JSC::JSValue(syncRequestID.toUInt64()));
             RETURN_IF_EXCEPTION(scope, nullptr);
         }
-    } else if (messageReplyArgumentDescriptions(decoder.messageName())) {
-        if (uint64_t listenerID = 0; decoder.decode(listenerID)) {
-            jsResult->putDirect(vm, JSC::Identifier::fromString(vm, "listenerID"_s), JSC::JSValue(listenerID));
-            RETURN_IF_EXCEPTION(scope, nullptr);
-        }
     }
 
     auto arrayBuffer = JSC::ArrayBuffer::create(decoder.buffer(), decoder.length());


### PR DESCRIPTION
#### 7b6a305bc03e8e5cae75c892e710abf524f651b5
<pre>
Fix IPC testing API after 256008@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=247236">https://bugs.webkit.org/show_bug.cgi?id=247236</a>
rdar://101720110

Reviewed by Ryosuke Niwa.

* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):

Canonical link: <a href="https://commits.webkit.org/256159@main">https://commits.webkit.org/256159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de269e1acf57c65bd2d6ee23f0b723c9da2586bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/3979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104434 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4053 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32162 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100359 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2922 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81342 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29923 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72807 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38570 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19485 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2034 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38715 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->