### PR TITLE
[GStreamer][WebRTC] Minor cleanups in IncomingSourceGStreamer

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -39,10 +39,8 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer(const CaptureDe
     m_tee = gst_element_factory_make("tee", nullptr);
     g_object_set(m_tee.get(), "allow-not-linked", true, nullptr);
 
-    auto* queue = gst_element_factory_make("queue", nullptr);
-    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_valve.get(), queue, m_tee.get(), nullptr);
-
-    gst_element_link_many(m_valve.get(), queue, m_tee.get(), nullptr);
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_valve.get(), m_tee.get(), nullptr);
+    gst_element_link(m_valve.get(), m_tee.get());
 
     auto sinkPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
@@ -51,32 +49,20 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer(const CaptureDe
 void RealtimeIncomingSourceGStreamer::startProducingData()
 {
     GST_DEBUG_OBJECT(bin(), "Starting data flow");
-    openValve();
+    if (m_valve)
+        g_object_set(m_valve.get(), "drop", FALSE, nullptr);
 }
 
 void RealtimeIncomingSourceGStreamer::stopProducingData()
 {
     GST_DEBUG_OBJECT(bin(), "Stopping data flow");
-    closeValve();
+    if (m_valve)
+        g_object_set(m_valve.get(), "drop", TRUE, nullptr);
 }
 
 const RealtimeMediaSourceCapabilities& RealtimeIncomingSourceGStreamer::capabilities()
 {
     return RealtimeMediaSourceCapabilities::emptyCapabilities();
-}
-
-void RealtimeIncomingSourceGStreamer::closeValve() const
-{
-    GST_DEBUG_OBJECT(m_bin.get(), "Closing valve");
-    if (m_valve)
-        g_object_set(m_valve.get(), "drop", true, nullptr);
-}
-
-void RealtimeIncomingSourceGStreamer::openValve() const
-{
-    GST_DEBUG_OBJECT(m_bin.get(), "Opening valve");
-    if (m_valve)
-        g_object_set(m_valve.get(), "drop", false, nullptr);
 }
 
 void RealtimeIncomingSourceGStreamer::registerClient()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -36,11 +36,6 @@ public:
 protected:
     RealtimeIncomingSourceGStreamer(const CaptureDevice&);
 
-    void closeValve() const;
-    void openValve() const;
-
-    GRefPtr<GstElement> m_valve;
-
 private:
     // RealtimeMediaSource API
     void startProducingData() final;
@@ -51,6 +46,7 @@ private:
     void handleDownstreamEvent(GRefPtr<GstEvent>&&);
 
     GRefPtr<GstElement> m_bin;
+    GRefPtr<GstElement> m_valve;
     GRefPtr<GstElement> m_tee;
 };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -45,7 +45,7 @@ RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomS
     m_currentSettings = RealtimeMediaSourceSettings { };
     m_currentSettings->setSupportedConstraints(WTFMove(constraints));
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "sink"));
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(bin(), "sink"));
     gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
         auto videoFrameTimeMetadata = std::make_optional<VideoFrameTimeMetadata>({ });
         videoFrameTimeMetadata->receiveTime = MonotonicTime::now().secondsSinceEpoch();


### PR DESCRIPTION
#### 25fd4849d5a2c72c90733a1e5eb46d9b5acf1c69
<pre>
[GStreamer][WebRTC] Minor cleanups in IncomingSourceGStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=247423">https://bugs.webkit.org/show_bug.cgi?id=247423</a>

Reviewed by Xabier Rodriguez-Calvar.

There is no need for a queue between the valve and the tee. Utility methods for opening/closing now
un-needed were removed as well.

* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::startProducingData):
(WebCore::RealtimeIncomingSourceGStreamer::stopProducingData):
(WebCore::RealtimeIncomingSourceGStreamer::closeValve const): Deleted.
(WebCore::RealtimeIncomingSourceGStreamer::openValve const): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:

Canonical link: <a href="https://commits.webkit.org/256393@main">https://commits.webkit.org/256393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a11d375468f05767723eb77ba233359b6ba39ce1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104890 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165155 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4578 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33589 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100775 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3335 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82016 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73245 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39020 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18722 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42744 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39254 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->