### PR TITLE
MessagePort is unexpectedly GC'ed after activity absence

### DIFF
--- a/LayoutTests/fast/events/message-port-gc-after-closing-expected.txt
+++ b/LayoutTests/fast/events/message-port-gc-after-closing-expected.txt
@@ -1,0 +1,11 @@
+Checks that MessagePort objects get GC'd after closing them
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Closing ports...
+PASS At least one port got GC'd after closing
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/message-port-gc-after-closing.html
+++ b/LayoutTests/fast/events/message-port-gc-after-closing.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Checks that MessagePort objects get GC'd after closing them");
+jsTestIsAsync = true;
+
+const messagePortsToCreate = 50;
+let portIdentifiers = [];
+let ports = [];
+let worker = new Worker("resources/message-port-gc-worker.js");
+for (let i = 0; i < messagePortsToCreate; ++i) {
+    let { port1, port2 } = new MessageChannel();
+    worker.postMessage("port", [port2]);
+    port1.onmessage = (event) => {
+        testFailed("Received unexpected message on MessagePort");
+    };
+    portIdentifiers.push(internals.messagePortIdentifier(port1));
+    ports.push(port1);
+}
+
+function checkSomePortsGotGCd()
+{
+    gc();
+    for (let portIdentifier of portIdentifiers) {
+        if (!internals.isMessagePortAlive(portIdentifier)) {
+            testPassed("At least one port got GC'd after closing");
+            finishJSTest();
+            clearInterval(intervalHandle);
+            return;
+        }
+    }
+}
+
+gc();
+setTimeout(() => {
+    gc();
+    for (let portIdentifier of portIdentifiers) {
+        if (!internals.isMessagePortAlive(portIdentifier)) {
+            testFailed("MessagePort was GC'd too eagerly");
+            finishJSTest();
+            return;
+        }
+    }
+    debug("Closing ports...");
+    for (let port of ports)
+        port.close();
+
+    ports = [];    
+
+    gc();
+    intervalHandle = setInterval(checkSomePortsGotGCd, 100);
+}, 0);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/events/message-port-gc-after-removing-event-listener-expected.txt
+++ b/LayoutTests/fast/events/message-port-gc-after-removing-event-listener-expected.txt
@@ -1,0 +1,11 @@
+Checks that MessagePort objects get GC'd once they no longer have an event listener
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Removing event listeners on ports...
+PASS At least one port got GC'd after removing their event listener
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/message-port-gc-after-removing-event-listener.html
+++ b/LayoutTests/fast/events/message-port-gc-after-removing-event-listener.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Checks that MessagePort objects get GC'd once they no longer have an event listener");
+jsTestIsAsync = true;
+
+const messagePortsToCreate = 50;
+let portIdentifiers = [];
+let ports = [];
+let worker = new Worker("resources/message-port-gc-worker.js");
+for (let i = 0; i < messagePortsToCreate; ++i) {
+    let { port1, port2 } = new MessageChannel();
+    worker.postMessage("port", [port2]);
+    port1.onmessage = (event) => {
+        testFailed("Received unexpected message on MessagePort");
+    };
+    portIdentifiers.push(internals.messagePortIdentifier(port1));
+    ports.push(port1);
+}
+
+function checkSomePortsGotGCd()
+{
+    gc();
+    for (let portIdentifier of portIdentifiers) {
+        if (!internals.isMessagePortAlive(portIdentifier)) {
+            testPassed("At least one port got GC'd after removing their event listener");
+            finishJSTest();
+            clearInterval(intervalHandle);
+            return;
+        }
+    }
+}
+
+gc();
+setTimeout(() => {
+    gc();
+    for (let portIdentifier of portIdentifiers) {
+        if (!internals.isMessagePortAlive(portIdentifier)) {
+            testFailed("MessagePort was GC'd too eagerly");
+            finishJSTest();
+            return;
+        }
+    }
+    debug("Removing event listeners on ports...");
+    for (let port of ports)
+        port.onmessage = null;
+
+    ports = [];    
+
+    gc();
+    intervalHandle = setInterval(checkSomePortsGotGCd, 100);
+}, 0);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/events/resources/message-port-gc-worker.js
+++ b/LayoutTests/fast/events/resources/message-port-gc-worker.js
@@ -1,0 +1,5 @@
+let ports = [];
+
+onmessage = (event) => {
+    ports.push(event.ports[0]);
+}

--- a/LayoutTests/http/tests/messaging/messageport-gc-after-xhr-expected.txt
+++ b/LayoutTests/http/tests/messaging/messageport-gc-after-xhr-expected.txt
@@ -1,0 +1,11 @@
+Tests that MessagePort doesn't get GC'd while still entangled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Posting message to the iframe.
+PASS Received the message from the iframe. The MessagePort was not GC'd
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/messaging/messageport-gc-after-xhr.html
+++ b/LayoutTests/http/tests/messaging/messageport-gc-after-xhr.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<iframe id="testFrame" src="resources/messageport-pong-after-xhr.html" style="display:none"></iframe>
+<script>
+description("Tests that MessagePort doesn't get GC'd while still entangled.");
+jsTestIsAsync = true;
+
+window.onload = () => {
+    let { port1, port2 } = new MessageChannel();
+    debug("Posting message to the iframe.");
+    document.getElementById('testFrame').contentWindow.postMessage("ping", "*", [port2]);
+    port1.onmessage = (e) => {
+        testPassed("Received the message from the iframe. The MessagePort was not GC'd");
+        finishJSTest();
+    };
+
+    setInterval(gc, 100);
+
+    setTimeout(() => {
+        testFailed("Did not receive the message from the iframe. The MessagePort was probably GC'd.");
+        finishJSTest();
+    }, 5000);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/messaging/resources/messageport-pong-after-xhr.html
+++ b/LayoutTests/http/tests/messaging/resources/messageport-pong-after-xhr.html
@@ -1,0 +1,11 @@
+<script>
+onmessage = (e) => {
+    let port = e.ports[0];
+    let xhr = new XMLHttpRequest();
+    xhr.open("GET", "/incremental/resources/delayed-css.py?delay=300");
+    xhr.onload = () => {
+        port.postMessage("pong");
+    };
+    xhr.send();
+}
+</script>

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -64,6 +64,7 @@ public:
     static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<RefPtr<MessagePort>>&&);
     static Vector<RefPtr<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
 
+    WEBCORE_EXPORT static bool isMessagePortAliveForTesting(const MessagePortIdentifier&);
     WEBCORE_EXPORT static bool isExistingMessagePortLocallyReachable(const MessagePortIdentifier&);
     WEBCORE_EXPORT static void notifyMessageAvailable(const MessagePortIdentifier&);
 

--- a/Source/WebCore/dom/MessagePort.idl
+++ b/Source/WebCore/dom/MessagePort.idl
@@ -27,6 +27,7 @@
 
 [
     ActiveDOMObject,
+    ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker,AudioWorklet),
     GenerateIsReachable=Impl,
     JSCustomMarkFunction,

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -148,6 +148,7 @@
 #include "MediaUsageInfo.h"
 #include "MemoryCache.h"
 #include "MemoryInfo.h"
+#include "MessagePort.h"
 #include "MockAudioDestinationCocoa.h"
 #include "MockLibWebRTCPeerConnection.h"
 #include "MockPageOverlay.h"
@@ -2859,6 +2860,17 @@ bool Internals::isDocumentAlive(const String& documentIdentifier) const
     auto uuid = UUID::parseVersion4(documentIdentifier);
     ASSERT(uuid);
     return uuid ? Document::allDocumentsMap().contains({ *uuid, Process::identifier() }) : false;
+}
+
+uint64_t Internals::messagePortIdentifier(const MessagePort& port) const
+{
+    return port.identifier().portIdentifier.toUInt64();
+}
+
+bool Internals::isMessagePortAlive(uint64_t messagePortIdentifier) const
+{
+    MessagePortIdentifier portIdentifier { Process::identifier(), makeObjectIdentifier<MessagePortIdentifier::PortIdentifierType>(messagePortIdentifier) };
+    return MessagePort::isMessagePortAliveForTesting(portIdentifier);
 }
 
 uint64_t Internals::storageAreaMapCount() const

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -105,6 +105,7 @@ class MallocStatistics;
 class MediaStream;
 class MediaStreamTrack;
 class MemoryInfo;
+class MessagePort;
 class MockCDMFactory;
 class MockContentFilterSettings;
 class MockPageOverlay;
@@ -531,6 +532,9 @@ public:
 
     String documentIdentifier(const Document&) const;
     bool isDocumentAlive(const String& documentIdentifier) const;
+
+    uint64_t messagePortIdentifier(const MessagePort&) const;
+    bool isMessagePortAlive(uint64_t messagePortIdentifier) const;
 
     uint64_t storageAreaMapCount() const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -977,6 +977,9 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     DOMString documentIdentifier(Document document);
     boolean isDocumentAlive(DOMString documentIdentifier);
 
+    unsigned long long messagePortIdentifier(MessagePort port);
+    boolean isMessagePortAlive(unsigned long long messagePortIdentifier);
+
     readonly attribute unsigned long long storageAreaMapCount;
 
     unsigned long long elementIdentifier(Element element);


### PR DESCRIPTION
#### a4790ba92ba790c7c332319b48b972b51053b765
<pre>
MessagePort is unexpectedly GC&apos;ed after activity absence
<a href="https://bugs.webkit.org/show_bug.cgi?id=193184">https://bugs.webkit.org/show_bug.cgi?id=193184</a>
rdar://54095480

Reviewed by Ryosuke Niwa and Geoffrey Garen.

Per the HTML specification [1], we should keep the MessagePort alive as long
as it is entangled. This makes sense since the port could receive messages as
long as it is entangled. However, we were missing this check inside
MessagePort::virtualHasPendingActivity().

We do still allow collection when entangled if there is no message event handler,
since it wouldn&apos;t be observable then. Even if a new message would arrive, there
would be no-one on JS side to notify.

[1] <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#ports-and-garbage-collection">https://html.spec.whatwg.org/multipage/web-messaging.html#ports-and-garbage-collection</a>

* LayoutTests/http/tests/messaging/messageport-gc-after-xhr-expected.txt: Added.
* LayoutTests/http/tests/messaging/messageport-gc-after-xhr.html: Added.
* LayoutTests/http/tests/messaging/resources/messageport-pong-after-xhr.html: Added.
Add test coverage. The test is based on the one provided by Yoshiaki Jitsukawa from
Sony.

* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::virtualHasPendingActivity const):

Canonical link: <a href="https://commits.webkit.org/256342@main">https://commits.webkit.org/256342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44f591e52dc0a42d4e40110d626ed4fff8e6fc5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105045 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4757 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33465 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100911 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3476 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82075 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30550 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73387 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20137 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4384 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40928 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39383 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->