### PR TITLE
[GStreamer] Bump minimum version requirement to 1.16.2

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -68,11 +68,7 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
     auto caps = adoptGRef(gst_audio_info_to_caps(&info));
     auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, size, nullptr));
     auto offsets = copyBusData(bus, buffer.get(), muted());
-#if GST_CHECK_VERSION(1, 16, 0)
     gst_buffer_add_audio_meta(buffer.get(), &info, numberOfFrames, offsets.data());
-#else
-    UNUSED_VARIABLE(offsets);
-#endif
     auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
     GStreamerAudioData audioBuffer(WTFMove(sample), info);
     GStreamerAudioStreamDescription description(&info);

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -88,25 +88,7 @@ static void webKitGLVideoSinkConstructed(GObject* object)
     ASSERT(colorconvert);
     gst_bin_add_many(GST_BIN_CAST(sink), upload, colorconvert, sink->priv->appSink.get(), nullptr);
 
-    // Workaround until we can depend on GStreamer 1.16.2.
-    // https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/commit/8d32de090554cf29fe359f83aa46000ba658a693
-    // Forcing a color conversion to RGBA here allows glupload to internally use
-    // an uploader that adds a VideoMeta, through the TextureUploadMeta caps
-    // feature, without needing the patch above. However this specific caps
-    // feature is going to be removed from GStreamer so it is considered a
-    // short-term workaround. This code path most likely will have a negative
-    // performance impact on embedded platforms as well. Downstream embedders
-    // are highly encouraged to cherry-pick the patch linked above in their BSP
-    // and set the WEBKIT_GST_NO_RGBA_CONVERSION environment variable until
-    // GStreamer 1.16.2 is released.
-    // See also https://bugs.webkit.org/show_bug.cgi?id=201422
-    GRefPtr<GstCaps> caps;
-    if (webkitGstCheckVersion(1, 16, 2) || getenv("WEBKIT_GST_NO_RGBA_CONVERSION"))
-        caps = adoptGRef(gst_caps_from_string("video/x-raw, format = (string) " GST_GL_CAPS_FORMAT));
-    else {
-        GST_INFO_OBJECT(sink, "Forcing RGBA as GStreamer is not new enough.");
-        caps = adoptGRef(gst_caps_from_string("video/x-raw, format = (string) RGBA"));
-    }
+    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_from_string("video/x-raw, format = (string) " GST_GL_CAPS_FORMAT));
     gst_caps_set_features(caps.get(), 0, gst_caps_features_new(GST_CAPS_FEATURE_MEMORY_GL_MEMORY, nullptr));
     g_object_set(sink->priv->appSink.get(), "caps", caps.get(), nullptr);
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -61,10 +61,8 @@ public:
     const String& systemId() const { return m_systemId; }
     String payloadContainerType() const
     {
-#if GST_CHECK_VERSION(1, 16, 0)
         if (m_systemId == GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s)
             return "webm"_s;
-#endif
         return "cenc"_s;
     }
 
@@ -113,10 +111,8 @@ public:
     static constexpr auto s_WidevineKeySystem = "com.widevine.alpha"_s;
     static constexpr auto s_PlayReadyUUID = WEBCORE_GSTREAMER_EME_UTILITIES_PLAYREADY_UUID ""_s;
     static constexpr std::array<ASCIILiteral, 2> s_PlayReadyKeySystems = { "com.microsoft.playready"_s,  "com.youtube.playready"_s };
-#if GST_CHECK_VERSION(1, 16, 0)
     static constexpr auto s_unspecifiedUUID = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
     static constexpr auto s_unspecifiedKeySystem = GST_PROTECTION_UNSPECIFIED_SYSTEM_ID ""_s;
-#endif
 
     static bool isClearKeyKeySystem(const String& keySystem)
     {
@@ -148,7 +144,6 @@ public:
         return equalIgnoringASCIICase(uuid, s_PlayReadyUUID);
     }
 
-#if GST_CHECK_VERSION(1, 16, 0)
     static bool isUnspecifiedKeySystem(const String& keySystem)
     {
         return equalIgnoringASCIICase(keySystem, s_unspecifiedKeySystem);
@@ -158,7 +153,6 @@ public:
     {
         return equalIgnoringASCIICase(uuid, s_unspecifiedUUID);
     }
-#endif
 
     static const char* keySystemToUuid(const String& keySystem)
     {
@@ -171,10 +165,8 @@ public:
         if (isPlayReadyKeySystem(keySystem))
             return s_PlayReadyUUID;
 
-#if GST_CHECK_VERSION(1, 16, 0)
         if (isUnspecifiedKeySystem(keySystem))
             return s_unspecifiedUUID;
-#endif
 
         ASSERT_NOT_REACHED();
         return { };
@@ -191,10 +183,8 @@ public:
         if (isPlayReadyUUID(uuid))
             return s_PlayReadyKeySystems[0];
 
-#if GST_CHECK_VERSION(1, 16, 0)
         if (isUnspecifiedUUID(uuid))
             return s_unspecifiedKeySystem;
-#endif
 
         ASSERT_NOT_REACHED();
         return ""_s;

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -169,11 +169,8 @@ static GstCaps* transformCaps(GstBaseTransform* base, GstPadDirection direction,
 
                 // GST_PROTECTION_UNSPECIFIED_SYSTEM_ID was added in the GStreamer
                 // developement git master which will ship as version 1.16.0.
-                gst_structure_set_name(outgoingStructure.get(),
-#if GST_CHECK_VERSION(1, 16, 0)
-                    !g_strcmp0(klass->protectionSystemId(self), GST_PROTECTION_UNSPECIFIED_SYSTEM_ID) ? "application/x-webm-enc" :
-#endif
-                    "application/x-cenc");
+                gst_structure_set_name(outgoingStructure.get(), !g_strcmp0(klass->protectionSystemId(self),
+                    GST_PROTECTION_UNSPECIFIED_SYSTEM_ID) ? "application/x-webm-enc" : "application/x-cenc");
             }
         }
 

--- a/Source/cmake/GStreamerChecks.cmake
+++ b/Source/cmake/GStreamerChecks.cmake
@@ -36,7 +36,7 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
               list(APPEND GSTREAMER_COMPONENTS webrtc)
           endif ()
 
-          find_package(GStreamer 1.14.0 REQUIRED COMPONENTS ${GSTREAMER_COMPONENTS})
+          find_package(GStreamer 1.16.2 REQUIRED COMPONENTS ${GSTREAMER_COMPONENTS})
 
           if (ENABLE_WEB_AUDIO)
               if (NOT PC_GSTREAMER_AUDIO_FOUND OR NOT PC_GSTREAMER_FFT_FOUND)


### PR DESCRIPTION
#### b2517e465d9f2983fe3181b176767e91b3a7f32e
<pre>
[GStreamer] Bump minimum version requirement to 1.16.2
<a href="https://bugs.webkit.org/show_bug.cgi?id=247440">https://bugs.webkit.org/show_bug.cgi?id=247440</a>

Reviewed by Philippe Normand.

Remove compile-time and runtime GStreamer version checks that are
not needed anymore since we now require at least GStreamer 1.16.2 at
configure time.

* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp:
(WebCore::MediaStreamAudioSource::consumeAudio):
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h:
(WebCore::InitData::payloadContainerType const):
(WebCore::GStreamerEMEUtilities::isUnspecifiedUUID):
(WebCore::GStreamerEMEUtilities::keySystemToUuid):
(WebCore::GStreamerEMEUtilities::uuidToKeySystem):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformCaps):
* Source/cmake/GStreamerChecks.cmake:

Canonical link: <a href="https://commits.webkit.org/256284@main">https://commits.webkit.org/256284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/975d8af6f3ee7dc2f18b7bf7dea998570ff13f04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104903 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165165 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4590 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33309 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100786 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100974 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81887 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30393 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86395 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39032 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81677 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19971 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28085 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4343 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84353 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42776 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39211 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19051 "Passed tests") | 
<!--EWS-Status-Bubble-End-->