### PR TITLE
[EME] Keep MediaKeySystemAccess alive in createMediaKeys() async task

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h
@@ -30,6 +30,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include "ActiveDOMObject.h"
 #include "MediaKeySystemConfiguration.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
@@ -42,9 +43,9 @@ class DeferredPromise;
 class Document;
 class MediaKeys;
 
-class MediaKeySystemAccess : public RefCounted<MediaKeySystemAccess>, public CanMakeWeakPtr<MediaKeySystemAccess> {
+class MediaKeySystemAccess : public RefCounted<MediaKeySystemAccess>, public CanMakeWeakPtr<MediaKeySystemAccess>, public ActiveDOMObject {
 public:
-    static Ref<MediaKeySystemAccess> create(const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
+    static Ref<MediaKeySystemAccess> create(Document&, const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
     ~MediaKeySystemAccess();
 
     const String& keySystem() const { return m_keySystem; }
@@ -52,7 +53,10 @@ public:
     void createMediaKeys(Document&, Ref<DeferredPromise>&&);
 
 private:
-    MediaKeySystemAccess(const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
+    MediaKeySystemAccess(Document&, const String& keySystem, MediaKeySystemConfiguration&&, Ref<CDM>&&);
+
+    // ActiveDOMObject
+    const char *activeDOMObjectName() const final { return "MediaKeySystemAccess"; }
 
     String m_keySystem;
     std::unique_ptr<MediaKeySystemConfiguration> m_configuration;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.idl
@@ -27,6 +27,7 @@
  */
 
 [
+    ActiveDOMObject,
     Conditional=ENCRYPTED_MEDIA,
     EnabledBySetting=EncryptedMediaAPIEnabled,
     DisabledByQuirk=hasBrokenEncryptedMediaAPISupport,


### PR DESCRIPTION
#### ce9671b4d61efff2bce123ee2ec64018d9dc86fb
<pre>
[EME] Keep MediaKeySystemAccess alive in createMediaKeys() async task
<a href="https://bugs.webkit.org/show_bug.cgi?id=247490">https://bugs.webkit.org/show_bug.cgi?id=247490</a>

Reviewed by Philippe Normand.

Put MediaKeySystemAccess under ActiveDOMObject interface
and make sure that GC won&apos;t destroy an object before
it executes its async task and createMediaKeys() func is completed.

Sometimes it happens that GC destroys MediaKeySystemAccess object
in the middle of createMediaKeys() func, before promise is completed
and JS MediaKeys are never created.

This fixes YT Cert Test: EME, WidevineH264MultiMediaKeySessions

Patch based on one by Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt; coming from
<a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/922">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/922</a> .

* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp:
(WebCore::MediaKeySystemAccess::create):
(WebCore::MediaKeySystemAccess::MediaKeySystemAccess):
(WebCore::MediaKeySystemAccess::createMediaKeys):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.idl:
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WebCore::NavigatorEME::requestMediaKeySystemAccess):
(WebCore::tryNextSupportedConfiguration):

Canonical link: <a href="https://commits.webkit.org/256442@main">https://commits.webkit.org/256442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dada13633ef095ab4071686280dd365d6b505cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105017 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165286 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4729 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33440 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100890 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3461 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82049 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87266 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73364 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/list-markers, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39222 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18820 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36925 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4453 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42773 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39362 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->