### PR TITLE
Grid track sizing should reset the override width as well as height to compute intrinsic sizing.

### DIFF
--- a/LayoutTests/fast/dynamic/relayout-grid-should-reset-instrinsic-sizes-expected.html
+++ b/LayoutTests/fast/dynamic/relayout-grid-should-reset-instrinsic-sizes-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<div style="width: 150px; height: 150px; background-color: green"></div>
+</body>
+</html>

--- a/LayoutTests/fast/dynamic/relayout-grid-should-reset-instrinsic-sizes.html
+++ b/LayoutTests/fast/dynamic/relayout-grid-should-reset-instrinsic-sizes.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style>
+#grid_container {
+  display: grid;
+  align-items:end;
+}
+
+#inner {
+  width: 100%;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+<div id="grid_container">
+  <div>
+    <canvas id="inner" width="100" height="100"></img>
+  </div>
+</div>
+
+<script>
+  let container = document.getElementById('grid_container');
+  window.getComputedStyle(container).width;
+  container.style.width = '150px';
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -818,9 +818,9 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::logicalHeightForChild(RenderBox& ch
         child.setNeedsLayout(MarkOnlyThis);
     }
 
-    // We need to clear the stretched height to properly compute logical height during layout.
+    // We need to clear the stretched content size to properly compute logical height during layout.
     if (child.needsLayout())
-        child.clearOverridingLogicalHeight();
+        child.clearOverridingContentSize();
 
     child.layoutIfNeeded();
     return child.logicalHeight() + GridLayoutFunctions::marginLogicalSizeForChild(*renderGrid(), childBlockDirection, child) + m_algorithm.baselineOffsetForChild(child, gridAxisForDirection(direction()));

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -229,10 +229,10 @@ Vector<RenderBox*> RenderGrid::computeAspectRatioDependentAndBaselineItems()
     m_hasAspectRatioBlockSizeDependentItem = false;
 
     auto computeOrthogonalAndDependentItems = [&](RenderBox* child) {
-        // Grid's layout logic controls the grid item's override height, hence we need to
-        // clear any override height set previously, so it doesn't interfere in current layout
-        // execution. Grid never uses the override width, that's why we don't need to clear  it.
-        child->clearOverridingLogicalHeight();
+        // Grid's layout logic controls the grid item's override content size, hence we need to
+        // clear any override set previously, so it doesn't interfere in current layout
+        // execution.
+        child->clearOverridingContentSize();
 
         // We may need to repeat the track sizing in case of any grid item was orthogonal.
         if (GridLayoutFunctions::isOrthogonalChild(*this, *child))


### PR DESCRIPTION
#### f2e73e71c88c14822ac5f6d077634fc828ad686e
<pre>
Grid track sizing should reset the override width as well as height to compute intrinsic sizing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247465">https://bugs.webkit.org/show_bug.cgi?id=247465</a>
&lt;rdar://101304306&gt;

Reviewed by Alan Baradlay.

Grid layout (sometimes) sets the override content size and containing block sizes, so that grid items get sized relative to their grid tracks, rather than the size of the grid element.

During the sizing process, we want to know the intrinsic size of children, so we reset any overrides and re-layout children to measure them.

We&apos;re currently not resetting the content logical width, and there&apos;s a comment saying that grid never uses it, but that&apos;s out of date and we do need to reset this.

* LayoutTests/fast/dynamic/relayout-grid-should-reset-instrinsic-sizes-expected.html: Added.
* LayoutTests/fast/dynamic/relayout-grid-should-reset-instrinsic-sizes.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::logicalHeightForChild const):
* Source/WebCore/rendering/RenderGrid.cpp:

Canonical link: <a href="https://commits.webkit.org/256622@main">https://commits.webkit.org/256622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66089c2ee825aed2c57e27b6869a170b16146bfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105908 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166252 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration; Running set-build-summary") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5783 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34367 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102638 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102037 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82967 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31290 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74170 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40097 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37773 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4593 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/2476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40187 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->