### PR TITLE
Use more constrained types to represent CSS gradient values

### DIFF
--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -115,6 +115,10 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCursorImageValue>(*this));
     case CustomPropertyClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSCustomPropertyValue>(*this));
+    case DeprecatedLinearGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSDeprecatedLinearGradientValue>(*this));
+    case DeprecatedRadialGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSDeprecatedRadialGradientValue>(*this));
     case FilterImageClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFilterImageValue>(*this));
     case FontClass:
@@ -153,6 +157,10 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLinearGradientValue>(*this));
     case NamedImageClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSNamedImageValue>(*this));
+    case PrefixedLinearGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPrefixedLinearGradientValue>(*this));
+    case PrefixedRadialGradientClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSPrefixedRadialGradientValue>(*this));
     case RadialGradientClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSRadialGradientValue>(*this));
     case OffsetRotateClass:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -71,8 +71,8 @@ public:
     bool isFontValue() const { return m_classType == FontClass; }
     bool isFontStyleValue() const { return m_classType == FontStyleClass; }
     bool isFontStyleRangeValue() const { return m_classType == FontStyleRangeClass; }
-    bool isImageGeneratorValue() const { return m_classType >= CanvasClass && m_classType <= ConicGradientClass; }
-    bool isGradientValue() const { return m_classType >= LinearGradientClass && m_classType <= ConicGradientClass; }
+    bool isImageGeneratorValue() const { return m_classType >= CanvasClass && m_classType <= PrefixedRadialGradientClass; }
+    bool isGradientValue() const { return m_classType >= LinearGradientClass && m_classType <= PrefixedRadialGradientClass; }
     bool isNamedImageValue() const { return m_classType == NamedImageClass; }
     bool isImageSetValue() const { return m_classType == ImageSetClass; }
     bool isImageValue() const { return m_classType == ImageClass; }
@@ -88,6 +88,10 @@ public:
     bool isLinearGradientValue() const { return m_classType == LinearGradientClass; }
     bool isRadialGradientValue() const { return m_classType == RadialGradientClass; }
     bool isConicGradientValue() const { return m_classType == ConicGradientClass; }
+    bool isDeprecatedLinearGradientValue() const { return m_classType == DeprecatedLinearGradientClass; }
+    bool isDeprecatedRadialGradientValue() const { return m_classType == DeprecatedRadialGradientClass; }
+    bool isPrefixedLinearGradientValue() const { return m_classType == PrefixedLinearGradientClass; }
+    bool isPrefixedRadialGradientValue() const { return m_classType == PrefixedRadialGradientClass; }
     bool isReflectValue() const { return m_classType == ReflectClass; }
     bool isShadowValue() const { return m_classType == ShadowClass; }
     bool isCubicBezierTimingFunctionValue() const { return m_classType == CubicBezierTimingFunctionClass; }
@@ -161,6 +165,10 @@ protected:
         LinearGradientClass,
         RadialGradientClass,
         ConicGradientClass,
+        DeprecatedLinearGradientClass,
+        DeprecatedRadialGradientClass,
+        PrefixedLinearGradientClass,
+        PrefixedRadialGradientClass,
 
         // Timing function classes.
         CubicBezierTimingFunctionClass,

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2154,10 +2154,11 @@ static Ref<StyleGradientImage> autoFillStrongPasswordMaskImage()
 
     return StyleGradientImage::create(
         StyleGradientImage::LinearData {
-            nullptr, nullptr, nullptr, nullptr, CSSValuePool::singleton().createValue(90, CSSUnitType::CSS_DEG)
+            {
+                CSSLinearGradientValue::Angle { CSSValuePool::singleton().createValue(90, CSSUnitType::CSS_DEG) }
+            },
+            CSSGradientRepeat::NonRepeating
         },
-        CSSGradientRepeat::NonRepeating,
-        CSSGradientType::CSSLinearGradient,
         CSSGradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied),
         WTFMove(stops)
     );

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -112,8 +112,20 @@ RefPtr<StyleImage> BuilderState::createStyleImage(const CSSValue& value)
         return downcast<CSSCrossfadeValue>(value).createStyleImage(*this);
     if (is<CSSFilterImageValue>(value))
         return downcast<CSSFilterImageValue>(value).createStyleImage(*this);
-    if (is<CSSGradientValue>(value))
-        return downcast<CSSGradientValue>(value).createStyleImage(*this);
+    if (is<CSSLinearGradientValue>(value))
+        return downcast<CSSLinearGradientValue>(value).createStyleImage(*this);
+    if (is<CSSPrefixedLinearGradientValue>(value))
+        return downcast<CSSPrefixedLinearGradientValue>(value).createStyleImage(*this);
+    if (is<CSSDeprecatedLinearGradientValue>(value))
+        return downcast<CSSDeprecatedLinearGradientValue>(value).createStyleImage(*this);
+    if (is<CSSRadialGradientValue>(value))
+        return downcast<CSSRadialGradientValue>(value).createStyleImage(*this);
+    if (is<CSSPrefixedRadialGradientValue>(value))
+        return downcast<CSSPrefixedRadialGradientValue>(value).createStyleImage(*this);
+    if (is<CSSDeprecatedRadialGradientValue>(value))
+        return downcast<CSSDeprecatedRadialGradientValue>(value).createStyleImage(*this);
+    if (is<CSSConicGradientValue>(value))
+        return downcast<CSSConicGradientValue>(value).createStyleImage(*this);
 #if ENABLE(CSS_PAINTING_API)
     if (is<CSSPaintImageValue>(value))
         return downcast<CSSPaintImageValue>(value).createStyleImage(*this);

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -35,8 +35,7 @@
 #include "RenderStyle.h"
 #include "SVGURIReference.h"
 #include "Settings.h"
-#include "StyleCachedImage.h"
-#include "StyleGeneratedImage.h"
+#include "StyleImage.h"
 #include "TransformFunctions.h"
 
 namespace WebCore {


### PR DESCRIPTION
#### f62447bff59b85890116e58a9740fc50113bba06
<pre>
Use more constrained types to represent CSS gradient values
<a href="https://bugs.webkit.org/show_bug.cgi?id=247235">https://bugs.webkit.org/show_bug.cgi?id=247235</a>
rdar://101720047

Reviewed by Darin Adler.

To make further progress on moving the CSS gradient code toward
correct semantics, I took a moment to refactor the current CSS
value subclasses to better represent the parsed output. To do
this, I broke apart the deprecated, prefixed and standard variants
into their own types and now only store exactly what is needed
to represent the gradient, utilizing std::variant and additional
structs to provide the structure.

Now, if a gradient has a member that is a RefPtr&lt;&gt;, you can be
assured that it is required to check for nullptr, otherwise, a
Ref&lt;&gt; would have been used.

I also took the opertunity to remove the base CSSGradientValue
class as there was no need polymorphism being used and removing
it gets us closer to CSSValue value semantics.

* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::computeStops):
(WebCore::CSSLinearGradientValue::createStyleImage const):
(WebCore::CSSPrefixedLinearGradientValue::createStyleImage const):
(WebCore::CSSDeprecatedLinearGradientValue::createStyleImage const):
(WebCore::CSSRadialGradientValue::createStyleImage const):
(WebCore::CSSPrefixedRadialGradientValue::createStyleImage const):
(WebCore::CSSDeprecatedRadialGradientValue::createStyleImage const):
(WebCore::CSSConicGradientValue::createStyleImage const):
(WebCore::operator==):
(WebCore::cssText):
(WebCore::CSSLinearGradientValue::customCSSText const):
(WebCore::CSSLinearGradientValue::equals const):
(WebCore::CSSPrefixedLinearGradientValue::customCSSText const):
(WebCore::CSSPrefixedLinearGradientValue::equals const):
(WebCore::CSSDeprecatedLinearGradientValue::customCSSText const):
(WebCore::CSSDeprecatedLinearGradientValue::equals const):
(WebCore::CSSRadialGradientValue::customCSSText const):
(WebCore::CSSRadialGradientValue::equals const):
(WebCore::CSSPrefixedRadialGradientValue::customCSSText const):
(WebCore::CSSPrefixedRadialGradientValue::equals const):
(WebCore::CSSDeprecatedRadialGradientValue::customCSSText const):
(WebCore::CSSDeprecatedRadialGradientValue::equals const):
(WebCore::CSSConicGradientValue::customCSSText const):
(WebCore::CSSConicGradientValue::equals const):
(WebCore::CSSGradientValue::computeStops const): Deleted.
(WebCore::CSSGradientValue::createStyleImage const): Deleted.
(WebCore::CSSGradientValue::equals const): Deleted.
* Source/WebCore/css/CSSGradientValue.h:
(WebCore::CSSGradientValue::setFirstX): Deleted.
(WebCore::CSSGradientValue::setFirstY): Deleted.
(WebCore::CSSGradientValue::setSecondX): Deleted.
(WebCore::CSSGradientValue::setSecondY): Deleted.
(WebCore::CSSGradientValue::gradientType const): Deleted.
(WebCore::CSSGradientValue::CSSGradientValue): Deleted.
(WebCore::CSSGradientValue::firstX const): Deleted.
(WebCore::CSSGradientValue::firstY const): Deleted.
(WebCore::CSSGradientValue::secondX const): Deleted.
(WebCore::CSSGradientValue::secondY const): Deleted.
(WebCore::CSSGradientValue::stops const): Deleted.
(WebCore::CSSGradientValue::isRepeating const): Deleted.
(WebCore::CSSGradientValue::colorInterpolationMethod const): Deleted.
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isImageGeneratorValue const):
(WebCore::CSSValue::isGradientValue const):
(WebCore::CSSValue::isDeprecatedLinearGradientValue const):
(WebCore::CSSValue::isDeprecatedRadialGradientValue const):
(WebCore::CSSValue::isPrefixedLinearGradientValue const):
(WebCore::CSSValue::isPrefixedRadialGradientValue const):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedGradientPointValue):
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedGradientPoint):
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedGradientColorStops):
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedLinearGradient):
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedRadialGradient):
(WebCore::CSSPropertyParserHelpers::consumeDeprecatedGradient):
(WebCore::CSSPropertyParserHelpers::consumeColorStopList):
(WebCore::CSSPropertyParserHelpers::consumeLengthColorStopList):
(WebCore::CSSPropertyParserHelpers::consumeAngularColorStopList):
(WebCore::CSSPropertyParserHelpers::consumePrefixedRadialGradient):
(WebCore::CSSPropertyParserHelpers::consumeRadialGradient):
(WebCore::CSSPropertyParserHelpers::consumePrefixedLinearGradient):
(WebCore::CSSPropertyParserHelpers::consumeLinearGradient):
(WebCore::CSSPropertyParserHelpers::consumeConicGradient):
(WebCore::CSSPropertyParserHelpers::consumeGeneratedImage):
(WebCore::CSSPropertyParserHelpers::consumeGradientColorStops): Deleted.
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::autoFillStrongPasswordMaskImage):
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::operator==):
(WebCore::StyleGradientImage::StyleGradientImage):
(WebCore::StyleGradientImage::equals const):
(WebCore::StyleGradientImage::computedStyleValue const):
(WebCore::StyleGradientImage::computeStopsForDeprecatedVariants const):
(WebCore::StyleGradientImage::computeStops const):
(WebCore::positionFromValue):
(WebCore::computeEndPoint):
(WebCore::endPointsFromAngle):
(WebCore::endPointsFromAngleForPrefixedVariants):
(WebCore::resolveRadius):
(WebCore::distanceToClosestCorner):
(WebCore::distanceToFarthestCorner):
(WebCore::StyleGradientImage::createGradient const):
* Source/WebCore/rendering/style/StyleGradientImage.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::createStyleImage):
* Source/WebCore/style/StylePendingResources.cpp:

Canonical link: <a href="https://commits.webkit.org/256211@main">https://commits.webkit.org/256211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adc6def57f52e181923ff089076168bb35e4f1c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95129 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4269 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104726 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/164976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4363 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33105 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100623 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100797 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81663 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30158 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86921 "Build was cancelled. Recent messages:Configured build (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38859 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36679 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4295 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38999 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->