### PR TITLE
Fix table sizing when 'max-width' is used

### DIFF
--- a/LayoutTests/fast/table/css-table-max-width.html
+++ b/LayoutTests/fast/table/css-table-max-width.html
@@ -14,7 +14,7 @@
     border:1px solid yellow;
 }
 </style>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <div id="container" class="parent">
@@ -109,6 +109,5 @@ shouldBe("maxWidthZeroFixedLayout.getBoundingClientRect().width","2");
 
 document.body.removeChild(document.getElementById('container'));
 </script>
-<script src="../../resources/js-test-post.js"></script>
 <body>
 </html>

--- a/LayoutTests/fast/table/table-max-width-override-width-attribute-expected.html
+++ b/LayoutTests/fast/table/table-max-width-override-width-attribute-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style type="text/css">
+        table { background-color: green; }
+        #maxTest { width: 300px; }
+</style>
+</head>
+<body>
+<p>All of the elements below should be the same lenght.</p>
+<table id="maxTest">
+    <tr>
+        <td>Table testing max-width</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/LayoutTests/fast/table/table-max-width-override-width-attribute.html
+++ b/LayoutTests/fast/table/table-max-width-override-width-attribute.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style type="text/css">
+        table { background-color: green; }
+        #maxTest { width: 400px; max-width: 300px; }
+</style>
+</head>
+<body>
+<p>All of the elements below should be the same lenght.</p>
+<table id="maxTest">
+    <tr>
+        <td>Table testing max-width</td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
<pre>
Fix table sizing when 'max-width' is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=12396">https://bugs.webkit.org/show_bug.cgi?id=12396</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=149011&view=revision">https://src.chromium.org/viewvc/blink?revision=149011&view=revision</a>

This is to align "max-width" on tables behavior with Blink / Chrome and Gecko / Firefox.

The fix is to avoid constraining min-content and ensure that the table logical width 
is at least its min-content size.

* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::updateLogicalWidth): Update comment and add ASSERT with comment
(RenderTable::computePreferredLogicalWidths): Add comment and update m_maxPreferredLogicalWidth to take m_minPreferredLogicalWidth as first and second as m_maxPreferredLogicalWidth
* LayoutTests/fast/tables/css-table-max-width.html: Update to use "js-test.js"
* LayoutTests/fast/table/table-max-width-override-width-attribute.html: Added Test Case
* LayoutTests/fast/table/table-max-width-override-width-attribute-expected.html: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c792646b9483dccbfb558b5ee3bb6202afada70e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106847 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167110 "Found 1 new test failure: fast/table/table-max-width-override-width-attribute.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6894 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35329 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89738 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103526 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102991 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83957 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32178 "Found 1 new test failure: fast/table/table-max-width-override-width-attribute.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/608 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/591 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41121 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->