### PR TITLE
Assertion failure in TreeScopeOrderedMap::add by TreeScope::addElementByName

### DIFF
--- a/LayoutTests/fast/dom/move-element-with-empty-name-crash-expected.txt
+++ b/LayoutTests/fast/dom/move-element-with-empty-name-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not hit any debug assertions.
+
+PASS

--- a/LayoutTests/fast/dom/move-element-with-empty-name-crash.html
+++ b/LayoutTests/fast/dom/move-element-with-empty-name-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function run() {
+    container.appendChild(namedElement);
+    document.body.innerHTML = '<p>This test passes if WebKit does not hit any debug assertions.</p><p>PASS</p>';
+}
+</script>
+<body onload=run()>
+<div id="container">
+<img id="namedElement" name="">

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2477,7 +2477,7 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
                 updateIdForDocument(*newDocument, nullAtom(), idValue, AlwaysUpdateHTMLDocumentNamedItemMaps);
         }
 
-        if (auto& nameValue = getNameAttribute(); !nameValue.isNull()) {
+        if (auto& nameValue = getNameAttribute(); !nameValue.isEmpty()) {
             if (newScope)
                 newScope->addElementByName(*nameValue.impl(), *this);
             if (newDocument)


### PR DESCRIPTION
#### 6231b9849576f85498673d386c5fb5b8f961c561
<pre>
Assertion failure in TreeScopeOrderedMap::add by TreeScope::addElementByName
<a href="https://bugs.webkit.org/show_bug.cgi?id=247412">https://bugs.webkit.org/show_bug.cgi?id=247412</a>

Reviewed by Wenson Hsieh.

The assertion failure is caused by insertedIntoAncestor registering an element with an empty name
into TreeScope::m_elementsByName but removedFromAncestor not removing the element from it.

Fixed the bug by avoid adding such an element to m_elementsByName. TreeScope::getElementByName is
only used by CachedHTMLCollection&lt;HTMLCollectionClass, traversalType&gt;::namedItem, and this function
returns early when the input string is empty.

* LayoutTests/fast/dom/move-element-with-empty-name-crash-expected.txt: Added.
* LayoutTests/fast/dom/move-element-with-empty-name-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor):

Canonical link: <a href="https://commits.webkit.org/256286@main">https://commits.webkit.org/256286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80b68a9c6b3b73d121fc0c359a8f0086a964f635

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104872 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165137 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4546 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33274 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100757 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3305 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81820 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30327 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85206 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73226 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39002 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36810 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4341 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42745 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/39225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->