### PR TITLE
Assertion in WebCore::calculateAdjustedInnerBorder()

### DIFF
--- a/LayoutTests/css3/calc/inner-border-radius-longer-than-width-expected.html
+++ b/LayoutTests/css3/calc/inner-border-radius-longer-than-width-expected.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius">
+<style>
+.class4 {
+  /* bug happens when width < border-bottom-left-radius + border-bottom-right-radius (horizontal) with vertical axis of the elipse values set to 0 */
+  border-bottom: solid;
+  width: 200px;
+  height: 200px;
+  background-color: darkgoldenrod;
+  border-right: 100px solid red;
+  border-bottom-width: 43px;
+}
+</style>
+</head>
+<body>
+<div class="class4"></div>
+</body>
+</html>

--- a/LayoutTests/css3/calc/inner-border-radius-longer-than-width.html
+++ b/LayoutTests/css3/calc/inner-border-radius-longer-than-width.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius">
+<style>
+.class4 {
+  /* bug happens when width < border-bottom-left-radius + border-bottom-right-radius (horizontal) with vertical axis of the elipse values set to 0 */
+  border-bottom: solid;
+  width: 200px;
+  height: 200px;
+  background-color: darkgoldenrod;
+  border-right: 100px solid red;
+  border-bottom-width: 43px;
+
+  /* 130 + 130 = 260 > width */
+  border-bottom-left-radius: 130px 0px;
+  border-bottom-right-radius: 130px 0px;
+}
+</style>
+</head>
+<body>
+<div class="class4"></div>
+</body>
+</html>

--- a/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
+++ b/Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp
@@ -85,7 +85,7 @@ private:
 
     static bool borderWillArcInnerEdge(const FloatSize& firstRadius, const FloatSize& secondRadius)
     {
-        return !firstRadius.isZero() || !secondRadius.isZero();
+        return !firstRadius.isEmpty() || !secondRadius.isEmpty();
     }
 
     static bool borderStyleHasUnmatchedColorsAtCorner(BorderStyle, BoxSide, BoxSide adjacentSide);

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -536,7 +536,7 @@ void BorderPainter::paintTranslucentBorderSides(const RoundedRect& outerBorder, 
 
 static bool borderWillArcInnerEdge(const LayoutSize& firstRadius, const LayoutSize& secondRadius)
 {
-    return !firstRadius.isZero() || !secondRadius.isZero();
+    return !firstRadius.isEmpty() || !secondRadius.isEmpty();
 }
 
 inline bool styleRequiresClipPolygon(BorderStyle style)

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -59,10 +59,10 @@ public:
 
     bool hasBorderRadius() const
     {
-        return !m_radii.topLeft.width.isZero()
-            || !m_radii.topRight.width.isZero()
-            || !m_radii.bottomLeft.width.isZero()
-            || !m_radii.bottomRight.width.isZero();
+        return !m_radii.topLeft.isEmpty()
+            || !m_radii.topRight.isEmpty()
+            || !m_radii.bottomLeft.isEmpty()
+            || !m_radii.bottomRight.isEmpty();
     }
 
     float borderLeftWidth() const


### PR DESCRIPTION
#### bdb44a70527586f1b1b746cfda75a2b0ae00c7f6
<pre>
Assertion in WebCore::calculateAdjustedInnerBorder()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247569">https://bugs.webkit.org/show_bug.cgi?id=247569</a>
rdar://99885016

Reviewed by Antti Koivisto.

The adjusting function calculateAdjustedInnerBorder assumes it will be called only when:

[1]: the radii of one of the vertex of the edge we are painting is zero.

In BorderPainter::paintBorderSides(...), when borderWillArcInnerEdge(...) evaluates to true,
a path would be used for calling paintOneBorderSide(...) which would result in calculateAdjustedInnerBorder
being called when [1] does not hold for the test added here.

borderWillArcInnerEdge return trues if one of the radius it receives isZero(), however isZero() checks
that both height and width of the radius are zero, while one of them being zero would already invalidate
rendering the border as rounded, as described by <a href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radii">https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radii</a>

Therefore, we propose changing borderWillArcInnerEdge to use isEmpty(), that checks that the height or width of
the radius is zero.

* LayoutTests/css3/calc/inner-border-radius-longer-than-width.html: Added.
* LayoutTests/css3/calc/inner-border-radius-longer-than-width-expected.html: Added.

This test would trigger the following assertion on calculateAdjustedInnerBorder():
&apos;ASSERT(!(newRadii.bottomLeft().width() &amp;&amp; newRadii.bottomRight().width()));&apos;

* Source/WebCore/rendering/style/BorderData.h:
(WebCore::BorderData::hasBorderRadius const):
* Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp:
(WebCore::Display::BorderPainter::borderWillArcInnerEdge):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::borderWillArcInnerEdge):

borderWillArchInnerEdge() and hasBorderRadius() uses now isEmpty() instead of isZero(), since isEmpty()
checks if either the height or width of the radius is zero.

Canonical link: <a href="https://commits.webkit.org/256445@main">https://commits.webkit.org/256445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3ae35288874ae9ce9f0b86c55c2b77b532eb5ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105367 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165676 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5126 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33801 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88173 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101197 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101449 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82400 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73657 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39532 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37223 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4454 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41283 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39655 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->