### PR TITLE
Fix containerWidth for percentage margin and fix also when child's margin-box exceeds available width

### DIFF
--- a/LayoutTests/fast/block/marginbox-width-exceeds-container-width-expected.txt
+++ b/LayoutTests/fast/block/marginbox-width-exceeds-container-width-expected.txt
@@ -1,0 +1,3 @@
+When the width of a non-replaced block flow element's margin box exceeds the available width, its margins are set to zero.
+
+PASS

--- a/LayoutTests/fast/block/marginbox-width-exceeds-container-width.html
+++ b/LayoutTests/fast/block/marginbox-width-exceeds-container-width.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+    .container{
+        padding-left:300px;
+    }
+    .inner-content{
+        width:96%;
+        height: 20px;
+        margin: auto;
+        margin-right: 300px;
+        background-color: green;
+    }
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body>
+<p>When the width of a non-replaced block flow element's margin box exceeds the available width, its margins are set to zero.</p>
+<div class="container">
+    <div class="inner-content" data-expected-margin-left=0></div>
+</div>
+<script>
+checkLayout(".inner-content");
+</script>
+</body>

--- a/LayoutTests/fast/css/bfc-percentage-margin-expected.html
+++ b/LayoutTests/fast/css/bfc-percentage-margin-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+#container {
+    position: relative;
+}
+.square {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    position: absolute;
+}
+.right {
+    left: 120px;
+}
+</style>
+<p>You should see two blue squares below.</p>
+<div id="container">
+    <div class="square"></div>
+    <div class="square right"></div>
+</div>

--- a/LayoutTests/fast/css/bfc-percentage-margin.html
+++ b/LayoutTests/fast/css/bfc-percentage-margin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 400px;
+}
+
+.square {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+}
+
+#float {
+    float: left;
+}
+
+#bfc {
+    margin-left: 30%;
+    overflow: hidden;
+}
+</style>
+<p>You should see two blue squares below.</p>
+<div id="container">
+    <div id="float" class="square"></div>
+    <div id="bfc" class="square"></div>
+</div>

--- a/LayoutTests/fast/css/vertical-lr-bfc-auto-margins-beside-float-expected.html
+++ b/LayoutTests/fast/css/vertical-lr-bfc-auto-margins-beside-float-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 200px; height: 50px;
+    background-color: orange;
+    position: relative;
+}
+
+.square {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50px;
+    height: 50px;
+    background-color: blue;
+}
+
+.second {
+    left: 100px;
+}
+</style>
+<p>You should see four equally sized squares below. Two blue, and two orange.</p>
+<div id="container">
+    <div class="square"></div>
+    <div class="second square"></div>
+</div>

--- a/LayoutTests/fast/css/vertical-lr-bfc-auto-margins-beside-float.html
+++ b/LayoutTests/fast/css/vertical-lr-bfc-auto-margins-beside-float.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 200px; height: 50px;
+    background-color: orange;
+}
+
+#float {
+    float: left;
+    width: 50px; height: 50px; background: blue;
+}
+
+#vertical {
+    width: 50px; height: 50px;
+    writing-mode: vertical-rl;
+    overflow: hidden;
+    margin: 0 auto;
+    background: blue;
+}
+</style>
+<p>You should see four equally sized squares below. Two blue, and two orange.</p>
+<div id="container">
+    <div id="float"></div>
+    <div id="vertical"></div>
+</div>

--- a/LayoutTests/fast/css/vertical-lr-table-percent-margins-beside-float-expected.html
+++ b/LayoutTests/fast/css/vertical-lr-table-percent-margins-beside-float-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 200px; height: 50px;
+    background-color: orange;
+    position: relative;
+}
+
+.square {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50px;
+    height: 50px;
+    background-color: blue;
+}
+
+.second {
+    left: 100px;
+}
+</style>
+<p>You should see four equally sized squares below. Two blue, and two orange.</p>
+<div id="container">
+    <div class="square"></div>
+    <div class="second square"></div>
+</div>

--- a/LayoutTests/fast/css/vertical-lr-table-percent-margins-beside-float.html
+++ b/LayoutTests/fast/css/vertical-lr-table-percent-margins-beside-float.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+#container {
+    width: 200px; height: 50px;
+    background-color: orange;
+}
+
+#float {
+    float: left;
+    width: 50px; height: 50px; background: blue;
+}
+
+#verticalTable {
+    display: table;
+    width: 50px; height: 50px;
+    writing-mode: vertical-rl;
+    overflow: hidden;
+    margin-left: 50%;
+    background: blue;
+}
+</style>
+<p>You should see four equally sized squares below. Two blue, and two orange.</p>
+<div id="container">
+    <div id="float"></div>
+    <div id="verticalTable"></div>
+</div>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -388,7 +388,7 @@ public:
     };
     // Resolve auto margins in the inline direction of the containing block so that objects can be pushed to the start, middle or end
     // of the containing block.
-    void computeInlineDirectionMargins(const RenderBlock& containingBlock, LayoutUnit containerWidth, LayoutUnit childWidth, LayoutUnit& marginStart, LayoutUnit& marginEnd) const;
+    void computeInlineDirectionMargins(const RenderBlock& containingBlock, LayoutUnit containerWidth, LayoutUnit childWidth, LayoutUnit& marginStart, LayoutUnit& marginEnd, RenderFragmentContainer&) const;
 
     // Used to resolve margins in the containing block's block-flow direction.
     void computeBlockDirectionMargins(const RenderBlock& containingBlock, LayoutUnit& marginBefore, LayoutUnit& marginAfter) const;

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
  * This library is free software; you can redistribute it and/or
@@ -313,12 +313,9 @@ void RenderTable::updateLogicalWidth()
     setMarginStart(0);
     setMarginEnd(0);
     if (!hasPerpendicularContainingBlock) {
-        LayoutUnit containerLogicalWidthForAutoMargins = availableLogicalWidth;
-        if (avoidsFloats() && cb.containsFloats())
-            containerLogicalWidthForAutoMargins = containingBlockAvailableLineWidthInFragment(0); // FIXME: Work with regions someday.
         ComputedMarginValues marginValues;
         bool hasInvertedDirection =  cb.style().isLeftToRightDirection() == style().isLeftToRightDirection();
-        computeInlineDirectionMargins(cb, containerLogicalWidthForAutoMargins, logicalWidth(),
+        computeInlineDirectionMargins(cb, availableLogicalWidth, logicalWidth(),
             hasInvertedDirection ? marginValues.m_start : marginValues.m_end,
             hasInvertedDirection ? marginValues.m_end : marginValues.m_start);
         setMarginStart(marginValues.m_start);


### PR DESCRIPTION
<pre>
Fix containerWidth for percentage margin and fix also when child's margin-box exceeds available width
<a href="https://bugs.webkit.org/show_bug.cgi?id=247392">https://bugs.webkit.org/show_bug.cgi?id=247392</a>

Reviewed by NOBODY (OOPS!).

This is to align Webkit with Blink / Chrome and Gecko / Firefox and Web-Specification.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=169030">https://src.chromium.org/viewvc/blink?view=revision&revision=169030</a> &
<a href="https://src.chromium.org/viewvc/blink?revision=174236&view=revision">https://src.chromium.org/viewvc/blink?revision=174236&view=revision</a>

Blocks establishing a new BFC need to avoid floats in its parent BFC. Also,
computing used values for auto margins for such blocks is affected by the
available line width constrained by these floats. However, percentage sized
margins must be calculated based on the full containing block width, not the
available line width.

Per CSS 2.1 we should use the margin box rather than the border box when
deciding if a non-replaced block flow element exceeds the container width.

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::computeLogicalWidthInFragment): Remove conditions “containerLogicalWidthForAutoMargins” and change “computeInlineDirectionMargins” to use “containerLogicalWidth” without floats
(RenderBox::computeInlineDirectionMargin): Update logic to account for "availableWidth" by accounting for “avoidFloats” and “containerFloats”
* Source/WebCore/rendering/RenderTable.cpp:
(RenderTable::updateLogicalWidth): Remove conditions “containerLogicalWidthForAutoMargins” and change “computeInlineDirectionMargins” to use “availableLogicalWidth”
* LayoutTests/fast/block/marginbox-width-exceeds-container-width.html: Added Test Case
* LayoutTests/fast/block/marginbox-width-exceeds-container-width-expected.txt: Added Test Case Expectations
* LayoutTests/fast/css/vertical-lr-bfc-auto-margins-beside-floats.html: Added Test Case
* LayoutTests/fast/css/vertical-lr-bfc-auto-margins-beside-floats-expected.html: Added Test Case Expectations
* LayoutTests/fast/css/bfc-percentage-margin.html: Added Test Case
* LayoutTests/fast/css/bfc-percentage-margin-expected.html: Added Test Case Expectations
* LayoutTests/fast/css/vertical-lr-table-percent-margins-beside-float.html: Added Test Case
* LayoutTests/fast/css/vertical-lr-table-percent-margins-beside-float-expected.html: Added Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3d76969fd96ff1a377f4343398f39488b39a4b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95577 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4841 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28625 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105157 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165428 "Hash e3d76969 for PR 6065 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99563 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4879 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33585 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87948 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101008 "Hash e3d76969 for PR 6065 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101239 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/4879 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82189 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/87948 "Hash e3d76969 for PR 6065 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/4879 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/28625 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/87948 "Hash e3d76969 for PR 6065 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39329 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/28625 "Hash e3d76969 for PR 6065 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37029 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/28625 "Hash e3d76969 for PR 6065 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41026 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/82189 "Hash e3d76969 for PR 6065 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43014 "Hash e3d76969 for PR 6065 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/28625 "Hash e3d76969 for PR 6065 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->