### PR TITLE
Rename randomNumber to cryptographicallyRandomUnitInterval

### DIFF
--- a/Source/WTF/wtf/RandomNumber.cpp
+++ b/Source/WTF/wtf/RandomNumber.cpp
@@ -34,7 +34,7 @@
 
 namespace WTF {
 
-double randomNumber()
+double cryptographicallyRandomUnitInterval()
 {
     uint32_t bits = cryptographicallyRandomNumber();
     return static_cast<double>(bits) / (static_cast<double>(std::numeric_limits<uint32_t>::max()) + 1.0);

--- a/Source/WTF/wtf/RandomNumber.h
+++ b/Source/WTF/wtf/RandomNumber.h
@@ -30,7 +30,7 @@
 namespace WTF {
 
 // Returns a cryptographically secure pseudo-random number in the range [0, 1).
-WTF_EXPORT_PRIVATE double randomNumber();
+WTF_EXPORT_PRIVATE double cryptographicallyRandomUnitInterval();
 
 // Returns a cryptographically secure pseudo-random number in the range (0, UINT_MAX].
 WTF_EXPORT_PRIVATE unsigned cryptographicallyRandomUint32();
@@ -43,7 +43,7 @@ WTF_EXPORT_PRIVATE unsigned weakRandomUint32();
 
 }
 
-using WTF::randomNumber;
+using WTF::cryptographicallyRandomUnitInterval;
 using WTF::cryptographicallyRandomUint32;
 using WTF::cryptographicallyRandomUint64;
 using WTF::weakRandomUint32;

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
@@ -67,7 +67,7 @@ uint64_t CacheStorageConnection::computeRecordBodySize(const FetchResponse& resp
         uint64_t realSize = computeRealBodySize(body);
 
         // Padding the size as per https://github.com/whatwg/storage/issues/31.
-        uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(randomNumber() * 128000);
+        uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
         sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
 
         m_opaqueResponseToSizeWithPaddingMap.set(response.opaqueLoadIdentifier(), sizeWithPadding);

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -408,7 +408,7 @@ void MediaDevices::listenForDeviceChanges()
         if (!weakThis || isContextStopped() || m_scheduledEventTimer.isActive())
             return;
 
-        m_scheduledEventTimer.startOneShot(Seconds(randomNumber() / 2));
+        m_scheduledEventTimer.startOneShot(Seconds(cryptographicallyRandomUnitInterval() / 2));
     });
 }
 

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -232,7 +232,7 @@ void PrivateClickMeasurement::setSourceApplicationBundleIDForTesting(const Strin
 
 static Seconds randomlyBetweenTwentyFourAndFortyEightHours(PrivateClickMeasurement::IsRunningLayoutTest isRunningTest)
 {
-    return isRunningTest == PrivateClickMeasurement::IsRunningLayoutTest::Yes ? 1_s : 24_h + Seconds(randomNumber() * (24_h).value());
+    return isRunningTest == PrivateClickMeasurement::IsRunningLayoutTest::Yes ? 1_s : 24_h + Seconds(cryptographicallyRandomUnitInterval() * (24_h).value());
 }
 
 PCM::AttributionSecondsUntilSendData PrivateClickMeasurement::attributeAndGetEarliestTimeToSend(PCM::AttributionTriggerData&& attributionTriggerData, IsRunningLayoutTest isRunningTest)

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -407,7 +407,7 @@ std::optional<MonotonicTime> DOMTimer::alignedFireTime(MonotonicTime fireTime) c
     if (!alignmentInterval)
         return std::nullopt;
     
-    static const double randomizedProportion = randomNumber();
+    static const double randomizedProportion = cryptographicallyRandomUnitInterval();
 
     // Force alignment to randomizedAlignment fraction of the way between alignemntIntervals, e.g.
     // if alignmentInterval is 10_ms and randomizedAlignment is 0.3 this will align to 3, 13, 23, ...

--- a/Source/WebCore/page/DiagnosticLoggingClient.h
+++ b/Source/WebCore/page/DiagnosticLoggingClient.h
@@ -62,7 +62,7 @@ inline bool DiagnosticLoggingClient::shouldLogAfterSampling(ShouldSample shouldS
         return true;
 
     static const double selectionProbability = 0.05;
-    return randomNumber() <= selectionProbability;
+    return cryptographicallyRandomUnitInterval() <= selectionProbability;
 }
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -1183,7 +1183,7 @@ void Storage::shrink()
             unsigned bodyShareCount = m_blobStorage.shareCount(blobPath);
             auto probability = deletionProbability(times, bodyShareCount);
 
-            bool shouldDelete = randomNumber() < probability;
+            bool shouldDelete = cryptographicallyRandomUnitInterval() < probability;
 
             LOG(NetworkCacheStorage, "Deletion probability=%f bodyLinkCount=%d shouldDelete=%d", probability, bodyShareCount, shouldDelete);
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -436,7 +436,7 @@ void UserMediaPermissionRequestManagerProxy::scheduleNextRejection()
 {
     const double mimimumDelayBeforeReplying = .25;
     if (!m_rejectionTimer.isActive())
-        m_rejectionTimer.startOneShot(Seconds(mimimumDelayBeforeReplying + randomNumber()));
+        m_rejectionTimer.startOneShot(Seconds(mimimumDelayBeforeReplying + cryptographicallyRandomUnitInterval()));
 }
 
 #if ENABLE(MEDIA_STREAM)

--- a/Tools/TestWebKitAPI/Tests/WTF/BloomFilter.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BloomFilter.cpp
@@ -35,7 +35,7 @@ static Vector<unsigned> generateRandomHashes(size_t hashCount)
 {
     Vector<unsigned> hashes;
     for (unsigned i = 0; i < hashCount; ++i)
-        hashes.append(static_cast<unsigned>(randomNumber() * std::numeric_limits<unsigned>::max()));
+        hashes.append(cryptographicallyRandomUint32());
     return hashes;
 }
 
@@ -44,7 +44,7 @@ static Vector<SHA1::Digest> generateRandomDigests(size_t hashCount)
     Vector<SHA1::Digest> hashes;
     SHA1 sha1;
     for (unsigned i = 0; i < hashCount; ++i) {
-        double random = randomNumber();
+        double random = cryptographicallyRandomUnitInterval();
         sha1.addBytes(reinterpret_cast<uint8_t*>(&random), sizeof(double));
         SHA1::Digest digest;
         sha1.computeHash(digest);

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtras.cpp
@@ -63,9 +63,9 @@ void testFindBitInWord()
 
         // Fill in some random cases.
         for (size_t i = nextTestValue; i < numberOfTestValues; ++i) {
-            startIndex[i] = static_cast<uint8_t>(randomNumber() * bitsInWord);
+            startIndex[i] = static_cast<uint8_t>(cryptographicallyRandomUnitInterval() * bitsInWord);
             uint8_t remainingBits = bitsInWord - startIndex[i];
-            endIndex[i] = static_cast<uint8_t>(randomNumber() * remainingBits) + startIndex[i];
+            endIndex[i] = static_cast<uint8_t>(cryptographicallyRandomUnitInterval() * remainingBits) + startIndex[i];
         }
     };
 


### PR DESCRIPTION
#### 58234376adf2c562f9a7e4b626b115fbfac4e722
<pre>
Rename randomNumber to cryptographicallyRandomUnitInterval
<a href="https://bugs.webkit.org/show_bug.cgi?id=247469">https://bugs.webkit.org/show_bug.cgi?id=247469</a>

Reviewed by Yusuke Suzuki.

Generating a cryptographically random number is significantly more
costly than generating a weakly random one. A function with the name
`randomNumber` is more likely to be used for run of the mill
applications than one whose name starts with `cryptographicallyRandom`.
Also make the name more specific so it communicates the actual range of
values returned, [0, 1] is the unit interval.

* Source/WTF/wtf/RandomNumber.cpp:
* Source/WTF/wtf/RandomNumber.h:
* Source/WebCore/Modules/cache/CacheStorageConnection.cpp:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
* Source/WebCore/page/DOMTimer.cpp:
* Source/WebCore/page/DiagnosticLoggingClient.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
* Tools/TestWebKitAPI/Tests/WTF/BloomFilter.cpp:
* Tools/TestWebKitAPI/Tests/WTF/StdLibExtras.cpp:

Canonical link: <a href="https://commits.webkit.org/256308@main">https://commits.webkit.org/256308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1beeb608dbfdeb5fb9d0d5bb280bb87c93d3ffa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104966 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4667 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33378 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87750 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100848 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101048 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/81977 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30480 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73319 "Passed tests") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/86462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81752 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28105 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4357 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84429 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39299 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19067 "Passed tests") | 
<!--EWS-Status-Bubble-End-->