### PR TITLE
GPU Process should ensure CARingBuffers are used only for PCM audio

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -221,6 +221,7 @@ void RemoteAudioDestinationManager::stopAudioDestination(RemoteAudioDestinationI
 #if PLATFORM(COCOA)
 void RemoteAudioDestinationManager::audioSamplesStorageChanged(RemoteAudioDestinationIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
+    MESSAGE_CHECK(description.isPCM(), "Only PCM data is supported");
     if (auto* item = m_audioDestinations.get(identifier))
         item->audioSamplesStorageChanged(WTFMove(handle), description, numberOfFrames);
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -122,6 +122,11 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMed
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore)
 {
+    if (!description.isPCM()) {
+        ASSERT_IS_TESTING_IPC();
+        return;
+    }
+
     if (auto* unit = m_units.get(identifier))
         unit->start(WTFMove(handle), description, numberOfFrames, WTFMove(semaphore));
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -67,6 +67,7 @@ RemoteMediaRecorder::~RemoteMediaRecorder()
 void RemoteMediaRecorder::audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
 {
     MESSAGE_CHECK(m_recordAudio);
+    MESSAGE_CHECK(description.isPCM());
     m_audioBufferList = nullptr;
     m_ringBuffer = ConsumerSharedCARingBuffer::map(WTFMove(handle), description, numberOfFrames);
     if (!m_ringBuffer)


### PR DESCRIPTION
#### d66df43052837430db5bcfeeacffbdcb39a83882
<pre>
GPU Process should ensure CARingBuffers are used only for PCM audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=247485">https://bugs.webkit.org/show_bug.cgi?id=247485</a>
rdar://100552637

Reviewed by NOBODY (OOPS!).

* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::audioSamplesStorageChanged):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::audioSamplesStorageChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66df43052837430db5bcfeeacffbdcb39a83882

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105001 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4709 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33422 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100874 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101083 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3441 "Found 30 new test failures: fast/canvas/image-pattern-rotate.html, fast/history/page-cache-running-audiocontext.html, fast/history/page-cache-suspended-audiocontext.html, fast/mediastream/RTCRtpSender-outlives-RTCPeerConnection.html, fast/mediastream/audio-unit-reconfigure.html, fast/mediastream/media-devices-enumerate-devices.html, fast/mediastream/mock-media-source-webaudio.html, http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html, http/tests/security/webaudio-render-remote-audio-blocked-no-crossorigin-redirect.html, http/tests/security/webaudio-render-remote-audio-blocked-no-crossorigin.html ... (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82032 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30509 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73349 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20095 "Found 30 new test failures: fast/history/page-cache-running-audiocontext.html, fast/history/page-cache-suspended-audiocontext.html, fast/mediastream/RTCRtpSender-outlives-RTCPeerConnection.html, fast/mediastream/audio-unit-reconfigure.html, fast/mediastream/getUserMedia-webaudio.html, fast/mediastream/media-devices-enumerate-devices.html, fast/mediastream/mediastreamtrack-audio-clone.html, http/tests/appcache/top-frame-1.html, http/tests/security/webaudio-render-remote-audio-allowed-crossorigin-redirect.html, http/tests/security/webaudio-render-remote-audio-allowed-crossorigin.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40890 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39340 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->