### PR TITLE
XML Parser: &AMP;, &LT;, and &nvlt; should work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm
@@ -20,6 +20,7 @@
       // Next line because some browsers include the partial parsed result in the parser error returned document.
       parent.assert_equals(root.firstChild.nodeType, 3/*Text*/, friendlyMime + " parsing the entity reference caused a parse error;");
       var text = root.firstChild.data;
+      parent.assert_equals(text.length,expectedString.length);
       for (var i = 0, len = expectedString.length; i < len; i++) {
         parent.assert_equals(text.charCodeAt(i),expectedString.charCodeAt(i));
       }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-1-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML1.0 Transitional parsing &Amacr;
 PASS XHTML1.0 Transitional parsing &amacr;
 PASS XHTML1.0 Transitional parsing &amalg;
 PASS XHTML1.0 Transitional parsing &amp;
-FAIL XHTML1.0 Transitional parsing &AMP; assert_true: expected true got false
+PASS XHTML1.0 Transitional parsing &AMP;
 PASS XHTML1.0 Transitional parsing &andand;
 PASS XHTML1.0 Transitional parsing &And;
 PASS XHTML1.0 Transitional parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML1.0 Transitional parsing &lstrok;
 PASS XHTML1.0 Transitional parsing &ltcc;
 PASS XHTML1.0 Transitional parsing &ltcir;
 PASS XHTML1.0 Transitional parsing &lt;
-FAIL XHTML1.0 Transitional parsing &LT; assert_true: expected true got false
+PASS XHTML1.0 Transitional parsing &LT;
 PASS XHTML1.0 Transitional parsing &Lt;
 PASS XHTML1.0 Transitional parsing &ltdot;
 PASS XHTML1.0 Transitional parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML1.0 Transitional parsing &nvHarr;
 PASS XHTML1.0 Transitional parsing &nvinfin;
 PASS XHTML1.0 Transitional parsing &nvlArr;
 PASS XHTML1.0 Transitional parsing &nvle;
-FAIL XHTML1.0 Transitional parsing &nvlt; assert_equals: XHTML1.0 Transitional parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML1.0 Transitional parsing &nvlt;
 PASS XHTML1.0 Transitional parsing &nvltrie;
 PASS XHTML1.0 Transitional parsing &nvrArr;
 PASS XHTML1.0 Transitional parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-2-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML1.1 parsing &Amacr;
 PASS XHTML1.1 parsing &amacr;
 PASS XHTML1.1 parsing &amalg;
 PASS XHTML1.1 parsing &amp;
-FAIL XHTML1.1 parsing &AMP; assert_true: expected true got false
+PASS XHTML1.1 parsing &AMP;
 PASS XHTML1.1 parsing &andand;
 PASS XHTML1.1 parsing &And;
 PASS XHTML1.1 parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML1.1 parsing &lstrok;
 PASS XHTML1.1 parsing &ltcc;
 PASS XHTML1.1 parsing &ltcir;
 PASS XHTML1.1 parsing &lt;
-FAIL XHTML1.1 parsing &LT; assert_true: expected true got false
+PASS XHTML1.1 parsing &LT;
 PASS XHTML1.1 parsing &Lt;
 PASS XHTML1.1 parsing &ltdot;
 PASS XHTML1.1 parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML1.1 parsing &nvHarr;
 PASS XHTML1.1 parsing &nvinfin;
 PASS XHTML1.1 parsing &nvlArr;
 PASS XHTML1.1 parsing &nvle;
-FAIL XHTML1.1 parsing &nvlt; assert_equals: XHTML1.1 parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML1.1 parsing &nvlt;
 PASS XHTML1.1 parsing &nvltrie;
 PASS XHTML1.1 parsing &nvrArr;
 PASS XHTML1.1 parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-3-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML1.0 Strict parsing &Amacr;
 PASS XHTML1.0 Strict parsing &amacr;
 PASS XHTML1.0 Strict parsing &amalg;
 PASS XHTML1.0 Strict parsing &amp;
-FAIL XHTML1.0 Strict parsing &AMP; assert_true: expected true got false
+PASS XHTML1.0 Strict parsing &AMP;
 PASS XHTML1.0 Strict parsing &andand;
 PASS XHTML1.0 Strict parsing &And;
 PASS XHTML1.0 Strict parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML1.0 Strict parsing &lstrok;
 PASS XHTML1.0 Strict parsing &ltcc;
 PASS XHTML1.0 Strict parsing &ltcir;
 PASS XHTML1.0 Strict parsing &lt;
-FAIL XHTML1.0 Strict parsing &LT; assert_true: expected true got false
+PASS XHTML1.0 Strict parsing &LT;
 PASS XHTML1.0 Strict parsing &Lt;
 PASS XHTML1.0 Strict parsing &ltdot;
 PASS XHTML1.0 Strict parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML1.0 Strict parsing &nvHarr;
 PASS XHTML1.0 Strict parsing &nvinfin;
 PASS XHTML1.0 Strict parsing &nvlArr;
 PASS XHTML1.0 Strict parsing &nvle;
-FAIL XHTML1.0 Strict parsing &nvlt; assert_equals: XHTML1.0 Strict parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML1.0 Strict parsing &nvlt;
 PASS XHTML1.0 Strict parsing &nvltrie;
 PASS XHTML1.0 Strict parsing &nvrArr;
 PASS XHTML1.0 Strict parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-4-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML1.0 Frameset parsing &Amacr;
 PASS XHTML1.0 Frameset parsing &amacr;
 PASS XHTML1.0 Frameset parsing &amalg;
 PASS XHTML1.0 Frameset parsing &amp;
-FAIL XHTML1.0 Frameset parsing &AMP; assert_true: expected true got false
+PASS XHTML1.0 Frameset parsing &AMP;
 PASS XHTML1.0 Frameset parsing &andand;
 PASS XHTML1.0 Frameset parsing &And;
 PASS XHTML1.0 Frameset parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML1.0 Frameset parsing &lstrok;
 PASS XHTML1.0 Frameset parsing &ltcc;
 PASS XHTML1.0 Frameset parsing &ltcir;
 PASS XHTML1.0 Frameset parsing &lt;
-FAIL XHTML1.0 Frameset parsing &LT; assert_true: expected true got false
+PASS XHTML1.0 Frameset parsing &LT;
 PASS XHTML1.0 Frameset parsing &Lt;
 PASS XHTML1.0 Frameset parsing &ltdot;
 PASS XHTML1.0 Frameset parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML1.0 Frameset parsing &nvHarr;
 PASS XHTML1.0 Frameset parsing &nvinfin;
 PASS XHTML1.0 Frameset parsing &nvlArr;
 PASS XHTML1.0 Frameset parsing &nvle;
-FAIL XHTML1.0 Frameset parsing &nvlt; assert_equals: XHTML1.0 Frameset parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML1.0 Frameset parsing &nvlt;
 PASS XHTML1.0 Frameset parsing &nvltrie;
 PASS XHTML1.0 Frameset parsing &nvrArr;
 PASS XHTML1.0 Frameset parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-5-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML Basic parsing &Amacr;
 PASS XHTML Basic parsing &amacr;
 PASS XHTML Basic parsing &amalg;
 PASS XHTML Basic parsing &amp;
-FAIL XHTML Basic parsing &AMP; assert_true: expected true got false
+PASS XHTML Basic parsing &AMP;
 PASS XHTML Basic parsing &andand;
 PASS XHTML Basic parsing &And;
 PASS XHTML Basic parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML Basic parsing &lstrok;
 PASS XHTML Basic parsing &ltcc;
 PASS XHTML Basic parsing &ltcir;
 PASS XHTML Basic parsing &lt;
-FAIL XHTML Basic parsing &LT; assert_true: expected true got false
+PASS XHTML Basic parsing &LT;
 PASS XHTML Basic parsing &Lt;
 PASS XHTML Basic parsing &ltdot;
 PASS XHTML Basic parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML Basic parsing &nvHarr;
 PASS XHTML Basic parsing &nvinfin;
 PASS XHTML Basic parsing &nvlArr;
 PASS XHTML Basic parsing &nvle;
-FAIL XHTML Basic parsing &nvlt; assert_equals: XHTML Basic parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML Basic parsing &nvlt;
 PASS XHTML Basic parsing &nvltrie;
 PASS XHTML Basic parsing &nvrArr;
 PASS XHTML Basic parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-6-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML1.1+MathML parsing &Amacr;
 PASS XHTML1.1+MathML parsing &amacr;
 PASS XHTML1.1+MathML parsing &amalg;
 PASS XHTML1.1+MathML parsing &amp;
-FAIL XHTML1.1+MathML parsing &AMP; assert_true: expected true got false
+PASS XHTML1.1+MathML parsing &AMP;
 PASS XHTML1.1+MathML parsing &andand;
 PASS XHTML1.1+MathML parsing &And;
 PASS XHTML1.1+MathML parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML1.1+MathML parsing &lstrok;
 PASS XHTML1.1+MathML parsing &ltcc;
 PASS XHTML1.1+MathML parsing &ltcir;
 PASS XHTML1.1+MathML parsing &lt;
-FAIL XHTML1.1+MathML parsing &LT; assert_true: expected true got false
+PASS XHTML1.1+MathML parsing &LT;
 PASS XHTML1.1+MathML parsing &Lt;
 PASS XHTML1.1+MathML parsing &ltdot;
 PASS XHTML1.1+MathML parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML1.1+MathML parsing &nvHarr;
 PASS XHTML1.1+MathML parsing &nvinfin;
 PASS XHTML1.1+MathML parsing &nvlArr;
 PASS XHTML1.1+MathML parsing &nvle;
-FAIL XHTML1.1+MathML parsing &nvlt; assert_equals: XHTML1.1+MathML parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML1.1+MathML parsing &nvlt;
 PASS XHTML1.1+MathML parsing &nvltrie;
 PASS XHTML1.1+MathML parsing &nvrArr;
 PASS XHTML1.1+MathML parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-7-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML1.1+MathML+SVG parsing &Amacr;
 PASS XHTML1.1+MathML+SVG parsing &amacr;
 PASS XHTML1.1+MathML+SVG parsing &amalg;
 PASS XHTML1.1+MathML+SVG parsing &amp;
-FAIL XHTML1.1+MathML+SVG parsing &AMP; assert_true: expected true got false
+PASS XHTML1.1+MathML+SVG parsing &AMP;
 PASS XHTML1.1+MathML+SVG parsing &andand;
 PASS XHTML1.1+MathML+SVG parsing &And;
 PASS XHTML1.1+MathML+SVG parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML1.1+MathML+SVG parsing &lstrok;
 PASS XHTML1.1+MathML+SVG parsing &ltcc;
 PASS XHTML1.1+MathML+SVG parsing &ltcir;
 PASS XHTML1.1+MathML+SVG parsing &lt;
-FAIL XHTML1.1+MathML+SVG parsing &LT; assert_true: expected true got false
+PASS XHTML1.1+MathML+SVG parsing &LT;
 PASS XHTML1.1+MathML+SVG parsing &Lt;
 PASS XHTML1.1+MathML+SVG parsing &ltdot;
 PASS XHTML1.1+MathML+SVG parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML1.1+MathML+SVG parsing &nvHarr;
 PASS XHTML1.1+MathML+SVG parsing &nvinfin;
 PASS XHTML1.1+MathML+SVG parsing &nvlArr;
 PASS XHTML1.1+MathML+SVG parsing &nvle;
-FAIL XHTML1.1+MathML+SVG parsing &nvlt; assert_equals: XHTML1.1+MathML+SVG parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML1.1+MathML+SVG parsing &nvlt;
 PASS XHTML1.1+MathML+SVG parsing &nvltrie;
 PASS XHTML1.1+MathML+SVG parsing &nvrArr;
 PASS XHTML1.1+MathML+SVG parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-8-expected.txt
@@ -27,7 +27,7 @@ PASS MathML parsing &Amacr;
 PASS MathML parsing &amacr;
 PASS MathML parsing &amalg;
 PASS MathML parsing &amp;
-FAIL MathML parsing &AMP; assert_true: expected true got false
+PASS MathML parsing &AMP;
 PASS MathML parsing &andand;
 PASS MathML parsing &And;
 PASS MathML parsing &and;
@@ -1007,7 +1007,7 @@ PASS MathML parsing &lstrok;
 PASS MathML parsing &ltcc;
 PASS MathML parsing &ltcir;
 PASS MathML parsing &lt;
-FAIL MathML parsing &LT; assert_true: expected true got false
+PASS MathML parsing &LT;
 PASS MathML parsing &Lt;
 PASS MathML parsing &ltdot;
 PASS MathML parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS MathML parsing &nvHarr;
 PASS MathML parsing &nvinfin;
 PASS MathML parsing &nvlArr;
 PASS MathML parsing &nvle;
-FAIL MathML parsing &nvlt; assert_equals: MathML parsing the entity reference caused a parse error; expected 3 but got 1
+PASS MathML parsing &nvlt;
 PASS MathML parsing &nvltrie;
 PASS MathML parsing &nvrArr;
 PASS MathML parsing &nvrtrie;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-9-expected.txt
@@ -27,7 +27,7 @@ PASS XHTML Mobile parsing &Amacr;
 PASS XHTML Mobile parsing &amacr;
 PASS XHTML Mobile parsing &amalg;
 PASS XHTML Mobile parsing &amp;
-FAIL XHTML Mobile parsing &AMP; assert_true: expected true got false
+PASS XHTML Mobile parsing &AMP;
 PASS XHTML Mobile parsing &andand;
 PASS XHTML Mobile parsing &And;
 PASS XHTML Mobile parsing &and;
@@ -1007,7 +1007,7 @@ PASS XHTML Mobile parsing &lstrok;
 PASS XHTML Mobile parsing &ltcc;
 PASS XHTML Mobile parsing &ltcir;
 PASS XHTML Mobile parsing &lt;
-FAIL XHTML Mobile parsing &LT; assert_true: expected true got false
+PASS XHTML Mobile parsing &LT;
 PASS XHTML Mobile parsing &Lt;
 PASS XHTML Mobile parsing &ltdot;
 PASS XHTML Mobile parsing &lthree;
@@ -1294,7 +1294,7 @@ PASS XHTML Mobile parsing &nvHarr;
 PASS XHTML Mobile parsing &nvinfin;
 PASS XHTML Mobile parsing &nvlArr;
 PASS XHTML Mobile parsing &nvle;
-FAIL XHTML Mobile parsing &nvlt; assert_equals: XHTML Mobile parsing the entity reference caused a parse error; expected 3 but got 1
+PASS XHTML Mobile parsing &nvlt;
 PASS XHTML Mobile parsing &nvltrie;
 PASS XHTML Mobile parsing &nvrArr;
 PASS XHTML Mobile parsing &nvrtrie;


### PR DESCRIPTION
#### 154fb73e0c5be12c6ee7b3e7c54fed224e7a69c7
<pre>
XML Parser: &amp;AMP;, &amp;LT;, and &amp;nvlt; should work
<a href="https://bugs.webkit.org/show_bug.cgi?id=247417">https://bugs.webkit.org/show_bug.cgi?id=247417</a>

Reviewed by Martin Robinson.

They caused parsing errors because strings produced by them were not escaped.
This is a backport of <a href="https://chromium-review.googlesource.com/c/chromium/src/+/936983">https://chromium-review.googlesource.com/c/chromium/src/+/936983</a>

* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/support/xhtml-mathml-dtd-entity.htm:
  Assert that the strings have the same length, otherwise we are just testing that text has expectedString as a suffix.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-1-expected.txt: Update expectation now that the tests pass.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-2-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-3-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-4-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-5-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-6-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-7-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-8-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/the-xhtml-syntax/parsing-xhtml-documents/xhtml-mathml-dtd-entity-9-expected.txt: Ditto.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::getXHTMLEntity): Escape &quot;&amp;&quot;, &quot;&lt;&quot;, and &quot;&lt; with Combining Long Vertical Line Overlay&quot;.

Canonical link: <a href="https://commits.webkit.org/256391@main">https://commits.webkit.org/256391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a92dddcd1d593a960a97b699f870361bfbae823

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104875 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165140 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4555 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33524 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100760 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3315 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81961 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30330 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39005 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18704 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4420 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42699 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39236 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->