### PR TITLE
[MSE] Bring back some useful SourceBuffer logs

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -493,9 +493,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     if (isRemoved() || m_updating)
         return Exception { InvalidStateError };
 
-    StringPrintStream message;
-    message.printf("SourceBuffer::appendBufferInternal(%p) - append size = %u, buffered = %s\n", this, size, toString(m_private->buffered()->ranges()).utf8().data());
-    DEBUG_LOG(LOGIDENTIFIER, message.toString());
+    DEBUG_LOG(LOGIDENTIFIER, "size = ", size, ", buffered = ", m_private->buffered()->ranges());
 
     // 3. If the readyState attribute of the parent media source is in the "ended" state then run the following steps:
     // 3.1. Set the readyState attribute of the parent media source to "open"
@@ -592,9 +590,7 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(AppendResult result)
     m_source->monitorSourceBuffers();
     m_private->reenqueueMediaIfNeeded(m_source->currentTime());
 
-    StringPrintStream message;
-    message.printf("SourceBuffer::sourceBufferPrivateAppendComplete(%p) - buffered = %s", this, toString(m_private->buffered()->ranges()).utf8().data());
-    DEBUG_LOG(LOGIDENTIFIER, message.toString());
+    DEBUG_LOG(LOGIDENTIFIER, "buffered = ", m_private->buffered()->ranges());
 }
 
 void SourceBuffer::sourceBufferPrivateDidReceiveRenderingError(int64_t error)

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -28,6 +28,7 @@
 
 #include <math.h>
 #include <wtf/PrintStream.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
     
@@ -277,6 +278,16 @@ void PlatformTimeRanges::dump(PrintStream& out) const
 
     for (size_t i = 0; i < length(); ++i)
         out.print("[", start(i), "..", end(i), "] ");
+}
+
+String PlatformTimeRanges::toString() const
+{
+    StringBuilder result;
+
+    for (size_t i = 0; i < length(); ++i)
+        result.append("[", start(i).toString(), "..", end(i).toString(), "] ");
+
+    return result.toString();
 }
 
 }

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -70,6 +70,7 @@ public:
     MediaTime totalDuration() const;
 
     void dump(PrintStream&) const;
+    String toString() const;
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<PlatformTimeRanges> decode(Decoder&);
@@ -164,5 +165,14 @@ std::optional<PlatformTimeRanges> PlatformTimeRanges::decode(Decoder& decoder)
 }
 
 } // namespace WebCore
+
+namespace WTF {
+template<typename> struct LogArgument;
+
+template<> struct LogArgument<WebCore::PlatformTimeRanges> {
+    static String toString(const WebCore::PlatformTimeRanges& platformTimeRanges) { return platformTimeRanges.toString(); }
+};
+
+} // namespace WTF
 
 #endif


### PR DESCRIPTION
#### 445669890d9b15b6f2c452a7a03f2057c912ac8f
<pre>
[MSE] Bring back some useful SourceBuffer logs
<a href="https://bugs.webkit.org/show_bug.cgi?id=247122">https://bugs.webkit.org/show_bug.cgi?id=247122</a>

Follow up patch for <a href="https://commits.webkit.org/256224@main">https://commits.webkit.org/256224@main</a>, this time applying
Jer Noble&apos;s suggestions to use StringConcatenation instead of a printf-like
syntax.

Reviewed by Jer Noble.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::appendBufferInternal): Use string concatenation.
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete): Ditto.
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::toString const): Added String conversion method.
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
(WTF::LogArgument&lt;PlatformTimeRanges&gt;::toString): Ditto.

Canonical link: <a href="https://commits.webkit.org/256317@main">https://commits.webkit.org/256317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2923d81aa7179a5aecd9cec4abb0958c03893db4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104879 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165144 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4565 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33283 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100764 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3327 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81981 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30333 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73232 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39009 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20005 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4367 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39243 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->