### PR TITLE
WKWebView _loadHTMLString needs to add an allowed first party for cookies

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1712,6 +1712,8 @@ void WebPageProxy::loadAlternateHTML(const IPC::DataReference& htmlData, const S
     if (m_mainFrame)
         m_mainFrame->setUnreachableURL(unreachableURL);
 
+    websiteDataStore().networkProcess().send(Messages::NetworkProcess::AddAllowedFirstPartyForCookies(m_process->coreProcessIdentifier(), RegistrableDomain(baseURL)), 0);
+
     LoadParameters loadParameters;
     loadParameters.navigationID = 0;
     loadParameters.data = htmlData;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SchemeRegistry.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SchemeRegistry.mm
@@ -156,6 +156,24 @@ TEST(WebKit, RegisterAsCanDisplayOnlyIfCanRequest_CrossOriginLoad)
     }
 }
 
+TEST(WebKit, LoadAlternateHTMLStringAllowsFirstPartyForCookies)
+{
+    @autoreleasepool {
+        [NSURLProtocol registerClass:[EchoURLProtocol class]];
+        [WKBrowsingContextController registerSchemeForCustomProtocol:echoScheme];
+
+        auto webView = adoptNS([WKWebView new]);
+
+        NSString *htmlString = @"<link rel=stylesheet type='text/css' href='echo://base/page-load-errors.css'>";
+        [webView _loadAlternateHTMLString:htmlString baseURL:[NSURL URLWithString:@"echo://base/"] forUnreachableURL:[NSURL URLWithString:@"echo://unreachable/"]];
+        [webView _test_waitForDidFinishNavigation];
+        EXPECT_WK_STREQ(@"echo://base/page-load-errors.css", [lastEchoedURL absoluteString]);
+
+        [WKBrowsingContextController unregisterSchemeForCustomProtocol:echoScheme];
+        [NSURLProtocol unregisterClass:[EchoURLProtocol class]];
+    }
+}
+
 #if WK_HAVE_C_SPI
 
 TEST(WebKit, WKContextRegisterURLSchemeAsCanDisplayOnlyIfCanRequest_SameOriginLoad)


### PR DESCRIPTION
#### 7f1c15eb63aec1cbb30beffea788d62f07ec1450
<pre>
WKWebView _loadHTMLString needs to add an allowed first party for cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=247467">https://bugs.webkit.org/show_bug.cgi?id=247467</a>
rdar://101788379

Reviewed by Brady Eidson and Chris Dumez.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadAlternateHTML):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SchemeRegistry.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/256329@main">https://commits.webkit.org/256329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abed32ca56b19f54b38f3350bc409c09b07f1d83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104960 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165226 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4657 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33372 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100842 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3399 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81968 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30473 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73313 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20048 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2107 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39288 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->