### PR TITLE
Code style does not allow currently used member function explanation comments for vfuncs, ipc messages

### DIFF
--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -1372,6 +1372,40 @@ drawJpg(); // FIXME(joe): Make this code handle jpg in addition to the png suppo
 drawJpg(); // TODO: Make this code handle jpg in addition to the png support.
 ```
 
+[](#comments-override-disambiguation) If needed for clarity, add a comment containing the source class name for a block of virtual function override declarations.
+
+###### Right:
+```cpp
+class GPUProcessConnection : public RefCounted<GPUProcessConnection>, public IPC::Connection::Client {
+public:
+    /// ...
+
+    // IPC::Connection::Client
+    void didClose(IPC::Connection&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
+
+    // ...
+};
+```
+
+[](#comments-messages-disambiguation) If needed for clarity, add `// Messages` before a block of IPC message function declarations.
+
+###### Right:
+```cpp
+class GPUProcessConnection : public RefCounted<GPUProcessConnection>, public IPC::Connection::Client {
+public:
+    /// ...
+
+    // Messages
+    void didReceiveRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
+    void didInitialize(std::optional<GPUProcessConnectionInfo>&&);
+
+    // ...
+};
+```
+
 ### Overriding Virtual Methods
 
 [](#override-methods) The base level declaration of a virtual method inside a class must be declared with the `virtual` keyword. All subclasses of that class must either specify the `override` keyword when overriding the virtual method or the `final` keyword when overriding the virtual method and requiring that no further subclasses can override it. You never want to annotate a method with more than one of the `virtual`, `override`, or `final` keywords.


### PR DESCRIPTION
#### 09420100638c9d074649a4daf209af15b5731eae
<pre>
Code style does not allow currently used member function explanation comments for vfuncs, ipc messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=247313">https://bugs.webkit.org/show_bug.cgi?id=247313</a>
rdar://problem/101801434

Reviewed by Ryosuke Niwa and Darin Adler.

Allow the non-english sentence comments that do not end in a dot:
 // SomeBaseClassName
and
 // Messages

* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/256221@main">https://commits.webkit.org/256221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fd27ff91affbc7226134c58618a408371343ba3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104639 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4269 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32365 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100540 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100704 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81558 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30082 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/85180 "Found 1 new API test failure: TestWebKitAPI.WebLocks.SnapshotAcrossPagesInSameProcess (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38770 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18398 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36593 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19679 "Found 30 new test failures: compositing/iframes/repaint-after-losing-scrollbars.html, fast/scrolling/mac/adjust-scroll-snap-during-gesture.html, http/tests/navigation/page-cache-shared-worker.html, http/tests/resourceLoadStatistics/third-party-cookie-blocking-ephemeral.html, http/tests/websocket/tests/hybi/contentextensions/block-cookies-worker.py, http/tests/workers/service/interception-from-dedicated-worker-on-reload.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html, imported/w3c/web-platform-tests/css/css-ui/input-security-computed.html, imported/w3c/web-platform-tests/css/css-variables/variable-transitions-transition-property-variable-before-value.html ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40526 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38919 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->