### PR TITLE
Handle managed preferences file not found for MDM ITP relaxation

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -738,7 +738,10 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
         NSArray<NSString *> *crossSiteTrackingPreventionDisabledDomains;
 #if PLATFORM(MAC)
         NSDictionary *managedSitesPrefs = [NSDictionary dictionaryWithContentsOfFile:[[NSString stringWithFormat:@"/Library/Managed Preferences/%@/%@.plist", NSUserName(), kManagedSitesIdentifier] stringByStandardizingPath]];
-        crossSiteTrackingPreventionDisabledDomains = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionDisabledDomainsKey];
+        if (managedSitePrefs)
+            crossSiteTrackingPreventionDisabledDomains = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionDisabledDomainsKey];
+        else
+            crossSiteTrackingPreventionDisabledDomains = @[];
 #elif !PLATFORM(MACCATALYST)
         if ([PAL::getMCProfileConnectionClass() respondsToSelector:@selector(crossSiteTrackingAllowedDomains)])
             crossSiteTrackingPreventionDisabledDomains = [[PAL::getMCProfileConnectionClass() sharedConnection] crossSiteTrackingAllowedDomains];


### PR DESCRIPTION
#### 70b1837e324786d28fe4ac96e103db022d89c998
<pre>
Handle managed preferences file not found for MDM ITP relaxation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247320">https://bugs.webkit.org/show_bug.cgi?id=247320</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::initializeManagedDomains):
Check if dictionary with managed preferences is nil, if so don&apos;t retain it.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70b1837e324786d28fe4ac96e103db022d89c998

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4192 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/27964 "Hash 70b1837e for PR 5999 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104651 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4282 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32379 "Hash 70b1837e for PR 5999 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87355 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100552 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100716 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81576 "Hash 70b1837e for PR 5999 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30092 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/27964 "Hash 70b1837e for PR 5999 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/72989 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38782 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/27964 "Hash 70b1837e for PR 5999 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36605 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/27964 "Hash 70b1837e for PR 5999 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40538 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/81576 "Hash 70b1837e for PR 5999 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42517 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/27964 "Hash 70b1837e for PR 5999 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->