### PR TITLE
Strength reduction analyzes RegEx.exec incorrectly and generate a hole for the result array

### DIFF
--- a/JSTests/stress/regexp-strengthreduce-results-noholes.js
+++ b/JSTests/stress/regexp-strengthreduce-results-noholes.js
@@ -1,0 +1,42 @@
+// This teset passes if it doesn't throw.
+
+function runRegExp()
+{
+    let m = /ab(c)?d/.exec("abd");
+    return m;
+}
+
+noInline(runRegExp);
+
+let firstResult = undefined;
+let firstResultKeys = undefined;
+
+function assertSameAsFirstResult(testRun, o)
+{
+    if (firstResult.length != o.length)
+        throw testRun + " results have different length than the first results";
+
+    oKeys = Object.keys(o);
+
+    if (firstResultKeys.length != oKeys.length)
+        throw testRun + " results have different number of keys than the first result, first result keys: " + firstResultKeys + " this result keys: " + oKeys;
+
+    for (let i = 0; i < firstResultKeys.length; i++)
+    {
+        if (firstResultKeys[i] != oKeys[i])
+            throw testRun + " results mismatch, first result keys: " + firstResultKeys + " this result keys: " + oKeys;
+    }
+}
+
+let count = 20000;
+
+for (let i=0; i < count; i++) {
+    let result = runRegExp();
+    if (i == 0) {
+        firstResult = result;
+        firstResultKeys = Object.keys(firstResult);
+        continue;
+    }
+
+    assertSameAsFirstResult(i, result);
+}

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -748,8 +748,10 @@ private:
                             PromotedLocationDescriptor(NamedPropertyPLoc, groupsIndex));
 
                         auto materializeString = [&] (const String& string) -> Node* {
-                            if (string.isNull())
-                                return nullptr;
+                            if (string.isNull()) {
+                                return m_insertionSet.insertConstant(
+                                    m_nodeIndex, origin, jsUndefined());
+                            }
                             if (string.isEmpty()) {
                                 return m_insertionSet.insertConstant(
                                     m_nodeIndex, origin, vm().smallStrings.emptyString());
@@ -761,11 +763,10 @@ private:
                         };
 
                         for (unsigned i = 0; i < resultArray.size(); ++i) {
-                            if (Node* node = materializeString(resultArray[i])) {
-                                m_graph.m_varArgChildren.append(Edge(node, UntypedUse));
-                                data->m_properties.append(
-                                    PromotedLocationDescriptor(IndexedPropertyPLoc, i));
-                            }
+                            Node* node = materializeString(resultArray[i]);
+                            m_graph.m_varArgChildren.append(Edge(node, UntypedUse));
+                            data->m_properties.append(
+                                PromotedLocationDescriptor(IndexedPropertyPLoc, i));
                         }
 
                         Node* resultNode = m_insertionSet.insertNode(


### PR DESCRIPTION
#### b0b694fd099f5692c3d73f7d66abaca58c4f9b4e
<pre>
Strength reduction analyzes RegEx.exec incorrectly and generate a hole for the result array
<a href="https://bugs.webkit.org/show_bug.cgi?id=245464">https://bugs.webkit.org/show_bug.cgi?id=245464</a>
rdar://100494428

Reviewed by Mark Lam.

When employing RegExp.exec strength reductions, we need to create &quot;undefined&quot; entries in the result array
instead of null entries per the EcmaScript spec for RegExp.match.

* JSTests/stress/regexp-strengthreduce-results-noholes.js: Added.
(runRegExp):
(assertSameAsFirstResult):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/256241@main">https://commits.webkit.org/256241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a982cb04df3a4950cb3e070512b1bb628196c1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104624 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164877 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4253 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32347 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87328 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100525 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100689 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3088 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81687 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30068 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85002 "Found 3 new API test failures: TestWebKitAPI._WKDownload.DownloadRequestOriginalURLFrame, TestWebKitAPI.URLSchemeHandler.Frames, TestWebKitAPI.WKNavigation.Frames (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/84556 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72964 "Found 2 new API test failures: /TestWebKit:WebKit.NewFirstVisuallyNonEmptyLayoutFrames, /WebKitGTK/TestWebExtensions:/webkit/WebKitWebExtension/form-submission-steps (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38755 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18381 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81387 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19662 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40511 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84061 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/75/builds/2075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38897 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19002 "Passed tests") | 
<!--EWS-Status-Bubble-End-->