### PR TITLE
REGRESSION(254597@main): [ macOS wk1 Debug ] 4X imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/(Layout tests) are flakily crashing

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2142,12 +2142,6 @@ compositing/geometry/css-clip-oversize.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/245102 imported/w3c/web-platform-tests/html/browsers/windows/auxiliary-browsing-contexts/opener-noreferrer.html [ Pass Failure ]
 
-# webkit.org/b/245801 These tests are flakily crashing with a WorkerOrWorkletThread error
-[ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/worker-classic.https.html [ Skip ]
-[ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/worker-module.https.html [ Skip ]
-[ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-classic.https.html [ Skip ]
-[ Debug ] imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http-rp/upgrade/worker-module.https.html [ Skip ]
-
 webkit.org/b/245902 [ Debug ] contentfiltering/allow-media-document.html [ Skip ]
 
 webkit.org/b/246653 [ Debug ] media/modern-media-controls/media-documents/click-on-video-should-not-pause.html [ Skip ]

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -391,13 +391,13 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal()
     // This is always the last task to be performed, so the proxy is not needed for communication
     // in either side any more. However, the Worker object may still exist, and it assumes that the proxy exists, too.
     m_askedToTerminate = true;
-    m_workerThread = nullptr;
 
     m_inspectorProxy->workerTerminated();
 
     if (auto* workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(m_scriptExecutionContext.get()); workerGlobalScope && m_workerThread)
         workerGlobalScope->thread().removeChildThread(*m_workerThread);
 
+    m_workerThread = nullptr;
     m_scriptExecutionContext = nullptr;
 
     // This balances the original ref in construction.
@@ -415,6 +415,8 @@ void WorkerMessagingProxy::terminateWorkerGlobalScope()
 
     if (m_workerThread)
         m_workerThread->stop(nullptr);
+    else
+        m_scriptExecutionContext = nullptr;
 }
 
 void WorkerMessagingProxy::confirmMessageFromWorkerObject(bool hasPendingActivity)


### PR DESCRIPTION
#### 80256b359d2481c498bcf6d11524b0c52d9a79bf
<pre>
REGRESSION(254597@main): [ macOS wk1 Debug ] 4X imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-classic.http-rp/upgrade/(Layout tests) are flakily crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=245801">https://bugs.webkit.org/show_bug.cgi?id=245801</a>
rdar://100530286

Reviewed by Alex Christensen.

The tests were hitting the `m_globalScope-&gt;hasOneRef()` assertion in
WorkerOrWorkletThread::destroyWorkerGlobalScope(), indicating that something is
keeping the WorkerGlobalScope alive after its termination.

The issue was the WorkerMessagingProxy keeping the WorkerGlobalScope alive via
its m_scriptExecutionContext data member. This data member normally gets nulled
out inside WorkerMessagingProxy::workerGlobalScopeDestroyedInternal(). However,
this would only get called if we actually started a worker thread for this
Worker object. Because the first step is to actually load the script over the
network, it is possible that the Worker::terminate() gets called during script
fetching, before a worker thread has been started. In this case,
WorkerMessagingProxy::terminateWorkerGlobalScope() should clear
m_scriptExecutionContext, since nothing will clear it later on.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::workerGlobalScopeDestroyedInternal):
Fix issue where a nested worker would fail to unregister itself as a child of
its parent worker. This was because we would null check m_workerThread, which
we had just nulled out on the previous line :/

(WebCore::WorkerMessagingProxy::terminateWorkerGlobalScope):
If there is no worker thread, clear m_scriptExecutionContext since we shouldn&apos;t
be keeping our context alive anymore and workerGlobalScopeDestroyedInternal()
won&apos;t be called to do the clearing.

Canonical link: <a href="https://commits.webkit.org/256326@main">https://commits.webkit.org/256326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/019415c523f7e6d61c0b1e978f90f0ede9b27922

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104895 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165159 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4582 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33301 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100779 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3338 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82019 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30386 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39024 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36832 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20018 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40784 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2105 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39256 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->