### PR TITLE
[Live Range Selection] Expanding selection by granularity should expand anchor & focus

### DIFF
--- a/LayoutTests/editing/selection/double-click-expands-focus-anchor-live-range-expected.txt
+++ b/LayoutTests/editing/selection/double-click-expands-focus-anchor-live-range-expected.txt
@@ -1,0 +1,21 @@
+abc def ghi
+This tests selecting by granularity results in focus and anchor of selection to be adjusted
+To manually test, double click or double tap on "def".
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().anchorNode is content.firstChild
+PASS getSelection().anchorOffset is 4
+PASS getSelection().focusNode is content.firstChild
+PASS getSelection().focusOffset is 7
+PASS getSelection().rangeCount is 1
+window.range = getSelection().getRangeAt(0);
+PASS range.startContainer is content.firstChild
+PASS range.startOffset is 4
+PASS range.endContainer is content.firstChild
+PASS range.endOffset is 7
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/double-click-expands-focus-anchor-live-range.html
+++ b/LayoutTests/editing/selection/double-click-expands-focus-anchor-live-range.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<html>
+<head>
+<meta name=viewport content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body contenteditable>
+<span id="content">abc def ghi</span>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+
+description(`This tests selecting by granularity results in focus and anchor of selection to be adjusted<br>
+To manually test, double click or double tap on "def".`);
+
+jsTestIsAsync = true;
+
+function runAssertions() {
+    shouldBe('getSelection().anchorNode', 'content.firstChild');
+    shouldBe('getSelection().anchorOffset', '4');
+    shouldBe('getSelection().focusNode', 'content.firstChild');
+    shouldBe('getSelection().focusOffset', '7');
+    shouldBe('getSelection().rangeCount', '1');
+    evalAndLog('window.range = getSelection().getRangeAt(0);')
+    shouldBe('range.startContainer', 'content.firstChild');
+    shouldBe('range.startOffset', '4');
+    shouldBe('range.endContainer', 'content.firstChild');
+    shouldBe('range.endOffset', '7');
+}
+
+async function runTest()
+{
+    getSelection().removeAllRanges();
+    await UIHelper.selectWordByDoubleTapOrClick(content, content.offsetWidth / 2, content.offsetHeight / 2);
+    runAssertions();
+}
+
+if (window.eventSender) {
+    (async () => {
+        await runTest();
+        finishJSTest();        
+    })();
+} else {
+    let timer = null;
+    document.addEventListener('selectionchange', () => {
+        if (timer)
+            clearTimeout(timer);
+        timer = setTimeout(runAssertions, 1000);
+    });
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -418,8 +418,8 @@ void VisibleSelection::validate(TextGranularity granularity)
     adjustSelectionToAvoidCrossingEditingBoundaries();
     updateSelectionType();
 
-    bool shouldUpdateAnchor = false; // Set to false because of <rdar://problem/69542459>. Can be returned to original logic when this problem is fully fixed.
-    bool shouldUpdateFocus = false; // Ditto.
+    bool shouldUpdateAnchor = m_start != startBeforeAdjustments;
+    bool shouldUpdateFocus = m_end != endBeforeAdjustments;
 
     if (isRange()) {
         // "Constrain" the selection to be the smallest equivalent range of nodes.

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -33,6 +33,7 @@
 #include "PlatformMouseEvent.h"
 #include "RenderObject.h"
 #include "ScrollTypes.h"
+#include "SimpleRange.h"
 #include "TextEventInputType.h"
 #include "TextGranularity.h"
 #include "Timer.h"
@@ -606,6 +607,7 @@ private:
 
 #if ENABLE(DRAG_SUPPORT)
     LayoutPoint m_dragStartPosition;
+    std::optional<SimpleRange> m_dragStartSelection;
     RefPtr<Element> m_dragTarget;
     bool m_mouseDownMayStartDrag { false };
     bool m_dragMayStartSelectionInstead { false };


### PR DESCRIPTION
#### ca201a717c242c53d1171e58aee57a5665cd5bc5
<pre>
[Live Range Selection] Expanding selection by granularity should expand anchor &amp; focus
<a href="https://bugs.webkit.org/show_bug.cgi?id=247239">https://bugs.webkit.org/show_bug.cgi?id=247239</a>

Reviewed by Wenson Hsieh and Darin Adler.

This patch reverts commits.webkit.org/r268847 and implements a new fix.

Ideally, we fix VisibleSelection::adjustSelectionRespectingGranularity to not expand the end more than
required but that approach causes regressions (e.g. extending selection backwards will end up
deselecting the original word that was double tapped when drag selecting text backwards), some of which
are hard to overcome.

So, this patch instead detects when the ending is expanding unexpectedly, and corrects it in
EventHandler::updateSelectionForMouseDrag.

* LayoutTests/editing/selection/double-click-expands-focus-anchor-live-range-expected.txt: Added.
* LayoutTests/editing/selection/double-click-expands-focus-anchor-live-range.html: Added.

* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::validate): Reverted r268847.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDownDispatchingSelectStart):
(WebCore::EventHandler::handleMousePressEventDoubleClick):
(WebCore::EventHandler::updateSelectionForMouseDrag): Detect when the end is erroneously extending,
and correct back to the original end.

* Source/WebCore/page/EventHandler.h:

Canonical link: <a href="https://commits.webkit.org/256174@main">https://commits.webkit.org/256174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002cc4d652b20ce07be7d57d668b42dd01bb7661

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104542 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164806 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4170 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32268 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100462 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3013 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29998 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84927 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72889 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38677 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18313 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36508 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4257 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40434 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38828 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->