### PR TITLE
Add functions for generating random unsigned integers

### DIFF
--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -691,7 +691,7 @@ JSGlobalObject::JSGlobalObject(VM& vm, Structure* structure, const GlobalObjectM
     , m_varInjectionWatchpointSet(WatchpointSet::create(IsWatched))
     , m_varReadOnlyWatchpointSet(WatchpointSet::create(IsWatched))
     , m_regExpRecompiledWatchpointSet(WatchpointSet::create(IsWatched))
-    , m_weakRandom(Options::forceWeakRandomSeed() ? Options::forcedWeakRandomSeed() : static_cast<unsigned>(randomNumber() * (std::numeric_limits<unsigned>::max() + 1.0)))
+    , m_weakRandom(Options::forceWeakRandomSeed() ? Options::forcedWeakRandomSeed() : cryptographicallyRandomUint32())
     , m_runtimeFlags()
     , m_stackTraceLimit(Options::defaultErrorStackTraceLimit())
     , m_customGetterFunctionSet(vm)

--- a/Source/WTF/wtf/RandomNumber.cpp
+++ b/Source/WTF/wtf/RandomNumber.cpp
@@ -29,7 +29,6 @@
 #include <wtf/RandomNumber.h>
 
 #include <limits>
-#include <stdint.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/WeakRandom.h>
 
@@ -39,6 +38,17 @@ double randomNumber()
 {
     uint32_t bits = cryptographicallyRandomNumber();
     return static_cast<double>(bits) / (static_cast<double>(std::numeric_limits<uint32_t>::max()) + 1.0);
+}
+
+unsigned cryptographicallyRandomUint32()
+{
+    return cryptographicallyRandomNumber();
+}
+
+uint64_t cryptographicallyRandomUint64()
+{
+    auto high = static_cast<uint64_t>(cryptographicallyRandomNumber());
+    return (high << 32) | cryptographicallyRandomNumber();
 }
 
 unsigned weakRandomUint32()

--- a/Source/WTF/wtf/RandomNumber.h
+++ b/Source/WTF/wtf/RandomNumber.h
@@ -25,10 +25,18 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace WTF {
 
 // Returns a cryptographically secure pseudo-random number in the range [0, 1).
 WTF_EXPORT_PRIVATE double randomNumber();
+
+// Returns a cryptographically secure pseudo-random number in the range (0, UINT_MAX].
+WTF_EXPORT_PRIVATE unsigned cryptographicallyRandomUint32();
+
+// Returns a cryptographically secure pseudo-random number in the range (0, UINT64_MAX].
+WTF_EXPORT_PRIVATE uint64_t cryptographicallyRandomUint64();
 
 // Returns a cheap pseudo-random number in the range (0, UINT_MAX].
 WTF_EXPORT_PRIVATE unsigned weakRandomUint32();
@@ -36,4 +44,6 @@ WTF_EXPORT_PRIVATE unsigned weakRandomUint32();
 }
 
 using WTF::randomNumber;
+using WTF::cryptographicallyRandomUint32;
+using WTF::cryptographicallyRandomUint64;
 using WTF::weakRandomUint32;

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -140,7 +140,7 @@ Vector<char> generateUniqueBoundaryString()
     Vector<char> randomBytes;
 
     for (unsigned i = 0; i < 4; ++i) {
-        unsigned randomness = static_cast<unsigned>(randomNumber() * (std::numeric_limits<unsigned>::max() + 1.0));
+        unsigned randomness = cryptographicallyRandomUint32();
         randomBytes.append(alphaNumericEncodingMap[(randomness >> 24) & 0x3F]);
         randomBytes.append(alphaNumericEncodingMap[(randomness >> 16) & 0x3F]);
         randomBytes.append(alphaNumericEncodingMap[(randomness >> 8) & 0x3F]);

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -224,8 +224,7 @@ void RuleSetBuilder::pushCascadeLayer(const CascadeLayerName& name)
     auto nameResolvingAnonymous = [&] {
         if (name.isEmpty()) {
             // Make unique name for an anonymous layer.
-            unsigned long long random = randomNumber() * std::numeric_limits<unsigned long long>::max();
-            return CascadeLayerName { makeAtomString("anon_"_s, random) };
+            return CascadeLayerName { makeAtomString("anon_"_s, cryptographicallyRandomUint64()) };
         }
         return name;
     };

--- a/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ConnectionWin.cpp
@@ -44,7 +44,7 @@ bool createServerAndClientIdentifiers(HANDLE& serverIdentifier, HANDLE& clientId
     String pipeName;
 
     do {
-        unsigned uniqueID = randomNumber() * std::numeric_limits<unsigned>::max();
+        unsigned uniqueID = cryptographicallyRandomUint32();
         pipeName = makeString("\\\\.\\pipe\\com.apple.WebKit.", hex(uniqueID));
 
         serverIdentifier = ::CreateNamedPipe(pipeName.wideCharacters().data(),

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -140,7 +140,7 @@ static UnixFileDescriptor createSharedMemory()
 #else
     CString tempName;
     for (int tries = 0; fileDescriptor == -1 && tries < 10; ++tries) {
-        auto name = makeString("/WK2SharedMemory.", static_cast<unsigned>(WTF::randomNumber() * (std::numeric_limits<unsigned>::max() + 1.0)));
+        auto name = makeString("/WK2SharedMemory.", WTF::cryptographicallyRandomUint32());
         tempName = name.utf8();
 
         do {


### PR DESCRIPTION
#### ecc067cc894ba2088d6da3945e547491c2fdcdb5
<pre>
Add functions for generating random unsigned integers
<a href="https://bugs.webkit.org/show_bug.cgi?id=247446">https://bugs.webkit.org/show_bug.cgi?id=247446</a>

Reviewed by Yusuke Suzuki.

Add `cryptographicallyRandomUint32` and `cryptographicallyRandomUint64`
for generating unsigned integers. Replace uses of `randomNumber` that
were creating random unsigned integers. These were all just reversing
the operations used internally in `randomNumber`.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/WTF/wtf/RandomNumber.cpp:
* Source/WTF/wtf/RandomNumber.h:
* Source/WebCore/platform/network/FormDataBuilder.cpp:
* Source/WebCore/style/RuleSetBuilder.cpp:
* Source/WebKit/Platform/IPC/win/ConnectionWin.cpp:
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:

Canonical link: <a href="https://commits.webkit.org/256293@main">https://commits.webkit.org/256293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36845a229b6e54426e1787e3842a011fa45a6034

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4604 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104917 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165179 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4605 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33323 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100800 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100988 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81907 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30436 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86409 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39046 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81691 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36853 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28087 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4346 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40805 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84367 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42790 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19053 "Passed tests") | 
<!--EWS-Status-Bubble-End-->