### PR TITLE
Implement focus fixup rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/inert/dynamic-inert-on-focused-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/dynamic-inert-on-focused-element-expected.txt
@@ -1,22 +1,10 @@
 
-FAIL <input> that gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <input class="becomes-inert check-focus" inert=""></input>
-FAIL <input> whose parent gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <input class="check-focus"></input>
-FAIL <button> that gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <button class="becomes-inert check-focus" inert="">foo</b...
-FAIL <div> that gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <div class="becomes-inert check-focus" tabindex="-1" iner...
-FAIL <div> whose parent gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <div class="check-focus" tabindex="-1">bar</div>
-FAIL <div> whose grandparent gets 'inert' attribute assert_equals: The element stops being focused expected Element node <body><div id="log"></div>
-
-<div class="test-wrapper" dat... but got Element node <span class="check-focus" tabindex="-1">baz</span>
+PASS <input> that gets 'inert' attribute
+PASS <input> whose parent gets 'inert' attribute
+PASS <button> that gets 'inert' attribute
+PASS <div> that gets 'inert' attribute
+PASS <div> whose parent gets 'inert' attribute
+PASS <div> whose grandparent gets 'inert' attribute
 
 
 foo

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -233,6 +233,7 @@ enum class RenderingUpdateStep : uint32_t {
     FlushAutofocusCandidates        = 1 << 14,
     VideoFrameCallbacks             = 1 << 15,
     PrepareCanvasesForDisplay       = 1 << 16,
+    FocusFixupRule                  = 1 << 17,
 };
 
 constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {


### PR DESCRIPTION
#### f67e8bfb8608a6d6c6419a2a3f0a396bd2b5b7bd
<pre>
Implement focus fixup rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=237273">https://bugs.webkit.org/show_bug.cgi?id=237273</a>
rdar://89902824

Reviewed by NOBODY (OOPS!).

It&apos;s currently specced at <a href="https://github.com/whatwg/html/pull/8392">https://github.com/whatwg/html/pull/8392</a> as a rendering step after requestAnimationFrame callbacks.

* LayoutTests/imported/w3c/web-platform-tests/inert/dynamic-inert-on-focused-element-expected.txt:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f67e8bfb8608a6d6c6419a2a3f0a396bd2b5b7bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104853 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165122 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4552 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33411 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100740 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100925 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3311 "Found 3 new test failures: fast/shadow-dom/ios/accessory-bar-work-on-input-with-tabindex-in-shadow-tree.html, imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus.html, imported/w3c/web-platform-tests/css/selectors/focus-within-shadow-005.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81897 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30316 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/38984 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18791 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus.html, imported/w3c/web-platform-tests/css/selectors/focus-within-shadow-005.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36794 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20087 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus.html, imported/w3c/web-platform-tests/css/selectors/focus-within-shadow-005.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40741 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42645 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/container-queries/layout-dependent-focus.html, imported/w3c/web-platform-tests/css/selectors/focus-within-shadow-005.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39332 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->