### PR TITLE
[ews-build.webkit.org] Add Python hooks for results.webkit.org results-summary endpoint

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+import requests
+import sys
+
+
+class ResultsDatabase(object):
+    HOSTNAME = 'https://results.webkit.org'
+    # TODO: Support more suites (Note, the API we're talking to already does)
+    SUITE = 'layout-tests'
+    PERCENT_THRESHOLD = 10
+    CONFIGURATION_KEYS = [
+        'architecture',
+        'platform',
+        'is_simulator',
+        'version',
+        'flavor',
+        'style',
+        'model',
+        'version_name',
+        'sdk',
+    ]
+
+    @classmethod
+    def get_results_summary(cls, test, commit=None, configuration=None):
+        params = dict()
+        for key, value in configuration.items():
+            if key not in cls.CONFIGURATION_KEYS:
+                sys.stderr.write(f"'{key}' is not a valid configuration key\n")
+            params[key] = value
+        if commit:
+            params['ref'] = commit
+        response = requests.get(f'{cls.HOSTNAME}/api/results-summary/{cls.SUITE}/{test}', params=params)
+        if response.status_code != 200:
+            sys.stderr.write(f"Failed to query results summary with status code '{response.status_code}'\n")
+            return None
+        try:
+            return response.json()
+        except json.decoder.JSONDecodeError:
+            sys.stderr.write('Non-json response from results summary query\n')
+            return None
+
+    @classmethod
+    def is_test_expected_to(cls, test, result_type=None, commit=None, configuration=None, log=False):
+        data = cls.get_results_summary(test, commit=commit, configuration=configuration)
+        if log:
+            print(test)
+            for key, value in (data or dict()).items():
+                if not value:
+                    continue
+                print(f'    {key}: {value}%')
+            if not data:
+                print('    No historic data found for query')
+        if not data:
+            return -1
+        if result_type:
+            return data.get(result_type.lower(), 0) > cls.PERCENT_THRESHOLD
+        return 100 - (data.get('pass', 0) + data.get('warning', 0)) > cls.PERCENT_THRESHOLD
+
+    @classmethod
+    def main(cls, args=None):
+        parser = argparse.ArgumentParser(
+            description='A script which uses the same logic ews-build.webkit.org does to determine if a given ' +
+                        'test in a given configuration on a specific commit is currently expected to fail.',
+        )
+        parser.add_argument(
+            'test', type=str,
+            help='The test to return results for.',
+        )
+        parser.add_argument(
+            '-c', '--commit',
+            type=str, default=None,
+            help='Commit ref to focus on',
+        )
+        parser.add_argument(
+            '-r', '--result',
+            type=str, default=None,
+            help='Result to filter for (failure, crash, timeout, ect.)',
+        )
+        parser.add_argument(
+            '-s', '--style',
+            type=str, default=None,
+            help='Build style configuration to focus on (debug, release, ect.)',
+        )
+        parser.add_argument(
+            '-p', '--platform',
+            type=str, default=None,
+            help='Platform to focus on (mac, ios, gtk, ect.)',
+        )
+        parser.add_argument(
+            '-f', '--flavor',
+            type=str, default=None,
+            help='Flavor to focus on (wk1, wk2, ect.)',
+        )
+        parser.add_argument(
+            '-v', '--version',
+            type=str, default=None,
+            help='OS version focus on (Ventura, Monterey, ect.)',
+        )
+        parser.add_argument(
+            '-a', '--architecture',
+            type=str, default=None,
+            help='Architecture focus on (arm64, x86_64, ect.)',
+        )
+        parsed = parser.parse_args(args)
+
+        configuration = dict()
+        for key in cls.CONFIGURATION_KEYS:
+            attr = getattr(parsed, key, None)
+            if attr:
+                configuration[key] = attr
+
+        if cls.is_test_expected_to(parsed.test, result_type=parsed.result, commit=parsed.commit, log=True, configuration=configuration):
+            print('EXPECTED')
+        else:
+            print('UNEXPECTED')
+        return 0
+
+
+if __name__ == '__main__':
+    sys.exit(ResultsDatabase.main())


### PR DESCRIPTION
#### 808a499669d0be1ed31fd49e69eaa948d5b0d4d5
<pre>
[ews-build.webkit.org] Add Python hooks for results.webkit.org results-summary endpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=247489">https://bugs.webkit.org/show_bug.cgi?id=247489</a>
rdar://101960268

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/results_db.py: Added.
(ResultsDatabase.get_results_summary): Return summary endpoint data.
(ResultsDatabase.is_test_expected_to): Compare summary endpoint data to a
threshold and return a binary result.
(ResultsDatabase.main): Simple command line interface for local verification
of EWS behavior.

Canonical link: <a href="https://commits.webkit.org/256346@main">https://commits.webkit.org/256346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b277feb59a8a11decc19f6d4f36f49a908da490

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105081 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4794 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33501 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87870 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/100940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101163 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82112 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30576 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73413 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/94476 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/36962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20159 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4388 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/40958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/42946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39406 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->