### PR TITLE
Positioned element with percentage padding should recalc width when containing block changed

### DIFF
--- a/LayoutTests/fast/block/absolute-position-change-width-with-inline-container-expected.html
+++ b/LayoutTests/fast/block/absolute-position-change-width-with-inline-container-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+   <head>
+       <style type='text/css'>
+           #container {
+           position: relative;
+           }
+           .abs {
+               outline: solid 1px skyblue;
+                position: absolute;
+                left: 0;
+                top: 0;
+                right: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <p>When you click <button id="more">moooore</button>, the span.abs should expand with the container</p>
+        <p><span id="container"><span class="abs">&nbsp;</span>Words, words, words moooore</span>
+    </body>
+</html>

--- a/LayoutTests/fast/block/absolute-position-change-width-with-inline-container.html
+++ b/LayoutTests/fast/block/absolute-position-change-width-with-inline-container.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+   <head>
+       <style type='text/css'>
+           #container {
+           position: relative;
+           }
+           .abs {
+               outline: solid 1px skyblue;
+                position: absolute;
+                left: 0;
+                top: 0;
+                right: 0;
+            }
+        </style>
+        <script type='text/javascript'>
+            window.onload=function(){
+            var span = document.createElement('span');
+            span.innerHTML = ' moooore';
+            document.getElementById('container').appendChild(span);
+            };
+        </script>
+    </head>
+    <body>
+        <p>When you click <button id="more">moooore</button>, the span.abs should expand with the container</p>
+        <p><span id="container"><span class="abs">&nbsp;</span>Words, words, words</span>
+    </body>
+</html>

--- a/LayoutTests/fast/block/containing-block-change-percentage-padding-width-recalc-expected.html
+++ b/LayoutTests/fast/block/containing-block-change-percentage-padding-width-recalc-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+#dynamic-container {
+    width: 500px;
+}
+#percentage-padding {
+    position: absolute;
+    padding: 10%;
+}
+</style>
+<div id='dynamic-container'>
+    <div id='percentage-padding'>
+        There should be no line break.
+    </div>
+</div>

--- a/LayoutTests/fast/block/containing-block-change-percentage-padding-width-recalc.html
+++ b/LayoutTests/fast/block/containing-block-change-percentage-padding-width-recalc.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+#dynamic-container {
+    width: 500px;
+    transform: translateX(0);
+}
+#percentage-padding {
+    position: absolute;
+    padding: 10%;
+}
+</style>
+<div id='dynamic-container'>
+    <div id='percentage-padding'>
+        There should be no line break.
+    </div>
+</div>
+<script>
+    document.body.offsetTop;
+    document.getElementById('dynamic-container').style.transform = "none";
+</script>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -1810,8 +1810,11 @@ void RenderBlock::removePositionedObjects(const RenderBlock* newContainingBlockC
         if (newContainingBlockCandidate && !renderer->isDescendantOf(newContainingBlockCandidate))
             continue;
         renderersToRemove.append(renderer);
-        if (containingBlockState == NewContainingBlock)
+        if (containingBlockState == NewContainingBlock) {
             renderer->setChildNeedsLayout(MarkOnlyThis);
+            if (renderer->needsPreferredWidthsRecalculation())
+                renderer->setPreferredLogicalWidthsDirty(true, MarkOnlyThis);
+        }
         // It is the parent block's job to add positioned children to positioned objects list of its containing block.
         // Dirty the parent to ensure this happens. We also need to make sure the new containing block is dirty as well so
         // that it gets to these new positioned objects.


### PR DESCRIPTION
#### c1324d73bd3c9620496236c7b3abbda0c0cbd607
<pre>
Positioned element with percentage padding should recalc width when containing block changed

Positioned element with percentage padding should recalc width when containing block changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=80808">https://bugs.webkit.org/show_bug.cgi?id=80808</a>

Reviewed by Alan Baradlay.

This patch is to align Webkit behavior with Blink / Chrome and Gecko / Firefox.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=184672

and a test case from Patch Authored by SravanKumar Sandela.

RenderBlock::removePositionObjects usually don&apos;t recalc the width of
positioned descendants with percentage padding unless its width is changed.
For positioned elements which changed their containing block, it should be considered as if the width of the containing block changed.

* Source/WebCore/rendering/RenderBlock.cpp:
(RenderBlock::removePositionObjects): Add condition to recalculate the width
* LayoutTests/fast/block/containing-block-change-percentage-padding-width-recalc.html: Added Test Case
* LayoutTests/fast/block/containing-block-change-percentage-padding-width-recalc-expected.html: Added Test Case Expectations
* LayoutTests/fast/block/absolute-position-change-width-with-inline-container.html: Added Test Case
* LayoutTests/fast/block/absolute-position-change-width-with-inline-container-expected.html: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256315@main">https://commits.webkit.org/256315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ffd7eb60402e6adbd1d4de9670ab8d1a901d657

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104932 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165193 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4620 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33338 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100814 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3374 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81929 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30451 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73291 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39061 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4364 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40820 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39278 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->