### PR TITLE
Constructing shared CARingBuffer cannot fail

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -114,7 +114,7 @@ private:
 
     RefPtr<AudioSampleBufferList> m_scratchBuffer;
 
-    UniqueRef<CARingBuffer> m_ringBuffer;
+    InProcessCARingBuffer m_ringBuffer;
     size_t m_maximumSampleCount { 0 };
 
     float m_volume { 1.0 };

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -38,64 +38,10 @@ typedef struct AudioBufferList AudioBufferList;
 
 namespace WebCore {
 
-class CARingBufferStorage {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    virtual ~CARingBufferStorage() = default;
-    virtual bool allocate(size_t, const CAAudioStreamDescription& format, size_t frameCount) = 0;
-    virtual void deallocate() = 0;
-    virtual void* data() = 0;
-    virtual void getCurrentFrameBounds(uint64_t& startTime, uint64_t& endTime) = 0;
-    virtual void setCurrentFrameBounds(uint64_t startFrame, uint64_t endFrame) = 0;
-    virtual void updateFrameBounds() { }
-    virtual uint64_t currentStartFrame() const = 0;
-    virtual uint64_t currentEndFrame() const = 0;
-    virtual void flush() = 0;
-    virtual size_t size() const = 0;
-};
-
-class CARingBufferStorageVector final : public CARingBufferStorage {
-public:
-    CARingBufferStorageVector();
-    ~CARingBufferStorageVector() = default;
-
-private:
-    bool allocate(size_t byteCount, const CAAudioStreamDescription&, size_t) final;
-    void deallocate() final { m_buffer.clear(); }
-    void* data() final { return m_buffer.data(); }
-    void getCurrentFrameBounds(uint64_t& startTime, uint64_t& endTime) final;
-    void setCurrentFrameBounds(uint64_t startFrame, uint64_t endFrame) final;
-    uint64_t currentStartFrame() const final;
-    uint64_t currentEndFrame() const final;
-    void flush() final;
-    size_t size() const final { return m_buffer.size(); }
-
-    struct TimeBounds {
-        TimeBounds()
-            : m_startFrame(0)
-            , m_endFrame(0)
-            , m_updateCounter(0)
-        {
-        }
-        volatile uint64_t m_startFrame;
-        volatile uint64_t m_endFrame;
-        volatile uint32_t m_updateCounter;
-    };
-
-    Vector<uint8_t> m_buffer;
-    Vector<TimeBounds> m_timeBoundsQueue;
-    Lock m_currentFrameBoundsLock;
-    std::atomic<int32_t> m_timeBoundsQueuePtr { 0 };
-};
-
 class CARingBuffer {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT CARingBuffer();
-    WEBCORE_EXPORT explicit CARingBuffer(UniqueRef<CARingBufferStorage>&&);
-    WEBCORE_EXPORT ~CARingBuffer();
-
-    WEBCORE_EXPORT static UniqueRef<CARingBuffer> adoptStorage(UniqueRef<CARingBufferStorage>&&, const CAAudioStreamDescription&, size_t frameCount);
+    WEBCORE_EXPORT virtual ~CARingBuffer();
 
     enum Error {
         Ok,
@@ -113,36 +59,75 @@ public:
     // Fills buffer with silence if there is not enough data.
     WEBCORE_EXPORT void fetch(AudioBufferList*, size_t frameCount, uint64_t startFrame, FetchMode = Copy);
 
-    WEBCORE_EXPORT void flush();
+    virtual void flush() = 0;
 
     WEBCORE_EXPORT void getCurrentFrameBounds(uint64_t& startFrame, uint64_t& endFrame);
 
     uint32_t channelCount() const { return m_channelCount; }
-    CARingBufferStorage& storage() { return m_buffers; }
+
+protected:
+    WEBCORE_EXPORT CARingBuffer();
+    WEBCORE_EXPORT void initializeAfterAllocation(const CAAudioStreamDescription& format, size_t frameCount);
+
+    WEBCORE_EXPORT static CheckedSize computeCapacityBytes(const CAAudioStreamDescription& format, size_t frameCount);
+    WEBCORE_EXPORT static CheckedSize computeSizeForBuffers(const CAAudioStreamDescription& format, size_t frameCount);
+
+    virtual bool allocateBuffers(size_t, const CAAudioStreamDescription& format, size_t frameCount) = 0;
+    virtual void deallocateBuffers() = 0;
+    virtual void* data() = 0;
+    virtual void getCurrentFrameBoundsWithoutUpdate(uint64_t& startTime, uint64_t& endTime) = 0;
+    virtual void setCurrentFrameBounds(uint64_t startFrame, uint64_t endFrame) = 0;
+    virtual void updateFrameBounds() { }
+    virtual uint64_t currentStartFrame() const = 0;
+    virtual uint64_t currentEndFrame() const = 0;
+    virtual size_t size() const = 0;
 
 private:
-    void updateFrameBounds();
     size_t frameOffset(uint64_t frameNumber) const { return (frameNumber % m_frameCount) * m_bytesPerFrame; }
-
     void clipTimeBounds(uint64_t& startRead, uint64_t& endRead);
-    void setCurrentFrameBounds(uint64_t startFrame, uint64_t endFrame);
-
-    void getCurrentFrameBoundsWithoutUpdate(uint64_t& startFrame, uint64_t& endFrame);
     void fetchInternal(AudioBufferList*, size_t frameCount, uint64_t startFrame, FetchMode);
 
-    void initializeAfterAllocation(const CAAudioStreamDescription& format, size_t frameCount);
-
-    uint64_t currentStartFrame() const;
-    uint64_t currentEndFrame() const;
-
-    UniqueRef<CARingBufferStorage> m_buffers;
     Vector<Byte*> m_pointers;
     uint32_t m_channelCount { 0 };
     size_t m_bytesPerFrame { 0 };
     uint32_t m_frameCount { 0 };
     size_t m_capacityBytes { 0 };
-
     CAAudioStreamDescription m_description;
+};
+
+class InProcessCARingBuffer final : public CARingBuffer {
+public:
+    WEBCORE_EXPORT InProcessCARingBuffer();
+    WEBCORE_EXPORT ~InProcessCARingBuffer();
+    WEBCORE_EXPORT void flush() final;
+
+protected:
+    bool allocateBuffers(size_t byteCount, const CAAudioStreamDescription&, size_t) final;
+    void deallocateBuffers() final { m_buffer.clear(); }
+    void* data() final { return m_buffer.data(); }
+    void getCurrentFrameBoundsWithoutUpdate(uint64_t& startTime, uint64_t& endTime) final;
+    void setCurrentFrameBounds(uint64_t startFrame, uint64_t endFrame) final;
+    uint64_t currentStartFrame() const final;
+    uint64_t currentEndFrame() const final;
+    size_t size() const final { return m_buffer.size(); }
+
+private:
+    struct TimeBounds {
+        TimeBounds()
+            : m_startFrame(0)
+            , m_endFrame(0)
+            , m_updateCounter(0)
+        {
+        }
+        volatile uint64_t m_startFrame;
+        volatile uint64_t m_endFrame;
+        volatile uint32_t m_updateCounter;
+    };
+
+    Vector<uint8_t> m_buffer;
+    Vector<TimeBounds> m_timeBoundsQueue;
+    Lock m_currentFrameBoundsLock;
+    std::atomic<int32_t> m_timeBoundsQueuePtr { 0 };
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -71,7 +71,7 @@ RefPtr<AudioSourceProviderAVFObjC> AudioSourceProviderAVFObjC::create(AVPlayerIt
 
 AudioSourceProviderAVFObjC::AudioSourceProviderAVFObjC(AVPlayerItem *item)
     : m_avPlayerItem(item)
-    , m_ringBufferCreationCallback([] { return makeUniqueRef<CARingBuffer>(); })
+    , m_ringBufferCreationCallback([] { return makeUniqueRef<InProcessCARingBuffer>(); })
 {
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -30,7 +30,7 @@
 #include "Connection.h"
 #include "IPCSemaphore.h"
 #include "RemoteAudioDestinationIdentifier.h"
-#include "SharedMemory.h"
+#include "SharedCARingBuffer.h"
 #include <memory>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
@@ -68,7 +68,7 @@ private:
     void startAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
     void stopAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
 #if PLATFORM(COCOA)
-    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
 #endif
 
     HashMap<RemoteAudioDestinationIdentifier, UniqueRef<RemoteAudioDestination>> m_audioDestinations;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -31,7 +31,7 @@ messages -> RemoteAudioDestinationManager NotRefCounted {
     StartAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
     StopAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
 #if PLATFORM(COCOA)
-    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -57,9 +57,9 @@ RemoteAudioSourceProviderProxy::~RemoteAudioSourceProviderProxy() = default;
 
 UniqueRef<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::createRingBuffer()
 {
-    return makeUniqueRef<WebCore::CARingBuffer>(makeUniqueRef<SharedRingBufferStorage>([protectedThis = Ref { *this }](SharedMemory* memory, const WebCore::CAAudioStreamDescription& format, size_t frameCount) mutable {
+    return makeUniqueRef<ProducerSharedCARingBuffer>([protectedThis = Ref { *this }](SharedMemory* memory, const WebCore::CAAudioStreamDescription& format, size_t frameCount) mutable {
         protectedThis->storageChanged(memory, format, frameCount);
-    }));
+    });
 }
 
 void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -28,7 +28,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
 
 #include "Connection.h"
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include <WebCore/AudioSourceProviderClient.h>
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaPlayerIdentifier.h>

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -60,7 +60,7 @@
 #endif
 
 #if PLATFORM(COCOA)
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #endif
 
 #if USE(AVFOUNDATION)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -29,7 +29,7 @@
 
 #include "AudioMediaStreamTrackRendererInternalUnitIdentifier.h"
 #include "Connection.h"
-#include "SharedMemory.h"
+#include "SharedCARingBuffer.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 
@@ -64,7 +64,7 @@ private:
     // Messages
     void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, CompletionHandler<void(const WebCore::CAAudioStreamDescription&, size_t)>&& callback);
     void deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
-    void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&);
+    void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, ConsumerSharedCARingBuffer::Handle&& , const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&);
     void stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
     void setAudioOutputDevice(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&);
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager NotRefCounted
     CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier) -> (WebCore::CAAudioStreamDescription description, size_t frameChunkSize)
     DeleteUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
-    StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore renderSemaphore)
+    StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore renderSemaphore)
     StopUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
     SetAudioOutputDevice(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceId)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -31,7 +31,7 @@
 #include "MediaRecorderIdentifier.h"
 #include "MessageReceiver.h"
 #include "RemoteVideoFrameIdentifier.h"
-#include "SharedMemory.h"
+#include "SharedCARingBuffer.h"
 #include "SharedVideoFrame.h"
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaRecorderPrivateWriterCocoa.h>
@@ -43,7 +43,6 @@ class Decoder;
 }
 
 namespace WebCore {
-class CARingBuffer;
 class WebAudioBufferList;
 struct MediaRecorderPrivateOptions;
 }
@@ -51,7 +50,6 @@ struct MediaRecorderPrivateOptions;
 namespace WebKit {
 
 class GPUConnectionToWebProcess;
-class SharedRingBufferStorage;
 
 class RemoteMediaRecorder : private IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -69,7 +67,7 @@ private:
     RemoteMediaRecorder(GPUConnectionToWebProcess&, MediaRecorderIdentifier, Ref<WebCore::MediaRecorderPrivateWriter>&&, bool recordAudio);
 
     // IPC::MessageReceiver
-    void audioSamplesStorageChanged(const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
     void audioSamplesAvailable(MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(SharedVideoFrame&&);
     void fetchData(CompletionHandler<void(IPC::DataReference&&, double)>&&);
@@ -84,8 +82,9 @@ private:
     Ref<WebCore::MediaRecorderPrivateWriter> m_writer;
 
     WebCore::CAAudioStreamDescription m_description;
-    std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+    std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_audioBufferList;
+    const bool m_recordAudio;
 
     SharedVideoFrameReader m_sharedVideoFrameReader;
 };

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in
@@ -24,7 +24,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 messages -> RemoteMediaRecorder NotRefCounted {
-    AudioSamplesStorageChanged(WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
     AudioSamplesAvailable(MediaTime time, uint64_t numberOfFrames)
     VideoFrameAvailable(struct WebKit::SharedVideoFrame frame)
     FetchData() -> (IPC::DataReference buffer, double timeCode)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -387,6 +387,7 @@ def conditions_for_header(header):
     conditions = {
         '"InputMethodState.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"GestureTypes.h"': ["PLATFORM(IOS_FAMILY)"],
+        '"SharedCARingBuffer.h"': ["PLATFORM(COCOA)"],
         '"WCContentBufferIdentifier.h"': ["USE(GRAPHICS_LAYER_WC)"],
         '"WCLayerTreeHostIdentifier.h"': ["USE(GRAPHICS_LAYER_WC)"],
         '<WebCore/CVUtilities.h>': ["PLATFORM(COCOA)", ],
@@ -889,6 +890,7 @@ def headers_for_type(type):
         'WebKit::AuthenticationChallengeIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::BackForwardListItemState': ['"SessionState.h"'],
         'WebKit::CallDownloadDidStart': ['"DownloadManager.h"'],
+        'WebKit::ConsumerSharedCARingBuffer::Handle': ['"SharedCARingBuffer.h"'],
         'WebKit::ContentWorldIdentifier': ['"ContentWorldShared.h"'],
         'WebKit::DocumentEditingContextRequest': ['"DocumentEditingContext.h"'],
         'WebKit::FindDecorationStyle': ['"WebFindOptions.h"'],

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -161,7 +161,7 @@ Shared/Cocoa/RevealItem.mm
 Shared/Cocoa/SandboxExtensionCocoa.mm
 Shared/Cocoa/SandboxInitialiationParametersCocoa.mm
 Shared/Cocoa/SandboxUtilities.mm
-Shared/Cocoa/SharedRingBufferStorage.cpp
+Shared/Cocoa/SharedCARingBuffer.cpp
 Shared/Cocoa/TCCSoftLink.mm
 Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
 Shared/Cocoa/WebErrorsCocoa.mm

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -31,7 +31,7 @@
 #include "Connection.h"
 #include "RemoteCaptureSampleManagerMessages.h"
 #include "RemoteVideoFrameObjectHeap.h"
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include "UserMediaCaptureManagerMessages.h"
 #include "UserMediaCaptureManagerProxyMessages.h"
 #include "WebCoreArgumentCoders.h"
@@ -89,7 +89,7 @@ public:
         m_source->removeObserver(*this);
 
         if (m_ringBuffer)
-            static_cast<SharedRingBufferStorage&>(m_ringBuffer->storage()).invalidate();
+            m_ringBuffer->invalidate();
     }
 
     RealtimeMediaSource& source() { return m_source; }
@@ -160,7 +160,7 @@ private:
             // Allocate a ring buffer large enough to contain 2 seconds of audio.
             m_numberOfFrames = m_description.sampleRate() * 2;
             m_ringBuffer.reset();
-            m_ringBuffer = makeUnique<CARingBuffer>(makeUniqueRef<SharedRingBufferStorage>(std::bind(&SourceProxy::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
+            m_ringBuffer = makeUnique<ProducerSharedCARingBuffer>(std::bind(&SourceProxy::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
             m_ringBuffer->allocate(m_description.streamDescription(), m_numberOfFrames);
         }
 
@@ -242,7 +242,7 @@ private:
     Ref<IPC::Connection> m_connection;
     ProcessIdentity m_resourceOwner;
     Ref<RealtimeMediaSource> m_source;
-    std::unique_ptr<CARingBuffer> m_ringBuffer;
+    std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     CAAudioStreamDescription m_description { };
     int64_t m_numberOfFrames { 0 };
     bool m_isStopped { false };

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -32,7 +32,7 @@
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManager.h"
 
 #if PLATFORM(COCOA)
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/WebAudioBufferList.h>
 #endif
@@ -48,9 +48,6 @@ SpeechRecognitionRemoteRealtimeMediaSource::SpeechRecognitionRemoteRealtimeMedia
     : WebCore::RealtimeMediaSource(captureDevice, { }, pageIdentifier)
     , m_identifier(identifier)
     , m_manager(manager)
-#if PLATFORM(COCOA)
-    , m_ringBuffer(makeUnique<WebCore::CARingBuffer>())
-#endif
 {
     m_manager->addSource(*this, captureDevice);
 }
@@ -75,16 +72,13 @@ void SpeechRecognitionRemoteRealtimeMediaSource::stopProducingData()
 
 #if PLATFORM(COCOA)
 
-void SpeechRecognitionRemoteRealtimeMediaSource::setStorage(const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void SpeechRecognitionRemoteRealtimeMediaSource::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
-    if (!numberOfFrames) {
-        m_ringBuffer = nullptr;
-        m_buffer = nullptr;
+    m_buffer = nullptr;
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    if (!m_ringBuffer)
         return;
-    }
-
     m_description = description;
-    m_ringBuffer = WebCore::CARingBuffer::adoptStorage(makeUniqueRef<ReadOnlySharedRingBufferStorage>(handle), description, numberOfFrames).moveToUniquePtr();
     m_buffer = makeUnique<WebCore::WebAudioBufferList>(description);
 }
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -27,18 +27,17 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include "SharedMemory.h"
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
 
 #if PLATFORM(COCOA)
+#include "SharedCARingBuffer.h"
 #include <WebCore/CAAudioStreamDescription.h>
 #endif
 
 namespace WebCore {
 class CaptureDevice;
 #if PLATFORM(COCOA)
-class CARingBuffer;
 class WebAudioBufferList;
 #endif
 }
@@ -54,7 +53,7 @@ public:
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_identifier; }
 
 #if PLATFORM(COCOA)
-    void setStorage(const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
 #endif
 
     void remoteAudioSamplesAvailable(MediaTime, uint64_t numberOfFrames);
@@ -77,7 +76,7 @@ private:
 
 #if PLATFORM(COCOA)
     WebCore::CAAudioStreamDescription m_description;
-    std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+    std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
 #endif
 };

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -108,10 +108,10 @@ uint64_t SpeechRecognitionRemoteRealtimeMediaSourceManager::messageSenderDestina
 
 #if PLATFORM(COCOA)
 
-void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     if (auto source = m_sources.get(identifier))
-        source->setStorage(handle, description, numberOfFrames);
+        source->setStorage(WTFMove(handle), description, numberOfFrames);
 }
 
 #endif

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -29,8 +29,11 @@
 
 #include "MessageReceiver.h"
 #include "MessageSender.h"
-#include "SharedMemory.h"
 #include <WebCore/RealtimeMediaSourceIdentifier.h>
+
+#if PLATFORM(COCOA)
+#include "SharedCARingBuffer.h"
+#endif
 
 namespace WTF {
 class MediaTime;
@@ -38,10 +41,6 @@ class MediaTime;
 
 namespace WebCore {
 class CaptureDevice;
-
-#if PLATFORM(COCOA)
-class CAAudioStreamDescription;
-#endif
 }
 
 namespace WebKit {
@@ -61,7 +60,7 @@ private:
     void remoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier);
     void remoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier);
 #if PLATFORM(COCOA)
-    void setStorage(WebCore::RealtimeMediaSourceIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void setStorage(WebCore::RealtimeMediaSourceIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
 #endif
 
     // IPC::MessageReceiver.

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
@@ -28,7 +28,7 @@ messages -> SpeechRecognitionRemoteRealtimeMediaSourceManager NotRefCounted {
     RemoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier identifier)
     RemoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier identifier)
 #if PLATFORM(COCOA)
-    SetStorage(WebCore::RealtimeMediaSourceIdentifier identifier, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    SetStorage(WebCore::RealtimeMediaSourceIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
 #endif
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1978,7 +1978,7 @@
 		CD491B131E73482100009066 /* UserMediaCaptureManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CD491B111E73482100009066 /* UserMediaCaptureManagerProxy.h */; };
 		CD491B171E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD491B151E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp */; };
 		CD491B181E73525500009066 /* UserMediaCaptureManagerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = CD491B161E73525500009066 /* UserMediaCaptureManagerProxyMessages.h */; };
-		CD4B4D9D1E765E0000D27092 /* SharedRingBufferStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = CD4B4D9B1E765E0000D27092 /* SharedRingBufferStorage.h */; };
+		CD4B4D9D1E765E0000D27092 /* SharedCARingBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = CD4B4D9B1E765E0000D27092 /* SharedCARingBuffer.h */; };
 		CD5C66A1134B9D38004FE2A8 /* InjectedBundlePageFullScreenClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CD5C669F134B9D37004FE2A8 /* InjectedBundlePageFullScreenClient.h */; };
 		CD73BA47131ACC9A00EEDED2 /* WebFullScreenManagerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD73BA45131ACC8800EEDED2 /* WebFullScreenManagerProxyMessageReceiver.cpp */; };
 		CD73BA4E131ACDB700EEDED2 /* WebFullScreenManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD73BA48131ACD8E00EEDED2 /* WebFullScreenManagerMessageReceiver.cpp */; };
@@ -6924,8 +6924,8 @@
 		CD491B141E7349F300009066 /* UserMediaCaptureManagerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = UserMediaCaptureManagerProxy.messages.in; path = ../Cocoa/UserMediaCaptureManagerProxy.messages.in; sourceTree = "<group>"; };
 		CD491B151E73525500009066 /* UserMediaCaptureManagerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UserMediaCaptureManagerProxyMessageReceiver.cpp; path = DerivedSources/WebKit/UserMediaCaptureManagerProxyMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD491B161E73525500009066 /* UserMediaCaptureManagerProxyMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UserMediaCaptureManagerProxyMessages.h; path = DerivedSources/WebKit/UserMediaCaptureManagerProxyMessages.h; sourceTree = BUILT_PRODUCTS_DIR; };
-		CD4B4D9A1E765E0000D27092 /* SharedRingBufferStorage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedRingBufferStorage.cpp; sourceTree = "<group>"; };
-		CD4B4D9B1E765E0000D27092 /* SharedRingBufferStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedRingBufferStorage.h; sourceTree = "<group>"; };
+		CD4B4D9A1E765E0000D27092 /* SharedCARingBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedCARingBuffer.cpp; sourceTree = "<group>"; };
+		CD4B4D9B1E765E0000D27092 /* SharedCARingBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedCARingBuffer.h; sourceTree = "<group>"; };
 		CD5C669E134B9D36004FE2A8 /* InjectedBundlePageFullScreenClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InjectedBundlePageFullScreenClient.cpp; sourceTree = "<group>"; };
 		CD5C669F134B9D37004FE2A8 /* InjectedBundlePageFullScreenClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedBundlePageFullScreenClient.h; sourceTree = "<group>"; };
 		CD73BA37131A29FE00EEDED2 /* WebFullScreenManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebFullScreenManager.cpp; path = FullScreen/WebFullScreenManager.cpp; sourceTree = "<group>"; };
@@ -10417,8 +10417,8 @@
 				7AB4EA4122777FC70085BBAA /* SandboxInitialiationParametersCocoa.mm */,
 				E19BDA88193686A400B97F57 /* SandboxUtilities.h */,
 				7AB4EA42227780DD0085BBAA /* SandboxUtilities.mm */,
-				CD4B4D9A1E765E0000D27092 /* SharedRingBufferStorage.cpp */,
-				CD4B4D9B1E765E0000D27092 /* SharedRingBufferStorage.h */,
+				CD4B4D9A1E765E0000D27092 /* SharedCARingBuffer.cpp */,
+				CD4B4D9B1E765E0000D27092 /* SharedCARingBuffer.h */,
 				44C51842266BE8C3006DD522 /* TCCSoftLink.h */,
 				44C51843266BE8C3006DD522 /* TCCSoftLink.mm */,
 				1AB1F78E1D1B34A6007C9BD1 /* WebCoreArgumentCodersCocoa.mm */,
@@ -15261,9 +15261,9 @@
 				F43A9CE025D72F1C00990E26 /* ShareableBitmapUtilities.h in Headers */,
 				51217461164C20E30037A5C1 /* ShareableResource.h in Headers */,
 				A183494224EF467800BDC9A8 /* SharedBufferReference.h in Headers */,
+				CD4B4D9D1E765E0000D27092 /* SharedCARingBuffer.h in Headers */,
 				93122C862710CCDF001D819F /* SharedFileHandle.h in Headers */,
 				1A24BED5120894D100FBB059 /* SharedMemory.h in Headers */,
-				CD4B4D9D1E765E0000D27092 /* SharedRingBufferStorage.h in Headers */,
 				8313F7EC1F7DAE0800B944EB /* SharedStringHashStore.h in Headers */,
 				8313F7EE1F7DAE0800B944EB /* SharedStringHashTable.h in Headers */,
 				83F9644E1FA0F76E00C47750 /* SharedStringHashTableReadOnly.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -60,7 +60,7 @@ RemoteAudioDestinationProxy::RemoteAudioDestinationProxy(AudioIOCallback& callba
 #if PLATFORM(COCOA)
     : WebCore::AudioDestinationCocoa(callback, numberOfOutputChannels, sampleRate, false)
     , m_numberOfFrames(hardwareSampleRate() * ringBufferSizeInSecond)
-    , m_ringBuffer(makeUnique<WebCore::CARingBuffer>(makeUniqueRef<SharedRingBufferStorage>(std::bind(&RemoteAudioDestinationProxy::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3))))
+    , m_ringBuffer(makeUnique<ProducerSharedCARingBuffer>(std::bind(&RemoteAudioDestinationProxy::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)))
     , m_sampleRate(hardwareSampleRate())
 #else
     : WebCore::AudioDestinationGStreamer(callback, numberOfOutputChannels, sampleRate)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -37,20 +37,17 @@
 #include <wtf/Threading.h>
 
 #if PLATFORM(COCOA)
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include <WebCore/AudioDestinationCocoa.h>
 #else
 #include <WebCore/AudioDestinationGStreamer.h>
 #endif
 
 namespace WebCore {
-class CARingBuffer;
 class WebAudioBufferList;
 }
 
 namespace WebKit {
-
-class SharedRingBufferFrameBounds;
 
 class RemoteAudioDestinationProxy final
 #if PLATFORM(COCOA)
@@ -100,7 +97,7 @@ private:
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 #if PLATFORM(COCOA)
     uint64_t m_numberOfFrames { 0 };
-    std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+    std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_audioBufferList;
     uint64_t m_currentFrame { 0 };
     float m_sampleRate;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -28,11 +28,11 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 #include "Connection.h"
+#include "SharedCARingBuffer.h"
 #include "SharedMemory.h"
 #include "WebProcess.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/CAAudioStreamDescription.h>
-#include <WebCore/CARingBuffer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/WebAudioBufferList.h>
 
@@ -55,7 +55,7 @@ private:
     RemoteAudioSourceProviderManager();
 
     // Messages
-    void audioStorageChanged(WebCore::MediaPlayerIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioStorageChanged(WebCore::MediaPlayerIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
     void audioSamplesAvailable(WebCore::MediaPlayerIdentifier, uint64_t startFrame, uint64_t numberOfFrames);
 
     void setConnection(IPC::Connection*);
@@ -65,13 +65,13 @@ private:
     public:
         explicit RemoteAudio(Ref<RemoteAudioSourceProvider>&&);
 
-        void setStorage(const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
         void audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames);
 
     private:
         Ref<RemoteAudioSourceProvider> m_provider;
         WebCore::CAAudioStreamDescription m_description;
-        std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+        std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
         std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
     };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
@@ -26,7 +26,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 messages -> RemoteAudioSourceProviderManager NotRefCounted {
-    AudioStorageChanged(WebCore::MediaPlayerIdentifier id, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioStorageChanged(WebCore::MediaPlayerIdentifier id, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
     AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames)
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -32,8 +32,7 @@
 #include "GPUProcessConnection.h"
 #include "IPCSemaphore.h"
 #include "RemoteAudioMediaStreamTrackRendererInternalUnitManagerMessages.h"
-#include "SharedMemory.h"
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include "WebProcess.h"
 #include <WebCore/AudioMediaStreamTrackRendererInternalUnit.h>
 #include <WebCore/AudioMediaStreamTrackRendererUnit.h>
@@ -82,7 +81,7 @@ private:
 
     std::optional<WebCore::CAAudioStreamDescription> m_description;
     std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
-    std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+    std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     int64_t m_writeOffset { 0 };
     size_t m_frameChunkSize { 0 };
     size_t m_numberOfFrames { 0 };
@@ -185,7 +184,7 @@ void AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start()
 
     m_numberOfFrames = m_description->sampleRate() * 2;
     m_ringBuffer.reset();
-    m_ringBuffer = makeUnique<WebCore::CARingBuffer>(makeUniqueRef<SharedRingBufferStorage>(std::bind(&AudioMediaStreamTrackRendererInternalUnitManager::Proxy::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
+    m_ringBuffer = makeUnique<ProducerSharedCARingBuffer>(std::bind(&AudioMediaStreamTrackRendererInternalUnitManager::Proxy::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     m_ringBuffer->allocate(m_description->streamDescription(), m_numberOfFrames);
 
     m_buffer = makeUnique<WebCore::WebAudioBufferList>(*m_description, m_numberOfFrames);

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 messages -> AudioMediaStreamTrackRendererInternalUnitManager NotRefCounted {
-    AudioStorageChanged(WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
+    AudioStorageChanged(WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -65,7 +65,7 @@ void MediaRecorderPrivate::startRecording(StartRecordingCallback&& callback)
 
     auto selectedTracks = MediaRecorderPrivate::selectTracks(m_stream);
     if (selectedTracks.audioTrack)
-        m_ringBuffer = makeUnique<CARingBuffer>(makeUniqueRef<SharedRingBufferStorage>(std::bind(&MediaRecorderPrivate::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
+        m_ringBuffer = makeUnique<ProducerSharedCARingBuffer>(std::bind(&MediaRecorderPrivate::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
     m_connection->sendWithAsyncReply(Messages::RemoteMediaRecorderManager::CreateRecorder { m_identifier, !!selectedTracks.audioTrack, !!selectedTracks.videoTrack, m_options }, [this, weakThis = WeakPtr { *this }, audioTrack = RefPtr { selectedTracks.audioTrack }, videoTrack = RefPtr { selectedTracks.videoTrack }, callback = WTFMove(callback)](auto&& exception, String&& mimeType, unsigned audioBitRate, unsigned videoBitRate) mutable {
         if (!weakThis) {

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -29,7 +29,7 @@
 
 #include "GPUProcessConnection.h"
 #include "MediaRecorderIdentifier.h"
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include "SharedVideoFrame.h"
 
 #include <WebCore/MediaRecorderPrivate.h>
@@ -75,7 +75,7 @@ private:
     Ref<WebCore::MediaStreamPrivate> m_stream;
     Ref<IPC::Connection> m_connection;
 
-    std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+    std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     WebCore::CAAudioStreamDescription m_description { };
     std::unique_ptr<WebCore::WebAudioBufferList> m_silenceAudioBuffer;
     int64_t m_numberOfFrames { 0 };

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -30,7 +30,7 @@
 #include "RemoteCaptureSampleManagerMessages.h"
 #include "RemoteVideoFrameObjectHeapProxy.h"
 #include "RemoteVideoFrameProxy.h"
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include "WebProcess.h"
 #include <WebCore/CVUtilities.h>
 #include <WebCore/VideoFrameCV.h>
@@ -128,7 +128,7 @@ void RemoteCaptureSampleManager::setVideoFrameObjectHeapProxy(RemoteVideoFrameOb
     m_videoFrameObjectHeapProxy = proxy;
 }
 
-void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier identifier, const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
+void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
 {
     ASSERT(!WTF::isMainRunLoop());
 
@@ -137,7 +137,7 @@ void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourc
         RELEASE_LOG_ERROR(WebRTC, "Unable to find source %llu for storageChanged", identifier.toUInt64());
         return;
     }
-    iterator->value->setStorage(handle, description, numberOfFrames, WTFMove(semaphore), mediaTime, frameChunkSize);
+    iterator->value->setStorage(WTFMove(handle), description, numberOfFrames, WTFMove(semaphore), mediaTime, frameChunkSize);
 }
 
 void RemoteCaptureSampleManager::videoFrameAvailable(RealtimeMediaSourceIdentifier identifier, RemoteVideoFrameProxy::Properties&& properties, VideoFrameTimeMetadata metadata)
@@ -214,24 +214,18 @@ void RemoteCaptureSampleManager::RemoteAudio::startThread()
     m_thread = Thread::create("RemoteCaptureSampleManager::RemoteAudio thread", WTFMove(threadLoop), ThreadType::Audio, Thread::QOS::UserInteractive);
 }
 
-void RemoteCaptureSampleManager::RemoteAudio::setStorage(const SharedMemory::Handle& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
+void RemoteCaptureSampleManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
 {
     stopThread();
-
-    if (!numberOfFrames) {
-        m_ringBuffer = nullptr;
-        m_buffer = nullptr;
+    m_buffer = nullptr;
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    if (!m_ringBuffer)
         return;
-    }
-
     m_semaphore = WTFMove(semaphore);
     m_description = description;
     m_startTime = mediaTime;
     m_frameChunkSize = frameChunkSize;
-
-    m_ringBuffer = CARingBuffer::adoptStorage(makeUniqueRef<ReadOnlySharedRingBufferStorage>(handle), description, numberOfFrames).moveToUniquePtr();
     m_buffer = makeUnique<WebAudioBufferList>(description, m_frameChunkSize);
-
     startThread();
 }
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -34,7 +34,7 @@
 #include "RemoteRealtimeVideoSource.h"
 #include "RemoteVideoFrameIdentifier.h"
 #include "RemoteVideoFrameProxy.h"
-#include "SharedMemory.h"
+#include "SharedCARingBuffer.h"
 #include "WorkQueueMessageReceiver.h"
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/CARingBuffer.h>
@@ -69,7 +69,7 @@ public:
 
 private:
     // Messages
-    void audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier, const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameSampleSize);
+    void audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameSampleSize);
     void audioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier, MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier, RemoteVideoFrameProxy::Properties&&, WebCore::VideoFrameTimeMetadata);
     // FIXME: Will be removed once RemoteVideoFrameProxy providers are the only ones sending data.
@@ -83,7 +83,7 @@ private:
         explicit RemoteAudio(Ref<RemoteRealtimeAudioSource>&&);
         ~RemoteAudio();
 
-        void setStorage(const SharedMemory::Handle&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameChunkSize);
+        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameChunkSize);
 
     private:
         void stopThread();
@@ -92,7 +92,7 @@ private:
         Ref<RemoteRealtimeAudioSource> m_source;
         WebCore::CAAudioStreamDescription m_description;
         std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
-        std::unique_ptr<WebCore::CARingBuffer> m_ringBuffer;
+        std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
         int64_t m_readOffset { 0 };
         MediaTime m_startTime;
         size_t m_frameChunkSize { 0 };

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 messages -> RemoteCaptureSampleManager NotRefCounted {
-    AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, WebKit::SharedMemory::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
+    AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
     VideoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier id, WebKit::RemoteVideoFrameProxy::Properties sample, struct WebCore::VideoFrameTimeMetadata metadata)
     VideoFrameAvailableCV(WebCore::RealtimeMediaSourceIdentifier id, RetainPtr<CVPixelBufferRef> pixelBuffer, WebCore::VideoFrame::Rotation rotation, bool mirrored, MediaTime presentationTime, struct WebCore::VideoFrameTimeMetadata metadata)
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -29,7 +29,7 @@
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 
 #include "GPUProcessConnection.h"
-#include "SharedRingBufferStorage.h"
+#include "SharedCARingBuffer.h"
 #include "UserMediaCaptureManager.h"
 #include "UserMediaCaptureManagerMessages.h"
 #include "UserMediaCaptureManagerProxyMessages.h"

--- a/Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp
@@ -41,7 +41,7 @@ public:
     virtual void SetUp()
     {
         WTF::initializeMainThread();
-        m_ringBuffer = makeUniqueWithoutFastMallocCheck<CARingBuffer>();
+        m_ringBuffer = makeUniqueWithoutFastMallocCheck<InProcessCARingBuffer>();
     }
 
     // CAAudioStreamDescription(double sampleRate, UInt32 numChannels, PCMFormat format, bool isInterleaved, size_t capacity)
@@ -78,7 +78,7 @@ public:
 private:
 
     std::unique_ptr<AudioBufferList> m_bufferList;
-    std::unique_ptr<CARingBuffer> m_ringBuffer;
+    std::unique_ptr<InProcessCARingBuffer> m_ringBuffer;
     CAAudioStreamDescription m_description = { };
     size_t m_capacity = { 0 };
 };


### PR DESCRIPTION
#### eece78fdf9b27b52c5bbfca25a207495098ce8c7
<pre>
Constructing shared CARingBuffer cannot fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=247360">https://bugs.webkit.org/show_bug.cgi?id=247360</a>
rdar://problem/101856691

Reviewed by Eric Carlson.

This is a problem because shared CARingBuffers are used cross-process,
and the WP might send data that would construct a potentially invalid
CARingBuffer. This leads to code that uses empty instances instead of
not checking all use-sites correctly. This in turn leads to running
code that is expected to only run when the ring buffer is correct.

Instead, make ConsumerCARingBuffer construction failable and hold
the instance accordingly. This is similar to many other related,
regular WebKit concepts like SharedMemory. Check all the construction
sites and use sites to not start audio processing unless the ring buffer is
present. This makes it easier in future to add more IPC validation
to the call sites that pass the ring buffer around and ensure that
the other parts of the code are consistent.

Previously, CARingBuffer was non-polymorphic class and its storage
class CARingBufferStorage was the polymorphic base class.
The usage was:
 CARingBuffer with CARingBufferStorageVector for in process ring buffer
 CARingBuffer with ReadOnlyRingBufferStorage for GPUP side consumer
 CARingBuffer with SharedRingBufferStorage for WP side producer

The two-class split does not make sense, as there are only one
non-polymorphic class and the arity is 1:1 in all cases.

Instead, rename:
 CARingBuffer is polymorphic base class
 InProcessCARingBuffer is the in-process ring buffer
 ProducerSharedCARingBuffer is the WP producer
 ConsumerSharedCARingBuffer is the read only GPUP side consumer

Moves the WebKit only code, CARingBuffer::adoptStorage() to
ConsumerSharedCARingBuffer::map().

Make sure Consumer is not superclass of Producer, as they&apos;re not
substitutable.

Use type alias ConsumerSharedCARingBuffer::Handle to communicate
the ring buffer to the receiver. This is so that it is obvious
what is being transferred as well as future-proofing the case
in which transferring ConsumerSharedCARingBuffer would need
more than the SHM handle. Use rvalue references to pass
the handle.

* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::AudioSampleDataSource):
(WebCore::AudioSampleDataSource::setOutputFormat):
(WebCore::AudioSampleDataSource::pushSamplesInternal):
(WebCore::AudioSampleDataSource::pullSamples):
(WebCore::AudioSampleDataSource::pullSamplesInternal):
(WebCore::AudioSampleDataSource::pullAvailableSampleChunk):
(WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::computeCapacityBytes):
(WebCore::CARingBuffer::computeSizeForBuffers):
(WebCore::CARingBuffer::initializeAfterAllocation):
(WebCore::CARingBuffer::allocate):
(WebCore::CARingBuffer::deallocate):
(WebCore::InProcessCARingBuffer::InProcessCARingBuffer):
(WebCore::InProcessCARingBuffer::flush):
(WebCore::InProcessCARingBuffer::allocateBuffers):
(WebCore::InProcessCARingBuffer::setCurrentFrameBounds):
(WebCore::InProcessCARingBuffer::getCurrentFrameBoundsWithoutUpdate):
(WebCore::InProcessCARingBuffer::currentStartFrame const):
(WebCore::InProcessCARingBuffer::currentEndFrame const):
(WebCore::CARingBufferStorageVector::CARingBufferStorageVector): Deleted.
(WebCore::CARingBuffer::CARingBuffer): Deleted.
(WebCore::CARingBuffer::~CARingBuffer): Deleted.
(WebCore::computeCapacityBytes): Deleted.
(WebCore::computeSizeForBuffers): Deleted.
(WebCore::CARingBuffer::adoptStorage): Deleted.
(WebCore::CARingBuffer::flush): Deleted.
(WebCore::CARingBufferStorageVector::allocate): Deleted.
(WebCore::CARingBufferStorageVector::flush): Deleted.
(WebCore::CARingBuffer::setCurrentFrameBounds): Deleted.
(WebCore::CARingBufferStorageVector::setCurrentFrameBounds): Deleted.
(WebCore::CARingBuffer::getCurrentFrameBoundsWithoutUpdate): Deleted.
(WebCore::CARingBufferStorageVector::getCurrentFrameBounds): Deleted.
(WebCore::CARingBuffer::currentStartFrame const): Deleted.
(WebCore::CARingBufferStorageVector::currentStartFrame const): Deleted.
(WebCore::CARingBuffer::currentEndFrame const): Deleted.
(WebCore::CARingBufferStorageVector::currentEndFrame const): Deleted.
(WebCore::CARingBuffer::updateFrameBounds): Deleted.
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
(WebCore::CARingBuffer::updateFrameBounds):
(WebCore::CARingBuffer::frameOffset const):
(WebCore::CARingBufferStorage::updateFrameBounds): Deleted.
(WebCore::CARingBuffer::storage): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::AudioSourceProviderAVFObjC):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::audioSamplesStorageChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::createRingBuffer):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::RemoteMediaRecorder):
(WebKit::RemoteMediaRecorder::audioSamplesStorageChanged):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp: Renamed from Source/WebKit/Shared/Cocoa/SharedRingBufferStorage.cpp.
(WebKit::SharedCARingBufferBase::data):
(WebKit::SharedCARingBufferBase::sharedFrameBounds const):
(WebKit::SharedCARingBufferBase::getCurrentFrameBoundsWithoutUpdate):
(WebKit::SharedCARingBufferBase::flush):
(WebKit::SharedCARingBufferBase::updateFrameBounds):
(WebKit::SharedCARingBufferBase::size const):
(WebKit::ConsumerSharedCARingBuffer::ConsumerSharedCARingBuffer):
(WebKit::ConsumerSharedCARingBuffer::map):
(WebKit::ConsumerSharedCARingBuffer::allocateBuffers):
(WebKit::ProducerSharedCARingBuffer::setStorage):
(WebKit::ProducerSharedCARingBuffer::allocateBuffers):
(WebKit::ProducerSharedCARingBuffer::deallocateBuffers):
(WebKit::ProducerSharedCARingBuffer::setCurrentFrameBounds):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h: Renamed from Source/WebKit/Shared/Cocoa/SharedRingBufferStorage.h.
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::~SourceProxy):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp:
(WebKit::m_manager):
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::setStorage):
(WebKit::m_ringBuffer): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::RemoteAudioDestinationProxy):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::audioStorageChanged):
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::RemoteAudio):
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::setStorage):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::startRecording):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::Source::Source):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::Source::~Source):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::Source::storage): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::audioStorageChanged):
(WebKit::RemoteCaptureSampleManager::RemoteAudio::setStorage):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp:
(TestWebKitAPI::CARingBufferTest::SetUp):

Canonical link: <a href="https://commits.webkit.org/256273@main">https://commits.webkit.org/256273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e52bc99e5a5e5f6a5b88b6cafebfff1313f449

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104869 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165135 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4543 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33272 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100755 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3303 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81815 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30322 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/98865 "webkitpy-tests (failure)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73222 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39000 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36808 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4334 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40759 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39151 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->