### PR TITLE
REGRESSION (255095@main): [iOS] 'caret-color: auto' displays a black caret color

### DIFF
--- a/LayoutTests/editing/caret/ios/caret-color-auto-expected.txt
+++ b/LayoutTests/editing/caret/ios/caret-color-auto-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that an 'auto' caret color uses the system default caret color on iOS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS caretColor is "rgb(66, 107, 242)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/caret/ios/caret-color-auto.html
+++ b/LayoutTests/editing/caret/ios/caret-color-auto.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+#editor {
+    width: 250px;
+    font-size: 20px;
+    padding: 10px;
+    display: block;
+    border: 1px solid tomato;
+    caret-color: auto;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that an 'auto' caret color uses the system default caret color on iOS.");
+
+    if (!window.testRunner)
+        return;
+
+    let editor = document.getElementById("editor");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+    await UIHelper.ensurePresentationUpdate();
+    caretColor = await UIHelper.selectionCaretBackgroundColor();
+
+    shouldBeEqualToString("caretColor", "rgb(66, 107, 242)");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div contenteditable id="editor"></div>
+</body>
+</html>

--- a/LayoutTests/editing/caret/ios/caret-color-currentcolor-expected.txt
+++ b/LayoutTests/editing/caret/ios/caret-color-currentcolor-expected.txt
@@ -1,0 +1,10 @@
+This test verifies the used caret color matches the value of an element's color property when 'caret-color: currentcolor' is explicitly specified.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS caretColor is "rgb(255, 0, 0)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/caret/ios/caret-color-currentcolor.html
+++ b/LayoutTests/editing/caret/ios/caret-color-currentcolor.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    color: red;
+}
+
+#editor {
+    width: 250px;
+    font-size: 20px;
+    padding: 10px;
+    display: block;
+    border: 1px solid tomato;
+    caret-color: currentcolor;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies the used caret color matches the value of an element's color property when 'caret-color: currentcolor' is explicitly specified.");
+
+    if (!window.testRunner)
+        return;
+
+    let editor = document.getElementById("editor");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+    await UIHelper.ensurePresentationUpdate();
+    caretColor = await UIHelper.selectionCaretBackgroundColor();
+
+    shouldBeEqualToString("caretColor", "rgb(255, 0, 0)");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div contenteditable id="editor"></div>
+</body>
+</html>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1848,6 +1848,8 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
     // On iOS, we want to fall back to the tintColor, and only override if CSS has explicitly specified a custom color.
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     UNUSED_PARAM(node);
+    if (elementStyle.hasAutoCaretColor())
+        return { };
     return elementStyle.colorResolvingCurrentColor(elementStyle.caretColor());
 #else
     RefPtr parentElement = node ? node->parentElement() : nullptr;


### PR DESCRIPTION
#### 80d228d483a602d40fa685f4b54325ccf2fc343e
<pre>
REGRESSION (255095@main): [iOS] &apos;caret-color: auto&apos; displays a black caret color
<a href="https://bugs.webkit.org/show_bug.cgi?id=247382">https://bugs.webkit.org/show_bug.cgi?id=247382</a>
rdar://101579150

Reviewed by Wenson Hsieh.

On iOS, the caret is drawn in the UIProcess, and the caret color is set using
post-layout data on EditorState. The system default caret color is used whenever
the Color is invalid.

Prior to 255095@main, `RenderStyle::caretColor()` returned a Color, rather than
a StyleColor, and &apos;currentcolor&apos; was represented using an invalid Color. The
initial value of caret color was the invalid Color, meaning that if no caret
color was specified by the author, or a value of &apos;currentcolor&apos; was specified,
the system default caret color would be used.

Now that `RenderStyle::caretColor()` returns a StyleColor rather than a Color,
it must be resolved prior to its use. StyleColor is only aware of &apos;currentcolor&apos;,
absolute colors, and system colors. Since there is no &quot;invalid&quot; StyleColor, the
initial value is `StyleColor::currentColor()`. This color is then resolved to
the value of the element&apos;s color property, which is commonly black (&apos;CanvasText&apos; in
light mode). The UIProcess always receives a valid Color in the post-layout data,
and does not use the system default caret color.

To fix, return an invalid color when &apos;caret-color: auto&apos; is specified. This
ensures the UIProcess will prefer the system default caret color. Additionally,
this solution preserves an improvement introduced by 255095@main, which is that
explicitly specifying &quot;caret-color: currentcolor&quot; will customize the caret color.

* LayoutTests/editing/caret/ios/caret-color-auto-expected.txt: Added.
* LayoutTests/editing/caret/ios/caret-color-auto.html: Added.
* LayoutTests/editing/caret/ios/caret-color-currentcolor-expected.txt: Added.
* LayoutTests/editing/caret/ios/caret-color-currentcolor.html: Added.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::computeCaretColor):

Canonical link: <a href="https://commits.webkit.org/256281@main">https://commits.webkit.org/256281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55d0363b135b7fc68a96d50959fb734e6184875b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4528 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104838 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165118 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4508 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33238 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87562 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100727 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3278 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81879 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30255 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73155 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38968 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36781 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19937 "Build was cancelled. Recent messages:Cleaned up git repository; Failed to updated working directory") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40724 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39181 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->