### PR TITLE
[git-webkit] Improve logging when redacting PRs due to the associated issue

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.8.4',
+    version='0.8.5',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 8, 4)
+version = Version(0, 8, 5)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -41,6 +41,7 @@ class Tracker(GenericTracker):
         r'\Ahttps?://{}/show_bug.cgi\?id=(?P<id>\d+)\Z',
         r'\A{}/show_bug.cgi\?id=(?P<id>\d+)\Z',
     ]
+    NAME = 'Bugzilla'
 
     class Encoder(GenericTracker.Encoder):
         @webkitcorepy.decorators.hybridmethod

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -56,6 +56,7 @@ class Tracker(GenericTracker):
         'already_exists': 'Another resource has the same value as this field. This can happen in resources that must have some unique key (such as label names).',
         'unprocessable': 'The inputs provided were invalid.'
     }
+    NAME = 'GitHub Issue'
 
 
     class Encoder(GenericTracker.Encoder):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -188,8 +188,11 @@ class Issue(object):
         )
         for key, value in self.tracker._redact.items():
             if key.search(match_string):
-                return value
-        return False
+                return self.tracker.Redaction(
+                    redacted=value,
+                    reason="is a {}".format(self.tracker.NAME) if key.pattern == '.*' else "matches '{}'".format(key.pattern),
+                )
+        return self.tracker.Redaction(redacted=False)
 
     def set_component(self, project=None, component=None, version=None):
         return self.tracker.set(self, project=project, component=component, version=version)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -78,6 +78,7 @@ class Tracker(GenericTracker):
     NOT_APPLICABLE = 'Not Applicable'
 
     REPRODUCIBILITY = [NOT_APPLICABLE, ALWAYS, SOMETIMES, RARELY, UNABLE, DIDNT_TRY]
+    NAME = 'Radar'
 
     class Encoder(GenericTracker.Encoder):
         @decorators.hybridmethod

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -420,10 +420,23 @@ What version of 'WebKit' should the bug be associated with?:
     def test_redaction(self):
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):
             self.assertEqual(bugzilla.Tracker(self.URL, redact=None).issue(1).redacted, False)
-            self.assertEqual(bugzilla.Tracker(self.URL, redact={'.*': True}).issue(1).redacted, True)
-            self.assertEqual(bugzilla.Tracker(self.URL, redact={'project:WebKit': True}).issue(1).redacted, True)
-            self.assertEqual(bugzilla.Tracker(self.URL, redact={'component:Text': True}).issue(1).redacted, True)
-            self.assertEqual(bugzilla.Tracker(self.URL, redact={'version:Other': True}).issue(1).redacted, True)
+            self.assertTrue(bool(bugzilla.Tracker(self.URL, redact={'.*': True}).issue(1).redacted))
+            self.assertEqual(
+                bugzilla.Tracker(self.URL, redact={'.*': True}).issue(1).redacted,
+                bugzilla.Tracker.Redaction(True, 'is a Bugzilla'),
+            )
+            self.assertEqual(
+                bugzilla.Tracker(self.URL, redact={'project:WebKit': True}).issue(1).redacted,
+                bugzilla.Tracker.Redaction(True, "matches 'project:WebKit'"),
+            )
+            self.assertEqual(
+                bugzilla.Tracker(self.URL, redact={'component:Text': True}).issue(1).redacted,
+                bugzilla.Tracker.Redaction(True, "matches 'component:Text'"),
+            )
+            self.assertEqual(
+                bugzilla.Tracker(self.URL, redact={'version:Other': True}).issue(1).redacted,
+                bugzilla.Tracker.Redaction(True, "matches 'version:Other'"),
+            )
 
     def test_cc_no_radar(self):
         with OutputCapture(level=logging.INFO), mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -387,10 +387,23 @@ What version of 'WebKit' should the bug be associated with?:
     def test_redaction(self):
         with mocks.GitHub(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):
             self.assertEqual(github.Tracker(self.URL, redact=None).issue(1).redacted, False)
-            self.assertEqual(github.Tracker(self.URL, redact={'.*': True}).issue(1).redacted, True)
-            self.assertEqual(github.Tracker(self.URL, redact={'project:WebKit': True}).issue(1).redacted, True)
-            self.assertEqual(github.Tracker(self.URL, redact={'component:Text': True}).issue(1).redacted, True)
-            self.assertEqual(github.Tracker(self.URL, redact={'version:Other': True}).issue(1).redacted, True)
+            self.assertTrue(bool(github.Tracker(self.URL, redact={'.*': True}).issue(1).redacted))
+            self.assertEqual(
+                github.Tracker(self.URL, redact={'.*': True}).issue(1).redacted,
+                github.Tracker.Redaction(True, 'is a GitHub Issue'),
+            )
+            self.assertEqual(
+                github.Tracker(self.URL, redact={'project:WebKit': True}).issue(1).redacted,
+                github.Tracker.Redaction(True, "matches 'project:WebKit'"),
+            )
+            self.assertEqual(
+                github.Tracker(self.URL, redact={'component:Text': True}).issue(1).redacted,
+                github.Tracker.Redaction(True, "matches 'component:Text'"),
+            )
+            self.assertEqual(
+                github.Tracker(self.URL, redact={'version:Other': True}).issue(1).redacted,
+                github.Tracker.Redaction(True, "matches 'version:Other'"),
+            )
 
     def test_parse_error(self):
         error_json = {'message': 'Validation Failed', 'errors': [{'resource': 'Issue', 'code': 'custom', 'field': 'body', 'message': 'body is too long (maximum is 65536 characters)'}], 'documentation_url': 'https://docs.github.com/rest/reference/pulls#create-a-pull-request'}

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -349,22 +349,26 @@ What version of 'WebKit Text' should the bug be associated with?:
                 redact=None,
             ).issue(1).redacted, False)
 
+            self.assertTrue(bool(radar.Tracker(
+                project='WebKit',
+                redact={'.*': True},
+            ).issue(1).redacted))
             self.assertEqual(radar.Tracker(
                 project='WebKit',
                 redact={'.*': True},
-            ).issue(1).redacted, True)
+            ).issue(1).redacted, radar.Tracker.Redaction(True, 'is a Radar'),)
 
             self.assertEqual(radar.Tracker(
                 project='WebKit',
                 redact={'project:WebKit': True},
-            ).issue(1).redacted, True)
+            ).issue(1).redacted, radar.Tracker.Redaction(True, "matches 'project:WebKit'"))
 
             self.assertEqual(radar.Tracker(
                 project='WebKit',
                 redact={'component:Text': True},
-            ).issue(1).redacted, True)
+            ).issue(1).redacted, radar.Tracker.Redaction(True, "matches 'component:Text'"))
 
             self.assertEqual(radar.Tracker(
                 project='WebKit',
                 redact={'version:Other': True},
-            ).issue(1).redacted, True)
+            ).issue(1).redacted, radar.Tracker.Redaction(True, "matches 'version:Other'"))

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -43,6 +43,39 @@ class Tracker(object):
                 return super(Tracker.Encoder, self).default(obj)
             return obj.Encoder.default(obj)
 
+    class Redaction(object):
+        def __init__(self, redacted=False, reason=None):
+            self.redacted = redacted
+            self.reason = reason
+
+        def __bool__(self):
+            return self.redacted
+
+        def __nonzero__(self):
+            return self.redacted
+
+        def __repr__(self):
+            if not self.redacted:
+                return 'is not redacted'
+            if self.reason:
+                return '{} and is thus redacted'.format(self.reason)
+            return 'is redacted for an unknown reason'
+
+        def __str__(self):
+            return self.__repr__()
+
+        def __eq__(self, other):
+            if isinstance(other, str):
+                return str(self) == other
+            elif isinstance(other, bool):
+                return self.redacted == other
+            elif isinstance(other, Tracker.Redaction):
+                return self.redacted == other.redacted and self.reason == other.reason
+            return False
+
+        def __ne__(self, other):
+            return not self.__eq__(other)
+
     @classmethod
     def from_json(cls, data):
         from . import bugzilla, github, radar
@@ -73,7 +106,6 @@ class Tracker(object):
             github=github.Tracker,
             radar=radar.Tracker,
         )[data['type']](**unpacked)
-
 
     @classmethod
     def register(cls, tracker):

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.7.10',
+    version='5.7.11',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 7, 10)
+version = Version(5, 7, 11)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -813,15 +813,16 @@ No pre-PR checks to run""")
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created the local development branch 'eng/1'\n"
-            "Your issue is redacted, diverting to a secure, non-origin remote you have access to.\n"
-            "Error. You do not have access to a secure, non-origin remote\n"
+            "https://bugs.example.com/show_bug.cgi?id=1 is considered the primary issue for your pull request\n"
+            "https://bugs.example.com/show_bug.cgi?id=1 is a Bugzilla and is thus redacted\n"
+            "Pull request needs to be sent to a secure remote for review\n"
             "Would you like to proceed anyways? \n"
             " (Yes/[No]): \n"
             "Created 'PR 1 | Example issue 1'!\n"
             "Posted pull request link to https://bugs.example.com/show_bug.cgi?id=1\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
-        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), 'Error. You do not have access to a secure remote to make a pull request for a redacted issue\n')
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [


### PR DESCRIPTION
#### e015c5839aca50f38f58fa3b6e145ced276c3e57
<pre>
[git-webkit] Improve logging when redacting PRs due to the associated issue
<a href="https://bugs.webkit.org/show_bug.cgi?id=247391">https://bugs.webkit.org/show_bug.cgi?id=247391</a>
rdar://101886383

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker): Add NAME.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker): Add NAME.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py:
(Issue.redacted): Return a Redaction object.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker): Add NAME.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.Redaction): Instead of just returning &apos;True&apos; or &apos;False&apos;, include a reason so that callers
can better explain any behavior derived from redactions.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request): Tell the user which issue reference we&apos;re considering the primary
one and explain the reason that issue is redacted.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:

Canonical link: <a href="https://commits.webkit.org/256757@main">https://commits.webkit.org/256757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6660dfdc87290010b83aa2931eef1b6594830024

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29856 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/106291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6241 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34761 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89149 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102438 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83377 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100355 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/65 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/95716 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/58 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4846 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2252 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/1284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->