### PR TITLE
[WebAuthn] Handle security keys with a full key store

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt
@@ -4,6 +4,7 @@ CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'na
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
+CONSOLE MESSAGE: User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' or 'navigator.credentials.get' within user activated events.
 
 PASS PublicKeyCredential's [[create]] with timeout in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with malicious payload in a mock hid authenticator.
@@ -12,4 +13,5 @@ PASS PublicKeyCredential's [[create]] with unsupported options in a mock hid aut
 PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with mixed options in a mock hid authenticator. 2
 PASS PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with full key store.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html
@@ -159,4 +159,27 @@
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCtapErrCredentialExcludedOnlyResponseBase64] } });
         return promiseRejects(t, "InvalidStateError", navigator.credentials.create(options), "At least one credential matches an entry of the excludeCredentials list in the authenticator.");
     }, "PublicKeyCredential's [[create]] with InvalidStateError in a mock hid authenticator.");
+
+        promise_test(function(t) {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "example.com"
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: asciiToUint8Array("123456"),
+                    displayName: "John",
+                },
+                challenge: asciiToUint8Array("123456"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                authenticatorSelection: { residentKey: "required" },
+                timeout: 10 // We wait for another authenticator upon full.
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", payloadBase64: [testCreateMessageFullKeyStoreBase64] } });
+        return promiseRejects(t, "NotAllowedError", navigator.credentials.create(options), "Operation timed out.");
+    }, "PublicKeyCredential's [[create]] with full key store.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https-expected.txt
@@ -18,4 +18,5 @@ PASS PublicKeyCredential's [[create]] with direct attestation in a mock hid auth
 PASS PublicKeyCredential's [[create]] with indirect attestation in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport extension in a mock hid authenticator.
 PASS PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid extensions in a mock hid authenticator.
+PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html
@@ -424,4 +424,29 @@
             checkCtapMakeCredentialResult(credential);
         });
     }, "PublicKeyCredential's [[create]] with googleLegacyAppidSupport and appid extensions in a mock hid authenticator.");
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                authenticatorSelection: { authenticatorAttachment: "cross-platform", residentKey: "preferred" },
+                extensions: { credProps: true }
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreateMessageFullKeyStoreBase64, testCreationMessageBase64] } });
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential);
+        });
+    }, "PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock hid authenticator with a full key store.");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt
@@ -6,4 +6,5 @@ PASS PublicKeyCredential's [[create]] with U2F in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with multiple physical tags in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with service restart in a mock nfc authenticator.
 PASS PublicKeyCredential's [[create]] with legacy U2F keys in a mock nfc authenticator.
+PASS PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock nfc authenticator with a full key store based on getInfo
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html
@@ -166,4 +166,31 @@
             checkCtapMakeCredentialResult(credential);
         });
     }, "PublicKeyCredential's [[create]] with legacy U2F keys in a mock nfc authenticator.");
+
+
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                rp: {
+                    name: "localhost",
+                },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+                authenticatorSelection: { authenticatorAttachment: "cross-platform", residentKey: "preferred" }
+            }
+        };
+
+        if (window.internals)
+        internals.setMockWebAuthenticationConfiguration({ nfc: { error: "success", payloadBase64: [testNfcCtapVersionBase64, testGetInfoResponseApduNoRemainingDiscoverableBase64, testCreationMessageApduBase64] } });
+
+        return navigator.credentials.create(options).then(credential => {
+            checkCtapMakeCredentialResult(credential);
+        });
+    }, "PublicKeyCredential's [[create]] with authenticatorSelection { 'cross-platform', 'preferred' } in a mock nfc authenticator with a full key store based on getInfo");
 </script>

--- a/LayoutTests/http/wpt/webauthn/resources/util.js
+++ b/LayoutTests/http/wpt/webauthn/resources/util.js
@@ -112,6 +112,8 @@ const testNfcCtapVersionBase64 = "RklET18yXzCQAA==";
 const testGetInfoResponseApduBase64 =
     "AKYBgmZVMkZfVjJoRklET18yXzACgWtobWFjLXNlY3JldANQbUS6m/bsLkm5MAyP" +
     "6SDLcwSkYnJr9WJ1cPVkcGxhdPRpY2xpZW50UGlu9AUZBLAGgQGQAA==";
+const testGetInfoResponseApduNoRemainingDiscoverableBase64 =
+    "AKcBgmZVMkZfVjJoRklET18yXzACgWtobWFjLXNlY3JldANQbUS6m/bsLkm5MAyP6SDLcwSkYnJr9WJ1cPVkcGxhdPRpY2xpZW50UGlu9AUZBLAGgQEUAJAA";
 const testCreationMessageApduBase64 =
     "AKMBZnBhY2tlZAJYxEbMf7lnnVWy25CS4cjZ5eHQK3WA8LSBLHcJYuHkj1rYQQAA" +
     "AE74oBHzjApNFYAGFxEfntx9AEAoCK3O6P5OyXN6V/f+9nAga0NA2Cgp4V3mgSJ5" +
@@ -143,6 +145,7 @@ const testAssertionMessageApduBase64 =
     "QoJ1L7Fe64G9uBeQAA==";
 const testCcidNoUidBase64 = "aIE=";
 const testCcidValidUidBase64 = "CH+d1ZAA";
+const testCreateMessageFullKeyStoreBase64 = "KA==";
 
 const RESOURCES_DIR = "/WebKit/webauthn/resources/";
 

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp
@@ -83,6 +83,12 @@ AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setTransports(Vector
     return *this;
 }
 
+AuthenticatorGetInfoResponse& AuthenticatorGetInfoResponse::setRemainingDiscoverableCredentials(uint32_t remainingDiscoverableCredentials)
+{
+    m_remainingDiscoverableCredentials = remainingDiscoverableCredentials;
+    return *this;
+}
+
 static String toString(WebCore::AuthenticatorTransport transport)
 {
     switch (transport) {
@@ -138,6 +144,9 @@ Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse& response)
         auto transports = *response.transports();
         deviceInfoMap.emplace(CBORValue(7), toArrayValue(transports.map(toString)));
     }
+
+    if (response.remainingDiscoverableCredentials())
+        deviceInfoMap.emplace(CBORValue(8), CBORValue(static_cast<int64_t>(*response.maxMsgSize())));
 
     auto encodedBytes = CBORWriter::write(CBORValue(WTFMove(deviceInfoMap)));
     ASSERT(encodedBytes);

--- a/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
+++ b/Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h
@@ -54,6 +54,7 @@ public:
     AuthenticatorGetInfoResponse& setExtensions(Vector<String>&&);
     AuthenticatorGetInfoResponse& setOptions(AuthenticatorSupportedOptions&&);
     AuthenticatorGetInfoResponse& setTransports(Vector<WebCore::AuthenticatorTransport>&&);
+    AuthenticatorGetInfoResponse& setRemainingDiscoverableCredentials(uint32_t);
 
     const StdSet<ProtocolVersion>& versions() const { return m_versions; }
     const Vector<uint8_t>& aaguid() const { return m_aaguid; }
@@ -62,6 +63,7 @@ public:
     const std::optional<Vector<String>>& extensions() const { return m_extensions; }
     const AuthenticatorSupportedOptions& options() const { return m_options; }
     const std::optional<Vector<WebCore::AuthenticatorTransport>>& transports() const { return m_transports; }
+    const std::optional<uint32_t>& remainingDiscoverableCredentials() const { return m_remainingDiscoverableCredentials; }
 
 private:
     StdSet<ProtocolVersion> m_versions;
@@ -71,6 +73,7 @@ private:
     std::optional<Vector<String>> m_extensions;
     AuthenticatorSupportedOptions m_options;
     std::optional<Vector<WebCore::AuthenticatorTransport>> m_transports;
+    std::optional<uint32_t> m_remainingDiscoverableCredentials;
 };
 
 WEBCORE_EXPORT Vector<uint8_t> encodeAsCBOR(const AuthenticatorGetInfoResponse&);

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -360,6 +360,14 @@ std::optional<AuthenticatorGetInfoResponse> readCTAPGetInfoResponse(const Vector
         response.setTransports(WTFMove(transports));
     }
 
+    it = responseMap.find(CBOR(20));
+    if (it != responseMap.end()) {
+        if (!it->second.isUnsigned())
+            return std::nullopt;
+
+        response.setRemainingDiscoverableCredentials(it->second.getUnsigned());
+    }
+
     return WTFMove(response);
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -51,6 +51,7 @@ typedef NS_ENUM(NSInteger, _WKWebAuthenticationPanelUpdate) {
     _WKWebAuthenticationPanelUpdateLAError,
     _WKWebAuthenticationPanelUpdateLAExcludeCredentialsMatched,
     _WKWebAuthenticationPanelUpdateLANoCredential,
+    _WKWebAuthenticationPanelUpdateKeyStoreFull,
 } WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 
 typedef NS_ENUM(NSInteger, _WKWebAuthenticationResult) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -76,6 +76,8 @@ static _WKWebAuthenticationPanelUpdate wkWebAuthenticationPanelUpdate(WebAuthent
         return _WKWebAuthenticationPanelUpdateLAExcludeCredentialsMatched;
     if (status == WebAuthenticationStatus::LANoCredential)
         return _WKWebAuthenticationPanelUpdateLANoCredential;
+    if (status == WebAuthenticationStatus::KeyStoreFull)
+        return _WKWebAuthenticationPanelUpdateKeyStoreFull;
     ASSERT_NOT_REACHED();
     return _WKWebAuthenticationPanelUpdateMultipleNFCTagsPresent;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h
@@ -49,6 +49,7 @@ enum class WebAuthenticationStatus : uint8_t {
     LAError,
     LAExcludeCredentialsMatched,
     LANoCredential,
+    KeyStoreFull,
 };
 
 enum class LocalAuthenticatorPolicy : bool {

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h
@@ -74,6 +74,7 @@ private:
 
     fido::AuthenticatorGetInfoResponse m_info;
     bool m_isDowngraded { false };
+    bool m_isKeyStoreFull { false };
     size_t m_remainingAssertionResponses { 0 };
     Vector<Ref<WebCore::AuthenticatorAssertionResponse>> m_assertionResponses;
     Vector<uint8_t> m_pinAuth;


### PR DESCRIPTION
#### 4ad382e777def610a6a4c6b079722b85bb042176
<pre>
[WebAuthn] Handle security keys with a full key store
<a href="https://bugs.webkit.org/show_bug.cgi?id=247339">https://bugs.webkit.org/show_bug.cgi?id=247339</a>
rdar://100241655

Reviewed by Brent Fulgham.

* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-failure-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-hid.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-local.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-create-success-nfc.https.html:
* LayoutTests/http/wpt/webauthn/resources/util.js:
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.cpp:
(fido::encodeAsCBOR):
* Source/WebCore/Modules/webauthn/fido/AuthenticatorGetInfoResponse.h:
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::readCTAPGetInfoResponse):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::updatePresenter):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::wkWebAuthenticationPanelUpdate):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationFlags.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.h:

Whenever security keys are unable to create a credential due to their internal key storage being full
they return the kCtap2ErrKeyStoreFull error code. In this case we should either retry the registeration
without a discoverable credential if the preference was set to preferred, otherwise surface an error to the
user notifying them they need to use a different key or clear space on the current key.

This patch fixes this by handling the kCtap2ErrKeyStoreFull error case. For security keys supporting the CTAP 2.1
standard, this patch also adds support for reading the &quot;remainingDiscoverableCredentials&quot; value from getInfo to detect
if the key store is full without having to first attempt a create.

Added layout tests for new functionality.

Canonical link: <a href="https://commits.webkit.org/257989@main">https://commits.webkit.org/257989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68800d0dcf2bbb3221b736f33ff1a676f451c662

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100614 "Failed to checkout and rebase branch from PR 6011") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109917 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/170194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/104598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10690 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/85/builds/295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107766 "Built successfully") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/106394 "Failed to checkout and rebase branch from PR 6011") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/8080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/91332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/34695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/77662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/3467 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/24252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/3481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/85/builds/295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9592 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5274 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2858 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->