### PR TITLE
Clear floats added dynamically to previous siblings

### DIFF
--- a/LayoutTests/fast/block/margin-collapse/clear-dynamically-added-float-expected.txt
+++ b/LayoutTests/fast/block/margin-collapse/clear-dynamically-added-float-expected.txt
@@ -1,0 +1,2 @@
+PASS
+Clear floats added dynamically to previous siblings. There should be a blue bar below the green bar and both should be 50px high.

--- a/LayoutTests/fast/block/margin-collapse/clear-dynamically-added-float.html
+++ b/LayoutTests/fast/block/margin-collapse/clear-dynamically-added-float.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0px;
+}
+.inner{
+    float: left;
+    display: none;
+    width: 100px;
+    height: 50px;
+    background-color: green;
+}
+.clear {
+    clear: both;
+}
+</style>
+<div style="width: 100px;">
+    <div>
+        <div class="inner"></div>
+        <div class="clear"></div>
+    </div>
+    <div style="margin-top: -20px;">
+        <div class="clear" id="clear" style="width: 100px; height:50px; background-color: blue" data-offset-y=50></div>
+    </div>
+</div>
+<div id="test-output"></div>
+<script src="../../../resources/check-layout.js"></script>
+<script>
+    document.body.offsetTop;
+    document.querySelector('.inner').style.display = 'block';
+    window.checkLayout("#clear", document.getElementById("test-output"));
+</script>
+<p>Clear floats added dynamically to previous siblings. There should be a blue bar below the green bar and both should be 50px high.</p>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1160,16 +1160,11 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Rende
 
     LayoutUnit beforeCollapseLogicalTop = logicalHeight();
     LayoutUnit logicalTop = beforeCollapseLogicalTop;
-
-    LayoutUnit clearanceForSelfCollapsingBlock;
-    
     // If the child's previous sibling is a self-collapsing block that cleared a float then its top border edge has been set at the bottom border edge
     // of the float. Since we want to collapse the child's top margin with the self-collapsing block's top and bottom margins we need to adjust our parent's height to match the 
     // margin top of the self-collapsing block. If the resulting collapsed margin leaves the child still intruding into the float then we will want to clear it.
-    if (!marginInfo.canCollapseWithMarginBefore() && is<RenderBlockFlow>(prevSibling) && downcast<RenderBlockFlow>(*prevSibling).isSelfCollapsingBlock()) {
-        clearanceForSelfCollapsingBlock = downcast<RenderBlockFlow>(*prevSibling).marginOffsetForSelfCollapsingBlock();
-        setLogicalHeight(logicalHeight() - clearanceForSelfCollapsingBlock);
-    }
+    if (!marginInfo.canCollapseWithMarginBefore() && is<RenderBlockFlow>(prevSibling) && downcast<RenderBlockFlow>(*prevSibling).isSelfCollapsingBlock())
+        setLogicalHeight(logicalHeight() - downcast<RenderBlockFlow>(*prevSibling).marginOffsetForSelfCollapsingBlock());
 
     if (childIsSelfCollapsing) {
         // This child has no height. We need to compute our
@@ -1227,10 +1222,10 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Rende
             addOverhangingFloats(block, false);
         setLogicalHeight(oldLogicalHeight);
 
-        // If |child|'s previous sibling is a self-collapsing block that cleared a float and margin collapsing resulted in |child| moving up
+        // If |child|'s previous sibling is or contains a self-collapsing block that cleared a float and margin collapsing resulted in |child| moving up
         // into the margin area of the self-collapsing block then the float it clears is now intruding into |child|. Layout again so that we can look for
         // floats in the parent that overhang |child|'s new logical top.
-        bool logicalTopIntrudesIntoFloat = clearanceForSelfCollapsingBlock > 0 && logicalTop < beforeCollapseLogicalTop;
+        bool logicalTopIntrudesIntoFloat = logicalTop < beforeCollapseLogicalTop;
         if (child && logicalTopIntrudesIntoFloat && containsFloats() && !child->avoidsFloats() && lowestFloatLogicalBottom() > logicalTop)
             child->setNeedsLayout();
     }


### PR DESCRIPTION
#### 6c2570b4a4d2472445444323e37741fc45e90904
<pre>
Clear floats added dynamically to previous siblings

Clear floats added dynamically to previous siblings
<a href="https://bugs.webkit.org/show_bug.cgi?id=247237">https://bugs.webkit.org/show_bug.cgi?id=247237</a>

Reviewed by Alan Baradlay.

This patch is to align Webkit behavior with Blink / Chrome and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/c75a8e71e60527400e95d0834f4a07a018087130">https://chromium.googlesource.com/chromium/src.git/+/c75a8e71e60527400e95d0834f4a07a018087130</a>

If margin collapsing moves a child up into a previous
sibling, we shouldn&apos;t add any floats that it may have cleared and prompt another layout
so that the child can also clear them if necessary. Confining the need for a layout to
cases where the self-collapsing block has margin excludes the more obvious case
where a sibling has a lot of negative margin and moves up into a sibling with
nested floats inside.

* Source/WebCore/rendering/RenderBlockFlow:
(RenderBlockFlow::collapseMarginsWithChildInfo): Remove &quot;clearanceForSelfCollapsingBlock&quot; and conditions and update comment as needed
* LayoutTests/fast/block/margin-collapse/clear-dynamically-added-float.html: Added Test Case
* LayoutTests/fast/block/margin-collapse/clear-dynamically-added-float-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256238@main">https://commits.webkit.org/256238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d183fcb1ba57a7140a47472176b9eacb88aeb1e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104630 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164883 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4260 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32355 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100531 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100695 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3093 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81547 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30073 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85006 "Found 1 new API test failure: TestWebKitAPI.ServiceWorkers.SuspendServiceWorkerProcessBasedOnClientProcessesWithoutSeparateServiceWorkerProcess (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72969 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38761 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18392 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19673 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4312 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40517 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42363 "Found 30 new test failures: editing/style/apply-style-iframe-crash.html, fast/frames/frame-limit.html, highlight/highlight-world-leak.html, http/tests/resourceLoadStatistics/ping-to-prevalent-resource.html, http/tests/ssl/upgrade-origin-usage.html, http/tests/websocket/tests/hybi/client-close-2.html, imported/w3c/web-platform-tests/IndexedDB/database-names-by-origin.html, imported/w3c/web-platform-tests/cookies/path/match.html, imported/w3c/web-platform-tests/custom-elements/enqueue-custom-element-callback-reactions-inside-another-callback.html, imported/w3c/web-platform-tests/custom-elements/throw-on-dynamic-markup-insertion-counter-construct-xml-parser.xhtml ... (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38909 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->