### PR TITLE
Don't apply aspect ratio scaling to gradient background images that don't have a natural aspect ratio

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4162,8 +4162,6 @@ webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/css-bord
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/first-letter-space-not-selected.html [ ImageOnlyFailure ]
 
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-attachment-fixed-inside-transform-1.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-041.html [ ImageOnlyFailure ]
-webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-042.html [ ImageOnlyFailure ]
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-043.html [ ImageOnlyFailure ]
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-044.html [ ImageOnlyFailure ]
 webkit.org/b/206753 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-percentage-root.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/css3/masking/mask-luminance-gradient-expected.html
+++ b/LayoutTests/css3/masking/mask-luminance-gradient-expected.html
@@ -15,7 +15,7 @@
                 padding: 50px;
                 -webkit-mask-image: linear-gradient(45deg, black, transparent 100%);
                 -webkit-mask-source-type: alpha;
-                -webkit-mask-size: 200px auto;
+                -webkit-mask-size: 200px 200px;
                 -webkit-mask-repeat: repeat;
                 -webkit-mask-origin: border-box;
                 -webkit-mask-clip: border-box;

--- a/LayoutTests/css3/masking/mask-luminance-gradient.html
+++ b/LayoutTests/css3/masking/mask-luminance-gradient.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta name="fuzzy" content="maxDifference=0-2;totalPixels=191000-212333" />
+        <meta name="fuzzy" content="maxDifference=0-2;totalPixels=191000-212750" />
         <style>
             #back {
                 width: 1000px;
@@ -16,7 +16,7 @@
                 padding: 50px;
                 -webkit-mask-image: linear-gradient(45deg, white, black);
                 -webkit-mask-source-type: luminance;
-                -webkit-mask-size: 200px auto;
+                -webkit-mask-size: 200px 200px;
                 -webkit-mask-repeat: repeat;
                 -webkit-mask-origin: border-box;
                 -webkit-mask-clip: border-box;

--- a/Source/WebCore/display/css/DisplayFillLayerImageGeometry.cpp
+++ b/Source/WebCore/display/css/DisplayFillLayerImageGeometry.cpp
@@ -91,7 +91,7 @@ static inline LayoutSize resolveAgainstIntrinsicRatio(LayoutSize size, const Lay
 static LayoutSize calculateImageIntrinsicDimensions(StyleImage* image, LayoutSize positioningAreaSize)
 {
     // A generated image without a fixed size, will always return the container size as intrinsic size.
-    if (image->isGeneratedImage() && image->usesImageContainerSize())
+    if (!image->imageHasNaturalDimensions())
         return LayoutSize(positioningAreaSize.width(), positioningAreaSize.height());
 
     // FIXME: Call computeIntrinsicDimensions().
@@ -168,11 +168,12 @@ static LayoutSize calculateFillTileSize(const FillLayer& fillLayer, LayoutSize p
 
         // If one of the values is auto we have to use the appropriate
         // scale to maintain our aspect ratio.
+        bool hasNaturalAspectRatio = image && image->imageHasNaturalDimensions();
         if (layerWidth.isAuto() && !layerHeight.isAuto()) {
-            if (imageIntrinsicSize.height())
+            if (hasNaturalAspectRatio && imageIntrinsicSize.height())
                 tileSize.setWidth(imageIntrinsicSize.width() * tileSize.height() / imageIntrinsicSize.height());
         } else if (!layerWidth.isAuto() && layerHeight.isAuto()) {
-            if (imageIntrinsicSize.width())
+            if (hasNaturalAspectRatio && imageIntrinsicSize.width())
                 tileSize.setHeight(imageIntrinsicSize.height() * tileSize.width() / imageIntrinsicSize.width());
         } else if (layerWidth.isAuto() && layerHeight.isAuto()) {
             // If both width and height are auto, use the image's intrinsic size.

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -723,11 +723,12 @@ LayoutSize BackgroundPainter::calculateFillTileSize(const RenderBoxModelObject& 
 
         // If one of the values is auto we have to use the appropriate
         // scale to maintain our aspect ratio.
+        bool hasNaturalAspectRatio = image && image->imageHasNaturalDimensions();
         if (layerWidth.isAuto() && !layerHeight.isAuto()) {
-            if (imageIntrinsicSize.height())
+            if (hasNaturalAspectRatio && imageIntrinsicSize.height())
                 tileSize.setWidth(imageIntrinsicSize.width() * tileSize.height() / imageIntrinsicSize.height());
         } else if (!layerWidth.isAuto() && layerHeight.isAuto()) {
-            if (imageIntrinsicSize.width())
+            if (hasNaturalAspectRatio && imageIntrinsicSize.width())
                 tileSize.setHeight(imageIntrinsicSize.height() * tileSize.width() / imageIntrinsicSize.width());
         } else if (layerWidth.isAuto() && layerHeight.isAuto()) {
             // If both width and height are auto, use the image's intrinsic size.

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -711,7 +711,7 @@ static inline LayoutSize resolveAgainstIntrinsicRatio(const LayoutSize& size, co
 LayoutSize RenderBoxModelObject::calculateImageIntrinsicDimensions(StyleImage* image, const LayoutSize& positioningAreaSize, ScaleByEffectiveZoomOrNot shouldScaleOrNot) const
 {
     // A generated image without a fixed size, will always return the container size as intrinsic size.
-    if (image->isGeneratedImage() && image->usesImageContainerSize())
+    if (!image->imageHasNaturalDimensions())
         return LayoutSize(positioningAreaSize.width(), positioningAreaSize.height());
 
     Length intrinsicWidth;

--- a/Source/WebCore/rendering/style/StyleGeneratedImage.h
+++ b/Source/WebCore/rendering/style/StyleGeneratedImage.h
@@ -56,6 +56,7 @@ protected:
     bool imageHasRelativeHeight() const final { return !m_fixedSize; }
     bool usesImageContainerSize() const final { return !m_fixedSize; }
     void setContainerContextForRenderer(const RenderElement&, const FloatSize& containerSize, float) final { m_containerSize = containerSize; }
+    bool imageHasNaturalDimensions() const final { return !usesImageContainerSize(); }
     
     void addClient(RenderElement&) final;
     void removeClient(RenderElement&) final;

--- a/Source/WebCore/rendering/style/StyleImage.h
+++ b/Source/WebCore/rendering/style/StyleImage.h
@@ -74,6 +74,7 @@ public:
     virtual bool imageHasRelativeWidth() const = 0;
     virtual bool imageHasRelativeHeight() const = 0;
     virtual float imageScaleFactor() const { return 1; }
+    virtual bool imageHasNaturalDimensions() const { return true; }
 
     // Image.
     virtual RefPtr<Image> image(const RenderElement*, const FloatSize&) const = 0;


### PR DESCRIPTION
#### 759576401a3d3175f5f17ea8756f36423b147a51
<pre>
Don&apos;t apply aspect ratio scaling to gradient background images that don&apos;t have a natural aspect ratio
<a href="https://bugs.webkit.org/show_bug.cgi?id=247298">https://bugs.webkit.org/show_bug.cgi?id=247298</a>
&lt;rdar://101661731&gt;

Reviewed by Simon Fraser.

If we use a gradient as a background image, and set one of the background size dimension to auto, we currently scale that dimension by the same amount as the other axis to preserve the aspect ratio.

Gradients have no natural dimensions (and thus no natural aspect ratio) - <a href="https://w3c.github.io/csswg-drafts/css-images/#gradients.">https://w3c.github.io/csswg-drafts/css-images/#gradients.</a>

Background sizing should fall back to using 100% (for the case where we have one size, and auto), if there&apos;s no natural aspect ratio or dimensions - <a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#background-size">https://w3c.github.io/csswg-drafts/css-backgrounds/#background-size</a>

* LayoutTests/TestExpectations:
* Source/WebCore/display/css/DisplayFillLayerImageGeometry.cpp:
(WebCore::Display::calculateImageIntrinsicDimensions):
(WebCore::Display::calculateFillTileSize):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::calculateFillTileSize):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::calculateImageIntrinsicDimensions const):
* Source/WebCore/rendering/style/StyleGeneratedImage.h:
* Source/WebCore/rendering/style/StyleImage.h:
(WebCore::StyleImage::imageHasNaturalDimensions const):

Canonical link: <a href="https://commits.webkit.org/256256@main">https://commits.webkit.org/256256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7a97d791631e3b0fbe32bd8d80c4bc226478511

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104818 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4473 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87539 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100888 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38949 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36764 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4322 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40704 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42689 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/39083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->