### PR TITLE
JetStream driver should ignore references to URL parameters when run in `jsc` shell

### DIFF
--- a/PerformanceTests/JetStream2/JetStreamDriver.js
+++ b/PerformanceTests/JetStream2/JetStreamDriver.js
@@ -42,7 +42,14 @@ if (typeof testWorstCaseCountMap === "undefined")
 if (typeof dumpJSONResults === "undefined")
     var dumpJSONResults = false;
 
-const urlParameters = new URLSearchParams(window.location.search);
+let shouldReport = false;
+let customTestList = [];
+if (typeof(URLSearchParams) !== "undefined") {
+    const urlParameters = new URLSearchParams(window.location.search);
+    shouldReport = urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true';
+    if (urlParameters.has('test'))
+        customTestList = urlParameters.getAll("test");
+}
 
 // Used for the promise representing the current benchmark run.
 this.currentResolve = null;
@@ -406,7 +413,7 @@ class Driver {
         await this.prefetchResourcesForBrowser();
         await this.fetchResources();
         this.prepareToRun();
-        if (isInBrowser && urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true') {
+        if (isInBrowser && shouldReport) {
             setTimeout(() => this.start(), 4000);
         }
     }
@@ -496,7 +503,7 @@ class Driver {
         if (!isInBrowser)
             return;
 
-        if (urlParameters.has('report') && urlParameters.get('report').toLowerCase() != 'true')
+        if (!shouldReport)
             return;
 
         const content = this.resultsJSON();
@@ -1846,8 +1853,8 @@ if (false) {
 
 if (typeof testList !== "undefined") {
     processTestList(testList);
-} else if (urlParameters.has('test')) {
-    processTestList(urlParameters.getAll("test"));
+} else if (customTestList.length) {
+    processTestList(customTestList);
 } else {
     if (runARES)
         addTestsByGroup(ARESGroup);

--- a/PerformanceTests/JetStream3/JetStreamDriver.js
+++ b/PerformanceTests/JetStream3/JetStreamDriver.js
@@ -42,7 +42,14 @@ if (typeof testWorstCaseCountMap === "undefined")
 if (typeof dumpJSONResults === "undefined")
     var dumpJSONResults = false;
 
-const urlParameters = new URLSearchParams(window.location.search);
+let shouldReport = false;
+let customTestList = [];
+if (typeof(URLSearchParams) !== "undefined") {
+    const urlParameters = new URLSearchParams(window.location.search);
+    shouldReport = urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true';
+    if (urlParameters.has('test'))
+        customTestList = urlParameters.getAll("test");
+}
 
 // Used for the promise representing the current benchmark run.
 this.currentResolve = null;
@@ -406,7 +413,7 @@ class Driver {
         await this.prefetchResourcesForBrowser();
         await this.fetchResources();
         this.prepareToRun();
-        if (isInBrowser && urlParameters.has('report') && urlParameters.get('report').toLowerCase() == 'true') {
+        if (isInBrowser && shouldReport) {
             setTimeout(() => this.start(), 4000);
         }
     }
@@ -496,7 +503,7 @@ class Driver {
         if (!isInBrowser)
             return;
 
-        if (urlParameters.has('report') && urlParameters.get('report').toLowerCase() != 'true')
+        if (!shouldReport)
             return;
 
         const content = this.resultsJSON();
@@ -1846,8 +1853,8 @@ if (false) {
 
 if (typeof testList !== "undefined") {
     processTestList(testList);
-} else if (urlParameters.has('test')) {
-    processTestList(urlParameters.getAll("test"));
+} else if (customTestList.length) {
+    processTestList(customTestList);
 } else {
     if (runARES)
         addTestsByGroup(ARESGroup);


### PR DESCRIPTION
#### e43d0d6df74818c72e9270a1cc01e25c747c3545
<pre>
JetStream driver should ignore references to URL parameters when run in `jsc` shell
<a href="https://bugs.webkit.org/show_bug.cgi?id=247460">https://bugs.webkit.org/show_bug.cgi?id=247460</a>
rdar://101934826

Reviewed by Dewei Zhu.

Fix for JS2 tests in `jsc` shell (and also RAMification) being broken due to <a href="https://bugs.webkit.org/show_bug.cgi?id=247301">https://bugs.webkit.org/show_bug.cgi?id=247301</a>
`URLSearchParams` is undefined in the `jsc` shell. But when run in the shell, URL parameters are irrelevant anyways so ideally they should be ignored.
  - Set default values for whether to report test results (false) and which specific subtests to run (empty list, or run all tests by default).
  - Check if `URLSearchParams` is defined, and if it is, override default reporting/subtest values with the ones specified.

* PerformanceTests/JetStream2/JetStreamDriver.js:
(typeof):
(Driver.prototype.async initialize):
(Driver.prototype.async reportScoreToRunBenchmarkRunner):
(prototype.else):
* PerformanceTests/JetStream3/JetStreamDriver.js:
(typeof):
(Driver.prototype.async initialize):
(Driver.prototype.async reportScoreToRunBenchmarkRunner):
(prototype.else):

Canonical link: <a href="https://commits.webkit.org/256304@main">https://commits.webkit.org/256304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c164c98504bdebf5fe858913b75fb77ab42f399c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4638 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104949 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4642 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33359 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87731 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101024 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81952 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39081 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4352 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42827 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->