### PR TITLE
Explicitly close a document RTCNetworkManager on document teardown

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCNetworkManager.h
+++ b/Source/WebCore/Modules/mediastream/RTCNetworkManager.h
@@ -33,6 +33,7 @@ namespace WebCore {
 class RTCNetworkManager : public ThreadSafeRefCounted<RTCNetworkManager, WTF::DestructionThread::MainRunLoop> {
 public:
     virtual ~RTCNetworkManager() = default;
+    virtual void close() = 0;
     virtual void setICECandidateFiltering(bool) = 0;
     virtual void unregisterMDNSNames() = 0;
 };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -842,6 +842,13 @@ void Document::commonTeardown()
     m_timeline = nullptr;
     m_associatedFormControls.clear();
     m_didAssociateFormControlsTimer.stop();
+
+#if ENABLE(WEB_RTC)
+    if (m_rtcNetworkManager) {
+        m_rtcNetworkManager->close();
+        m_rtcNetworkManager = nullptr;
+    }
+#endif
 }
 
 Element* Document::elementForAccessKey(const String& key)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -48,6 +48,7 @@ LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExe
         auto newNetworkManager = adoptRef(*new LibWebRTCNetworkManager(identifier));
         networkManager = newNetworkManager.ptr();
         document->setRTCNetworkManager(WTFMove(newNetworkManager));
+        WebProcess::singleton().libWebRTCNetwork().monitor().addObserver(*networkManager);
     }
 
     return networkManager;
@@ -56,11 +57,18 @@ LibWebRTCNetworkManager* LibWebRTCNetworkManager::getOrCreate(WebCore::ScriptExe
 LibWebRTCNetworkManager::LibWebRTCNetworkManager(WebCore::ScriptExecutionContextIdentifier documentIdentifier)
     : m_documentIdentifier(documentIdentifier)
 {
-    WebProcess::singleton().libWebRTCNetwork().monitor().addObserver(*this);
 }
 
 LibWebRTCNetworkManager::~LibWebRTCNetworkManager()
 {
+    ASSERT(m_isClosed);
+}
+
+void LibWebRTCNetworkManager::close()
+{
+#if ASSERT_ENABLED
+    m_isClosed = true;
+#endif
     WebProcess::singleton().libWebRTCNetwork().monitor().removeObserver(*this);
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -47,6 +47,7 @@ private:
     // WebCore::RTCNetworkManager
     void setICECandidateFiltering(bool doFiltering) final { m_useMDNSCandidates = doFiltering; }
     void unregisterMDNSNames() final;
+    void close() final;
 
     // webrtc::NetworkManagerBase
     void StartUpdating() final;
@@ -64,6 +65,9 @@ private:
     WebCore::ScriptExecutionContextIdentifier m_documentIdentifier;
     bool m_useMDNSCandidates { true };
     bool m_receivedNetworkList { false };
+#if ASSERT_ENABLED
+    bool m_isClosed { false };
+#endif
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### f394e0a05ff1d91c0909c4319c5fecd5e4e86b98
<pre>
Explicitly close a document RTCNetworkManager on document teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=247413">https://bugs.webkit.org/show_bug.cgi?id=247413</a>
rdar://99799545

Reviewed by Eric Carlson.

The combination of keeping a WeakPtr of a ThreadSafeRefCounted is problematic,
as we might have lost the last Ref/RefPtr (hence the object is scheduled to be deleted)
but we still have a non null reference via a WeakPtr, which we could potentially create a new Ref on it.
We fix the particular issue here by closing explicitly LibWebRTCNetworkManager
which will remove the LibWebRTCNetworkManager from the WebRTCMonitor WeakHashSet.
Add ASSERTs to ensure close is called before destroying LibWebRTCNetworkManager.

* Source/WebCore/Modules/mediastream/RTCNetworkManager.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::getOrCreate):
(WebKit::LibWebRTCNetworkManager::LibWebRTCNetworkManager):
(WebKit::LibWebRTCNetworkManager::~LibWebRTCNetworkManager):
(WebKit::LibWebRTCNetworkManager::close):

Canonical link: <a href="https://commits.webkit.org/256319@main">https://commits.webkit.org/256319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2395132af6f327792fb7c3425321a9ba07446ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104873 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165138 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4551 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33276 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87646 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100758 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3309 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81943 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39003 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36811 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19990 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4369 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39229 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->