### PR TITLE
web manifest: implement orientation member parsing

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -28,6 +28,7 @@
 #if ENABLE(APPLICATION_MANIFEST)
 
 #include "Color.h"
+#include "ScreenOrientationLockType.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
@@ -60,6 +61,7 @@ struct ApplicationManifest {
     String description;
     URL scope;
     Display display;
+    ScreenOrientationLockType orientation;
     URL startURL;
     URL id;
     Color themeColor;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -162,6 +162,38 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
     return ApplicationManifest::Display::Browser;
 }
 
+WebCore::ScreenOrientationLockType ApplicationManifestParser::parseOrientation(const JSON::Object& manifest)
+{
+    auto value = manifest.getValue("orientation"_s);
+    if (!value)
+        return { };
+
+    auto stringValue = value->asString();
+    if (!stringValue) {
+        logManifestPropertyNotAString("orientation"_s);
+        return { };
+    }
+
+    static constexpr std::pair<ComparableLettersLiteral, WebCore::ScreenOrientationLockType> orientationValueMappings[] = {
+        { "any", WebCore::ScreenOrientationLockType::Any },
+        { "landscape-primary", WebCore::ScreenOrientationLockType::LandscapePrimary },
+        { "landscape-secondary", WebCore::ScreenOrientationLockType::LandscapeSecondary },
+        { "landscape", WebCore::ScreenOrientationLockType::Landscape },
+        { "natural", WebCore::ScreenOrientationLockType::Natural },
+        { "portrait-primary", WebCore::ScreenOrientationLockType::PortraitPrimary },
+        { "portrait-secondary", WebCore::ScreenOrientationLockType::PortraitSecondary },
+        { "portrait", WebCore::ScreenOrientationLockType::Portrait },
+    };
+
+    static SortedArrayMap orientationValues { orientationValueMappings };
+
+    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).stripWhiteSpace()))
+        return *orientationValue;
+
+    logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid orientation."_s));
+    return { };
+}
+
 String ApplicationManifestParser::parseName(const JSON::Object& manifest)
 {
     return parseGenericString(manifest, "name"_s);

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -46,6 +46,7 @@ private:
 
     URL parseStartURL(const JSON::Object&, const URL&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
+    WebCore::ScreenOrientationLockType parseOrientation(const JSON::Object&);
     String parseName(const JSON::Object&);
     String parseDescription(const JSON::Object&);
     String parseShortName(const JSON::Object&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -692,6 +692,17 @@ struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
     Fullscreen
 };
 
+enum class WebCore::ScreenOrientationLockType : uint8_t {
+    Any
+    Natural
+    Landscape
+    Portrait
+    PortraitPrimary
+    PortraitSecondary
+    LandscapePrimary
+    LandscapeSecondary
+};
+
 [Nested, OptionSet] enum class WebCore::ApplicationManifest::Icon::Purpose : uint8_t {
     Any
     Monochrome
@@ -711,6 +722,7 @@ struct WebCore::ApplicationManifest {
     String description
     URL scope
     WebCore::ApplicationManifest::Display display
+    WebCore::ScreenOrientationLockType orientation
     URL startURL
     URL id
     WebCore::Color themeColor

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -42,6 +42,17 @@ typedef NS_ENUM(NSInteger, _WKApplicationManifestDisplayMode) {
     _WKApplicationManifestDisplayModeFullScreen,
 } WK_API_AVAILABLE(macos(10.13.4), ios(11.3));
 
+typedef NS_OPTIONS(NSInteger, _WKApplicationManifestOrientation) {
+    _WKApplicationManifestOrientationAny = (1 << 0),
+    _WKApplicationManifestOrientationNatural = (1 << 1),
+    _WKApplicationManifestOrientationLandscape = (1 << 2),
+    _WKApplicationManifestOrientationPortrait = (1 << 3),
+    _WKApplicationManifestOrientationPortraitPrimary = (1 << 4),
+    _WKApplicationManifestOrientationPortraitSecondary = (1 << 5),
+    _WKApplicationManifestOrientationLandscapePrimary = (1 << 6),
+    _WKApplicationManifestOrientationLandscapeSecondary = (1 << 7),
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 typedef NS_ENUM(NSInteger, _WKApplicationManifestIconPurpose) {
     _WKApplicationManifestIconPurposeAny = (1 << 0),
     _WKApplicationManifestIconPurposeMonochrome = (1 << 1),

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -137,7 +137,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
 
 @end
 
-    
+
 @implementation _WKApplicationManifest
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -154,6 +154,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
     String description = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
     URL scopeURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"scope"];
     NSInteger display = [aDecoder decodeIntegerForKey:@"display"];
+    NSInteger orientation = [aDecoder decodeIntegerForKey:@"orientation"];
     URL startURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"start_url"];
     URL manifestId = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"manifestId"];
     WebCore::CocoaColor *themeColor = [aDecoder decodeObjectOfClass:[WebCore::CocoaColor class] forKey:@"theme_color"];
@@ -165,6 +166,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
         WTFMove(description),
         WTFMove(scopeURL),
         static_cast<WebCore::ApplicationManifest::Display>(display),
+        static_cast<WebCore::ScreenOrientationLockType>(orientation),
         WTFMove(startURL),
         WTFMove(manifestId),
         WebCore::roundAndClampToSRGBALossy(themeColor.CGColor),
@@ -193,6 +195,7 @@ static std::optional<WebCore::ApplicationManifest::Icon> makeVectorElement(const
     [aCoder encodeObject:self.applicationDescription forKey:@"description"];
     [aCoder encodeObject:self.scope forKey:@"scope"];
     [aCoder encodeInteger:static_cast<NSInteger>(_applicationManifest->applicationManifest().display) forKey:@"display"];
+    [aCoder encodeInteger:static_cast<NSInteger>(_applicationManifest->applicationManifest().orientation) forKey:@"orientation"];
     [aCoder encodeObject:self.startURL forKey:@"start_url"];
     [aCoder encodeObject:self.manifestId forKey:@"manifestId"];
     [aCoder encodeObject:self.themeColor forKey:@"theme_color"];
@@ -258,6 +261,29 @@ static NSString *nullableNSString(const WTF::String& string)
         return _WKApplicationManifestDisplayModeFullScreen;
     }
 
+    ASSERT_NOT_REACHED();
+}
+
+- (_WKApplicationManifestOrientation)orientation
+{
+    switch (_applicationManifest->applicationManifest().orientation) {
+    case WebCore::ScreenOrientationLockType::Any:
+        return _WKApplicationManifestOrientationAny;
+    case WebCore::ScreenOrientationLockType::Natural:
+        return _WKApplicationManifestOrientationNatural;
+    case WebCore::ScreenOrientationLockType::Landscape:
+        return _WKApplicationManifestOrientationLandscape;
+    case WebCore::ScreenOrientationLockType::Portrait:
+        return _WKApplicationManifestOrientationPortrait;
+    case WebCore::ScreenOrientationLockType::PortraitPrimary:
+        return _WKApplicationManifestOrientationPortraitPrimary;
+    case WebCore::ScreenOrientationLockType::PortraitSecondary:
+        return _WKApplicationManifestOrientationPortraitSecondary;
+    case WebCore::ScreenOrientationLockType::LandscapePrimary:
+        return _WKApplicationManifestOrientationLandscapePrimary;
+    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
+        return _WKApplicationManifestOrientationLandscapeSecondary;
+    }
     ASSERT_NOT_REACHED();
 }
 
@@ -328,6 +354,11 @@ static NSString *nullableNSString(const WTF::String& string)
 - (_WKApplicationManifestDisplayMode)displayMode
 {
     return _WKApplicationManifestDisplayModeBrowser;
+}
+
+- (_WKApplicationManifestOrientation)orientation
+{
+    return nil;
 }
 
 - (NSArray<_WKApplicationManifestIcon *> *)icons

--- a/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp
@@ -47,6 +47,29 @@ static inline std::ostream& operator<<(std::ostream& os, const ApplicationManife
         return os << "ApplicationManifest::Display::Fullscreen";
     }
 }
+
+static inline std::ostream& operator<<(std::ostream& os, const WebCore::ScreenOrientationLockType& orientation)
+{
+    switch (orientation) {
+    case WebCore::ScreenOrientationLockType::Any:
+        return os << "WebCore::ScreenOrientationLockType::Any";
+    case WebCore::ScreenOrientationLockType::Landscape:
+        return os << "WebCore::ScreenOrientationLockType::Landscape";
+    case WebCore::ScreenOrientationLockType::Portrait:
+        return os << "WebCore::ScreenOrientationLockType::Portrait";
+    case WebCore::ScreenOrientationLockType::PortraitPrimary:
+        return os << "WebCore::ScreenOrientationLockType::PortraitPrimary";
+    case WebCore::ScreenOrientationLockType::PortraitSecondary:
+        return os << "WebCore::ScreenOrientationLockType::PortraitSecondary";
+    case WebCore::ScreenOrientationLockType::LandscapePrimary:
+        return os << "WebCore::ScreenOrientationLockType::LandscapePrimary";
+    case WebCore::ScreenOrientationLockType::LandscapeSecondary:
+        return os << "WebCore::ScreenOrientationLockType::LandscapeSecondary";
+    case WebCore::ScreenOrientationLockType::Natural:
+        return os << "WebCore::ScreenOrientationLockType::Natural";
+    }
+}
+
 } // namespace WebCore
 
 class ApplicationManifestParserTest : public testing::Test {
@@ -103,6 +126,13 @@ public:
     {
         auto manifest = parseTopLevelProperty("display"_s, rawJSON);
         auto value = manifest.display;
+        EXPECT_EQ(expectedValue, value);
+    }
+
+    void testOrientation(const String& rawJSON, WebCore::ScreenOrientationLockType expectedValue)
+    {
+        auto manifest = parseTopLevelProperty("orientation"_s, rawJSON);
+        auto value = manifest.orientation;
         EXPECT_EQ(expectedValue, value);
     }
 
@@ -305,6 +335,26 @@ TEST_F(ApplicationManifestParserTest, Display)
     testDisplay("\"\t\nMINIMAL-UI \""_s, ApplicationManifest::Display::MinimalUI);
 }
 
+TEST_F(ApplicationManifestParserTest, Orientation)
+{
+    testOrientation("123"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("null"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("true"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("{ }"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("[ ]"_s, WebCore::ScreenOrientationLockType());
+    testOrientation("\"\""_s, WebCore::ScreenOrientationLockType());
+    testOrientation("\"garbage string\""_s, WebCore::ScreenOrientationLockType());
+
+    testOrientation("\"any\""_s, WebCore::ScreenOrientationLockType::Any);
+    testOrientation("\"natural\""_s, WebCore::ScreenOrientationLockType::Natural);
+    testOrientation("\"landscape\""_s, WebCore::ScreenOrientationLockType::Landscape);
+    testOrientation("\"landscape-primary\""_s, WebCore::ScreenOrientationLockType::LandscapePrimary);
+    testOrientation("\"landscape-secondary\""_s, WebCore::ScreenOrientationLockType::LandscapeSecondary);
+    testOrientation("\"portrait\""_s, WebCore::ScreenOrientationLockType::Portrait);
+    testOrientation("\"portrait-primary\""_s, WebCore::ScreenOrientationLockType::PortraitPrimary);
+    testOrientation("\"portrait-secondary\""_s, WebCore::ScreenOrientationLockType::PortraitSecondary);
+}
+
 TEST_F(ApplicationManifestParserTest, Name)
 {
     testName("123"_s, String());
@@ -440,7 +490,6 @@ TEST_F(ApplicationManifestParserTest, Icons)
     OptionSet<ApplicationManifest::Icon::Purpose> purposeMonochromeAny { ApplicationManifest::Icon::Purpose::Monochrome, ApplicationManifest::Icon::Purpose::Any };
 
     testIconsPurposes("\"monochrome any\""_s, purposeMonochromeAny);
-
 }
 
 #endif


### PR DESCRIPTION
#### 028845122272a8683b6280e1c5e2f4c33affb84d
<pre>
web manifest: implement orientation member parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247275">https://bugs.webkit.org/show_bug.cgi?id=247275</a>
rdar://101770484

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseOrientation):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithCoder:]):
(-[_WKApplicationManifest encodeWithCoder:]):
(-[_WKApplicationManifest orientation]):
* Tools/TestWebKitAPI/Tests/WebCore/ApplicationManifestParser.cpp:
(WebCore::operator&lt;&lt;):
(ApplicationManifestParserTest::testOrientation):
(ApplicationManifestParserTest::testIconsPurposes):
(TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/028845122272a8683b6280e1c5e2f4c33affb84d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105466 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165784 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5257 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33916 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101294 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101569 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3868 "Found 3 new test failures: applicationmanifest/display-mode-bad-manifest.html, applicationmanifest/display-mode-subframe.html, applicationmanifest/display-mode.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82513 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30902 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85722 "Found 2 new API test failures: TestWebKitAPI.ApplicationManifestParserTest.Orientation, TestWebKitAPI.ApplicationManifest.DisplayMode (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87626 "Found 2 new API test failures: TestWebKitAPI.ApplicationManifestParserTest.Orientation, TestWebKitAPI.ApplicationManifest.DisplayMode (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73735 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39647 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19162 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37328 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20495 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41755 "Hash 02884512 for PR 5971 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43120 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39751 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->