### PR TITLE
Deleting a button and typing text afterwards applies wrong styling to the typed text

### DIFF
--- a/LayoutTests/editing/inserting/insert-without-inheriting-style-expected.txt
+++ b/LayoutTests/editing/inserting/insert-without-inheriting-style-expected.txt
@@ -1,0 +1,5 @@
+PASS $("sample").innerHTML is "foo quux&nbsp;baz"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/inserting/insert-without-inheriting-style.html
+++ b/LayoutTests/editing/inserting/insert-without-inheriting-style.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<div id="container">
+    <div contenteditable="true" id="sample">foo <input type="button" value="bar"> baz</div>
+    </div>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+    function $(id) { return document.getElementById(id); }
+    
+    var range = document.createRange();
+    range.setStartAfter(document.querySelector('input'));
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.execCommand('Delete');
+    document.execCommand('InsertText', false, 'quux');
+    shouldBeEqualToString('$("sample").innerHTML', 'foo quux&nbsp;baz');
+    
+    if (window.testRunner)
+        $('container').outerHTML = '';
+    </script>
+    </body>
+    

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -427,6 +427,7 @@ void DeleteSelectionCommand::saveTypingStyleState()
     // Figure out the typing style in effect before the delete is done.
     m_typingStyle = EditingStyle::create(m_selectionToDelete.start(), EditingStyle::EditingPropertiesInEffect);
     m_typingStyle->removeStyleAddedByNode(enclosingAnchorElement(m_selectionToDelete.start()));
+    m_typingStyle->removeStyleAddedByNode(enclosingAtomicNode(m_selectionToDelete.start()));
 
     // If we're deleting into a Mail blockquote, save the style at end() instead of start()
     // We'll use this later in computeTypingStyleAfterDelete if we end up outside of a Mail blockquote

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -574,6 +574,11 @@ Element* enclosingAnchorElement(const Position& p)
     return nullptr;
 }
 
+Node* enclosingAtomicNode(const Position& start)
+{
+    return enclosingNodeOfType(start, isAtomicNode);
+}
+
 HTMLElement* enclosingList(Node* node)
 {
     if (!node)

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -59,6 +59,7 @@ Element* enclosingBlock(Node*, EditingBoundaryCrossingRule = CannotCrossEditingB
 Element* enclosingTableCell(const Position&);
 Node* enclosingEmptyListItem(const VisiblePosition&);
 Element* enclosingAnchorElement(const Position&);
+Node* enclosingAtomicNode(const Position&);
 Element* enclosingElementWithTag(const Position&, const QualifiedName&);
 Node* enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node*), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
 HTMLSpanElement* tabSpanNode(const Node*);


### PR DESCRIPTION
<pre>
Deleting a button and typing text afterwards applies wrong styling to the typed text
<a href="https://bugs.webkit.org/show_bug.cgi?id=107967">https://bugs.webkit.org/show_bug.cgi?id=107967</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=154067">https://src.chromium.org/viewvc/blink?view=revision&revision=154067</a>

This patch changes initialization of typing style not to populate from form control like elements,
which can't have range ending point, e.g. img, input, object, textarea, and so on.

* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(DeleteSelectionCommand::saveTypingStylesheet): Added logic to not inherit style upon node deletion
* Source/WebCore/editing/Editing.cpp: Add "enclosingAtomicNode" return value
* Source/WebCore/editing/Editing.h: Add "enclosingAtomicNode" definition
* LayoutTests/editing/inserting/insert-without-inheriting-style.html: Added Test Case
* LayoutTests/editing/inserting/insert-without-inheriting-style-expected.txt: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a91bf7a0314492a3b5767334d6bc06513b3f949

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106254 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166557 "Found 3 new test failures: editing/deleting/maintain-style-after-delete.html, editing/style/background-color-retained.html, editing/style/style-3681552-fix-002.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6205 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34727 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102964 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102401 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4638 "Found 5 new test failures: editing/deleting/maintain-style-after-delete.html, editing/execCommand/underline-selection-containing-image.html, editing/style/5084241.html, editing/style/background-color-retained.html, editing/style/style-3681552-fix-002.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83355 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31602 "Found 4 new test failures: editing/deleting/maintain-style-after-delete.html, editing/style/5084241.html, editing/style/background-color-retained.html, editing/style/style-3681552-fix-002.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74532 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/30 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19836 "Found 5 new test failures: editing/deleting/maintain-style-after-delete.html, editing/execCommand/underline-selection-containing-image.html, editing/style/5084241.html, editing/style/background-color-retained.html, editing/style/style-3681552-fix-002.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/27 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21254 "Found 5 new test failures: editing/deleting/maintain-style-after-delete.html, editing/execCommand/underline-selection-containing-image.html, editing/style/5084241.html, editing/style/background-color-retained.html, editing/style/style-3681552-fix-002.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4811 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43790 "Found 5 new test failures: editing/deleting/maintain-style-after-delete.html, editing/execCommand/underline-selection-containing-image.html, editing/style/5084241.html, editing/style/background-color-retained.html, editing/style/style-3681552-fix-002.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40536 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->