### PR TITLE
CARingBuffer uses CAAudioStreamDescription in a redundant way

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CAAudioStreamDescription.h"
 #include "CARingBuffer.h"
 #include "WebAudioBufferList.h"
 #include <CoreAudio/CoreAudioTypes.h>

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AudioSampleDataConverter.h"
+#include "CAAudioStreamDescription.h"
 #include "CARingBuffer.h"
 #include <CoreAudio/CoreAudioTypes.h>
 #include <wtf/LoggerHelper.h>
@@ -114,7 +115,7 @@ private:
 
     RefPtr<AudioSampleBufferList> m_scratchBuffer;
 
-    InProcessCARingBuffer m_ringBuffer;
+    std::unique_ptr<InProcessCARingBuffer> m_ringBuffer;
     size_t m_maximumSampleCount { 0 };
 
     float m_volume { 1.0 };

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -64,8 +64,8 @@ public:
 
     using AudioCallback = Function<void(uint64_t startFrame, uint64_t numberOfFrames)>;
     WEBCORE_EXPORT void setAudioCallback(AudioCallback&&);
-    using RingBufferCreationCallback = Function<UniqueRef<CARingBuffer>()>;
-    WEBCORE_EXPORT void setRingBufferCreationCallback(RingBufferCreationCallback&&);
+    using ConfigureAudioStorageCallback = Function<std::unique_ptr<CARingBuffer>(const CAAudioStreamDescription&, size_t frameCount)>;
+    WEBCORE_EXPORT void setConfigureAudioStorageCallback(ConfigureAudioStorageCallback&&);
 
 private:
     AudioSourceProviderAVFObjC(AVPlayerItem *);
@@ -111,7 +111,7 @@ private:
     class TapStorage;
     RefPtr<TapStorage> m_tapStorage;
     AudioCallback m_audioCallback;
-    RingBufferCreationCallback m_ringBufferCreationCallback;
+    ConfigureAudioStorageCallback m_configureAudioStorageCallback;
 };
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -100,7 +100,7 @@ public:
             if (m_isPlaying)
                 return;
         }
-        m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+        m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
         if (!m_ringBuffer)
             return;
         start();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -37,8 +37,8 @@ Ref<RemoteAudioSourceProviderProxy> RemoteAudioSourceProviderProxy::create(WebCo
 {
     auto remoteProvider = adoptRef(*new RemoteAudioSourceProviderProxy(identifier, WTFMove(connection)));
 
-    localProvider.setRingBufferCreationCallback([remoteProvider]() {
-        return remoteProvider->createRingBuffer();
+    localProvider.setConfigureAudioStorageCallback([remoteProvider](auto&&... args) {
+        return remoteProvider->configureAudioStorage(args...);
     });
     localProvider.setAudioCallback([remoteProvider](auto startFrame, auto numberOfFrames) {
         remoteProvider->newAudioSamples(startFrame, numberOfFrames);
@@ -55,24 +55,18 @@ RemoteAudioSourceProviderProxy::RemoteAudioSourceProviderProxy(WebCore::MediaPla
 
 RemoteAudioSourceProviderProxy::~RemoteAudioSourceProviderProxy() = default;
 
-UniqueRef<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::createRingBuffer()
+std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configureAudioStorage(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
-    return makeUniqueRef<ProducerSharedCARingBuffer>([protectedThis = Ref { *this }](SharedMemory* memory, const WebCore::CAAudioStreamDescription& format, size_t frameCount) mutable {
-        protectedThis->storageChanged(memory, format, frameCount);
-    });
+    auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, frameCount);
+    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format, frameCount }, 0);
+    // Use a redundant variable to avoid move in return position and to obtain copy elision. Clang or libc++ does not allow returning covariant of Ts from std::unique_ptr<T>s in this position.
+    std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTFMove(ringBuffer);  // NOLINT: see above.
+    return caRingBuffer;
 }
 
 void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames)
 {
     m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames }, 0);
-}
-
-void RemoteAudioSourceProviderProxy::storageChanged(SharedMemory* memory, const WebCore::CAAudioStreamDescription& format, size_t frameCount)
-{
-    SharedMemory::Handle handle;
-    if (memory)
-        memory->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, handle, format, frameCount }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -47,13 +47,11 @@ public:
     static Ref<RemoteAudioSourceProviderProxy> create(WebCore::MediaPlayerIdentifier, Ref<IPC::Connection>&&, WebCore::AudioSourceProviderAVFObjC&);
     ~RemoteAudioSourceProviderProxy();
 
-    UniqueRef<WebCore::CARingBuffer> createRingBuffer();
     void newAudioSamples(uint64_t startFrame, uint64_t endFrame);
 
 private:
     RemoteAudioSourceProviderProxy(WebCore::MediaPlayerIdentifier, Ref<IPC::Connection>&&);
-
-    void storageChanged(SharedMemory*, const WebCore::CAAudioStreamDescription& format, size_t frameCount);
+    std::unique_ptr<WebCore::CARingBuffer> configureAudioStorage(const WebCore::CAAudioStreamDescription&, size_t frameCount);
 
     // AudioSourceProviderClient
     void setFormat(size_t numberOfChannels, float sampleRate) final { }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -210,7 +210,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(Consume
 {
     if (m_isPlaying)
         stop();
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_readOffset = 0;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -68,7 +68,7 @@ void RemoteMediaRecorder::audioSamplesStorageChanged(ConsumerSharedCARingBuffer:
 {
     MESSAGE_CHECK(m_recordAudio);
     m_audioBufferList = nullptr;
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_description = description;

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -65,13 +65,7 @@ public:
     };
 
     class Handle {
-        WTF_MAKE_NONCOPYABLE(Handle);
     public:
-        Handle();
-        ~Handle();
-        Handle(Handle&&);
-        Handle& operator=(Handle&&);
-
         bool isNull() const;
 
         size_t size() const { return m_size; }

--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -73,14 +73,6 @@ static inline std::optional<size_t> safeRoundPage(size_t size)
     return roundedSize;
 }
 
-SharedMemory::Handle::Handle() = default;
-
-SharedMemory::Handle::Handle(Handle&&) = default;
-
-auto SharedMemory::Handle::operator=(Handle&& other) -> Handle& = default;
-
-SharedMemory::Handle::~Handle() = default;
-
 void SharedMemory::Handle::takeOwnershipOfMemory(MemoryLedger memoryLedger) const
 {
 #if HAVE(MACH_MEMORY_ENTRY)

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -52,17 +52,6 @@
 
 namespace WebKit {
 
-SharedMemory::Handle::Handle()
-{
-}
-
-SharedMemory::Handle::~Handle()
-{
-}
-
-SharedMemory::Handle::Handle(Handle&&) = default;
-SharedMemory::Handle& SharedMemory::Handle::operator=(Handle&& other) = default;
-
 void SharedMemory::Handle::clear()
 {
     *this = { };

--- a/Source/WebKit/Platform/win/SharedMemoryWin.cpp
+++ b/Source/WebKit/Platform/win/SharedMemoryWin.cpp
@@ -32,14 +32,6 @@
 
 namespace WebKit {
 
-SharedMemory::Handle::Handle() = default;
-
-SharedMemory::Handle::Handle(Handle&&) = default;
-
-SharedMemory::Handle& SharedMemory::Handle::operator=(Handle&&) = default;
-
-SharedMemory::Handle::~Handle() = default;
-
 bool SharedMemory::Handle::isNull() const
 {
     return !m_handle;

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -75,7 +75,7 @@ void SpeechRecognitionRemoteRealtimeMediaSource::stopProducingData()
 void SpeechRecognitionRemoteRealtimeMediaSource::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     m_buffer = nullptr;
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_description = description;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -88,10 +88,6 @@ private:
     unsigned numberOfOutputChannels() const { return m_numberOfOutputChannels; }
 #endif
 
-#if PLATFORM(COCOA)
-    void storageChanged(SharedMemory*, const WebCore::CAAudioStreamDescription& format, size_t frameCount);
-#endif
-
     RemoteAudioDestinationIdentifier m_destinationID; // Call destinationID() getter to make sure the destinationID is valid.
 
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -123,7 +123,7 @@ void RemoteAudioSourceProviderManager::RemoteAudio::setStorage(ConsumerSharedCAR
 {
     m_buffer = nullptr;
     handle.takeOwnershipOfMemory(MemoryLedger::Media);
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_description = description;

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -64,9 +64,6 @@ void MediaRecorderPrivate::startRecording(StartRecordingCallback&& callback)
     // Currently we only choose the first track as the recorded track.
 
     auto selectedTracks = MediaRecorderPrivate::selectTracks(m_stream);
-    if (selectedTracks.audioTrack)
-        m_ringBuffer = makeUnique<ProducerSharedCARingBuffer>(std::bind(&MediaRecorderPrivate::storageChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-
     m_connection->sendWithAsyncReply(Messages::RemoteMediaRecorderManager::CreateRecorder { m_identifier, !!selectedTracks.audioTrack, !!selectedTracks.videoTrack, m_options }, [this, weakThis = WeakPtr { *this }, audioTrack = RefPtr { selectedTracks.audioTrack }, videoTrack = RefPtr { selectedTracks.videoTrack }, callback = WTFMove(callback)](auto&& exception, String&& mimeType, unsigned audioBitRate, unsigned videoBitRate) mutable {
         if (!weakThis) {
             callback(Exception { InvalidStateError }, 0, 0);
@@ -125,7 +122,10 @@ void MediaRecorderPrivate::audioSamplesAvailable(const MediaTime& time, const Pl
 
         // Allocate a ring buffer large enough to contain 2 seconds of audio.
         m_numberOfFrames = m_description.sampleRate() * 2;
-        m_ringBuffer->allocate(m_description.streamDescription(), m_numberOfFrames);
+        auto& format = m_description.streamDescription();
+        auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, m_numberOfFrames);
+        m_ringBuffer = WTFMove(ringBuffer);
+        m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format, m_numberOfFrames }, m_identifier);
         m_silenceAudioBuffer = nullptr;
     }
 
@@ -141,18 +141,6 @@ void MediaRecorderPrivate::audioSamplesAvailable(const MediaTime& time, const Pl
     } else
         m_ringBuffer->store(downcast<WebAudioBufferList>(audioData).list(), numberOfFrames, time.timeValue());
     m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesAvailable { time, numberOfFrames }, m_identifier);
-}
-
-void MediaRecorderPrivate::storageChanged(SharedMemory* storage, const WebCore::CAAudioStreamDescription& format, size_t frameCount)
-{
-    // Heap allocations are forbidden on the audio thread for performance reasons so we need to
-    // explicitly allow the following allocation(s).
-    DisableMallocRestrictionsForCurrentThreadScope disableMallocRestrictions;
-
-    SharedMemory::Handle handle;
-    if (storage)
-        storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format, frameCount }, m_identifier);
 }
 
 void MediaRecorderPrivate::fetchData(CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, const String& mimeType, double)>&& completionHandler)

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -31,7 +31,7 @@
 #include "MediaRecorderIdentifier.h"
 #include "SharedCARingBuffer.h"
 #include "SharedVideoFrame.h"
-
+#include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaRecorderPrivate.h>
 #include <wtf/MediaTime.h>
 #include <wtf/WeakPtr.h>
@@ -69,8 +69,6 @@ private:
     // GPUProcessConnection::Client
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
-    void storageChanged(SharedMemory*, const WebCore::CAAudioStreamDescription& format, size_t frameCount);
-
     MediaRecorderIdentifier m_identifier;
     Ref<WebCore::MediaStreamPrivate> m_stream;
     Ref<IPC::Connection> m_connection;
@@ -78,7 +76,7 @@ private:
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     WebCore::CAAudioStreamDescription m_description { };
     std::unique_ptr<WebCore::WebAudioBufferList> m_silenceAudioBuffer;
-    int64_t m_numberOfFrames { 0 };
+    uint64_t m_numberOfFrames { 0 };
     WebCore::MediaRecorderPrivateOptions m_options;
     bool m_hasVideo { false };
     bool m_isStopped { false };

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -218,7 +218,7 @@ void RemoteCaptureSampleManager::RemoteAudio::setStorage(ConsumerSharedCARingBuf
 {
     stopThread();
     m_buffer = nullptr;
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_semaphore = WTFMove(semaphore);


### PR DESCRIPTION
#### 678b80c4edb8be97cb21b7f1141c9b154c50b591
<pre>
CARingBuffer uses CAAudioStreamDescription in a redundant way
<a href="https://bugs.webkit.org/show_bug.cgi?id=247430">https://bugs.webkit.org/show_bug.cgi?id=247430</a>
rdar://problem/101914553

Reviewed by Eric Carlson.

CARingBuffer structure is defined by channelCount, bytesPerFrame, frameCount. However,
it also stores CAAudioStreamDescription to define the contents of each frame
in case client wants to mix (contents can be floats, ints of different size).
CARingBuffer might also be used to transfer undefined frames (possibly non-PCM data), via the
copy operation.

Using CAAudioStreamDescription is problematic, as it is redundant information and it smuggles
the non-PCM data definition via the platform-specific descriptor which is not consistent.
In order to stop using CAAudioStreamDescription in the future patches, remove it from
CARingBuffer. The fetch() caller already knows what kind of data is expected, so this information
is redundant. This fixes the problem that the caller expectation and what is inside the
CARingBuffer could diverge.

Leave the use of CAAudioStreamDescription in the constructors, but remove it from the
internals of the classes.

This patch would affect the base-class constructors and functions. Take the opportunity
to change the CARingBuffer allocation logic: previously, one would construct an empty
instance and then at some point call allocate(). In case the allocate would fail, the
instance would stay &quot;empty&quot; with quite undefined behavior. Instead, make all CARingBuffer
classes be normal memory buffer classes: creation will allocate the buffer, and this
might fail. Deletion will deallocate.

Previously ProducerSharedCARingBuffer allocation sequence was a bit convoluted:
- WP proxy class would construct empty instance with a resize callback.
- When allocate and deallocate would succeed, the resize callback would be called.
- The callers would construct with a resize callback that would then
  send the &quot;audio storage changed&quot; message to the other process, typically GPUP.
The sequence would be linear, resize callback invocation would always follow
an allocate. However, it was written in non-linear fashion.

Instead just have a linear logic:
- WP proxy class constructs the shared buffer, and gets the buffer and
  client handle as a result.
- WP proxy class sends the client handle to the other process.

In order to return ConsumerSharedCARingBuffer::Handle (alias for
SharedMemory::Handle) as part of a struct, make it copyable.
Recent changes to SharedMemory::Handle enable this and were made
to for this purpose.

* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::setOutputFormat):
(WebCore::AudioSampleDataSource::pushSamplesInternal):
(WebCore::AudioSampleDataSource::pullSamples):
(WebCore::AudioSampleDataSource::pullSamplesInternal):
(WebCore::AudioSampleDataSource::pullAvailableSampleChunk):
(WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::CARingBuffer):
(WebCore::CARingBuffer::computeCapacityBytes):
(WebCore::CARingBuffer::computeSizeForBuffers):
(WebCore::CARingBuffer::initialize):
(WebCore::FetchABL):
(WebCore::CARingBuffer::fetchInternal):
(WebCore::InProcessCARingBuffer::allocate):
(WebCore::InProcessCARingBuffer::InProcessCARingBuffer):
(WebCore::CARingBuffer::initializeAfterAllocation): Deleted.
(WebCore::CARingBuffer::allocate): Deleted.
(WebCore::CARingBuffer::deallocate): Deleted.
(WebCore::InProcessCARingBuffer::allocateBuffers): Deleted.
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
(WebCore::CARingBuffer::fetchModeForMixing):
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::AudioSourceProviderAVFObjC):
(WebCore::AudioSourceProviderAVFObjC::prepare):
(WebCore::AudioSourceProviderAVFObjC::process):
(WebCore::AudioSourceProviderAVFObjC::setConfigureAudioStorageCallback):
(WebCore::AudioSourceProviderAVFObjC::setRingBufferCreationCallback): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::create):
(WebKit::RemoteAudioSourceProviderProxy::configureAudioStorage):
(WebKit::RemoteAudioSourceProviderProxy::createRingBuffer): Deleted.
(WebKit::RemoteAudioSourceProviderProxy::storageChanged): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::audioSamplesStorageChanged):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemory::Handle::Handle): Deleted.
(WebKit::SharedMemory::Handle::~Handle): Deleted.
* Source/WebKit/Platform/win/SharedMemoryWin.cpp:
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::SharedCARingBufferBase::SharedCARingBufferBase):
(WebKit::SharedCARingBufferBase::data):
(WebKit::SharedCARingBufferBase::sharedFrameBounds const):
(WebKit::SharedCARingBufferBase::updateFrameBounds):
(WebKit::SharedCARingBufferBase::size const):
(WebKit::ConsumerSharedCARingBuffer::map):
(WebKit::ProducerSharedCARingBuffer::allocate):
(WebKit::ProducerSharedCARingBuffer::setCurrentFrameBounds):
(WebKit::ConsumerSharedCARingBuffer::ConsumerSharedCARingBuffer): Deleted.
(WebKit::ConsumerSharedCARingBuffer::allocateBuffers): Deleted.
(WebKit::ProducerSharedCARingBuffer::setStorage): Deleted.
(WebKit::ProducerSharedCARingBuffer::allocateBuffers): Deleted.
(WebKit::ProducerSharedCARingBuffer::deallocateBuffers): Deleted.
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::~SourceProxy):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::storageChanged): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::setStorage):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::RemoteAudioDestinationProxy):
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::storageChanged): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::setStorage):
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::storageChanged): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::startRecording):
(WebKit::MediaRecorderPrivate::audioSamplesAvailable):
(WebKit::MediaRecorderPrivate::storageChanged): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::Source::Source):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::Source::~Source):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::Source::storageChanged): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::RemoteAudio::setStorage):
* Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp:
(TestWebKitAPI::CARingBufferTest::SetUp):
(TestWebKitAPI::CARingBufferTest::setup):
(TestWebKitAPI::MixingTest::run):

Canonical link: <a href="https://commits.webkit.org/256392@main">https://commits.webkit.org/256392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcdbbc3bdef76e90c8235295856fc504d5ef0e0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105229 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165529 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4979 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33667 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101078 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101312 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82269 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87428 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39401 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37100 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20282 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4419 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41096 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39533 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->