### PR TITLE
REGRESSION(255229@main): Do not restore selection when changing input types

### DIFF
--- a/LayoutTests/fast/forms/change-input-type-during-setSelectionRange-crash-expected.txt
+++ b/LayoutTests/fast/forms/change-input-type-during-setSelectionRange-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if this does not crash
+
+

--- a/LayoutTests/fast/forms/change-input-type-during-setSelectionRange-crash.html
+++ b/LayoutTests/fast/forms/change-input-type-during-setSelectionRange-crash.html
@@ -1,0 +1,18 @@
+<script>
+    addEventListener("load", () => {
+        initialFocus.focus();
+        input.setSelectionRange(0, 0);
+    });
+    function focusout() {
+        input.type = 'password';
+    }
+    function focusin() {
+        input.type = 'text';
+    }
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<p>PASS if this does not crash</p>
+<div tabindex="0" id="initialFocus" onfocusout="focusout()">
+    <input id="input" onfocusin="focusin()">
+</div>

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -486,7 +486,7 @@ void TextFieldInputType::createDataListDropdownIndicator()
 {
     ASSERT(!m_dataListDropdownIndicator);
     if (!m_container)
-        createContainer();
+        createContainer(PreserveSelectionRange::Yes);
 
     ScriptDisallowedScope::EventAllowedScope allowedScope(*m_container);
     m_dataListDropdownIndicator = DataListButtonElement::create(element()->document(), *this);
@@ -822,7 +822,7 @@ void TextFieldInputType::autoFillButtonElementWasClicked()
     page->chrome().client().handleAutoFillButtonClick(*element());
 }
 
-void TextFieldInputType::createContainer()
+void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelection)
 {
     ASSERT(!m_container);
     ASSERT(element());
@@ -833,7 +833,7 @@ void TextFieldInputType::createContainer()
 
     // FIXME: <https://webkit.org/b/245977> Suppress selectionchange events during subtree modification.
     std::optional<std::tuple<unsigned, unsigned, TextFieldSelectionDirection>> selectionState;
-    if (enclosingTextFormControl(element()->document().selection().selection().start()) == element())
+    if (preserveSelection == PreserveSelectionRange::Yes && enclosingTextFormControl(element()->document().selection().selection().start()) == element())
         selectionState = { element()->selectionStart(), element()->selectionEnd(), element()->computeSelectionDirection() };
 
     m_container = TextControlInnerContainer::create(element()->document());
@@ -878,7 +878,7 @@ void TextFieldInputType::updateAutoFillButton()
 
     if (shouldDrawAutoFillButton()) {
         if (!m_container)
-            createContainer();
+            createContainer(PreserveSelectionRange::Yes);
 
         AutoFillButtonType autoFillButtonType = element()->autoFillButtonType();
         if (!m_autoFillButton)

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -121,7 +121,8 @@ private:
     bool shouldDrawCapsLockIndicator() const;
     bool shouldDrawAutoFillButton() const;
 
-    void createContainer();
+    enum class PreserveSelectionRange : bool { No, Yes };
+    void createContainer(PreserveSelectionRange = PreserveSelectionRange::No);
     void createAutoFillButton(AutoFillButtonType);
 
 #if ENABLE(DATALIST_ELEMENT)


### PR DESCRIPTION
#### 6a72f93c2426d299da554ee796072305aa3e1de2
<pre>
REGRESSION(255229@main): Do not restore selection when changing input types
<a href="https://bugs.webkit.org/show_bug.cgi?id=247472">https://bugs.webkit.org/show_bug.cgi?id=247472</a>
rdar://101885601

Reviewed by Ryosuke Niwa.

Restoring selection range causes focusin events to fire, and allows the input type to be changed when the container is being recreated for a new input type.

* LayoutTests/fast/forms/change-input-type-during-setSelectionRange-crash-expected.txt: Added.
* LayoutTests/fast/forms/change-input-type-during-setSelectionRange-crash.html: Added.
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createDataListDropdownIndicator):
(WebCore::TextFieldInputType::createContainer):
(WebCore::TextFieldInputType::updateAutoFillButton):
* Source/WebCore/html/TextFieldInputType.h:

Canonical link: <a href="https://commits.webkit.org/256323@main">https://commits.webkit.org/256323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d67e7be9a991136eb4a099df005b4c37e087fcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105016 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4728 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33439 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100889 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101098 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40905 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2104 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42894 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/39361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->