### PR TITLE
WebDriver: [Cocoa] Regression(255359@main) Exception when deleting remote automation session

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -818,6 +818,7 @@ private:
 
     bool m_shouldDeferViewInWindowChanges { false };
     bool m_viewInWindowChangeWasDeferred { false };
+    bool m_isPreparingToUnparentView { false };
     RetainPtr<NSWindow> m_targetWindowForMovePreparation;
 
     id m_flagsChangedEventMonitor { nullptr };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -270,7 +270,6 @@ WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
 @implementation WKWindowVisibilityObserver {
     NSView *_view;
     WebKit::WebViewImpl *_impl;
-    __weak NSWindow *_observedWindow;
 
     BOOL _didRegisterForLookupPopoverCloseNotifications;
     BOOL _shouldObserveFontPanel;
@@ -333,15 +332,14 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     if (_shouldObserveFontPanel)
         [self startObservingFontPanel];
 
-    [self _observeWindow:window];
+    [window addObserver:self forKeyPath:@"contentLayoutRect" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
+    [window addObserver:self forKeyPath:@"titlebarAppearsTransparent" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
 }
 
 - (void)stopObserving:(NSWindow *)window
 {
     if (!window)
         return;
-
-    ASSERT_IMPLIES(_observedWindow, _observedWindow == window);
 
     NSNotificationCenter *defaultNotificationCenter = [NSNotificationCenter defaultCenter];
 
@@ -364,25 +362,8 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     if (_shouldObserveFontPanel)
         [[NSFontPanel sharedFontPanel] removeObserver:self forKeyPath:@"visible" context:keyValueObservingContext];
 
-    [self _observeWindow:nil];
-}
-
-- (void)_observeWindow:(NSWindow *)window
-{
-    if (_observedWindow == window)
-        return;
-
-    if (_observedWindow) {
-        [_observedWindow removeObserver:self forKeyPath:@"contentLayoutRect" context:keyValueObservingContext];
-        [_observedWindow removeObserver:self forKeyPath:@"titlebarAppearsTransparent" context:keyValueObservingContext];
-    }
-
-    _observedWindow = window;
-
-    if (window) {
-        [window addObserver:self forKeyPath:@"contentLayoutRect" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
-        [window addObserver:self forKeyPath:@"titlebarAppearsTransparent" options:NSKeyValueObservingOptionInitial context:keyValueObservingContext];
-    }
+    [window removeObserver:self forKeyPath:@"contentLayoutRect" context:keyValueObservingContext];
+    [window removeObserver:self forKeyPath:@"titlebarAppearsTransparent" context:keyValueObservingContext];
 }
 
 - (void)startObservingFontPanel
@@ -2128,7 +2109,7 @@ bool WebViewImpl::windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint poin
 void WebViewImpl::viewWillMoveToWindowImpl(NSWindow *window)
 {
     // If we're in the middle of preparing to move to a window, we should only be moved to that window.
-    ASSERT(!m_targetWindowForMovePreparation || (m_targetWindowForMovePreparation == window));
+    ASSERT_IMPLIES(m_targetWindowForMovePreparation, m_targetWindowForMovePreparation == window);
 
     NSWindow *currentWindow = [m_view window];
     if (window == currentWindow)
@@ -2136,9 +2117,11 @@ void WebViewImpl::viewWillMoveToWindowImpl(NSWindow *window)
 
     clearAllEditCommands();
 
-    NSWindow *stopObservingWindow = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : [m_view window];
-    [m_windowVisibilityObserver stopObserving:stopObservingWindow];
-    [m_windowVisibilityObserver startObserving:window];
+    if (!m_isPreparingToUnparentView) {
+        NSWindow *stopObservingWindow = m_targetWindowForMovePreparation.get() ?: [m_view window];
+        [m_windowVisibilityObserver stopObserving:stopObservingWindow];
+        [m_windowVisibilityObserver startObserving:window];
+    }
 
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)
     if (m_isRegisteredScrollViewSeparatorTrackingAdapter) {
@@ -2152,6 +2135,7 @@ void WebViewImpl::viewWillMoveToWindow(NSWindow *window)
 {
     viewWillMoveToWindowImpl(window);
     m_targetWindowForMovePreparation = nil;
+    m_isPreparingToUnparentView = false;
 }
 
 void WebViewImpl::viewDidMoveToWindow()
@@ -2408,6 +2392,7 @@ void WebViewImpl::prepareForMoveToWindow(NSWindow *targetWindow, WTF::Function<v
 {
     m_shouldDeferViewInWindowChanges = true;
     viewWillMoveToWindowImpl(targetWindow);
+    m_isPreparingToUnparentView = !targetWindow;
     m_targetWindowForMovePreparation = targetWindow;
     viewDidMoveToWindow();
 


### PR DESCRIPTION
#### c46be5c1183bb2076c4996fd4528e6c638fc5a91
<pre>
WebDriver: [Cocoa] Regression(255359@main) Exception when deleting remote automation session
<a href="https://bugs.webkit.org/show_bug.cgi?id=247384">https://bugs.webkit.org/show_bug.cgi?id=247384</a>
rdar://101872145

Reviewed by Wenson Hsieh.

Revert the changes in 255359@main and instead apply a more targeted approach to fixing that specific issue. Previous
attempts to fix this with more state management in `WKWindowVisibilityObserver` created more issues, so a more targeted
fix it is!

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver stopObserving:]):
(WebKit::WebViewImpl::viewWillMoveToWindowImpl):
(WebKit::WebViewImpl::viewWillMoveToWindow):
(WebKit::WebViewImpl::prepareForMoveToWindow):
(-[WKWindowVisibilityObserver _observeWindow:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/256334@main">https://commits.webkit.org/256334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a722e9feafeba03cab3326f8cb997834f7a4aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105025 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4737 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33446 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100896 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101107 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82058 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30533 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73373 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20124 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40912 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2108 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39370 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->