### PR TITLE
Add the support for outputting ranges to dump-as-markup.js and use it in editing/selection/getRangeAt.html

### DIFF
--- a/LayoutTests/editing/selection/getRangeAt-expected.txt
+++ b/LayoutTests/editing/selection/getRangeAt-expected.txt
@@ -1,7 +1,8 @@
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 This tests that Selection::getRangeAt(int) returns a valid Range object.
-
-hello
-hello
-[object Text]
-[object Text]
+| "\n"
+| <div>
+|   id="test"
+|   style="border:1px solid black; padding:1em;"
+|   "[range #0 start]<#selection-anchor>hello<#selection-focus>[range #0 end]"
+| "\n\n\n"

--- a/LayoutTests/editing/selection/getRangeAt.html
+++ b/LayoutTests/editing/selection/getRangeAt.html
@@ -1,20 +1,13 @@
+<!DOCTYPE html>
 <html>
 <head>
+<script src="../../resources/dump-as-markup.js"></script>
 <script>
 if (window.testRunner)
      testRunner.dumpEditingCallbacks();
-</script>
-<script>
-function log(str) {
-    if (str == null)
-        str = "null"
-    var li = document.createElement("li");
-    var pre = document.createElement("pre");
-    pre.appendChild(document.createTextNode(str));
-    li.appendChild(pre);
-    var console = document.getElementById("console");
-    console.appendChild(li);
-}
+
+Markup.description('This tests that Selection::getRangeAt(int) returns a valid Range object.');
+Markup.noAutoDump();
 
 function runTest() {
     var elem = document.getElementById("test");
@@ -23,21 +16,14 @@ function runTest() {
     if (window.testRunner)
         window.testRunner.dumpAsText();
 
-    try {
-        sel.setBaseAndExtent(elem, 0, elem, 1);
-        var range = sel.getRangeAt(0);
-        log(range);
-        log(range.startContainer);
-        log(range.endContainer);
-        
-    } catch(e) {
-        log("Error: " + e);
-    }
+    sel.setBaseAndExtent(elem, 0, elem, 1);
+    Markup.addRange(sel.getRangeAt(0));
+    Markup.dump(document.body);
+    Markup.notifyDone();
 }
-</script></head>
+</script>
+</head>
 <body onload="runTest();">
-<p>This tests that Selection::getRangeAt(int) returns a valid Range object.</p>
 <div id="test" style="border:1px solid black; padding:1em;">hello</div>
-<ul id="console"></ul>
 </body>
 </html>


### PR DESCRIPTION
#### 2b20e33c2fcc31b39a7e4c5295e53d96f6aceec4
<pre>
Add the support for outputting ranges to dump-as-markup.js and use it in editing/selection/getRangeAt.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=247309">https://bugs.webkit.org/show_bug.cgi?id=247309</a>

Reviewed by Darin Adler.

This patch adds the support for logging DOM ranges (in addition to selection) to dump-as-markup.js
and uses it in editing/selection/getRangeAt.html.

* LayoutTests/editing/selection/getRangeAt-expected.txt:
* LayoutTests/editing/selection/getRangeAt.html:
* LayoutTests/resources/dump-as-markup.js:
(Markup.addRange): Added.
(Markup._get):
(Markup._getMarkupForTextNode):
(Markup._getSelectionAndRangeMarkersWithIdentation): Renamed from _getSelectionMarkerWithIdentation.
(Markup._getSelectionMarker):
(Markup._getRangeStartMarkers) Added.:
(Markup._getRangeEndMarkers): Added.

Canonical link: <a href="https://commits.webkit.org/256212@main">https://commits.webkit.org/256212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f62c03139faec564051659df6781c152838eed79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104629 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164882 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4258 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32354 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100530 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3090 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81546 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30072 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85004 "Found 1 new API test failure: TestWebKitAPI.UserContentWorld.IsolatedWorldPlugIn (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72968 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38760 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36583 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19707 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40516 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2060 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38948 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->