### PR TITLE
Make sure scriptExecutionContext stays around when invoking listeners

### DIFF
--- a/LayoutTests/js/frame-application-cache-with-listener-crash-expected.txt
+++ b/LayoutTests/js/frame-application-cache-with-listener-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash or hit any assertions

--- a/LayoutTests/js/frame-application-cache-with-listener-crash.html
+++ b/LayoutTests/js/frame-application-cache-with-listener-crash.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script>
+function runTest()
+{
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    iframe.contentWindow.applicationCache.addEventListener("checking", () => {
+        document.body.appendChild(iframe);
+        document.body.innerHTML = 'This test passes if WebKit does not crash or hit any assertions';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, {capture: true, passive: true});
+}
+</script>
+<body onload="runTest()">
+<iframe id="iframe" src="data:text/html,foo"></iframe>
+<div id="container">
+</body>

--- a/Source/WebCore/loader/appcache/DOMApplicationCache.cpp
+++ b/Source/WebCore/loader/appcache/DOMApplicationCache.cpp
@@ -87,10 +87,10 @@ void DOMApplicationCache::abort()
 
 ScriptExecutionContext* DOMApplicationCache::scriptExecutionContext() const
 {
-    auto* frame = this->frame();
-    if (!frame)
+    auto* window = this->window();
+    if (!window)
         return nullptr;
-    return frame->document();
+    return window->document();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1624156ba5f959a0e7cdb9e804271e3a493853ed
<pre>
Make sure scriptExecutionContext stays around when invoking listeners
<a href="https://bugs.webkit.org/show_bug.cgi?id=247380">https://bugs.webkit.org/show_bug.cgi?id=247380</a>

Reviewed by Ryosuke Niwa.

This change fixes DOMApplicationCache::scriptExecutionContext to get the
correct scriptExecutionContext by getting it from the window instead of
the frame because the frame can navigate when invoking event listeners, in which
case the scriptExecutionContext will become NULL.

* LayoutTests/js/frame-application-cache-with-listener-crash-expected.txt: Added.
* LayoutTests/js/frame-application-cache-with-listener-crash.html: Added.
* Source/WebCore/loader/appcache/DOMApplicationCache.cpp:
(WebCore::DOMApplicationCache::scriptExecutionContext const):

Canonical link: <a href="https://commits.webkit.org/256402@main">https://commits.webkit.org/256402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16de0a84ef33c083ba16e74bd552796c672241b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105064 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165330 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4778 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33484 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100927 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3492 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82094 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30564 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85384 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39250 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36951 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20151 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4427 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42805 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39398 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->