### PR TITLE
MiniBrowser should accept the '--url' command line argument

### DIFF
--- a/Tools/MiniBrowser/mac/AppDelegate.m
+++ b/Tools/MiniBrowser/mac/AppDelegate.m
@@ -40,6 +40,8 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 
+static const NSString * const kURLArgumentString = @"--url";
+
 enum {
     WebKit1NewWindowTag = 1,
     WebKit2NewWindowTag = 2,
@@ -190,6 +192,20 @@ static WKWebsiteDataStore *persistentDataStore(void)
     return controller;
 }
 
+- (NSString *)targetURLOrDefaultURL
+{
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    const NSUInteger targetURLIndex = [args indexOfObject:kURLArgumentString];
+    NSString *targetURL = nil;
+
+    if (targetURLIndex != NSNotFound && targetURLIndex + 1 < [args count])
+        targetURL = [args objectAtIndex:targetURLIndex + 1];
+
+    if (!targetURL || [targetURL isEqualToString:@""])
+        return _settingsController.defaultURL;
+    return targetURL;
+}
+
 - (IBAction)newWindow:(id)sender
 {
     BrowserWindowController *controller = [self createBrowserWindowController:sender];
@@ -197,7 +213,7 @@ static WKWebsiteDataStore *persistentDataStore(void)
         return;
 
     [[controller window] makeKeyAndOrderFront:sender];
-    [controller loadURLString:_settingsController.defaultURL];
+    [controller loadURLString:[self targetURLOrDefaultURL]];
 }
 
 - (IBAction)newPrivateWindow:(id)sender


### PR DESCRIPTION
#### f5f63bec40dd7da7b6a041b369639bcfb47c58d5
<pre>
MiniBrowser should accept the &apos;--url&apos; command line argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=247451">https://bugs.webkit.org/show_bug.cgi?id=247451</a>
rdar://101924215

Reviewed by Tim Horton.

Just like <a href="https://bugs.webkit.org/show_bug.cgi?id=247378">https://bugs.webkit.org/show_bug.cgi?id=247378</a> we want Mac MiniBrowser to accept
the --url command line argument.

And just like in the MobileMiniBrowser case, this patch will allow you to set a --url argument
in the Xcode scheme with something like --url <a href="https://www.apple.com">https://www.apple.com</a>

* Tools/MiniBrowser/mac/AppDelegate.m:
(-[BrowserAppDelegate targetURLOrDefaultURL]):
(-[BrowserAppDelegate newWindow:]):

Canonical link: <a href="https://commits.webkit.org/256289@main">https://commits.webkit.org/256289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0330945f1e5629fa6b52e8c054b746a799078995

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4602 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104915 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4603 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33321 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100798 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/100986 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81904 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30429 "Updated gtk dependencies (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39044 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36851 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40803 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2094 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42788 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->