### PR TITLE
[Content Extensions] QueryTransforms should not unconditionally redirect to form-encoded URLs

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -783,37 +783,66 @@ void RedirectAction::URLTransformAction::applyToURL(URL& url) const
 
 void RedirectAction::URLTransformAction::QueryTransform::applyToURL(URL& url) const
 {
-    auto form = WTF::URLParser::parseURLEncodedForm(url.query());
+    if (!url.hasQuery())
+        return;
 
     HashSet<String> keysToRemove;
     for (auto& key : removeParams)
         keysToRemove.add(key);
-    form.removeAllMatching([&] (auto& keyValue) {
-        bool modifiedQuery = keysToRemove.contains(keyValue.key);
-        if (modifiedQuery)
-            RELEASE_LOG(ContentExtensions, "QueryTransform::applyToURL - %s", keyValue.key.utf8().data());
-        return modifiedQuery;
-    });
 
-    Vector<WTF::KeyValuePair<String, String>> keysToAdd;
+    Vector<KeyValuePair<String, String>> keysToAdd;
     HashMap<String, String> keysToReplace;
-    for (auto& keyValue : addOrReplaceParams) {
-        if (keyValue.replaceOnly)
-            keysToReplace.add(keyValue.key, keyValue.value);
+    for (auto& [key, replaceOnly, value] : addOrReplaceParams) {
+        if (replaceOnly)
+            keysToReplace.add(key, value);
         else
-            keysToAdd.append({ keyValue.key, keyValue.value });
+            keysToAdd.append({ key, value });
     }
-    for (auto& keyValue : form) {
-        auto iterator = keysToReplace.find(keyValue.key);
-        if (iterator != keysToReplace.end())
-            keyValue.value = iterator->value;
-    }
-    form.appendVector(WTFMove(keysToAdd));
 
+    bool modifiedQuery = false;
     StringBuilder transformedQuery;
-    for (auto& keyValue : form)
-        transformedQuery.append(transformedQuery.isEmpty() ? "" : "&", keyValue.key, !!keyValue.value ? "=" : "", keyValue.value);
-    url.setQuery(transformedQuery);
+    for (auto bytes : url.query().split('&')) {
+        auto nameAndValue = WTF::URLParser::parseQueryNameAndValue(bytes);
+        if (!nameAndValue) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+
+        auto& key = nameAndValue->key;
+        if (key.isEmpty()) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
+
+        // Removal takes precedence over replacement.
+        if (keysToRemove.contains(key)) {
+            modifiedQuery = true;
+            RELEASE_LOG(ContentExtensions, "QueryTransform::applyToURL - removing %s", key.utf8().data());
+            continue;
+        }
+
+        if (!transformedQuery.isEmpty())
+            transformedQuery.append('&');
+
+        if (auto iterator = keysToReplace.find(key); iterator != keysToReplace.end()) {
+            modifiedQuery = true;
+            transformedQuery.append(key, '=', iterator->value);
+            continue;
+        }
+
+        transformedQuery.append(bytes);
+    }
+
+    // Adding takes precedence over both removal and replacement.
+    for (auto& [keyToAdd, valueToAdd] : keysToAdd) {
+        if (!transformedQuery.isEmpty())
+            transformedQuery.append('&');
+        transformedQuery.append(keyToAdd, '=', valueToAdd);
+        modifiedQuery = true;
+    }
+
+    if (modifiedQuery)
+        url.setQuery(transformedQuery.toString());
 }
 
 auto RedirectAction::URLTransformAction::QueryTransform::isolatedCopy() const & -> QueryTransform

--- a/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp
@@ -3072,6 +3072,18 @@ TEST_F(ContentExtensionTest, Serialization)
     EXPECT_EQ(modifyHeaders, deserializedModifyHeaders);
 }
 
+TEST_F(ContentExtensionTest, QueryTransformActions)
+{
+    RedirectAction::URLTransformAction::QueryTransform action {
+        { { "foo"_s, true, "bar"_s }, { "one"_s, false, "two"_s } }, /* addOrReplaceParams */
+        { "baz"_s }, /* removeParams */
+    };
+
+    URL testURL { "https://webkit.org/?foo=garply&baz=test&x+y=z&h%20llo=w%20rld"_s };
+    action.applyToURL(testURL);
+    EXPECT_STREQ("https://webkit.org/?foo=bar&x+y=z&h%20llo=w%20rld&one=two", testURL.string().utf8().data());
+}
+
 TEST_F(ContentExtensionTest, IfFrameURL)
 {
     auto basic = makeBackend("[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\"https\", \"if-frame-url\":[\"whatwg\"]}}]"_s);


### PR DESCRIPTION
#### b60c1a321a03a8912f9b8511018525271477aefc
<pre>
[Content Extensions] QueryTransforms should not unconditionally redirect to form-encoded URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=247365">https://bugs.webkit.org/show_bug.cgi?id=247365</a>

Reviewed by Tim Horton and Timothy Hatcher.

Refactor `QueryTransform::applyToURL`, so that it doesn&apos;t unconditionally call into
`parseURLEncodedForm()`, and set the query to this URL-encoded form. Currently, this causes query
parameters and values in the input URL to become percent-encoded, regardless of whether or not any
of the query transformation rules matched.

Instead, we change this behavior to leave query parameters intact, in the case where they don&apos;t
match any of the query transformation rules. This means that if a URL query contains `&quot;x+y=z&quot;` and
it doesn&apos;t match any transformation rules, the final result will remain as-is, rather than
`&quot;x%20y=z&quot;`.

Test: ContentExtensionTest.QueryTransformActions

* Source/WebCore/contentextensions/ContentExtensionActions.cpp:

Also, add an early return in the case where the URL has no query parameters at all, so that we can
avoid spending any time checking against rules. We also avoid calling `setQuery` at all in the case
where no actions were applied, so that we don&apos;t need to unnecessarily re-parse the URL if nothing
changed.

(WebCore::ContentExtensions::RedirectAction::URLTransformAction::QueryTransform::applyToURL const):
* Tools/TestWebKitAPI/Tests/WebCore/ContentExtensions.cpp:

Add an API test to exercise the bug.

Canonical link: <a href="https://commits.webkit.org/256260@main">https://commits.webkit.org/256260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/063aff6711c421758585c9980397af33ccf5986c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104802 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165061 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4458 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33208 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100697 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3249 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81755 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30216 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/86985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73118 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38934 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19826 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4324 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40688 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39068 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->