### PR TITLE
[run-webkit-tests] Extra thread spawned for each worker

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -34,6 +34,7 @@ from webkitcorepy.string_utils import BytesIO, StringIO, UnicodeIO, unicode
 from webkitcorepy.timeout import Timeout
 from webkitcorepy.subprocess_utils import TimeoutExpired, CompletedProcess, run, Thread
 from webkitcorepy.output_capture import LoggerCapture, OutputCapture, OutputDuplicate
+from webkitcorepy.null_context import NullContext
 from webkitcorepy.task_pool import TaskPool
 from webkitcorepy.timer import Timer
 from webkitcorepy.terminal import Terminal
@@ -44,9 +45,8 @@ from webkitcorepy.nested_fuzzy_dict import NestedFuzzyDict
 from webkitcorepy.call_by_need import CallByNeed
 from webkitcorepy.editor import Editor
 from webkitcorepy.file_lock import FileLock
-from webkitcorepy.null_context import NullContext
 
-version = Version(0, 13, 19)
+version = Version(0, 13, 20)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/multiprocessing_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/multiprocessing_utils.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+import sys
+
+from webkitcorepy import NullContext
+
+if sys.version_info < (3, 0):
+    raise ImportError('Not supported in Python 2')
+
+from multiprocessing import context, RLock
+from multiprocessing.queues import SimpleQueue
+
+import queue as BaseQueue
+
+
+class Queue(SimpleQueue):
+    Empty = BaseQueue.Empty
+
+    def __init__(self):
+        self._closed = False
+        super(Queue, self).__init__(ctx=context._default_context)
+        self._rlock = RLock()
+
+    def close(self):
+        self._closed = True
+        self._reader.close()
+        self._writer.close()
+
+    def __getstate__(self):
+        return super(Queue, self).__getstate__(), self._closed
+
+    def __setstate__(self, state):
+        self._closed = state[-1]
+        super(Queue, self).__setstate__(state[0])
+
+    def get(self, block=True, timeout=None):
+        if self._closed:
+            raise ValueError("Queue is closed")
+        if block and timeout is None:
+            return super(Queue, self).get()
+
+        deadline = (time.monotonic() + timeout) if block else None
+        if not self._rlock.acquire(block, timeout):
+            raise self.Empty
+        try:
+            if deadline:
+                if not self._poll(deadline - time.monotonic()):
+                    raise self.Empty
+            elif not self._poll():
+                raise self.Empty
+            return super(Queue, self).get()
+        finally:
+            self._rlock.release()

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,12 +27,15 @@ import multiprocessing
 import signal
 import sys
 
-if sys.version_info < (3, 0):
-    import Queue
-else:
-    import queue as Queue
-
 from webkitcorepy import OutputCapture, Timeout, log
+
+if sys.version_info < (3, 0):
+    import Queue as SimpleQueue
+    from multiprocessing import Queue
+    Empty = SimpleQueue.Empty
+else:
+    from webkitcorepy.multiprocessing_utils import Queue
+    Empty = Queue.Empty
 
 
 class _Message(object):
@@ -136,8 +139,8 @@ class _ChildException(_Message):
 
 class _BiDirectionalQueue(object):
     def __init__(self, outgoing=None, incoming=None):
-        self.outgoing = outgoing or multiprocessing.Queue()
-        self.incoming = incoming or multiprocessing.Queue()
+        self.outgoing = outgoing or Queue()
+        self.incoming = incoming or Queue()
 
     def send(self, object):
         if self.outgoing._closed:
@@ -155,15 +158,15 @@ class _BiDirectionalQueue(object):
                 if difference is not None:
                     return self.incoming.get(timeout=difference)
                 return self.incoming.get()
-            except Queue.Empty:
+            except Empty:
                 pass
 
     def close(self):
         with OutputCapture():
             self.outgoing.close()
             self.incoming.close()
-            self.outgoing.join_thread()
-            self.incoming.join_thread()
+            getattr(self.outgoing, 'join_thread', lambda: None)()
+            getattr(self.incoming, 'join_thread', lambda: None)()
 
 
 class _DummyQueue(object):
@@ -418,7 +421,7 @@ class TaskPool(object):
             while self.pending_count > 2 * self._num_workers:
                 try:
                     self.queue.receive(blocking=False)(self)
-                except Queue.Empty:
+                except Empty:
                     break
 
     def wait(self):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/multiprocessing_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/multiprocessing_utils_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,46 +20,30 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup
+import sys
+import unittest
 
+if sys.version_info >= (3, 0):
+    from webkitcorepy.multiprocessing_utils import Queue
 
-def readme():
-    with open('README.md') as f:
-        return f.read()
+    class QueueUnittest(unittest.TestCase):
 
+        def test_basic(self):
+            q = Queue()
+            q.put('data')
 
-setup(
-    name='webkitcorepy',
-    version='0.13.20',
-    description='Library containing various Python support classes and functions.',
-    long_description=readme(),
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: Other/Proprietary License',
-        'Operating System :: MacOS',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    keywords='python unicode',
-    url='https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy',
-    author='Jonathan Bedard',
-    author_email='jbedard@apple.com',
-    license='Modified BSD',
-    packages=[
-        'webkitcorepy',
-        'webkitcorepy.mocks',
-        'webkitcorepy.tests',
-        'webkitcorepy.tests.mocks',
-    ],
-    install_requires=[
-        'mock',
-        'requests',
-        'six',
-        'tblib',
-        'whichcraft',
-    ],
-    include_package_data=True,
-    zip_safe=False,
-)
+            self.assertEqual(q.get(), 'data')
+
+        def test_no_block(self):
+            q = Queue()
+
+            with self.assertRaises(Queue.Empty):
+                q.get(block=False)
+
+        def test_timeout(self):
+            q = Queue()
+            q.put('data')
+
+            self.assertEqual(q.get(timeout=.5), 'data')
+            with self.assertRaises(Queue.Empty):
+                q.get(timeout=.5)


### PR DESCRIPTION
#### db09bfbcf7d0202ce90ff92340f51f4309501770
<pre>
[run-webkit-tests] Extra thread spawned for each worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=247324">https://bugs.webkit.org/show_bug.cgi?id=247324</a>
rdar://101813483

Reviewed by Elliott Williams.

* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Bump version, import
NullContext before TaskPool.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/multiprocessing_utils.py: Added.
(Queue.__init__):
(Queue.close):
(Queue.__getstate__):
(Queue.__setstate__):
(Queue.get):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/task_pool.py:
(_BiDirectionalQueue.__init__): Use multiprocessing_utils.Queue for Python 3, multiprocessing.Queue for Python 2.
(_BiDirectionalQueue.receive): Use Python 2/3 compatible Empty exception.
(_BiDirectionalQueue.close): Only invoke thread join if the Queue has the function.
(TaskPool.do): Use Python 2/3 compatible Empty exception.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/multiprocessing_utils_unittest.py: Added.
(QueueUnittest.test_basic):
(QueueUnittest.test_no_block):
(QueueUnittest.test_timeout):

Canonical link: <a href="https://commits.webkit.org/256262@main">https://commits.webkit.org/256262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/234aad19b971f508b23a481c4047ebdfaf3509ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95253 "4 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/4535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104847 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4519 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100919 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/87570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/98842 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38978 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/94230 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2085 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42719 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->