### PR TITLE
Fix debug assertion failure in IndentOutdentCommand::indentIntoBlockquote

### DIFF
--- a/LayoutTests/editing/execCommand/indent-user-select-all-blockquotes-expected.txt
+++ b/LayoutTests/editing/execCommand/indent-user-select-all-blockquotes-expected.txt
@@ -1,0 +1,11 @@
+This tests indenting into a new blockquote when blockquotes are styled as -webkit-user-select: all. -webkit-user-select: all causes the new blockquote element to be uneditable so we should bail out and not indent.
+
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS No blockquote created
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/execCommand/indent-user-select-all-blockquotes.html
+++ b/LayoutTests/editing/execCommand/indent-user-select-all-blockquotes.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+  blockquote {
+    -webkit-user-select: all;
+  }
+</style>
+</head>
+<body>
+<p id="object"></p>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+description('This tests indenting into a new blockquote when blockquotes are styled as -webkit-user-select: all. -webkit-user-select: all causes the new blockquote element to be uneditable so we should bail out and not indent.');
+
+if (window.testRunner)
+    window.testRunner.dumpAsText();
+
+let selection = window.getSelection();
+selection.removeAllRanges();
+let range = document.createRange();
+range.setStartBefore(object, 0);
+range.setEndAfter(object, 0);
+selection.addRange(range);
+document.designMode = 'on'
+document.execCommand('Indent');
+
+if (document.getElementsByTagName("blockquote").length)
+    testFailed("Should not have blockquote");
+else
+    testPassed("No blockquote created");
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -118,6 +118,10 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
             insertNodeAt(*targetBlockquote, start);
         else if (!insertNodeBefore(*targetBlockquote, *outerBlock))
             return;
+        if (!targetBlockquote->hasEditableStyle()) {
+            removeNode(*targetBlockquote);
+            return;
+        }
         startOfContents = positionInParentAfterNode(targetBlockquote.get());
     }
     


### PR DESCRIPTION
#### 8a344c3387b2bfe58dc8c8a94b1683187effef2e
<pre>
Fix debug assertion failure in IndentOutdentCommand::indentIntoBlockquote
<a href="https://bugs.webkit.org/show_bug.cgi?id=240377">https://bugs.webkit.org/show_bug.cgi?id=240377</a>
rdar://93236442

Reviewed by Ryosuke Niwa.

When indenting an element into a new uneditable blockquote we end up
replacing the element with an empty blockquote instead of indenting.
This also fails an assert in debug builds.
We should just bail out instead of trying to indent if the blockquote
is not editable.

* LayoutTests/editing/execCommand/indent-user-select-all-blockquotes-expected.txt: Added.
* LayoutTests/editing/execCommand/indent-user-select-all-blockquotes.html: Added.
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::indentIntoBlockquote):

Canonical link: <a href="https://commits.webkit.org/256749@main">https://commits.webkit.org/256749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f336f585f50298b25e18a6feccbf116020a1961

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106135 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166468 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6061 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34603 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102846 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4521 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83212 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31491 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88239 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74404 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40334 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37997 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21134 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43677 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2246 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40410 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->