### PR TITLE
REGRESSION (256117@main): Unable to toggle network connection integrity using `-_setNetworkConnectionIntegrityEnabled:`

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -591,10 +591,10 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     return _websitePolicies->networkConnectionIntegrityPolicy().contains(WebCore::NetworkConnectionIntegrity::Enabled);
 }
 
-- (void)_setNetworkConnectionIntegrityEnabled:(BOOL)networkConnectionIntegrityEnabled
+- (void)_setNetworkConnectionIntegrityEnabled:(BOOL)enabled
 {
     auto webCorePolicy = _websitePolicies->networkConnectionIntegrityPolicy();
-    webCorePolicy.add(WebCore::NetworkConnectionIntegrity::Enabled);
+    webCorePolicy.set(WebCore::NetworkConnectionIntegrity::Enabled, enabled);
     _websitePolicies->setNetworkConnectionIntegrityPolicy(webCorePolicy);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1754,3 +1754,15 @@ TEST(WebpagePreferences, UserExplicitlyPrefersColorSchemeDark)
     [webView loadTestPageNamed:@"color-scheme"];
     [webView waitForMessage:@"dark-detected"];
 }
+
+TEST(WebpagePreferences, ToggleNetworkConnectionIntegrity)
+{
+    auto preferences = adoptNS([WKWebpagePreferences new]);
+    EXPECT_FALSE([preferences _networkConnectionIntegrityEnabled]);
+    [preferences _setNetworkConnectionIntegrityEnabled:YES];
+    EXPECT_TRUE([preferences _networkConnectionIntegrityEnabled]);
+    [preferences _setNetworkConnectionIntegrityEnabled:NO];
+    EXPECT_FALSE([preferences _networkConnectionIntegrityEnabled]);
+    [preferences _setNetworkConnectionIntegrityEnabled:YES];
+    EXPECT_TRUE([preferences _networkConnectionIntegrityEnabled]);
+}


### PR DESCRIPTION
#### 778b4272eb823f94bfb1162f0aa935096b09f105
<pre>
REGRESSION (256117@main): Unable to toggle network connection integrity using `-_setNetworkConnectionIntegrityEnabled:`
<a href="https://bugs.webkit.org/show_bug.cgi?id=247246">https://bugs.webkit.org/show_bug.cgi?id=247246</a>

Reviewed by Tim Horton.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setNetworkConnectionIntegrityEnabled:]):

Add or remove the `Enabled` flag, instead of unconditionally adding the flag.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:

Add a simple API test to exercise the change.

Canonical link: <a href="https://commits.webkit.org/256179@main">https://commits.webkit.org/256179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/606bbc0d5ef0bec96239fcc327331ecb61e2b5c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104477 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164740 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4105 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32201 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100398 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/2965 "Passed tests") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/29950 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72834 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38612 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36446 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19535 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-popup.https.html (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40369 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42225 "Unable to confirm if test failures are introduced by change, retrying build") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2046 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38765 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->