### PR TITLE
JetStream2 driver should be able to specify individual subtests/test groups to run

### DIFF
--- a/PerformanceTests/JetStream2/JetStreamDriver.js
+++ b/PerformanceTests/JetStream2/JetStreamDriver.js
@@ -42,6 +42,8 @@ if (typeof testWorstCaseCountMap === "undefined")
 if (typeof dumpJSONResults === "undefined")
     var dumpJSONResults = false;
 
+const urlParameters = new URLSearchParams(window.location.search);
+
 // Used for the promise representing the current benchmark run.
 this.currentResolve = null;
 this.currentReject = null;
@@ -404,7 +406,7 @@ class Driver {
         await this.prefetchResourcesForBrowser();
         await this.fetchResources();
         this.prepareToRun();
-        if (isInBrowser && window.location.search == '?report=true') {
+        if (isInBrowser && urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true') {
             setTimeout(() => this.start(), 4000);
         }
     }
@@ -494,7 +496,7 @@ class Driver {
         if (!isInBrowser)
             return;
 
-        if (window.location.search !== '?report=true')
+        if (urlParameters.has('report') && urlParameters.get('report').toLowerCase() != 'true')
             return;
 
         const content = this.resultsJSON();
@@ -1844,6 +1846,8 @@ if (false) {
 
 if (typeof testList !== "undefined") {
     processTestList(testList);
+} else if (urlParameters.has('test')) {
+    processTestList(urlParameters.getAll("test"));
 } else {
     if (runARES)
         addTestsByGroup(ARESGroup);

--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -42,6 +42,8 @@ if (typeof testWorstCaseCountMap === "undefined")
 if (typeof dumpJSONResults === "undefined")
     var dumpJSONResults = false;
 
+const urlParameters = new URLSearchParams(window.location.search);
+
 // Used for the promise representing the current benchmark run.
 this.currentResolve = null;
 this.currentReject = null;
@@ -404,7 +406,7 @@ class Driver {
         await this.prefetchResourcesForBrowser();
         await this.fetchResources();
         this.prepareToRun();
-        if (isInBrowser && window.location.search == '?report=true') {
+        if (isInBrowser && urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true') {
             setTimeout(() => this.start(), 4000);
         }
     }
@@ -494,7 +496,7 @@ class Driver {
         if (!isInBrowser)
             return;
 
-        if (window.location.search !== '?report=true')
+        if (urlParameters.has('report') && urlParameters.get('report').toLowerCase() != 'true')
             return;
 
         const content = this.resultsJSON();
@@ -1844,6 +1846,8 @@ if (false) {
 
 if (typeof testList !== "undefined") {
     processTestList(testList);
+} else if (urlParameters.has('test')) {
+    processTestList(urlParameters.getAll("test"));
 } else {
     if (runARES)
         addTestsByGroup(ARESGroup);


### PR DESCRIPTION
#### c770d8fffc0827be18ed9a216fec2ba1de920aa0
<pre>
JetStream2 driver should be able to specify individual subtests/test groups to run
<a href="https://bugs.webkit.org/show_bug.cgi?id=247301">https://bugs.webkit.org/show_bug.cgi?id=247301</a>
rdar://101783726

Reviewed by Alexey Shvayka.

- Refactor existing `report` argument parsing to use URLSearchParams
- Add a new URL parameter, `test`, that runs a given list of tests and/or test groups.

Eventually, we&apos;d like to be able to add profiling/ARTrace support to JetStream2, and being able to measure individual subtests would be useful as measuring the whole test may be too long and costly.

* PerformanceTests/JetStream2/JetStreamDriver.js:
(Driver.prototype.async initialize):
(Driver.prototype.async reportScoreToRunBenchmarkRunner):
(prototype.else):
* PerformanceTests/JetStream3/JetStreamDriver.js:
(Driver.prototype.async initialize):
(Driver.prototype.async reportScoreToRunBenchmarkRunner):
(prototype.else):

Canonical link: <a href="https://commits.webkit.org/256264@main">https://commits.webkit.org/256264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cca23617075e3bb6343c823623d531964cda667

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4534 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104846 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4517 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87569 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100917 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81792 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38976 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36787 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4326 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40733 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42717 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->