### PR TITLE
Remove operationAllocateResultsArray assert

### DIFF
--- a/JSTests/wasm/stress/f32-tuple-jsapi-exported.js
+++ b/JSTests/wasm/stress/f32-tuple-jsapi-exported.js
@@ -1,0 +1,21 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (result f32 f32)
+        (return (f32.const nan:0x100000) (f32.const nan:0x100000))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(isNaN(test()[1]), true)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/f32-tuple-jsapi.js
+++ b/JSTests/wasm/stress/f32-tuple-jsapi.js
@@ -1,0 +1,24 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $f (result f32 f32)
+        (return (f32.const nan:0x100000) (f32.const nan:0x100000))
+    )
+
+    (func (export "test") (result f32 f32)
+        (return (call $f)))
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(isNaN(test()[1]), true)
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -630,7 +630,6 @@ JSC_DEFINE_JIT_OPERATION(operationAllocateResultsArray, JSArray*, (CallFrame* ca
         result->initializeIndex(initializationScope, i, value);
     }
 
-    ASSERT(result->indexingType() == indexingType);
     return result;
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -236,6 +236,7 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
             jit.subPtr(CCallHelpers::TrustedImm32(maxFrameExtentForSlowPathCall), CCallHelpers::stackPointerRegister);
         ASSERT(wasmContextInstanceGPR != savedResultsGPR);
         jit.setupArguments<decltype(operationAllocateResultsArray)>(wasmContextInstanceGPR, CCallHelpers::TrustedImmPtr(&typeDefinition), indexingType, savedResultsGPR);
+        JIT_COMMENT(jit, "operationAllocateResultsArray");
         jit.callOperation(operationAllocateResultsArray);
         if constexpr (!!maxFrameExtentForSlowPathCall)
             jit.addPtr(CCallHelpers::TrustedImm32(maxFrameExtentForSlowPathCall), CCallHelpers::stackPointerRegister);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -183,6 +183,9 @@ Wasm::Instance* WebAssemblyFunction::previousInstance(CallFrame* callFrame)
 
 CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 {
+    if (Options::forceICFailure())
+        return nullptr;
+
     VM& vm = this->vm();
     CCallHelpers jit;
 


### PR DESCRIPTION
#### 44fc0790939c6c19503d64497f1c4af907b77fff
<pre>
Remove operationAllocateResultsArray assert
<a href="https://bugs.webkit.org/show_bug.cgi?id=247338">https://bugs.webkit.org/show_bug.cgi?id=247338</a>

Reviewed by Yusuke Suzuki.

Suppose we are inside a WASM function that returns a tuple to JS. At the
boundary (in marshallJSResult), we call operationAllocateResultsArray to
allocate the JSArray that represents this WASM tuple. When we put a NaN
in the result tuple array, our indexing type changes from Double to Contiguous
because NaN is used to store holes in Double mode.

This assertion checked that our indexing mode did not change from our initially
chosen one, but this assumption is not used by later jit code. Hence, this was
probably just added to make sure we picked the optimal indexing type first.

We remove the assertion and add a test.

* JSTests/wasm/stress/f32-tuple-jsapi-exported.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.f32.f32.return.f32.const.nan.0x100000.f32.const.nan.0x100000.async test):
* JSTests/wasm/stress/f32-tuple-jsapi.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.f.result.f32.f32.return.f32.const.nan.0x100000.f32.const.nan.0x100000.func.export.string_appeared_here.result.f32.f32.return.call.f.async test):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::marshallJSResult):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):

Canonical link: <a href="https://commits.webkit.org/256210@main">https://commits.webkit.org/256210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ece18aae6e0e335a7032914138ee18c594e944d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4249 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104706 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164955 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4341 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/32844 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100605 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100776 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81639 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30141 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86907 "Build was cancelled. Recent messages:Configured build (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38839 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81473 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36660 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28044 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4294 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40594 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84147 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/38984 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19021 "Passed tests") | 
<!--EWS-Status-Bubble-End-->