### PR TITLE
Change MDM keys for ResourceLoadStatistics relaxation

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/ManagedConfigurationSPI.h
@@ -34,7 +34,7 @@ WTF_EXTERN_C_BEGIN
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
 #import <ManagedConfiguration/ManagedConfiguration.h>
 @interface MCProfileConnection ()
-- (NSArray<NSString *> *)crossSiteTrackingAllowedDomains;
+- (NSArray<NSString *> *)crossSiteTrackingPreventionRelaxedDomains;
 @end
 
 #else
@@ -66,7 +66,7 @@ typedef enum MCRestrictedBoolType {
 + (MCProfileConnection *)sharedConnection;
 - (MCRestrictedBoolType)effectiveBoolValueForSetting:(NSString *)feature;
 - (BOOL)isURLManaged:(NSURL *)url;
-- (NSArray<NSString *> *)crossSiteTrackingAllowedDomains;
+- (NSArray<NSString *> *)crossSiteTrackingPreventionRelaxedDomains;
 @end
 
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -722,7 +722,7 @@ static HashSet<WebCore::RegistrableDomain>& managedDomains()
 }
 
 NSString *kManagedSitesIdentifier = @"com.apple.mail-shared";
-NSString *kCrossSiteTrackingPreventionDisabledDomainsKey = @"crossSiteTrackingRelaxedDomains";
+NSString *kCrossSiteTrackingPreventionRelaxedDomainsKey = @"CrossSiteTrackingPreventionRelaxedDomains";
 
 void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReinitialization)
 {
@@ -735,26 +735,26 @@ void WebsiteDataStore::initializeManagedDomains(ForceReinitialization forceReini
         if (hasInitializedManagedDomains && forceReinitialization != ForceReinitialization::Yes)
             return;
         static const auto maxManagedDomainCount = 10;
-        NSArray<NSString *> *crossSiteTrackingPreventionDisabledDomains = nil;
+        NSArray<NSString *> *crossSiteTrackingPreventionRelaxedDomains = nil;
 #if PLATFORM(MAC)
         NSDictionary *managedSitesPrefs = [NSDictionary dictionaryWithContentsOfFile:[[NSString stringWithFormat:@"/Library/Managed Preferences/%@/%@.plist", NSUserName(), kManagedSitesIdentifier] stringByStandardizingPath]];
-        crossSiteTrackingPreventionDisabledDomains = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionDisabledDomainsKey];
+        crossSiteTrackingPreventionRelaxedDomains = [managedSitesPrefs objectForKey:kCrossSiteTrackingPreventionRelaxedDomainsKey];
 #elif !PLATFORM(MACCATALYST)
-        if ([PAL::getMCProfileConnectionClass() instancesRespondToSelector:@selector(crossSiteTrackingAllowedDomains)])
-            crossSiteTrackingPreventionDisabledDomains = [[PAL::getMCProfileConnectionClass() sharedConnection] crossSiteTrackingAllowedDomains];
+        if ([PAL::getMCProfileConnectionClass() instancesRespondToSelector:@selector(crossSiteTrackingPreventionRelaxedDomains)])
+            crossSiteTrackingPreventionRelaxedDomains = [[PAL::getMCProfileConnectionClass() sharedConnection] crossSiteTrackingPreventionRelaxedDomains];
         else
-            crossSiteTrackingPreventionDisabledDomains = @[];
+            crossSiteTrackingPreventionRelaxedDomains = @[];
 #endif
-        managedKeyExists = crossSiteTrackingPreventionDisabledDomains ? true : false;
+        managedKeyExists = crossSiteTrackingPreventionRelaxedDomains ? true : false;
     
-        RunLoop::main().dispatch([forceReinitialization, crossSiteTrackingPreventionDisabledDomains = retainPtr(crossSiteTrackingPreventionDisabledDomains)] {
+        RunLoop::main().dispatch([forceReinitialization, crossSiteTrackingPreventionRelaxedDomains = retainPtr(crossSiteTrackingPreventionRelaxedDomains)] {
             if (hasInitializedManagedDomains && forceReinitialization != ForceReinitialization::Yes)
                 return;
 
             if (forceReinitialization == ForceReinitialization::Yes)
                 managedDomains().clear();
 
-            for (NSString *data in crossSiteTrackingPreventionDisabledDomains.get()) {
+            for (NSString *data in crossSiteTrackingPreventionRelaxedDomains.get()) {
                 if (managedDomains().size() >= maxManagedDomainCount)
                     break;
 


### PR DESCRIPTION
#### a896ac41fe5a79021481d78edb0c2201ddc5bfb4
<pre>
Change MDM keys for ResourceLoadStatistics relaxation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247441">https://bugs.webkit.org/show_bug.cgi?id=247441</a>
rdar://101885740

Reviewed by Tim Nguyen.

* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::initializeManagedDomains):

These names have been changed to more accurately describe what they represent.

The associated changes have been made in other frameworks.

Canonical link: <a href="https://commits.webkit.org/256294@main">https://commits.webkit.org/256294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c7ebb90eebef3a8cb47261642008b88f61d6ae7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4591 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104904 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165166 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4591 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33310 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100787 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3345 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81888 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30394 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html, imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39033 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36840 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19964 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 6084") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4347 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39206 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->