### PR TITLE
Add a logging channel for debugging content extensions

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(CONTENT_EXTENSIONS)
 
 #include "ContentExtensionError.h"
+#include "Logging.h"
 #include "ResourceRequest.h"
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <JavaScriptCore/JavaScript.h>
@@ -788,7 +789,10 @@ void RedirectAction::URLTransformAction::QueryTransform::applyToURL(URL& url) co
     for (auto& key : removeParams)
         keysToRemove.add(key);
     form.removeAllMatching([&] (auto& keyValue) {
-        return keysToRemove.contains(keyValue.key);
+        bool modifiedQuery = keysToRemove.contains(keyValue.key);
+        if (modifiedQuery)
+            RELEASE_LOG(ContentExtensions, "QueryTransform::applyToURL - %s", keyValue.key.utf8().data());
+        return modifiedQuery;
     });
 
     Vector<WTF::KeyValuePair<String, String>> keysToAdd;

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -48,6 +48,7 @@ namespace WebCore {
     M(ClipRects) \
     M(Compositing) \
     M(CompositingOverlap) \
+    M(ContentExtensions) \
     M(ContentFiltering) \
     M(ContentObservation) \
     M(DatabaseTracker) \


### PR DESCRIPTION
#### db1bc3388c3f792aa58e86bfba48fb934bf58407
<pre>
Add a logging channel for debugging content extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247348">https://bugs.webkit.org/show_bug.cgi?id=247348</a>
rdar://101820591

Reviewed by Wenson Hsieh.

This adds logging for content extensions that apply the URL query transformation.

* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::RedirectAction::URLTransformAction::QueryTransform::applyToURL const):
* Source/WebCore/platform/Logging.h:

Canonical link: <a href="https://commits.webkit.org/256239@main">https://commits.webkit.org/256239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71f5aa1251a54b89486cad2e650b99f5f483e025

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4338 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104783 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165041 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4439 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33189 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100679 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3229 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81735 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86966 "Build was cancelled. Recent messages:") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73103 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38915 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19807 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40669 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2073 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39048 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->