### PR TITLE
JetStream3 harness: remove `await` right after `return` in async functions

### DIFF
--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -201,20 +201,20 @@ const fileLoader = (function() {
                 throw new Error("Fetch failed");
             }
             if (url.indexOf(".js") !== -1)
-                return await response.text();
+                return response.text();
             else if (url.indexOf(".wasm") !== -1)
-                return await response.arrayBuffer();
+                return response.arrayBuffer();
 
             throw new Error("should not be reached!");
         }
 
         async load(url) {
             if (this.requests.has(url))
-                return (await this.requests.get(url));
+                return this.requests.get(url);
 
             let promise = this._loadInternal(url);
             this.requests.set(url, promise);
-            return (await promise);
+            return promise;
         }
     }
     return new Loader;
@@ -711,11 +711,11 @@ class Benchmark {
 
         let promise = JetStream.loadCache[resource];
         if (promise)
-            return await promise;
+            return promise;
 
         promise = this.doLoadBlob(resource);
         JetStream.loadCache[resource] = promise;
-        return await promise;
+        return promise;
     }
 
     updateCounter() {


### PR DESCRIPTION
#### 8fc72133af5b348dd53040a8b69568add700b9a9
<pre>
JetStream3 harness: remove `await` right after `return` in async functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247271">https://bugs.webkit.org/show_bug.cgi?id=247271</a>

Reviewed by Tim Nguyen.

Awaiting a promise before returning from an async function is redundant as the
function&apos;s result is a promise anyway. This is a non-observable style change.

* PerformanceTests/JetStream3/JetStreamDriver.js:
(prototype.async _loadInternal):
(prototype.async load):
(const.fileLoader):
(prototype.async loadBlob):

Canonical link: <a href="https://commits.webkit.org/256584@main">https://commits.webkit.org/256584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9e9468abc161c6b5ff0594626be5e4cf217a98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96232 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/5487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/105779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/5611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/101903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/5611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/88616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/5611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/37647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/69 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2186 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/70 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/29291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->