### PR TITLE
REGRESSION(253327@main): [ iOS ] imported/w3c/web-platform-tests/css/css-pseudo/target-text-008.html is an almost constant failure

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/no-iframe-match-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/no-iframe-match-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/tests/scroll-to-text-fragment/no-iframe-match.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/no-iframe-match.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-emoji.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-emoji.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-sentence.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-sentence.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/tests/scroll-to-text-fragment/start-text-word.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/start-text-word.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/http/tests/scroll-to-text-fragment/word-display-none.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/word-display-none.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ScrollToTextFragmentIndicatorEnabled=false ] -->
+<!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Scroll to text fragment - highlight simple start text</title>
 <link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3713,7 +3713,6 @@ webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/javascript-url.https.html [ Pass Failure ]
 webkit.org/b/243690 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/restrict-properties/iframe-popup-to-so.https.html [ Pass Failure ]
 
-webkit.org/b/243962 imported/w3c/web-platform-tests/css/css-pseudo/target-text-008.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243962 imported/w3c/web-platform-tests/css/css-pseudo/highlight-paired-cascade-005.html [ Pass ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-transforms/ttwf-css-3d-polygon-cycle.html [ ImageOnlyFailure ]

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -2298,7 +2298,7 @@ bool FrameView::scrollToFragment(const URL& url)
                 // FIXME: <http://webkit.org/b/245262> (Scroll To Text Fragment should use DelegateMainFrameScroll)
                 TemporarySelectionChange selectionChange(document, { range }, { TemporarySelectionOption::RevealSelection, TemporarySelectionOption::RevealSelectionBounds, TemporarySelectionOption::UserTriggered, TemporarySelectionOption::ForceCenterScroll });
                 maintainScrollPositionAtScrollToTextFragmentRange(range);
-                if (frame().settings().scrollToTextFragmentIndicatorEnabled())
+                if (frame().settings().scrollToTextFragmentIndicatorEnabled() && !frame().page()->isControlledByAutomation())
                     m_delayedTextFragmentIndicatorTimer.startOneShot(100_ms);
                 return true;
             }

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -93,6 +93,7 @@ const TestFeatures& TestOptions::defaults()
             { "RequiresUserGestureForAudioPlayback", false },
             { "RequiresUserGestureForMediaPlayback", false },
             { "RequiresUserGestureForVideoPlayback", false },
+            { "ScrollToTextFragmentIndicatorEnabled", false },
             { "ShouldPrintBackgrounds", true },
             { "ShrinksStandaloneImagesToFit", true },
             { "TextAreasAreResizable", true },

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -115,6 +115,7 @@ const TestFeatures& TestOptions::defaults()
             { "RequiresUserGestureForAudioPlayback", false },
             { "RequiresUserGestureForMediaPlayback", false },
             { "RequiresUserGestureForVideoPlayback", false },
+            { "ScrollToTextFragmentIndicatorEnabled", false },
             { "ShowModalDialogEnabled", false },
             { "SpeakerSelectionRequiresUserGesture", false },
             { "TabsToLinks", false },


### PR DESCRIPTION
#### 82e61f0babb2aba02d4b377262d780f556f4cbd7
<pre>
REGRESSION(253327@main): [ iOS ] imported/w3c/web-platform-tests/css/css-pseudo/target-text-008.html is an almost constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=243962">https://bugs.webkit.org/show_bug.cgi?id=243962</a>
rdar://98693973

Reviewed by Aditya Keerthi and Megan Gardner.

This test is failing because the snapshot occasionally captures the text indicator.
We work around this in our own tests with the `scrollToTextFragmentIndicatorEnabled()`
setting. This is not easily an option for WPT, since WPT tests the standard
configuration.

This PR works around this by disabling the text indicator if `isControlledByAutomation`
is true, which will fix the test when it is run with the WPT infrastructure.
WebKitTestRunner will also need some of its behavior to change so that the preference
is disabled when the test is run with our own infrastructure.

* LayoutTests/http/tests/scroll-to-text-fragment/no-iframe-match-expected.html:
* LayoutTests/http/tests/scroll-to-text-fragment/no-iframe-match.html:
* LayoutTests/http/tests/scroll-to-text-fragment/start-text-emoji.html:
* LayoutTests/http/tests/scroll-to-text-fragment/start-text-quote.html:
* LayoutTests/http/tests/scroll-to-text-fragment/start-text-sentence.html:
* LayoutTests/http/tests/scroll-to-text-fragment/start-text-word.html:
* LayoutTests/http/tests/scroll-to-text-fragment/word-display-none.html:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::scrollToFragment):
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/256615@main">https://commits.webkit.org/256615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7864baf9a757b251e63a1cbb840f2bcda4148795

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105772 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166110 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5604 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34244 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102524 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4157 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82831 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31178 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74005 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39966 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19433 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20792 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4587 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/62 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43391 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/63 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40059 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->