### PR TITLE
REGRESSION (iOS 16): <optgroup> labels are duplicated

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -564,12 +564,6 @@ static const float GroupOptionTextColorAlpha = 0.5;
             NSString *groupText = optionItem.text;
             NSMutableArray *groupedItems = [NSMutableArray array];
 
-            if (groupText.length) {
-                UIAction *action = [UIAction actionWithTitle:groupText image:nil identifier:nil handler:^(UIAction *action) { }];
-                action.attributes = UIMenuElementAttributesDisabled;
-                [groupedItems addObject:action];
-            }
-
             currentIndex++;
             while (currentIndex < _view.focusedSelectElementOptions.size()) {
                 auto& childOptionItem = _view.focusedSelectElementOptions[currentIndex];
@@ -627,10 +621,6 @@ static const float GroupOptionTextColorAlpha = 0.5;
 
         UIMenu *groupedMenu = (UIMenu *)menuElement;
         NSUInteger numGroupedOptions = groupedMenu.children.count;
-
-        // The first child of a grouped menu with a title represents the title, and is not a selectable option.
-        if (groupedMenu.title.length)
-            numGroupedOptions--;
 
         if (currentIndex + numGroupedOptions <= (NSUInteger)optionIndex)
             currentIndex += numGroupedOptions;


### PR DESCRIPTION
#### ad03a719b1d933e3df519c9323b77dab9b417f3b
<pre>
REGRESSION (iOS 16): &lt;optgroup&gt; labels are duplicated
<a href="https://bugs.webkit.org/show_bug.cgi?id=247443">https://bugs.webkit.org/show_bug.cgi?id=247443</a>
rdar://101241715

Reviewed by Wenson Hsieh.

WebKit displays &lt;optgroup&gt; elements as inline submenus. Prior to iOS 16, UIKit
did not display titles for inline submenus. Consequently, WebKit inserted a
disabled menu item at the top of each submenu, containing the &lt;optgroup&gt;&apos;s
label.

However, UIKit began displaying titles for submenus in iOS 16, resulting in
duplicate labels. To fix, remove the labels added by WebKit.

* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker createMenu]):
(-[WKSelectPicker actionForOptionIndex:]):

Canonical link: <a href="https://commits.webkit.org/256324@main">https://commits.webkit.org/256324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aa48b4b960cd1b67e69c47fe7a5752eab934bdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104909 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4596 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33315 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100792 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3351 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81894 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30425 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87127 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73264 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-web-process-responsive (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39038 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/19976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4373 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40797 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42644 "Found 1 new test failure: storage/indexeddb/crash-on-getdatabases.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39214 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->