### PR TITLE
Have PlatformCALayerRemoteCustom plumb preservesFlip to UIProcess

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -183,6 +183,7 @@ typedef enum {
 @interface CALayerHost : CALayer
 @property uint32_t contextId;
 @property BOOL inheritsSecurity;
+@property BOOL preservesFlip;
 @end
 
 @interface CASpringAnimation (Private)

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
@@ -32,7 +32,7 @@
 
 @interface CALayer (WebCoreCALayerExtras)
 
-+ (CALayer *)_web_renderLayerWithContextID:(uint32_t)contextID;
++ (CALayer *)_web_renderLayerWithContextID:(uint32_t)contextID shouldPreserveFlip:(BOOL)preservesFlip;
 
 - (void)web_disableAllActions;
 - (void)_web_setLayerBoundsOrigin:(CGPoint)origin;

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
@@ -80,13 +80,14 @@
     [self setPosition:newPosition];
 }
 
-+ (CALayer *)_web_renderLayerWithContextID:(uint32_t)contextID
++ (CALayer *)_web_renderLayerWithContextID:(uint32_t)contextID shouldPreserveFlip:(BOOL)preservesFlip
 {
     CALayerHost *layerHost = [CALayerHost layer];
 #ifndef NDEBUG
     [layerHost setName:@"Hosting layer"];
 #endif
     layerHost.contextId = contextID;
+    layerHost.preservesFlip = preservesFlip;
     return layerHost;
 }
 

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -93,7 +93,7 @@ std::unique_ptr<LayerHostingContext> LayerHostingContext::createForExternalPlugi
 
 RetainPtr<CALayer> LayerHostingContext::createPlatformLayerForHostingContext(LayerHostingContextID contextID)
 {
-    return [CALayer _web_renderLayerWithContextID:contextID];
+    return [CALayer _web_renderLayerWithContextID:contextID shouldPreserveFlip:NO];
 }
 
 #endif // HAVE(OUT_OF_PROCESS_LAYER_HOSTING)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -120,6 +120,7 @@ public:
 
         uint32_t hostingContextID;
         float hostingDeviceScaleFactor;
+        bool preservesFlip;
         
 #if ENABLE(MODEL_ELEMENT)
         RefPtr<WebCore::Model> model;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -48,6 +48,7 @@ RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties()
     , type(WebCore::PlatformCALayer::LayerTypeLayer)
     , hostingContextID(0)
     , hostingDeviceScaleFactor(1)
+    , preservesFlip(false)
 {
 }
 
@@ -59,6 +60,7 @@ void RemoteLayerTreeTransaction::LayerCreationProperties::encode(IPC::Encoder& e
     // PlatformCALayerRemoteCustom
     encoder << hostingContextID;
     encoder << hostingDeviceScaleFactor;
+    encoder << preservesFlip;
     
 #if ENABLE(MODEL_ELEMENT)
     // PlatformCALayerRemoteModelHosting
@@ -82,6 +84,9 @@ auto RemoteLayerTreeTransaction::LayerCreationProperties::decode(IPC::Decoder& d
         return std::nullopt;
 
     if (!decoder.decode(result.hostingDeviceScaleFactor))
+        return std::nullopt;
+    
+    if (!decoder.decode(result.preservesFlip))
         return std::nullopt;
     
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -312,7 +312,7 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
     case PlatformCALayer::LayerTypeAVPlayerLayer:
         if (m_isDebugLayerTreeHost)
             return RemoteLayerTreeNode::createWithPlainLayer(properties.layerID);
-        return makeWithLayer([CALayer _web_renderLayerWithContextID:properties.hostingContextID]);
+        return makeWithLayer([CALayer _web_renderLayerWithContextID:properties.hostingContextID shouldPreserveFlip:properties.preservesFlip]);
 
     case PlatformCALayer::LayerTypeShapeLayer:
         return makeWithLayer(adoptNS([[CAShapeLayer alloc] init]));

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -599,7 +599,7 @@ void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& lay
 {
     ASSERT(!layerTreeContext.isEmpty());
 
-    CALayer *renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID];
+    CALayer *renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID shouldPreserveFlip:NO];
     m_impl->enterAcceleratedCompositingWithRootLayer(renderLayer);
 }
 
@@ -607,7 +607,7 @@ void PageClientImpl::didFirstLayerFlush(const LayerTreeContext& layerTreeContext
 {
     ASSERT(!layerTreeContext.isEmpty());
 
-    CALayer *renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID];
+    CALayer *renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID shouldPreserveFlip:NO];
     m_impl->setAcceleratedCompositingRootLayer(renderLayer);
 }
 
@@ -620,7 +620,7 @@ void PageClientImpl::updateAcceleratedCompositingMode(const LayerTreeContext& la
 {
     ASSERT(!layerTreeContext.isEmpty());
 
-    CALayer *renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID];
+    CALayer *renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID shouldPreserveFlip:NO];
     m_impl->setAcceleratedCompositingRootLayer(renderLayer);
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -798,6 +798,11 @@ CGFloat PluginView::contentScaleFactor() const
     return m_plugin->scaleFactor();
 }
 
+bool PluginView::isUsingUISideCompositing() const
+{
+    return m_webPage->isUsingUISideCompositing();
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -98,6 +98,8 @@ public:
     std::tuple<String, PDFSelection *, NSDictionary *> lookupTextAtLocation(const WebCore::FloatPoint&, WebHitTestResultData&) const;
     WebCore::FloatRect rectForSelectionInRootView(PDFSelection *) const;
     CGFloat contentScaleFactor() const;
+    
+    bool isUsingUISideCompositing() const;
 
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -104,6 +104,7 @@ void PlatformCALayerRemoteCustom::populateCreationProperties(RemoteLayerTreeTran
     PlatformCALayerRemote::populateCreationProperties(properties, context, type);
     properties.hostingContextID = hostingContextID();
     properties.hostingDeviceScaleFactor = context.deviceScaleFactor();
+    properties.preservesFlip = YES;
 }
 
 Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteCustom::clone(PlatformCALayerClient* owner) const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8342,6 +8342,15 @@ void WebPage::updateImageAnimationEnabled()
 }
 #endif
 
+bool WebPage::isUsingUISideCompositing() const
+{
+#if PLATFORM(COCOA)
+    return m_drawingAreaType == DrawingAreaType::RemoteLayerTree;
+#else
+    return false;
+#endif
+}
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1586,6 +1586,8 @@ public:
 #endif
 
     void generateTestReport(String&& message, String&& group);
+    
+    bool isUsingUISideCompositing() const;
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     void updateImageAnimationEnabled();


### PR DESCRIPTION
#### 3912f312cb1e86980a0630241041c5ddc80c189f
<pre>
Have PlatformCALayerRemoteCustom plumb preservesFlip to UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=247341">https://bugs.webkit.org/show_bug.cgi?id=247341</a>
rdar://101786702

Reviewed by Tim Horton and Simon Fraser.

Since the effects of setGeometryFlipped don&apos;t cross a hosting boundary,
it is not propogated to the PDFKit layers being hosted in the WebProcess
when UI-side compositing is on. This causes rendering to look wrong and
scrolling in the wrong direction. To solve this issue, we plumb a bit through
to the UIProcess to set preservesFlip, which allows the value of geometryFlipped
to propogate through layer hosting. We also add a check for ui-side compositing
when creating PDF scrollbars due to a bug where the scrollbars didn&apos;t reflect the
geometryFlipped value of its ancestor.

* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(+[CALayer _web_renderLayerWithContextID:shouldPreserveFlip:]):
(+[CALayer _web_renderLayerWithContextID:]): Deleted.
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::createPlatformLayerForHostingContext):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::decode):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::enterAcceleratedCompositingMode):
(WebKit::PageClientImpl::didFirstLayerFlush):
(WebKit::PageClientImpl::updateAcceleratedCompositingMode):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::populateCreationProperties):

Canonical link: <a href="https://commits.webkit.org/257379@main">https://commits.webkit.org/257379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/773713ad291e6c6f90ecec0e3454292d3b16bfb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107949 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168220 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8246 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85123 "Build is in progress. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/105952 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104195 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6259 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33248 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88077 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21176 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1671 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22705 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1591 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45204 "Found 4 new test failures: css3/supports-dom-api.html, fast/text/text-edge-with-margin-padding-border-simple.html, ipc/pasteboard-write-custom-data.html, media/video-inaccurate-duration-ended.html (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42129 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2559 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->