### PR TITLE
REGRESSION (STP): Animating image inside clipping border-radius ignores overflow hidden

### DIFF
--- a/LayoutTests/compositing/clipping/clip-stack-hidden-and-radius-expected.html
+++ b/LayoutTests/compositing/clipping/clip-stack-hidden-and-radius-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            position: absolute;
+            border-top-right-radius: 10px;
+            overflow: hidden;
+            height: 400px;
+            width: 600px;
+            z-index: 0;
+            box-sizing: border-box;
+            background-color: silver;
+        }
+
+        .clipping {
+            display: block;
+            position: relative;
+            overflow: hidden;
+            border: 12px solid black;
+            box-sizing: border-box;
+            z-index: 0;
+            height: 400px;
+            width: 450px;
+        }
+        
+        .composited {
+            display: block;
+            width: 600px;
+            height: 400px;
+            background-color: green;
+            will-change: transform;
+        }
+    </style>
+</head>
+<body>
+    <p>The green square should be enclosed by the black border.</p>
+    <div class="container">
+        <div class="clipping">
+            <div class="composited"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/clipping/clip-stack-hidden-and-radius.html
+++ b/LayoutTests/compositing/clipping/clip-stack-hidden-and-radius.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            position: absolute;
+            border-top-right-radius: 10px;
+            overflow: hidden;
+            height: 400px;
+            width: 600px;
+            box-sizing: border-box;
+            background-color: silver;
+        }
+
+        .clipping {
+            display: block;
+            position: relative;
+            overflow: hidden;
+            border: 12px solid black;
+            box-sizing: border-box;
+            height: 400px;
+            width: 450px;
+        }
+        
+        .composited {
+            display: block;
+            width: 600px;
+            height: 400px;
+            background-color: green;
+            will-change: transform;
+        }
+    </style>
+</head>
+<body>
+    <p>The green square should be enclosed by the black border.</p>
+    <div class="container">
+        <div class="clipping">
+            <div class="composited"></div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
#### c91af32319e79e687c345bf10927febf64d42476
<pre>
REGRESSION (STP): Animating image inside clipping border-radius ignores overflow hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=245769">https://bugs.webkit.org/show_bug.cgi?id=245769</a>
rdar://100514998

Reviewed by Alan Baradlay.

When composited layers are clipped by non-stacking-context ancestors, we build an &quot;ancestor clipping stack&quot;
to represent those clips. Contiguous sets of non-scrollable, non-radius clips can be collapsed into
a single entry as the intersection of the clip rects, which is what `pushNonScrollableClip()` does
in `RenderLayerCompositor::computeAncestorClippingStack()`.

While walking up the ancestor chain, if we encounter a clip-with-radius or overflow:scroll,
we need to push any pending non-scrollable clip, but the border-radius clause here failed
to do that, resulting in an incorrect attempt to push a clip with an infinite rect at
the end.

Fix by ensuring that the `hasBorderRadius()` clause calls `pushNonScrollableClip()` just as
the `hasCompositedScrollableOverflow()` one does.

* LayoutTests/compositing/clipping/clip-stack-hidden-and-radius-expected.html: Added.
* LayoutTests/compositing/clipping/clip-stack-hidden-and-radius.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeAncestorClippingStack const):

Canonical link: <a href="https://commits.webkit.org/256202@main">https://commits.webkit.org/256202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaa71a93e5bd0bad099fa29b072c4529dfaa4a72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/94992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104594 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164853 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/98986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4223 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32318 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100503 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3061 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81587 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30042 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/84976 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/84560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72935 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38729 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36553 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19666 "Found 6 new test failures: http/tests/resourceLoadStatistics/third-party-cookie-blocking-ephemeral.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-allow-popups-to-same-origin.https.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_anchor_download_allow_downloads.tentative.html, imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener_base.html, storage/indexeddb/intversion-long-queue.html, storage/indexeddb/modern/transaction-scheduler-1-private.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4285 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38901 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->