### PR TITLE
Use WEBGL prefix for the provoking vertex extension

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3978,7 +3978,7 @@ webgl/1.0.x/conformance/extensions/oes-vertex-array-object.html [ Pass ]
 # Explicitly turn on conformance test until all of webgl/2.0.y is enabled
 webgl/2.0.y/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/ext-texture-norm16.html [ Pass ]
-webgl/2.0.y/conformance2/extensions/ext-provoking-vertex.html [ Pass ]
+webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/oes-draw-buffers-indexed.html [ Pass ]
 webgl/2.0.y/conformance2/extensions/promoted-extensions-in-shaders.html [ Pass ]
 webgl/2.0.y/conformance2/rendering/rasterizer-discard-and-implicit-clear.html [ Pass ]

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -5,10 +5,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 TEST COMPLETE: 5 PASS, 0 FAIL
 
 
-PASS webgl2:EXT_provoking_vertex: Supported
-PASS webgl2:EXT_provoking_vertex: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
+PASS webgl2:WEBGL_provoking_vertex: Supported
+PASS webgl2:WEBGL_provoking_vertex: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -5,9 +5,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 TEST COMPLETE: 4 PASS, 0 FAIL
 
 
-PASS webgl2:EXT_provoking_vertex: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
+PASS webgl2:WEBGL_provoking_vertex: Not supported
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -5,10 +5,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 TEST COMPLETE: 5 PASS, 0 FAIL
 
 
-PASS webgl2:EXT_provoking_vertex: Supported
-PASS webgl2:EXT_provoking_vertex: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
+PASS webgl2:WEBGL_provoking_vertex: Supported
+PASS webgl2:WEBGL_provoking_vertex: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex-expected.txt
+++ b/LayoutTests/webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex-expected.txt
@@ -1,4 +1,4 @@
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
-Test: ../../../resources/webgl_test_files/conformance2/extensions/ext-provoking-vertex.html?webglVersion=2
+Test: ../../../resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html?webglVersion=2
 [ PASS ] All tests passed

--- a/LayoutTests/webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex.html
+++ b/LayoutTests/webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex.html
@@ -3,15 +3,15 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL Conformance Test Wrapper for ext-provoking-vertex.html</title>
+<title>WebGL Conformance Test Wrapper for webgl-provoking-vertex.html</title>
 <script type="text/javascript" src="../../../resources/js-test-pre.js"></script>
 <script type="text/javascript" src="../../../resources/webkit-webgl-test-harness.js"></script>
 </head>
 <body>
 <p>This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.</p>
-Test: <a href="../../../resources/webgl_test_files/conformance2/extensions/ext-provoking-vertex.html?webglVersion=2">../../../resources/webgl_test_files/conformance2/extensions/ext-provoking-vertex.html?webglVersion=2</a>
+Test: <a href="../../../resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html?webglVersion=2">../../../resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html?webglVersion=2</a>
 <div id="iframe">
-<iframe src="../../../resources/webgl_test_files/conformance2/extensions/ext-provoking-vertex.html?webglVersion=2" width="800" height="600"></iframe>
+<iframe src="../../../resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html?webglVersion=2" width="800" height="600"></iframe>
 </div>
 <div id="result"></div>
 </body>

--- a/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
+++ b/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
@@ -6,9 +6,9 @@ let currentDraftExtensions = {
     "webgl": [
     ],
     "webgl2" : [
-        "EXT_provoking_vertex",
         "WEBGL_draw_instanced_base_vertex_base_instance",
         "WEBGL_multi_draw_instanced_base_vertex_base_instance",
+        "WEBGL_provoking_vertex",
     ]
 };
 

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html
@@ -8,7 +8,7 @@ found in the LICENSE.txt file.
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL EXT_provoking_vertex Conformance Tests</title>
+<title>WebGL WEBGL_provoking_vertex Conformance Tests</title>
 <LINK rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -19,7 +19,7 @@ found in the LICENSE.txt file.
 <div id="console"></div>
 <script>
 "use strict";
-description("This test verifies the functionality of the EXT_provoking_vertex extension, if it is available.");
+description("This test verifies the functionality of the WEBGL_provoking_vertex extension, if it is available.");
 
 debug("");
 
@@ -30,7 +30,7 @@ var ext;
 function runTestNoExtension() {
     debug("");
     debug("Check getParameter without the extension");
-    shouldBeNull("gl.getParameter(0x8E4F /* PROVOKING_VERTEX_EXT */)");
+    shouldBeNull("gl.getParameter(0x8E4F /* PROVOKING_VERTEX_WEBGL */)");
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "parameter unknown without enabling the extension");
     debug("");
 }
@@ -38,33 +38,33 @@ function runTestNoExtension() {
 function runTestExtension() {
     debug("");
     debug("Check enums");
-    shouldBe("ext.FIRST_VERTEX_CONVENTION_EXT", "0x8E4D");
-    shouldBe("ext.LAST_VERTEX_CONVENTION_EXT", "0x8E4E");
-    shouldBe("ext.PROVOKING_VERTEX_EXT", "0x8E4F");
-    shouldBe("ext.QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION_EXT", "undefined");
+    shouldBe("ext.FIRST_VERTEX_CONVENTION_WEBGL", "0x8E4D");
+    shouldBe("ext.LAST_VERTEX_CONVENTION_WEBGL", "0x8E4E");
+    shouldBe("ext.PROVOKING_VERTEX_WEBGL", "0x8E4F");
+    shouldBe("ext.QUADS_FOLLOW_PROVOKING_VERTEX_CONVENTION_WEBGL", "undefined");
 
     debug("");
     debug("Check default state");
-    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_EXT)", "ext.LAST_VERTEX_CONVENTION_EXT");
+    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_WEBGL)", "ext.LAST_VERTEX_CONVENTION_WEBGL");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "parameter known with the extension enabled");
 
     debug("");
     debug("Check state updates");
-    ext.provokingVertexEXT(ext.FIRST_VERTEX_CONVENTION_EXT);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "provokingVertexEXT(ext.FIRST_VERTEX_CONVENTION_EXT) generates no errors");
-    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_EXT)", "ext.FIRST_VERTEX_CONVENTION_EXT");
+    ext.provokingVertexWEBGL(ext.FIRST_VERTEX_CONVENTION_WEBGL);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "provokingVertexWEBGL(ext.FIRST_VERTEX_CONVENTION_WEBGL) generates no errors");
+    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_WEBGL)", "ext.FIRST_VERTEX_CONVENTION_WEBGL");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-    ext.provokingVertexEXT(ext.LAST_VERTEX_CONVENTION_EXT);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "provokingVertexEXT(ext.LAST_VERTEX_CONVENTION_EXT) generates no errors");
-    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_EXT)", "ext.LAST_VERTEX_CONVENTION_EXT");
+    ext.provokingVertexWEBGL(ext.LAST_VERTEX_CONVENTION_WEBGL);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "provokingVertexWEBGL(ext.LAST_VERTEX_CONVENTION_WEBGL) generates no errors");
+    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_WEBGL)", "ext.LAST_VERTEX_CONVENTION_WEBGL");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
     debug("");
     debug("Check invalid provoking vertex mode");
-    ext.provokingVertexEXT(ext.FIRST_VERTEX_CONVENTION_EXT);
-    ext.provokingVertexEXT(ext.PROVOKING_VERTEX_EXT);
+    ext.provokingVertexWEBGL(ext.FIRST_VERTEX_CONVENTION_WEBGL);
+    ext.provokingVertexWEBGL(ext.PROVOKING_VERTEX_WEBGL);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "invalid provoking mode generates an error");
-    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_EXT)", "ext.FIRST_VERTEX_CONVENTION_EXT");
+    shouldBe("gl.getParameter(ext.PROVOKING_VERTEX_WEBGL)", "ext.FIRST_VERTEX_CONVENTION_WEBGL");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
     debug("");
@@ -114,7 +114,7 @@ function runTestExtension() {
 
     const pixel = new Int32Array(4);
 
-    ext.provokingVertexEXT(ext.LAST_VERTEX_CONVENTION_EXT);
+    ext.provokingVertexWEBGL(ext.LAST_VERTEX_CONVENTION_WEBGL);
     gl.clearBufferiv(gl.COLOR, 0, new Int32Array(4));
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     gl.readPixels(0, 0, 1, 1, gl.RGBA_INTEGER, gl.INT, pixel);
@@ -125,7 +125,7 @@ function runTestExtension() {
         testFailed("Incorrect last provoking vertex");
     }
 
-    ext.provokingVertexEXT(ext.FIRST_VERTEX_CONVENTION_EXT);
+    ext.provokingVertexWEBGL(ext.FIRST_VERTEX_CONVENTION_WEBGL);
     gl.clearBufferiv(gl.COLOR, 0, new Int32Array(4));
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     gl.readPixels(0, 0, 1, 1, gl.RGBA_INTEGER, gl.INT, pixel);
@@ -145,14 +145,14 @@ function runTest() {
 
     runTestNoExtension();
 
-    ext = gl.getExtension("EXT_provoking_vertex");
+    ext = gl.getExtension("WEBGL_provoking_vertex");
 
-    wtu.runExtensionSupportedTest(gl, "EXT_provoking_vertex", ext !== null);
+    wtu.runExtensionSupportedTest(gl, "WEBGL_provoking_vertex", ext !== null);
 
     if (ext !== null) {
       runTestExtension();
     } else {
-      testPassed("No EXT_provoking_vertex support -- this is legal");
+      testPassed("No WEBGL_provoking_vertex support -- this is legal");
     }
   }
 }

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -5,12 +5,12 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 TEST COMPLETE: 7 PASS, 0 FAIL
 
 
-PASS webgl2:EXT_provoking_vertex: Supported
-PASS webgl2:EXT_provoking_vertex: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Has object.
+PASS webgl2:WEBGL_provoking_vertex: Supported
+PASS webgl2:WEBGL_provoking_vertex: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -5,9 +5,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 TEST COMPLETE: 4 PASS, 0 FAIL
 
 
-PASS webgl2:EXT_provoking_vertex: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
+PASS webgl2:WEBGL_provoking_vertex: Not supported
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -5,12 +5,12 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 TEST COMPLETE: 7 PASS, 0 FAIL
 
 
-PASS webgl2:EXT_provoking_vertex: Supported
-PASS webgl2:EXT_provoking_vertex: Has object.
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Has object.
+PASS webgl2:WEBGL_provoking_vertex: Supported
+PASS webgl2:WEBGL_provoking_vertex: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1853,7 +1853,6 @@ if (ENABLE_WEBGL)
         html/canvas/EXTColorBufferHalfFloat.cpp
         html/canvas/EXTFloatBlend.cpp
         html/canvas/EXTFragDepth.cpp
-        html/canvas/EXTProvokingVertex.cpp
         html/canvas/EXTShaderTextureLOD.cpp
         html/canvas/EXTTextureCompressionBPTC.cpp
         html/canvas/EXTTextureCompressionRGTC.cpp
@@ -1895,6 +1894,7 @@ if (ENABLE_WEBGL)
         html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
         html/canvas/WebGLObject.cpp
         html/canvas/WebGLProgram.cpp
+        html/canvas/WebGLProvokingVertex.cpp
         html/canvas/WebGLQuery.cpp
         html/canvas/WebGLRenderbuffer.cpp
         html/canvas/WebGLRenderingContext.cpp
@@ -1920,7 +1920,6 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/EXTColorBufferHalfFloat.idl
     html/canvas/EXTFloatBlend.idl
     html/canvas/EXTFragDepth.idl
-    html/canvas/EXTProvokingVertex.idl
     html/canvas/EXTShaderTextureLOD.idl
     html/canvas/EXTTextureCompressionBPTC.idl
     html/canvas/EXTTextureCompressionRGTC.idl
@@ -1960,6 +1959,7 @@ list(APPEND WebCore_IDL_FILES
     html/canvas/WebGLMultiDraw.idl
     html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.idl
     html/canvas/WebGLProgram.idl
+    html/canvas/WebGLProvokingVertex.idl
     html/canvas/WebGLQuery.idl
     html/canvas/WebGLRenderbuffer.idl
     html/canvas/WebGLRenderingContext.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1345,7 +1345,6 @@ $(PROJECT_DIR)/html/canvas/EXTColorBufferFloat.idl
 $(PROJECT_DIR)/html/canvas/EXTColorBufferHalfFloat.idl
 $(PROJECT_DIR)/html/canvas/EXTFloatBlend.idl
 $(PROJECT_DIR)/html/canvas/EXTFragDepth.idl
-$(PROJECT_DIR)/html/canvas/EXTProvokingVertex.idl
 $(PROJECT_DIR)/html/canvas/EXTShaderTextureLOD.idl
 $(PROJECT_DIR)/html/canvas/EXTTextureCompressionBPTC.idl
 $(PROJECT_DIR)/html/canvas/EXTTextureCompressionRGTC.idl
@@ -1392,6 +1391,7 @@ $(PROJECT_DIR)/html/canvas/WebGLLoseContext.idl
 $(PROJECT_DIR)/html/canvas/WebGLMultiDraw.idl
 $(PROJECT_DIR)/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.idl
 $(PROJECT_DIR)/html/canvas/WebGLProgram.idl
+$(PROJECT_DIR)/html/canvas/WebGLProvokingVertex.idl
 $(PROJECT_DIR)/html/canvas/WebGLQuery.idl
 $(PROJECT_DIR)/html/canvas/WebGLRenderbuffer.idl
 $(PROJECT_DIR)/html/canvas/WebGLRenderingContext.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -813,8 +813,6 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFloatBlend.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFloatBlend.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFragDepth.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTFragDepth.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTProvokingVertex.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTProvokingVertex.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTShaderTextureLOD.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTShaderTextureLOD.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSEXTTextureCompressionBPTC.cpp
@@ -2845,6 +2843,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLMultiDrawInstancedBaseVertex
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLMultiDrawInstancedBaseVertexBaseInstance.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLProgram.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLProgram.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLProvokingVertex.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLProvokingVertex.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLQuery.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLQuery.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebGLRenderbuffer.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1189,7 +1189,6 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/EXTColorBufferHalfFloat.idl \
     $(WebCore)/html/canvas/EXTFloatBlend.idl \
     $(WebCore)/html/canvas/EXTFragDepth.idl \
-    $(WebCore)/html/canvas/EXTProvokingVertex.idl \
     $(WebCore)/html/canvas/EXTShaderTextureLOD.idl \
     $(WebCore)/html/canvas/EXTTextureCompressionBPTC.idl \
     $(WebCore)/html/canvas/EXTTextureCompressionRGTC.idl \
@@ -1236,6 +1235,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/html/canvas/WebGLMultiDraw.idl \
     $(WebCore)/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.idl \
     $(WebCore)/html/canvas/WebGLProgram.idl \
+    $(WebCore)/html/canvas/WebGLProvokingVertex.idl \
     $(WebCore)/html/canvas/WebGLQuery.idl \
     $(WebCore)/html/canvas/WebGLRenderbuffer.idl \
     $(WebCore)/html/canvas/WebGLRenderingContext.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1411,7 +1411,6 @@ html/canvas/EXTColorBufferFloat.cpp
 html/canvas/EXTColorBufferHalfFloat.cpp
 html/canvas/EXTFloatBlend.cpp
 html/canvas/EXTFragDepth.cpp
-html/canvas/EXTProvokingVertex.cpp
 html/canvas/EXTShaderTextureLOD.cpp
 html/canvas/EXTTextureCompressionBPTC.cpp
 html/canvas/EXTTextureCompressionRGTC.cpp
@@ -1460,6 +1459,7 @@ html/canvas/WebGLMultiDraw.cpp
 html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
 html/canvas/WebGLObject.cpp
 html/canvas/WebGLProgram.cpp
+html/canvas/WebGLProvokingVertex.cpp
 html/canvas/WebGLQuery.cpp
 html/canvas/WebGLRenderbuffer.cpp
 html/canvas/WebGLRenderingContext.cpp
@@ -3240,7 +3240,6 @@ JSEXTColorBufferFloat.cpp
 JSEXTColorBufferHalfFloat.cpp
 JSEXTFloatBlend.cpp
 JSEXTFragDepth.cpp
-JSEXTProvokingVertex.cpp
 JSEXTShaderTextureLOD.cpp
 JSEXTTextureCompressionBPTC.cpp
 JSEXTTextureCompressionRGTC.cpp
@@ -4190,6 +4189,7 @@ JSWebGLLoseContext.cpp
 JSWebGLMultiDraw.cpp
 JSWebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
 JSWebGLProgram.cpp
+JSWebGLProvokingVertex.cpp
 JSWebGLQuery.cpp
 JSWebGLRenderbuffer.cpp
 JSWebGLRenderingContext.cpp

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -35,7 +35,6 @@
 #include "JSEXTColorBufferHalfFloat.h"
 #include "JSEXTFloatBlend.h"
 #include "JSEXTFragDepth.h"
-#include "JSEXTProvokingVertex.h"
 #include "JSEXTShaderTextureLOD.h"
 #include "JSEXTTextureCompressionBPTC.h"
 #include "JSEXTTextureCompressionRGTC.h"
@@ -71,6 +70,7 @@
 #include "JSWebGLMultiDraw.h"
 #include "JSWebGLMultiDrawInstancedBaseVertexBaseInstance.h"
 #include "JSWebGLProgram.h"
+#include "JSWebGLProvokingVertex.h"
 #include "JSWebGLRenderbuffer.h"
 #include "JSWebGLSampler.h"
 #include "JSWebGLTexture.h"
@@ -176,7 +176,6 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         TO_JS(EXTColorBufferHalfFloat)
         TO_JS(EXTFloatBlend)
         TO_JS(EXTFragDepth)
-        TO_JS(EXTProvokingVertex)
         TO_JS(EXTShaderTextureLOD)
         TO_JS(EXTTextureCompressionBPTC)
         TO_JS(EXTTextureCompressionRGTC)
@@ -209,6 +208,7 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
         TO_JS(WebGLLoseContext)
         TO_JS(WebGLMultiDraw)
         TO_JS(WebGLMultiDrawInstancedBaseVertexBaseInstance)
+        TO_JS(WebGLProvokingVertex)
     }
     ASSERT_NOT_REACHED();
     return jsNull();

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -32,7 +32,6 @@
 #include "EXTColorBufferFloat.h"
 #include "EXTColorBufferHalfFloat.h"
 #include "EXTFloatBlend.h"
-#include "EXTProvokingVertex.h"
 #include "EXTTextureCompressionBPTC.h"
 #include "EXTTextureCompressionRGTC.h"
 #include "EXTTextureFilterAnisotropic.h"
@@ -66,6 +65,7 @@
 #include "WebGLMultiDraw.h"
 #include "WebGLMultiDrawInstancedBaseVertexBaseInstance.h"
 #include "WebGLProgram.h"
+#include "WebGLProvokingVertex.h"
 #include "WebGLQuery.h"
 #include "WebGLRenderbuffer.h"
 #include "WebGLSampler.h"
@@ -2606,7 +2606,6 @@ WebGLExtension* WebGL2RenderingContext::getExtension(const String& name)
     ENABLE_IF_REQUESTED(EXTColorBufferFloat, m_extColorBufferFloat, "EXT_color_buffer_float"_s, EXTColorBufferFloat::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferHalfFloat, m_extColorBufferHalfFloat, "EXT_color_buffer_half_float"_s, EXTColorBufferHalfFloat::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTFloatBlend, m_extFloatBlend, "EXT_float_blend"_s, EXTFloatBlend::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTProvokingVertex, m_extProvokingVertex, "EXT_provoking_vertex"_s, EXTProvokingVertex::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(EXTTextureCompressionBPTC, m_extTextureCompressionBPTC, "EXT_texture_compression_bptc"_s, EXTTextureCompressionBPTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureCompressionRGTC, m_extTextureCompressionRGTC, "EXT_texture_compression_rgtc"_s, EXTTextureCompressionRGTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureFilterAnisotropic, m_extTextureFilterAnisotropic, "EXT_texture_filter_anisotropic"_s, EXTTextureFilterAnisotropic::supported(*m_context));
@@ -2628,6 +2627,7 @@ WebGLExtension* WebGL2RenderingContext::getExtension(const String& name)
     ENABLE_IF_REQUESTED(WebGLLoseContext, m_webglLoseContext, "WEBGL_lose_context"_s, true);
     ENABLE_IF_REQUESTED(WebGLMultiDraw, m_webglMultiDraw, "WEBGL_multi_draw"_s, WebGLMultiDraw::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLMultiDrawInstancedBaseVertexBaseInstance, m_webglMultiDrawInstancedBaseVertexBaseInstance, "WEBGL_multi_draw_instanced_base_vertex_base_instance"_s, WebGLMultiDrawInstancedBaseVertexBaseInstance::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(WebGLProvokingVertex, m_webglProvokingVertex, "WEBGL_provoking_vertex"_s, WebGLProvokingVertex::supported(*m_context) && enableDraftExtensions);
     return nullptr;
 }
 
@@ -2647,7 +2647,6 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("EXT_color_buffer_float", EXTColorBufferFloat::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_float_blend", EXTFloatBlend::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_provoking_vertex", EXTProvokingVertex::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_filter_anisotropic", EXTTextureFilterAnisotropic::supported(*m_context))
@@ -2669,6 +2668,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("WEBGL_lose_context", true)
     APPEND_IF_SUPPORTED("WEBGL_multi_draw", WebGLMultiDraw::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_multi_draw_instanced_base_vertex_base_instance", WebGLMultiDrawInstancedBaseVertexBaseInstance::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("WEBGL_provoking_vertex", WebGLProvokingVertex::supported(*m_context) && enableDraftExtensions)
 
     return result;
 }
@@ -3183,10 +3183,10 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
         if (m_boundVertexArrayObject->isDefaultObject())
             return nullptr;
         return static_pointer_cast<WebGLVertexArrayObject>(m_boundVertexArrayObject);
-    case GraphicsContextGL::PROVOKING_VERTEX_EXT:
-        if (m_extProvokingVertex)
-            return getUnsignedIntParameter(GraphicsContextGL::PROVOKING_VERTEX_EXT);
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, EXT_provoking_vertex not enabled");
+    case GraphicsContextGL::PROVOKING_VERTEX_ANGLE:
+        if (m_webglProvokingVertex)
+            return getUnsignedIntParameter(GraphicsContextGL::PROVOKING_VERTEX_ANGLE);
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getParameter", "invalid parameter name, WEBGL_provoking_vertex not enabled");
         return nullptr;
     default:
         return WebGLRenderingContextBase::getParameter(pname);

--- a/Source/WebCore/html/canvas/WebGLExtension.h
+++ b/Source/WebCore/html/canvas/WebGLExtension.h
@@ -63,7 +63,6 @@ public:
         EXTColorBufferHalfFloatName,
         EXTFloatBlendName,
         EXTFragDepthName,
-        EXTProvokingVertexName,
         EXTShaderTextureLODName,
         EXTTextureCompressionBPTCName,
         EXTTextureCompressionRGTCName,
@@ -96,6 +95,7 @@ public:
         WebGLLoseContextName,
         WebGLMultiDrawName,
         WebGLMultiDrawInstancedBaseVertexBaseInstanceName,
+        WebGLProvokingVertexName,
     };
 
     WebGLRenderingContextBase* context() { return m_context; }

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
@@ -23,23 +23,44 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
 
-#include "WebGLExtension.h"
+#if ENABLE(WEBGL)
+#include "WebGLProvokingVertex.h"
+
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
-class EXTProvokingVertex final : public WebGLExtension {
-    WTF_MAKE_ISO_ALLOCATED(EXTProvokingVertex);
-public:
-    explicit EXTProvokingVertex(WebGLRenderingContextBase&);
-    virtual ~EXTProvokingVertex();
+WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLProvokingVertex);
 
-    ExtensionName getName() const override;
+WebGLProvokingVertex::WebGLProvokingVertex(WebGLRenderingContextBase& context)
+    : WebGLExtension(context)
+{
+    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_provoking_vertex"_s);
+}
 
-    static bool supported(GraphicsContextGL&);
+WebGLProvokingVertex::~WebGLProvokingVertex() = default;
 
-    void provokingVertexEXT(GCGLenum mode);
-};
+WebGLExtension::ExtensionName WebGLProvokingVertex::getName() const
+{
+    return WebGLProvokingVertexName;
+}
+
+bool WebGLProvokingVertex::supported(GraphicsContextGL& context)
+{
+    return context.supportsExtension("GL_ANGLE_provoking_vertex"_s);
+}
+
+void WebGLProvokingVertex::provokingVertexWEBGL(GCGLenum mode)
+{
+    auto context = WebGLExtensionScopedContext(this);
+    if (context.isLost())
+        return;
+
+    context->graphicsContextGL()->provokingVertexANGLE(mode);
+}
 
 } // namespace WebCore
+
+#endif // ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.h
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.h
@@ -23,14 +23,23 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNoInterfaceObject,
-    Conditional=WEBGL,
-    GenerateIsReachable=ImplWebGLRenderingContext,
-] interface EXTProvokingVertex {
-    const unsigned long FIRST_VERTEX_CONVENTION_EXT = 0x8E4D;
-    const unsigned long LAST_VERTEX_CONVENTION_EXT  = 0x8E4E;
-    const unsigned long PROVOKING_VERTEX_EXT        = 0x8E4F;
+#pragma once
 
-    undefined provokingVertexEXT(unsigned long mode);
+#include "WebGLExtension.h"
+
+namespace WebCore {
+
+class WebGLProvokingVertex final : public WebGLExtension {
+    WTF_MAKE_ISO_ALLOCATED(WebGLProvokingVertex);
+public:
+    explicit WebGLProvokingVertex(WebGLRenderingContextBase&);
+    virtual ~WebGLProvokingVertex();
+
+    ExtensionName getName() const override;
+
+    static bool supported(GraphicsContextGL&);
+
+    void provokingVertexWEBGL(GCGLenum mode);
 };
+
+} // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.idl
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.idl
@@ -23,44 +23,14 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
+[
+    LegacyNoInterfaceObject,
+    Conditional=WEBGL,
+    GenerateIsReachable=ImplWebGLRenderingContext,
+] interface WebGLProvokingVertex {
+    const unsigned long FIRST_VERTEX_CONVENTION_WEBGL = 0x8E4D;
+    const unsigned long LAST_VERTEX_CONVENTION_WEBGL  = 0x8E4E;
+    const unsigned long PROVOKING_VERTEX_WEBGL        = 0x8E4F;
 
-#if ENABLE(WEBGL)
-#include "EXTProvokingVertex.h"
-
-#include <wtf/IsoMallocInlines.h>
-
-namespace WebCore {
-
-WTF_MAKE_ISO_ALLOCATED_IMPL(EXTProvokingVertex);
-
-EXTProvokingVertex::EXTProvokingVertex(WebGLRenderingContextBase& context)
-    : WebGLExtension(context)
-{
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_provoking_vertex"_s);
-}
-
-EXTProvokingVertex::~EXTProvokingVertex() = default;
-
-WebGLExtension::ExtensionName EXTProvokingVertex::getName() const
-{
-    return EXTProvokingVertexName;
-}
-
-bool EXTProvokingVertex::supported(GraphicsContextGL& context)
-{
-    return context.supportsExtension("GL_ANGLE_provoking_vertex"_s);
-}
-
-void EXTProvokingVertex::provokingVertexEXT(GCGLenum mode)
-{
-    auto context = WebGLExtensionScopedContext(this);
-    if (context.isLost())
-        return;
-
-    context->graphicsContextGL()->provokingVertexANGLE(mode);
-}
-
-} // namespace WebCore
-
-#endif // ENABLE(WEBGL)
+    undefined provokingVertexWEBGL(unsigned long mode);
+};

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -39,7 +39,6 @@
 #include "EXTColorBufferHalfFloat.h"
 #include "EXTFloatBlend.h"
 #include "EXTFragDepth.h"
-#include "EXTProvokingVertex.h"
 #include "EXTShaderTextureLOD.h"
 #include "EXTTextureCompressionBPTC.h"
 #include "EXTTextureCompressionRGTC.h"
@@ -105,6 +104,7 @@
 #include "WebGLMultiDraw.h"
 #include "WebGLMultiDrawInstancedBaseVertexBaseInstance.h"
 #include "WebGLProgram.h"
+#include "WebGLProvokingVertex.h"
 #include "WebGLRenderbuffer.h"
 #include "WebGLRenderingContext.h"
 #include "WebGLSampler.h"
@@ -2983,7 +2983,6 @@ bool WebGLRenderingContextBase::extensionIsEnabled(const String& name)
     CHECK_EXTENSION(m_extColorBufferHalfFloat, "EXT_color_buffer_half_float");
     CHECK_EXTENSION(m_extFloatBlend, "EXT_float_blend");
     CHECK_EXTENSION(m_extFragDepth, "EXT_frag_depth");
-    CHECK_EXTENSION(m_extProvokingVertex, "EXT_provoking_vertex");
     CHECK_EXTENSION(m_extShaderTextureLOD, "EXT_shader_texture_lod");
     CHECK_EXTENSION(m_extTextureCompressionBPTC, "EXT_texture_compression_bptc");
     CHECK_EXTENSION(m_extTextureCompressionRGTC, "EXT_texture_compression_rgtc");
@@ -3017,6 +3016,7 @@ bool WebGLRenderingContextBase::extensionIsEnabled(const String& name)
     CHECK_EXTENSION(m_webglLoseContext, "WEBGL_lose_context");
     CHECK_EXTENSION(m_webglMultiDraw, "WEBGL_multi_draw");
     CHECK_EXTENSION(m_webglMultiDrawInstancedBaseVertexBaseInstance, "WEBGL_multi_draw_instanced_base_vertex_base_instance");
+    CHECK_EXTENSION(m_webglProvokingVertex, "WEBGL_provoking_vertex");
     return false;
 }
 
@@ -5788,7 +5788,6 @@ void WebGLRenderingContextBase::loseExtensions(LostContextMode mode)
     LOSE_EXTENSION(m_extColorBufferHalfFloat);
     LOSE_EXTENSION(m_extFloatBlend);
     LOSE_EXTENSION(m_extFragDepth);
-    LOSE_EXTENSION(m_extProvokingVertex);
     LOSE_EXTENSION(m_extShaderTextureLOD);
     LOSE_EXTENSION(m_extTextureCompressionBPTC);
     LOSE_EXTENSION(m_extTextureCompressionRGTC);
@@ -5821,6 +5820,7 @@ void WebGLRenderingContextBase::loseExtensions(LostContextMode mode)
     LOSE_EXTENSION(m_webglLoseContext);
     LOSE_EXTENSION(m_webglMultiDraw);
     LOSE_EXTENSION(m_webglMultiDrawInstancedBaseVertexBaseInstance);
+    LOSE_EXTENSION(m_webglProvokingVertex);
 }
 
 void WebGLRenderingContextBase::activityStateDidChange(OptionSet<ActivityState::Flag> oldActivityState, OptionSet<ActivityState::Flag> newActivityState)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -82,7 +82,6 @@ class EXTColorBufferFloat;
 class EXTColorBufferHalfFloat;
 class EXTFloatBlend;
 class EXTFragDepth;
-class EXTProvokingVertex;
 class EXTShaderTextureLOD;
 class EXTTextureCompressionBPTC;
 class EXTTextureCompressionRGTC;
@@ -127,6 +126,7 @@ class WebGLLoseContext;
 class WebGLMultiDraw;
 class WebGLMultiDrawInstancedBaseVertexBaseInstance;
 class WebGLObject;
+class WebGLProvokingVertex;
 class WebGLShader;
 class WebGLShaderPrecisionFormat;
 class WebGLSharedObject;
@@ -736,7 +736,6 @@ protected:
     RefPtr<EXTColorBufferHalfFloat> m_extColorBufferHalfFloat;
     RefPtr<EXTFloatBlend> m_extFloatBlend;
     RefPtr<EXTFragDepth> m_extFragDepth;
-    RefPtr<EXTProvokingVertex> m_extProvokingVertex;
     RefPtr<EXTShaderTextureLOD> m_extShaderTextureLOD;
     RefPtr<EXTTextureCompressionBPTC> m_extTextureCompressionBPTC;
     RefPtr<EXTTextureCompressionRGTC> m_extTextureCompressionRGTC;
@@ -769,6 +768,7 @@ protected:
     RefPtr<WebGLLoseContext> m_webglLoseContext;
     RefPtr<WebGLMultiDraw> m_webglMultiDraw;
     RefPtr<WebGLMultiDrawInstancedBaseVertexBaseInstance> m_webglMultiDrawInstancedBaseVertexBaseInstance;
+    RefPtr<WebGLProvokingVertex> m_webglProvokingVertex;
 
     bool m_areWebGL2TexImageSourceFormatsAndTypesAdded { false };
     bool m_areOESTextureFloatFormatsAndTypesAdded { false };

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -789,10 +789,10 @@ public:
     static constexpr GCGLenum RGB16_SNORM_EXT = 0x8F9A;
     static constexpr GCGLenum RGBA16_SNORM_EXT = 0x8F9B;
 
-    // GL_EXT_provoking_vertex
-    static constexpr GCGLenum FIRST_VERTEX_CONVENTION_EXT = 0x8E4D;
-    static constexpr GCGLenum LAST_VERTEX_CONVENTION_EXT = 0x8E4E;
-    static constexpr GCGLenum PROVOKING_VERTEX_EXT = 0x8E4F;
+    // GL_ANGLE_provoking_vertex
+    static constexpr GCGLenum FIRST_VERTEX_CONVENTION_ANGLE = 0x8E4D;
+    static constexpr GCGLenum LAST_VERTEX_CONVENTION_ANGLE = 0x8E4E;
+    static constexpr GCGLenum PROVOKING_VERTEX_ANGLE = 0x8E4F;
 
     // GL_ARB_draw_buffers / GL_EXT_draw_buffers
     static constexpr GCGLenum MAX_DRAW_BUFFERS_EXT = 0x8824;


### PR DESCRIPTION
#### 7a20f60a6ff47c7d97c9f14c51ba33f31f3e460a
<pre>
Use WEBGL prefix for the provoking vertex extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=247335">https://bugs.webkit.org/show_bug.cgi?id=247335</a>

Reviewed by Kimmo Kinnunen.

Renamed EXT_provoking_vertex extension to
WEBGL_provoking_vertex.

Synced the extension CTS with the upstream repo.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt:
* LayoutTests/webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex-expected.txt: Renamed from LayoutTests/webgl/2.0.y/conformance2/extensions/ext-provoking-vertex-expected.txt.
* LayoutTests/webgl/2.0.y/conformance2/extensions/webgl-provoking-vertex.html: Renamed from LayoutTests/webgl/2.0.y/conformance2/extensions/ext-provoking-vertex.html.
* LayoutTests/webgl/resources/webgl-draft-extensions-flag.js:
* LayoutTests/webgl/resources/webgl_test_files/conformance2/extensions/webgl-provoking-vertex.html: Renamed from LayoutTests/webgl/resources/webgl_test_files/conformance2/extensions/ext-provoking-vertex.html.
* LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
(WebCore::convertToJSValue):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getExtension):
(WebCore::WebGL2RenderingContext::getSupportedExtensions):
(WebCore::WebGL2RenderingContext::getParameter):
* Source/WebCore/html/canvas/WebGLExtension.h:
* Source/WebCore/html/canvas/WebGLProvokingVertex.cpp: Renamed from Source/WebCore/html/canvas/EXTProvokingVertex.cpp.
(WebCore::WebGLProvokingVertex::WebGLProvokingVertex):
(WebCore::WebGLProvokingVertex::getName const):
(WebCore::WebGLProvokingVertex::supported):
(WebCore::WebGLProvokingVertex::provokingVertexWEBGL):
* Source/WebCore/html/canvas/WebGLProvokingVertex.h: Renamed from Source/WebCore/html/canvas/EXTProvokingVertex.h.
* Source/WebCore/html/canvas/WebGLProvokingVertex.idl: Renamed from Source/WebCore/html/canvas/EXTProvokingVertex.idl.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::extensionIsEnabled):
(WebCore::WebGLRenderingContextBase::loseExtensions):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/256272@main">https://commits.webkit.org/256272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c01e93056918c08567c4f5cf34ad8d8eb16a4eff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104740 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164994 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99134 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4379 "Archived built product (failure)") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33145 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100636 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100810 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/4379 "Archived built product (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81682 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30170 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/4379 "Archived built product (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73068 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38872 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36691 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4333 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42467 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39093 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->