### PR TITLE
[git-webkit] Add show sub-command

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.9.1',
+    version='5.10.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 9, 1)
+version = Version(5, 10, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -45,6 +45,7 @@ from .pull_request import PullRequest
 from .revert import Revert
 from .setup_git_svn import SetupGitSvn
 from .setup import Setup
+from .show import Show
 from .trace import Trace
 from .track import Track
 
@@ -86,7 +87,7 @@ def main(
         Clean, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
-        Pickable, CherryPick, Trace, Track,
+        Pickable, CherryPick, Trace, Track, Show,
     ]
     if subversion:
         programs.append(SetupGitSvn)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/show.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/show.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,40 +27,54 @@ import sys
 from webkitcorepy import arguments, Terminal
 from webkitscmpy import local
 from webkitscmpy.program.command import FilteredCommand
-from webkitscmpy.program.show import Show
 
 
-class Log(FilteredCommand):
-    name = 'log'
-    help = "Filter raw output of 'git log' or 'svn log' to replace native commit representation with identifiers"
+class Show(FilteredCommand):
+    name = 'show'
+    help = "Filter raw output of 'git show' to replace native commit representation with identifiers"
 
     @classmethod
     def parser(cls, parser, loggers=None):
-        Show.parser(parser, loggers=loggers)
+        FilteredCommand.parser(parser, loggers=loggers)
         parser.add_argument(
-            '--max-count', '-n', type=int,
-            help='Limit the number of commits to output.',
-            dest='max_count',
+            '--pretty', '--format', type=str,
+            help='Pretty-print the contents of the commit logs in a given format, where <format> can be\n'
+                'one of oneline, short, medium, full, fuller, reference, email, raw, format:<string> and\n'
+                'tformat:<string>. When <format> is none of the above, and has %%placeholder in it, it\n'
+                'acts as if --pretty=tformat:<format> were given.\n\n'
+                'See the "PRETTY FORMATS" section for some additional details for each format. When\n'
+                '=<format> part is omitted, it defaults to medium.\n\n'
+                'Note: you can specify the default pretty format in the repository configuration (see\n'
+                'git-config(1)).',
+            dest='pretty',
             default=None,
         )
         parser.add_argument(
-            '--skip', type=int,
-            help='Skip number commits before starting to show the commit output.',
-            dest='skip',
+            '--abbrev-commit', '--no-abbrev-commit',
+            help='Instead of showing the full 40-byte hexadecimal commit object name, show a prefix that\n'
+                'names the object uniquely. "--abbrev=<n>" (which also modifies diff output, if it is\n'
+                'displayed) option can be used to specify the minimum length of the prefix.',
+            action=arguments.NoAction,
+            dest='abbrev_commit',
+            default=None,
+        )
+        parser.add_argument(
+            '--oneline',
+            help='This is a shorthand for "--pretty=oneline --abbrev-commit" used together.',
+            action='store_true',
+            dest='oneline',
             default=None,
         )
 
     @classmethod
     def main(cls, args, repository, **kwargs):
+        if not isinstance(repository, local.Git):
+            sys.stderr.write("Can only 'show' on a native Git repository\n")
+            return 1
+
         config = getattr(repository, 'config', lambda: {})()
         Terminal.colors = config.get('color.diff', config.get('color.ui', 'auto')) != 'false'
 
-        max_count = getattr(args, 'max_count', None)
-        if max_count:
-            args.args.insert(0, '--max-count={}'.format(max_count))
-        skip = getattr(args, 'skip', None)
-        if skip:
-            args.args.insert(0, '--skip={}'.format(skip))
         pretty = getattr(args, 'pretty', None)
         if pretty:
             args.args.insert(0, '--pretty={}'.format(pretty))
@@ -75,7 +89,7 @@ class Log(FilteredCommand):
 
 
 if __name__ == '__main__':
-    sys.exit(Log.main(
+    sys.exit(Show.main(
         sys.argv[4:],
         local.Scm.from_path(path=sys.argv[1], cached=True),
         representation=sys.argv[2],

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import time
+import sys
+
+from datetime import datetime
+
+from webkitcorepy import OutputCapture, Terminal, testing
+from webkitscmpy import program, mocks
+
+
+class TestShow(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def setUp(self):
+        super(TestShow, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        os.mkdir(os.path.join(self.path, '.svn'))
+
+    def test_git(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as mocked, mocks.local.Svn(), Terminal.override_atty(sys.stdin, isatty=False):
+            commit = mocked.commits['main'][-1]
+            self.assertEqual(-1, program.main(
+                args=('show', 'main'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '''commit 5@main (d8bce26fa65c6fc8f39c17927abb77f69fab82fc)
+Author: Jonathan Bedard <jbedard@apple.com>
+Date:   {}
+
+    Patch Series
+
+diff --git a/Source/main.cpp b/Source/main.cpp
+index 2deba859a126..7b85f5cecd66 100644
+--- a/Source/main.cpp
+--- b/Source/main.cpp
+@@ -2948,6 +2948,8 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
+     auto backgroundClip = clippedLayer.backgroundClipRect(RenderLayer::ClipRectsContext(&clippingRoot, TemporaryClipRects, options));
+     ASSERT(!backgroundClip.affectedByRadius());
+     auto clipRect = backgroundClip.rect();
++    if (clipRect.isInfinite())
++        return;
+    auto offset = layer.convertToLayerCoords(&clippingRoot, {{ }}, RenderLayer::AdjustForColumns);
+    clipRect.moveBy(-offset);
+'''.format(datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')),
+        )
+
+    def test_git_svn(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path, git_svn=True) as mocked, mocks.local.Svn(), Terminal.override_atty(sys.stdin, isatty=False):
+            commit = mocked.commits['main'][-1]
+            self.assertEqual(-1, program.main(
+                args=('show', 'main'),
+                path=self.path,
+            ))
+
+        self.maxDiff = None
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '''commit 5@main (d8bce26fa65c6fc8f39c17927abb77f69fab82fc, r9)
+Author: Jonathan Bedard <jbedard@apple.com>
+Date:   {}
+
+    Patch Series
+    git-svn-id: https://svn.example.org/repository/repository/trunk@9 268f45cc-cd09-0410-ab3c-d52691b4dbfc
+
+diff --git a/Source/main.cpp b/Source/main.cpp
+index 2deba859a126..7b85f5cecd66 100644
+--- a/Source/main.cpp
+--- b/Source/main.cpp
+@@ -2948,6 +2948,8 @@ Vector<CompositedClipData> RenderLayerCompositor::computeAncestorClippingStack(c
+     auto backgroundClip = clippedLayer.backgroundClipRect(RenderLayer::ClipRectsContext(&clippingRoot, TemporaryClipRects, options));
+     ASSERT(!backgroundClip.affectedByRadius());
+     auto clipRect = backgroundClip.rect();
++    if (clipRect.isInfinite())
++        return;
+    auto offset = layer.convertToLayerCoords(&clippingRoot, {{ }}, RenderLayer::AdjustForColumns);
+    clipRect.moveBy(-offset);
+'''.format(datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')),
+        )
+
+    def test_svn(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(self.path), Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(1, program.main(
+                args=('show',),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), "Can only 'show' on a native Git repository\n")
+
+    def test_none(self):
+        with OutputCapture() as captured, mocks.local.Git(), mocks.local.Svn(), Terminal.override_atty(sys.stdin, isatty=False):
+            self.assertEqual(1, program.main(
+                args=('show',),
+                path=self.path,
+            ))
+
+        self.assertEqual(captured.stderr.getvalue(), "Can only 'show' on a native Git repository\n")


### PR DESCRIPTION
#### dd82be82d070b9ec480db4497b44aad8c363df7d
<pre>
[git-webkit] Add show sub-command
<a href="https://bugs.webkit.org/show_bug.cgi?id=242400">https://bugs.webkit.org/show_bug.cgi?id=242400</a>
rdar://96963230

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py: Add mock &apos;git show&apos;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py: Add &apos;show&apos; sub command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/command.py:
(FilteredCommand.main): &apos;git show&apos; will display diffs after the commit message, those diffs should be appropriately colorized.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/log.py:
(Log.parser): Move some options to Show.parser and invoke Show.parser.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/show.py: Copied from Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/log.py.
(Show.parser): Moved from Log.parser.
(Show.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py: Added.
(TestShow.test_git):
(TestShow.test_git_svn):
(TestShow.test_svn):
(TestShow.test_none):

Canonical link: <a href="https://commits.webkit.org/257760@main">https://commits.webkit.org/257760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47651014b8bfdf9c6c597a79ccdd99bebe8a0220

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99936 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33015 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/109285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/169522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86399 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/107188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105704 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/92383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/103453 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/22214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/92383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/2905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/98859 "Passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8995 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/43201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/4713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2735 "Built successfully and passed tests") | | | | 
<!--EWS-Status-Bubble-End-->