### PR TITLE
[GTK] Handle files being disallowed in DragDataGtk after 254380@main

### DIFF
--- a/Source/WebCore/platform/gtk/DragDataGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragDataGtk.cpp
@@ -1,4 +1,6 @@
 /*
+ *  Copyright (C) 2016 Igalia S.L.
+ *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
  *  License as published by the Free Software Foundation; either
@@ -33,16 +35,18 @@ bool DragData::containsColor() const
 
 bool DragData::containsFiles() const
 {
-    return m_platformDragData->hasFilenames();
+    return !m_disallowFileAccess && m_platformDragData->hasFilenames();
 }
 
 unsigned DragData::numberOfFiles() const
 {
-    return m_platformDragData->filenames().size();
+    return !m_disallowFileAccess ? m_platformDragData->filenames().size() : 0;
 }
 
 Vector<String> DragData::asFilenames() const
 {
+    if (m_disallowFileAccess)
+        return { };
     return m_platformDragData->filenames();
 }
 


### PR DESCRIPTION
#### 0d05bac8d326001e57a518b42ae7ad3eafb2c186
<pre>
[GTK] Handle files being disallowed in DragDataGtk after 254380@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=247359">https://bugs.webkit.org/show_bug.cgi?id=247359</a>

Reviewed by Michael Catanzaro.

We need to do the same changes done in 254380@main for DragDataGtk.

* Source/WebCore/platform/gtk/DragDataGtk.cpp:
(WebCore::DragData::containsFiles const):
(WebCore::DragData::numberOfFiles const):
(WebCore::DragData::asFilenames const):

Canonical link: <a href="https://commits.webkit.org/256232@main">https://commits.webkit.org/256232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/935a86155947589ebc0a1fbf58ce175c53bd44bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4284 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104742 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/164995 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4381 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33147 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100638 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3193 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81685 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30169 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86935 "Build was cancelled. Recent messages:") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38874 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19773 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40629 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39014 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->