### PR TITLE
[Build Fix] Replace Deprecated macros with direct calls.

### DIFF
--- a/Tools/MobileMiniBrowser/MobileMiniBrowserUITests/MobileMiniBrowserUITests.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserUITests/MobileMiniBrowserUITests.m
@@ -108,7 +108,7 @@
     [self loadURL:@"bundle:/looping.html"];
     [self waitToTapButtonNamed:@"Start Playback" forApp:app];
 
-    UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
+    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
     if (idiom == UIUserInterfaceIdiomPhone) {
         [self waitToTapButtonNamed:@"PauseButton" forApp:app];
         [self waitToTapButtonNamed:@"Done" forApp:app];
@@ -121,7 +121,7 @@
     [self loadURL:@"bundle:/looping.html"];
     [self waitToTapButtonNamed:@"Start Playback" forApp:app];
     
-    UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
+    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
     if (idiom == UIUserInterfaceIdiomPad)
         [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
     
@@ -137,7 +137,7 @@
     [self loadURL:@"bundle:/looping.html"];
     [self waitToTapButtonNamed:@"Start Playback" forApp:app];
     
-    UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
+    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
     if (idiom == UIUserInterfaceIdiomPad)
         [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
     
@@ -153,7 +153,7 @@
     [self loadURL:@"bundle:/looping.html"];
     [self waitToTapButtonNamed:@"Start Playback" forApp:app];
     
-    UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
+    UIUserInterfaceIdiom idiom = [[UIDevice currentDevice] userInterfaceIdiom];
     if (idiom == UIUserInterfaceIdiomPad)
         [self waitToTapButtonNamed:@"Display Full Screen" forApp:app];
     


### PR DESCRIPTION
#### 978e825ba5e56165476b0c9c27238823d8883d68
<pre>
[Build Fix] Replace Deprecated macros with direct calls.

Unreviewed build fix. Replaced deprecated macros with direct calls to UIDevice messages.

* Tools/MobileMiniBrowser/MobileMiniBrowserUITests/MobileMiniBrowserUITests.m:
(-[MobileMiniBrowserUITests testBasicVideoPlayback]):
(-[MobileMiniBrowserUITests testBasicVideoFullscreen]):
(-[MobileMiniBrowserUITests testVideoFullscreenAndRotationAnimation]):
(-[MobileMiniBrowserUITests testVideoFullscreenControlCenter]):

Canonical link: <a href="https://commits.webkit.org/256249@main">https://commits.webkit.org/256249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e25255ce78cb346eb39666812beabd0db2d4d8ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95228 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/4517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/99218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/4480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87546 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/100894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/4480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/4480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/40710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2079 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42695 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->