### PR TITLE
[Gardening]: New Tests(255047@main): [ iOS macOS ] 3X imported/w3c/web-platform-tests/feature-policy/(Layout tests) are constantly failing

### DIFF
--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2399,10 +2399,7 @@ webkit.org/b/245745 [ Debug ] svg/compositing/inline-svg-non-integer-position-di
 
 webkit.org/b/246357 imported/w3c/web-platform-tests/feature-policy/reporting/payment-reporting.https.html [ Pass Failure ]
 
-# webkit.org/b/245967 3X imported/w3c/web-platform-tests/feature-policy/(Layout tests) failing since added
-imported/w3c/web-platform-tests/feature-policy/reporting/picture-in-picture-reporting.html [ Pass Failure ]
-imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub.html [ Pass Failure ]
-imported/w3c/web-platform-tests/feature-policy/experimental-features/vertical-scroll-scrollintoview.tentative.html [ Failure ]
+webkit.org/b/245967 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub.html [ Pass Failure ]
 
 webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-streams/construct-byob-request.any.worker.html [ Pass Failure ]
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/feature-policy/reporting/picture-in-picture-reporting-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/feature-policy/reporting/picture-in-picture-reporting-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Picture-in-Picture Report Format promise_rejects_dom: Picture-in-Picture should not be allowed in this document. function "function () { throw e }" threw object "NotSupportedError: The Picture-in-Picture mode is not supported." that is not a DOMException SecurityError: property "code" is equal to 9, expected 18
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/feature-policy/experimental-features/vertical-scroll-scrollintoview.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/feature-policy/experimental-features/vertical-scroll-scrollintoview.tentative-expected.txt
@@ -1,0 +1,9 @@
+An <iframe> further below which is not allowed to block scroll.
+
+
+Making sure there is room for vertical scroll
+
+
+PASS Calling 'scrollIntoView()' inside a <iframe> will propagate up by default('vertical-scroll' enabled).
+FAIL Calling 'scrollIntoView()' inside a <iframe> with 'vertical-scroll none;'will not propagate upwards. assert_equals: Main frame must not scroll vertically. expected 0 but got 3851
+


### PR DESCRIPTION
#### cd4a1c53cdbbca0cd116fdae27492dbabc9194f4
<pre>
[Gardening]: New Tests(255047@main): [ iOS macOS ] 3X imported/w3c/web-platform-tests/feature-policy/(Layout tests) are constantly failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=245967">https://bugs.webkit.org/show_bug.cgi?id=245967</a>

Unreviewed test gardening.

* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/feature-policy/reporting/picture-in-picture-reporting-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/feature-policy/experimental-features/vertical-scroll-scrollintoview.tentative-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/256250@main">https://commits.webkit.org/256250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a500271376c933f698f2abda9470b8424e9f737e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95230 "check-webkit-style (failure)") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/4519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/104826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/4482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/100896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/4482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/81777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/87548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/4482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/87548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/38957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/40712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/81777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2080 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42697 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->