### PR TITLE
[Service Workers] Add WPT coverage for calling update() on a ServiceWorkerRegistration with cross-origin importScripts

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https.html
@@ -123,5 +123,13 @@ promise_test(async t => {
   assert_active_only(registration, expected_url);
 }, 'update() should find an update in an imported script but update() should ' +
    'result in failure due to missing the other imported script.');
+
+promise_test(async t => {
+  const [registration, expected_url] = await prepare_ready_normal_worker(
+    t, 'import-scripts-cross-origin-worker.sub.js');
+  t.add_cleanup(() => registration.unregister());
+  await registration.update();
+  assert_installing_and_active(registration, expected_url);
+}, 'update() should work with cross-origin importScripts.');
 </script>
 </body>

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https-expected.txt
@@ -3,5 +3,5 @@ PASS update() should fail when a new worker imports an unavailable script.
 PASS update() should succeed when the old imported script no longer exist but the new worker doesn't import it.
 PASS update() should treat 404 on imported scripts as no change.
 FAIL update() should find an update in an imported script but update() should result in failure due to missing the other imported script. assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL update() should work with cross-origin importScripts. assert_unreached: unregister and register should not fail: NetworkError: Load failed Reached unreachable code
+PASS update() should work with cross-origin importScripts.
 


### PR DESCRIPTION
#### f84001c6aea236241ab6b4f5dd696737d02ad34e
<pre>
[Service Workers] Add WPT coverage for calling update() on a ServiceWorkerRegistration with cross-origin importScripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=247390">https://bugs.webkit.org/show_bug.cgi?id=247390</a>
rdar://101885464

Reviewed by Brent Fulgham.

Cross-origin importScripts is covered with
LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/import-scripts-cross-origin.https.html
though that test does not cover the case where ServiceWorkerRegistration.update() is called. Further, the update-import-scripts
tests do not cover the cross-origin case either. This patch adds that missing coverage.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https.html:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/service-workers/service-worker/update-import-scripts.https-expected.txt: Added

Canonical link: <a href="https://commits.webkit.org/256330@main">https://commits.webkit.org/256330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1fd21f6305a6560bdbb824d1ebba1b06943a254

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104894 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165158 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4581 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33300 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100778 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3336 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82020 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30350 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73248 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39023 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36831 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4377 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39261 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->