### PR TITLE
Remove sandbox v2 telemetry for known entries

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -56,9 +56,16 @@
 (allow iokit-open-service (iokit-user-client-class "IOSurfaceRoot"))
 (allow iokit-open-service (iokit-user-client-class "AppleCLCD2"))
 
-(allow file-map-executable
-    (subpath "/System/Library/Components")
-    (subpath "/System/Library/Video/Plug-Ins"))
+(allow iokit-open-service (iokit-registry-entry-class
+    "AppleGFXHDAEngineOutputDP"
+    "AppleUpstreamUserClientDriver"
+    "AudioAUUCDriver"
+    "IOAudioSelectorControl"))
+
+(allow file-map-executable (subpath
+    "/System/Library/Components"
+    "/System/Library/Extensions"
+    "/System/Library/Video/Plug-Ins"))
 
 (allow iokit-open-user-client (iokit-user-client-class "AGXDeviceUserClient"))
 (allow iokit-open-service

--- a/Source/WebKit/Shared/Sandbox/macOS/common.sb
+++ b/Source/WebKit/Shared/Sandbox/macOS/common.sb
@@ -45,15 +45,8 @@
 (with-filter (mac-policy-name "Quarantine")
     (allow system-mac-syscall (mac-syscall-number 84 87)))
 
-(allow file-test-existence (with telemetry))
-(allow file-test-existence
-    (literal "/etc/localtime")
-    (literal "/private/etc/localtime")
-    (subpath "/System/Library/PrivateFrameworks")
-    (subpath "/System/Library/Frameworks")
-    (subpath "/usr/share/icu")
-    (subpath "/private/var/db/timezone")
-    (subpath "/var/db/timezone"))
+(allow file-test-existence)
+
 #define IOKIT_OPEN_USER_CLIENT iokit-open-user-client
 #define IOKIT_OPEN_SERVICE iokit-open-service
 #else

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -41,8 +41,10 @@
 (allow process-info-rusage (target self))
 
 (allow iokit-open-service (iokit-user-client-class "IOSurfaceRoot"))
-(allow iokit-open-service (iokit-registry-entry-class "IOAccelerator"))
-(allow iokit-open-service (iokit-registry-entry-class "AppleM2ScalerCSCDriver"))
+(allow iokit-open-service (iokit-registry-entry-class
+    "AGPM"
+    "IOAccelerator"
+    "AppleM2ScalerCSCDriver"))
 
 (deny iokit-open-service (with no-report) (iokit-registry-entry-class "AppleJPEGDriver"))
 


### PR DESCRIPTION
#### 5fd2411bada85ea6f8bf18544f0e52ea68c13574
<pre>
Remove sandbox v2 telemetry for known entries
<a href="https://bugs.webkit.org/show_bug.cgi?id=247318">https://bugs.webkit.org/show_bug.cgi?id=247318</a>
rdar://101806362

Reviewed by Brent Fulgham.

Remove sandbox v2 telemetry for entries that are known to be in use on macOS.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/Shared/Sandbox/macOS/common.sb:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/256188@main">https://commits.webkit.org/256188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71bb7ebfe5752b5f80d07355382f6829df1d8d1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104647 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4278 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32374 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100548 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100712 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3105 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81571 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30094 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/85848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/72991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38778 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36601 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40534 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38929 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->