### PR TITLE
The size of a video track's settings is incorrect in the second MediaStream created when the 'aspectRatio' contraint is applied

### DIFF
--- a/LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio-expected.txt
+++ b/LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS First gUM stream
+PASS Second gUM stream
+

--- a/LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio.html
+++ b/LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>'aspectRatio' correct with cloned media stream</title>
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id=video-1 autoplay playsinline controls></video>
+        <video id=video-2 autoplay playsinline controls></video>
+
+        <script>
+            const validateStream = async (video, message) => {
+
+                const stream = await navigator.mediaDevices.getUserMedia({ video: { aspectRatio: 1 }});
+
+                const settings = stream.getVideoTracks()[0].getSettings();
+                assert_equals(settings.width, settings.height, `settings.width === setting.height for ${message}`);
+
+                video.srcObject = stream;
+                await new Promise((resolve, reject) => { 
+                    video.oncanplay = resolve;
+                    setTimeout(() => reject(`timeout waiting for video to load for ${message}`), 5000);
+                });
+
+                assert_equals(settings.width, video.videoWidth, `settings.width === video.videoWidth for ${message}`);
+                assert_equals(settings.height, video.videoHeight, `settings.height === video.videoHeight for ${message}`);
+            }
+            
+            promise_test(async (test) => {
+
+                await validateStream(document.getElementById('video-1'), 'first stream');
+
+            }, 'First gUM stream');
+
+            promise_test(async (test) => {
+
+                await validateStream(document.getElementById('video-2'), 'second stream');
+
+            }, 'Second gUM stream');
+
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1011,6 +1011,9 @@ const IntSize RealtimeMediaSource::size() const
             size.setHeight(size.width() * (m_intrinsicSize.height() / static_cast<double>(m_intrinsicSize.width())));
         else if (size.height())
             size.setWidth(size.height() * (m_intrinsicSize.width() / static_cast<double>(m_intrinsicSize.height())));
+
+        if (m_aspectRatio)
+            size.setHeight(static_cast<int>(static_cast<float>(size.width()) / m_aspectRatio));
     }
 
     return size;
@@ -1059,8 +1062,14 @@ void RealtimeMediaSource::setAspectRatio(double ratio)
     ALWAYS_LOG_IF(m_logger, LOGIDENTIFIER, ratio);
     
     m_aspectRatio = ratio;
-    m_size.setHeight(m_size.width() / ratio);
-    notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::AspectRatio, RealtimeMediaSourceSettings::Flag::Height });
+
+    auto size = m_size;
+    if (!size.isEmpty()) {
+        size.setHeight(static_cast<int>(static_cast<float>(size.width()) / ratio));
+        setSize(size);
+    }
+
+    notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::AspectRatio });
 }
 
 void RealtimeMediaSource::setFacingMode(RealtimeMediaSourceSettings::VideoFacingMode mode)

--- a/Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp
@@ -122,6 +122,14 @@ void RealtimeVideoSource::setSizeAndFrameRate(std::optional<int> width, std::opt
     RealtimeMediaSource::setSizeAndFrameRate(width, height, frameRate);
 }
 
+void RealtimeVideoSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag> settings)
+{
+    if (settings.containsAny({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height })) {
+        auto size = this->size();
+        setSizeAndFrameRate(size.width(), size.height(), { });
+    }
+}
+
 void RealtimeVideoSource::sourceMutedChanged()
 {
     notifyMutedChange(m_source->muted());

--- a/Source/WebCore/platform/mediastream/RealtimeVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoSource.h
@@ -51,6 +51,7 @@ private:
     void stopProducingData() final;
     bool supportsSizeAndFrameRate(std::optional<int> width, std::optional<int> height, std::optional<double> frameRate) final;
     void setSizeAndFrameRate(std::optional<int> width, std::optional<int> height, std::optional<double> frameRate) final;
+    void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
     Ref<RealtimeMediaSource> clone() final;
     void endProducingData() final;
     void stopBeingObserved() final;


### PR DESCRIPTION
#### fc20b78a56dcc355e091918cd8e9e2e7981e00a3
<pre>
The size of a video track&apos;s settings is incorrect in the second MediaStream created when the &apos;aspectRatio&apos; contraint is applied
<a href="https://bugs.webkit.org/show_bug.cgi?id=245511">https://bugs.webkit.org/show_bug.cgi?id=245511</a>
rdar://100254156

Reviewed by Youenn Fablet.

* LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio-expected.txt: Added.
* LayoutTests/fast/mediastream/cloned-video-stream-aspect-ratio.html: Added.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::size const): Apply aspectRatio to size.
(WebCore::RealtimeMediaSource::setAspectRatio): Call `setSize` instead of modifying m_size
directly so observers will know the size has changed.

* Source/WebCore/platform/mediastream/RealtimeVideoSource.cpp:
(WebCore::RealtimeVideoSource::settingsDidChange): Call setSizeAndFrameRate when size changes
so settings are updated.
* Source/WebCore/platform/mediastream/RealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/256433@main">https://commits.webkit.org/256433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17be03ddd68a4d749f8b8fb31cd7603ee2b5445d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28492 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105019 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165290 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4731 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33442 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100892 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3460 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82051 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30528 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87269 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73369 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39224 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18823 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36927 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4448 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40908 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42774 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39365 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->