### PR TITLE
The second pointerdown/touchstart event is missing on double-tap gesture

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8574,6 +8574,9 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
 
         if (gestureRecognizer == [_textInteractionAssistant loupeGesture])
             return YES;
+        
+        if (gestureRecognizer == _highlightLongPressGestureRecognizer)
+            return YES;
 
         if (auto *tapGesture = dynamic_objc_cast<UITapGestureRecognizer>(gestureRecognizer))
             return tapGesture.numberOfTapsRequired > 1 && tapGesture.numberOfTouchesRequired < 2;


### PR DESCRIPTION
#### 6115b3860098606a435a3cd00b7a6f48662b0617
<pre>
The second pointerdown/touchstart event is missing on double-tap gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=246313">https://bugs.webkit.org/show_bug.cgi?id=246313</a>
rdar://101273397

Reviewed by Wenson Hsieh.

On iOS, `WKContentViewInteraction` has a gesture recognizer of type `WKHighlightLongPressGestureRecognizer`.
In Safari, this recognizer is disabled because of the condition `!self._shouldUseContextMenus || !self.webView.allowsLinkPreview`,
which is `false` in Safari.

However, when adding a site to the Home Screen and launching it from there, this condition is true, causing
the recognizer to participate in the WKContentView&apos;s gesture recognizer graph. This causes a failure
Dependency between the recognizer and the touchstart deferring gesture recognizer for &quot;immediately
resettable&quot; gestures, and so double tapping an element only results in a single touchstart event triggered.

This PR fixes this by adding the gesture recognizer to the set of recognizers which may delay a reset,
which fixes the dependency graph.

No new tests, as the issue has been difficult to reproduce in WebKitTestRunner.
This is tracked in <a href="https://bugs.webkit.org/show_bug.cgi?id=246313.">https://bugs.webkit.org/show_bug.cgi?id=246313.</a>

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):

Canonical link: <a href="https://commits.webkit.org/256348@main">https://commits.webkit.org/256348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9806e255c219197ea529d72445823288bbd3859d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105018 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4730 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33456 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100891 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3457 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82050 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30526 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39223 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20113 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4389 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39359 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->