### PR TITLE
Add fuzz to preserve3d-and-flattening-z-order-008.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Google" href="http://www.google.com/">
 <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#3d-transform-rendering">
 <meta name="assert" content="Elements are drawn in the correct z-order.">
-<meta name="fuzzy" content="maxDifference=1; totalPixels=0-3000">
+<meta name="fuzzy" content="maxDifference=1; totalPixels=0-3244">
 <link rel="match" href="reference/green.html">
 
 <style>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3708,7 +3708,6 @@ imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/worker-module.http
 webkit.org/b/243962 imported/w3c/web-platform-tests/css/css-pseudo/target-text-008.html [ Pass ImageOnlyFailure ]
 webkit.org/b/243962 imported/w3c/web-platform-tests/css/css-pseudo/highlight-paired-cascade-005.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/243961 imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html [ Pass ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-transforms/ttwf-css-3d-polygon-cycle.html [ ImageOnlyFailure ]
 
 # These tests have similar image failures, rounded edges issues. See webkit.org/b/244046


### PR DESCRIPTION
#### 64476ce36f6f51c4c80c9b01a1985e78c2648b3d
<pre>
Add fuzz to preserve3d-and-flattening-z-order-008.
<a href="https://bugs.webkit.org/show_bug.cgi?id=243961">https://bugs.webkit.org/show_bug.cgi?id=243961</a>

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-flattening-z-order-008.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/256385@main">https://commits.webkit.org/256385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a127a5584bc9e5445ad658da970308e9fbcad14f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104849 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165117 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4548 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33396 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100736 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3307 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81895 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30299 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73199 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38980 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20085 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4413 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40737 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42643 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/close/setInterval.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39330 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->