### PR TITLE
Add remaining sandbox rules implicitly allowed in v1

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -120,6 +120,10 @@
 (allow socket-ioctl
     (ioctl-command CTLIOCGINFO))
 
+;; FIXME: Add telemetry to these
+(allow system-necp-client-action)
+(allow necp-client-open)
+
 (allow iokit-open-service (iokit-registry-entry-class "IOPMrootDomain"))
 
 (allow file-link

--- a/Source/WebKit/Shared/Sandbox/macOS/common.sb
+++ b/Source/WebKit/Shared/Sandbox/macOS/common.sb
@@ -40,6 +40,21 @@
 (allow system-mac-syscall (with telemetry))
 (allow syscall-mach)
 
+;; FIXME: Add telemetry to these
+(allow darwin-notification-post)
+(allow dynamic-code-generation)
+(allow file-clone)
+(allow fs-quota*)
+(allow fs-snapshot-mount)
+(allow mach-bootstrap)
+(allow mach-cross-domain-lookup)
+(allow mach-kernel-endpoint)
+(allow process-info-codesignature)
+(allow socket-ioctl)
+(allow socket-option-get)
+(allow socket-option-set)
+(allow system-memorystatus-control)
+
 (with-filter (mac-policy-name "Sandbox")
     (allow system-mac-syscall (mac-syscall-number 2 4 6 7)))
 


### PR DESCRIPTION
#### 0e292b40eb1f9b418e9994bb6de3b53b277c3219
<pre>
Add remaining sandbox rules implicitly allowed in v1
<a href="https://bugs.webkit.org/show_bug.cgi?id=247444">https://bugs.webkit.org/show_bug.cgi?id=247444</a>
rdar://101894771

Reviewed by Brent Fulgham.

Add remaining sandbox rules implicitly allowed in v1 in the sandboxes on macOS. This change will make the v1
and v2 sandboxes equal in terms of what they allow.

* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Shared/Sandbox/macOS/common.sb:

Canonical link: <a href="https://commits.webkit.org/256287@main">https://commits.webkit.org/256287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61af340c538a82f5144c4c831fc61b62ddf7f4ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4594 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104907 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4594 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33313 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100790 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100978 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81891 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30427 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39036 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36843 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/19966 "Build was cancelled. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 6089") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40795 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2092 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39208 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->