### PR TITLE
Generate remaining simple argument coders

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -196,8 +196,11 @@ public:
         : m_colorData(colorData)
     {
     }
+    SetInlineFillColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)
+        : SetInlineFillColor(SRGBA<uint8_t> { red, green, blue, alpha }) { }
 
     Color color() const { return { m_colorData }; }
+    const SRGBA<uint8_t>& colorData() const { return m_colorData; }
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:
@@ -215,9 +218,11 @@ public:
         : m_colorData(colorData)
     {
     }
+    SetInlineStrokeColor(uint8_t red, uint8_t green, uint8_t blue, uint8_t alpha)
+        : SetInlineStrokeColor(SRGBA<uint8_t> { red, green, blue, alpha }) { }
 
     Color color() const { return { m_colorData }; }
-
+    const SRGBA<uint8_t>& colorData() const { return m_colorData; }
     WEBCORE_EXPORT void apply(GraphicsContext&) const;
 
 private:

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -34,6 +34,7 @@ class SerializedType(object):
         self.parent_class_name = parent_class_name
         self.parent_class = None
         self.members = members
+        self.alias = None
         self.condition = condition
         self.encoders = ['Encoder']
         self.serialize_with_function_calls = False
@@ -53,6 +54,8 @@ class SerializedType(object):
                         self.create_using = value
                     if key == 'LegacyPopulateFrom' and value == 'EmptyConstructor':
                         self.populate_from_empty_constructor = True
+                    if key == 'Alias':
+                        self.alias = value
                 else:
                     if attribute == 'Nested':
                         self.nested = True
@@ -183,6 +186,11 @@ def argument_coder_declarations(serialized_types, skip_nested):
     return result
 
 
+def remove_template_parameters(alias):
+    match = re.search(r'(.*)<', alias)
+    assert match
+    return match.groups()[0]
+
 def generate_header(serialized_types, serialized_enums):
     result = []
     result.append(_license_header)
@@ -208,10 +216,16 @@ def generate_header(serialized_types, serialized_enums):
             continue
         if type.condition is not None:
             result.append('#if ' + type.condition)
-        if type.namespace is None:
-            result.append(type.struct_or_class + ' ' + type.name + ';')
+        if type.alias is not None:
+            result.append('namespace ' + type.namespace + ' {')
+            result.append('template<typename> class ' + remove_template_parameters(type.alias) + ';')
+            result.append('using ' + type.name + ' = ' + type.alias + ';')
+            result.append('}')
         else:
-            result.append('namespace ' + type.namespace + ' { ' + type.struct_or_class + ' ' + type.name + '; }')
+            if type.namespace is None:
+                result.append(type.struct_or_class + ' ' + type.name + ';')
+            else:
+                result.append('namespace ' + type.namespace + ' { ' + type.struct_or_class + ' ' + type.name + '; }')
         if type.condition is not None:
             result.append('#endif')
     result.append('')
@@ -621,27 +635,27 @@ def parse_serialized_types(file, file_name):
             assert underlying_type != 'bool'
             continue
 
-        match = re.search(r'\[(.*)\] (struct|class) (.*)::(.*) : (.*) {', line)
+        match = re.search(r'\[(.*)\] (struct|class|alias) (.*)::(.*) : (.*) {', line)
         if match:
             attributes, struct_or_class, namespace, name, parent_class_name = match.groups()
             continue
-        match = re.search(r'(struct|class) (.*)::(.*) : (.*) {', line)
+        match = re.search(r'(struct|class|alias) (.*)::(.*) : (.*) {', line)
         if match:
             struct_or_class, namespace, name, parent_class_name = match.groups()
             continue
-        match = re.search(r'\[(.*)\] (struct|class) (.*)::(.*) {', line)
+        match = re.search(r'\[(.*)\] (struct|class|alias) (.*)::(.*) {', line)
         if match:
             attributes, struct_or_class, namespace, name = match.groups()
             continue
-        match = re.search(r'(struct|class) (.*)::(.*) {', line)
+        match = re.search(r'(struct|class|alias) (.*)::(.*) {', line)
         if match:
             struct_or_class, namespace, name = match.groups()
             continue
-        match = re.search(r'\[(.*)\] (struct|class) (.*) {', line)
+        match = re.search(r'\[(.*)\] (struct|class|alias) (.*) {', line)
         if match:
             attributes, struct_or_class, name = match.groups()
             continue
-        match = re.search(r'(struct|class) (.*) {', line)
+        match = re.search(r'(struct|class|alias) (.*) {', line)
         if match:
             struct_or_class, name = match.groups()
             continue

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -38,6 +38,7 @@
 #include <Namespace/EmptyConstructorNullable.h>
 #include <Namespace/EmptyConstructorStruct.h>
 #include <Namespace/ReturnRefClass.h>
+#include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <wtf/CreateUsingClass.h>
@@ -466,6 +467,51 @@ std::optional<WTF::CreateUsingClass> ArgumentCoder<WTF::CreateUsingClass>::decod
         WTF::CreateUsingClass::fromDouble(
             WTFMove(*value)
         )
+    };
+}
+
+
+void ArgumentCoder<WebCore::FloatBoxExtent>::encode(Encoder& encoder, const WebCore::FloatBoxExtent& instance)
+{
+    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.top())>>, float>);
+    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.right())>>, float>);
+    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.bottom())>>, float>);
+    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.left())>>, float>);
+    encoder << instance.top();
+    encoder << instance.right();
+    encoder << instance.bottom();
+    encoder << instance.left();
+}
+
+std::optional<WebCore::FloatBoxExtent> ArgumentCoder<WebCore::FloatBoxExtent>::decode(Decoder& decoder)
+{
+    std::optional<float> top;
+    decoder >> top;
+    if (!top)
+        return std::nullopt;
+
+    std::optional<float> right;
+    decoder >> right;
+    if (!right)
+        return std::nullopt;
+
+    std::optional<float> bottom;
+    decoder >> bottom;
+    if (!bottom)
+        return std::nullopt;
+
+    std::optional<float> left;
+    decoder >> left;
+    if (!left)
+        return std::nullopt;
+
+    return {
+        WebCore::FloatBoxExtent {
+            WTFMove(*top),
+            WTFMove(*right),
+            WTFMove(*bottom),
+            WTFMove(*left)
+        }
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -47,6 +47,10 @@ namespace WebCore { class InheritsFrom; }
 namespace WebCore { class InheritanceGrandchild; }
 namespace WTF { class Seconds; }
 namespace WTF { class CreateUsingClass; }
+namespace WebCore {
+template<typename> class RectEdges;
+using FloatBoxExtent = RectEdges<float>;
+}
 
 namespace IPC {
 
@@ -106,6 +110,11 @@ template<> struct ArgumentCoder<WTF::Seconds> {
 template<> struct ArgumentCoder<WTF::CreateUsingClass> {
     static void encode(Encoder&, const WTF::CreateUsingClass&);
     static std::optional<WTF::CreateUsingClass> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::FloatBoxExtent> {
+    static void encode(Encoder&, const WebCore::FloatBoxExtent&);
+    static std::optional<WebCore::FloatBoxExtent> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -38,6 +38,7 @@
 #include <Namespace/EmptyConstructorNullable.h>
 #include <Namespace/EmptyConstructorStruct.h>
 #include <Namespace/ReturnRefClass.h>
+#include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
 #include <wtf/CreateUsingClass.h>
@@ -92,6 +93,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "CreateUsingClass"_s, {
             "double"_s,
+        } },
+        { "WebCore::FloatBoxExtent"_s, {
+            "float"_s,
+            "float"_s,
+            "float"_s,
+            "float"_s,
         } },
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -89,3 +89,10 @@ class WTF::Seconds {
 [CreateUsing=fromDouble] class WTF::CreateUsingClass {
     double value
 }
+
+[Alias=RectEdges<float>] alias WebCore::FloatBoxExtent {
+    float top()
+    float right()
+    float bottom()
+    float left()
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -137,27 +137,6 @@ namespace IPC {
 using namespace WebCore;
 using namespace WebKit;
 
-#define DEFINE_SIMPLE_ARGUMENT_CODER_FOR_SOURCE(Type) \
-    template<typename Encoder> \
-    void ArgumentCoder<Type>::encode(Encoder& encoder, const Type& value) { SimpleArgumentCoder<Type>::encode(encoder, value); } \
-    bool ArgumentCoder<Type>::decode(Decoder& decoder, Type& value) { return SimpleArgumentCoder<Type>::decode(decoder, value); } \
-    std::optional<Type> ArgumentCoder<Type>::decode(Decoder& decoder) \
-    { \
-        Type value; \
-        if (!decode(decoder, value)) \
-            return std::nullopt; \
-        return value; \
-    } \
-    template void ArgumentCoder<Type>::encode<Encoder>(Encoder&, const Type&); \
-    template void ArgumentCoder<Type>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, const Type&);
-
-DEFINE_SIMPLE_ARGUMENT_CODER_FOR_SOURCE(FloatBoxExtent)
-
-DEFINE_SIMPLE_ARGUMENT_CODER_FOR_SOURCE(DisplayList::SetInlineFillColor)
-DEFINE_SIMPLE_ARGUMENT_CODER_FOR_SOURCE(DisplayList::SetInlineStrokeColor)
-
-#undef DEFINE_SIMPLE_ARGUMENT_CODER_FOR_SOURCE
-
 void ArgumentCoder<DOMCacheEngine::Record>::encode(Encoder& encoder, const DOMCacheEngine::Record& record)
 {
     encoder << record.identifier;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -217,20 +217,6 @@ struct Record;
 
 namespace IPC {
 
-#define DEFINE_SIMPLE_ARGUMENT_CODER_FOR_HEADER(Type) \
-    template<> struct ArgumentCoder<Type> { \
-        template<typename Encoder> static void encode(Encoder&, const Type&); \
-        static WARN_UNUSED_RETURN bool decode(Decoder&, Type&); \
-        static std::optional<Type> decode(Decoder&); \
-    };
-
-DEFINE_SIMPLE_ARGUMENT_CODER_FOR_HEADER(WebCore::FloatBoxExtent)
-
-DEFINE_SIMPLE_ARGUMENT_CODER_FOR_HEADER(WebCore::DisplayList::SetInlineFillColor)
-DEFINE_SIMPLE_ARGUMENT_CODER_FOR_HEADER(WebCore::DisplayList::SetInlineStrokeColor)
-
-#undef DEFINE_SIMPLE_ARGUMENT_CODER_FOR_HEADER
-
 template<> struct ArgumentCoder<WebCore::AttributedString> {
     static void encode(Encoder&, const WebCore::AttributedString&);
     static std::optional<WebCore::AttributedString> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1121,3 +1121,26 @@ struct WebCore::ExceptionDetails {
     WebCore::ExceptionDetails::Type type;
     String sourceURL;
 };
+
+header: <WebCore/RectEdges.h>
+[Alias=RectEdges<float>, CustomHeader] alias WebCore::FloatBoxExtent {
+    float top()
+    float right()
+    float bottom()
+    float left()
+};
+
+header: <WebCore/DisplayListItems.h>
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineFillColor {
+    uint8_t colorData().resolved().red
+    uint8_t colorData().resolved().green
+    uint8_t colorData().resolved().blue
+    uint8_t colorData().resolved().alpha
+}
+
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::DisplayList::SetInlineStrokeColor {
+    uint8_t colorData().resolved().red
+    uint8_t colorData().resolved().green
+    uint8_t colorData().resolved().blue
+    uint8_t colorData().resolved().alpha
+}


### PR DESCRIPTION
#### 9288cf1ac62f35f333c0451b8a5ab6476c39a1a4
<pre>
Generate remaining simple argument coders
<a href="https://bugs.webkit.org/show_bug.cgi?id=247478">https://bugs.webkit.org/show_bug.cgi?id=247478</a>
rdar://101945785

Reviewed by Brady Eidson.

* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::SetInlineFillColor::SetInlineFillColor):
(WebCore::DisplayList::SetInlineFillColor::colorData const):
(WebCore::DisplayList::SetInlineStrokeColor::SetInlineStrokeColor):
(WebCore::DisplayList::SetInlineStrokeColor::colorData const):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(remove_template_parameters):
(generate_header):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebCore::FloatBoxExtent&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FloatBoxExtent&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/256327@main">https://commits.webkit.org/256327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1300e8a998cdfb5a6ac77dde46e952e791e22d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/104982 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165244 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4687 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33394 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87766 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100858 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3420 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82002 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30493 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/98989 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73333 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20069 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40874 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2106 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39310 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->