### PR TITLE
Fix expected, actual links for variant-based imported wpt tests

### DIFF
--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -299,22 +299,39 @@ class Utils
         return null;
     }
 
-    static stripExtension(testName)
+    static testPrefix(testName)
     {
-        // Temporary fix, also in Tools/Scripts/webkitpy/layout_tests/constrollers/test_result_writer.py, line 95.
-        // FIXME: Refactor to avoid confusing reference to both test and process names.
-        if (Utils.splitExtension(testName)[1].length > 5)
+        let parts = Utils.splitExtension(testName);
+        let prefix = parts[0];
+        let remains = parts[2];
+        if (remains) {
+            if (remains.includes('?'))
+                prefix += '_' + remains.split('?')[1]
+            else if (remains.includes('#'))
+                prefix += '_' + remains.split('#')[1]
+        } else if (Utils.splitExtension(parts[0])[1].length > 5) {
+            // Temporary fix, also in Tools/Scripts/webkitpy/layout_tests/constrollers/test_result_writer.py, line 115.
+            // FIXME: Refactor to avoid confusing reference to both test and process names.
             return testName;
-        return Utils.splitExtension(testName)[0];
+        }
+        return prefix;
     }
 
     static splitExtension(testName)
     {
-        let index = testName.lastIndexOf('.');
-        if (index == -1) {
-            return [testName, ''];
-        }
-        return [testName.substring(0, index), testName.substring(index + 1)];
+        // Splits 'foo/bar/boo.html?blah' to ['foo/bar/boo', '.html', '?blah']. Last item can be
+        // null if `testName` had no URL fragment or query separator.
+        let filenameIndex = testName.lastIndexOf("/");
+        let buffer = testName.substr(filenameIndex + 1);
+        buffer = buffer.split('?')[0];
+        buffer = buffer.split('#')[0];
+        let parts = buffer.split('.');
+        let extensionIndex = buffer.lastIndexOf(".");
+        let filename = buffer.substr(0, extensionIndex);
+        let ext = buffer.substr(extensionIndex);
+        let remainsIndex = testName.lastIndexOf(ext);
+        let remains = testName.substr(remainsIndex + ext.length);
+        return [testName.substr(0, filenameIndex) + '/' + filename, ext, remains];
     }
 
     static forEach(nodeList, handler)
@@ -1200,7 +1217,7 @@ class TestResultsController
                 TestResultsController._getResultContainer(node).remove();
             else if (url.match('-actual.png$')) {
                 let name = Utils.parentOfType(node, 'tbody').querySelector('.test-link').textContent;
-                TestResultsController._getResultContainer(node).outerHTML = togglingImageFunction(Utils.stripExtension(name));
+                TestResultsController._getResultContainer(node).outerHTML = togglingImageFunction(Utils.testPrefix(name));
             }
         }
     }
@@ -1376,7 +1393,7 @@ class FailuresSectionBuilder extends SectionBuilder {
 
         let actualTokens = testResult.info.actual.split(/\s+/);
 
-        let testPrefix = Utils.stripExtension(testResult.name);
+        let testPrefix = Utils.testPrefix(testResult.name);
         let imageResults = this.imageResultLinks(testResult, testPrefix, actualTokens[0]);
         if (!imageResults && actualTokens.length > 1)
             imageResults = this.imageResultLinks(testResult, 'retries/' + testPrefix, actualTokens[1]);
@@ -1406,12 +1423,12 @@ class FailuresSectionBuilder extends SectionBuilder {
 
     appendTextFailureLinks(testResult, cell)
     {
-        cell.innerHTML += this._resultsController.textResultLinks(Utils.stripExtension(testResult.name));
+        cell.innerHTML += this._resultsController.textResultLinks(Utils.testPrefix(testResult.name));
     }
     
     appendAudioFailureLinks(testResult, cell)
     {
-        let prefix = Utils.stripExtension(testResult.name);
+        let prefix = Utils.testPrefix(testResult.name);
         cell.innerHTML += TestResultsController.resultLink(prefix, '-expected.wav', 'expected audio')
             + TestResultsController.resultLink(prefix, '-actual.wav', 'actual audio')
             + TestResultsController.resultLink(prefix, '-diff.txt', 'textual diff');
@@ -1419,7 +1436,7 @@ class FailuresSectionBuilder extends SectionBuilder {
     
     appendActualOnlyLinks(testResult, cell)
     {
-        let prefix = Utils.stripExtension(testResult.name);
+        let prefix = Utils.testPrefix(testResult.name);
         if (testResult.isMissingAudio())
             cell.innerHTML += TestResultsController.resultLink(prefix, '-actual.wav', 'audio result');
 
@@ -1503,7 +1520,7 @@ class TestsWithStdErrSectionBuilder extends SectionBuilder {
 
     fillTestResultCell(testResult, cell)
     {
-        cell.innerHTML = TestResultsController.resultLink(Utils.stripExtension(testResult.name), '-stderr.txt', 'stderr');
+        cell.innerHTML = TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-stderr.txt', 'stderr');
     }
 };
 
@@ -1513,7 +1530,7 @@ class TimedOutTestsSectionBuilder extends SectionBuilder {
     fillTestResultCell(testResult, cell)
     {
         // FIXME: only include timeout actual/diff results here if we actually spit out results for timeout tests.
-        cell.innerHTML = this._resultsController.textResultLinks(Utils.stripExtension(testResult.name));
+        cell.innerHTML = this._resultsController.textResultLinks(Utils.testPrefix(testResult.name));
     }
 };
 
@@ -1522,8 +1539,8 @@ class CrashingTestsSectionBuilder extends SectionBuilder {
 
     fillTestResultCell(testResult, cell)
     {
-        cell.innerHTML = TestResultsController.resultLink(Utils.stripExtension(testResult.name), '-crash-log.txt', 'crash log')
-                       + TestResultsController.resultLink(Utils.stripExtension(testResult.name), '-sample.txt', 'sample');
+        cell.innerHTML = TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-crash-log.txt', 'crash log')
+                       + TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-sample.txt', 'sample');
     }
 };
 
@@ -1531,7 +1548,7 @@ class OtherCrashesSectionBuilder extends SectionBuilder {
     sectionTitle() { return 'Other crashes'; }
     fillTestResultCell(testResult, cell)
     {
-        cell.innerHTML = TestResultsController.resultLink(Utils.stripExtension(testResult.name), '-crash-log.txt', 'crash log');
+        cell.innerHTML = TestResultsController.resultLink(Utils.testPrefix(testResult.name), '-crash-log.txt', 'crash log');
     }
 
     createHistoryCell(testResult)

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py
@@ -100,18 +100,25 @@ class TestResultWriter(object):
 
         ext_parts = fs.splitext(self._test_name)
         output_basename = ext_parts[0]
-        if len(ext_parts) > 1 and '?' in ext_parts[1]:
-            output_basename += '_' + ext_parts[1].split('?')[1]
-        if len(ext_parts) > 1 and '#' in ext_parts[1]:
-            output_basename += '_' + ext_parts[1].split('#')[1]
+        extension = ext_parts[1]
 
-        output_filename = fs.join(self._root_output_dir, output_basename + ext_parts[1])
+        # Find the actual file extension while keeping track of URI fragment or query, if any. Only
+        # the last extra part will be used for naming the output file, eg if self._test_name is
+        # "foo.html?bar#blah" then final output_basename will be "foo_blah" and extension will be
+        # ".html".
+        extra_part = ''
+        for char in ('?', '#'):
+            index = extension.find(char)
+            if index != -1:
+                extension, extra_part = extension[:index], extension[index + 1:]
 
-        # Temporary fix, also in LayoutTests/fast/harness/results.html, line 275.
-        # FIXME: Refactor to avoid confusing reference to both test and process names.
-        if len(fs.splitext(output_filename)[1]) - 1 > 5:
-            return output_filename + modifier
-        return fs.splitext(output_filename)[0] + modifier
+        if len(extension) - 1 > 5:
+            # Temporary fix, also in LayoutTests/fast/harness/results.html, line 313.
+            # FIXME: Refactor to avoid confusing reference to both test and process names.
+            return fs.join(self._root_output_dir, self._test_name) + modifier
+        elif extra_part:
+            output_basename += '_' + extra_part
+        return fs.join(self._root_output_dir, output_basename) + modifier
 
     def _write_binary_file(self, path, contents):
         if contents is not None:

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
@@ -61,3 +61,24 @@ class TestResultWriterTest(unittest.TestCase):
         fs = host.filesystem
         writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), 'require-corp-revalidated-images.https.html')
         self.assertEqual(writer.output_filename('-diff.txt'), fs.join(port.results_directory(), 'require-corp-revalidated-images.https-diff.txt'))
+
+    def test_output_filename_worker_variant(self):
+        host = MockHost()
+        port = TestPort(host)
+        fs = host.filesystem
+        writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), 'template_test/pbkdf2.https.any.worker.html?1-1000')
+        self.assertEqual(fs.join(port.results_directory(), 'template_test/pbkdf2.https.any.worker_1-1000-diff.txt'), writer.output_filename('-diff.txt'))
+
+    def test_output_filename_variant(self):
+        host = MockHost()
+        port = TestPort(host)
+        fs = host.filesystem
+        writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), 'template_test2/pbkdf2.https.any.html?1-1000')
+        self.assertEqual(fs.join(port.results_directory(), 'template_test2/pbkdf2.https.any_1-1000-diff.txt'), writer.output_filename('-diff.txt'))
+
+    def test_output_svg_filename(self):
+        host = MockHost()
+        port = TestPort(host)
+        fs = host.filesystem
+        writer = test_result_writer.TestResultWriter(fs, port, port.results_directory(), 'svg/W3C-SVG-1.1/animate-elem-02-t.svg')
+        self.assertEqual(fs.join(port.results_directory(), 'svg/W3C-SVG-1.1/animate-elem-02-t-diff.txt'), writer.output_filename('-diff.txt'))


### PR DESCRIPTION
#### 3be2c0d6c2ab7ebbf322a81a391cd2627c687d77
<pre>
Fix expected, actual links for variant-based imported wpt tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=238832">https://bugs.webkit.org/show_bug.cgi?id=238832</a>
&lt;rdar://problem/91313891&gt;

Reviewed by Jonathan Bedard.

Ensure that the workaround involving &quot;len(fs.splitext(output_basename)[1]) - 1 &gt; 5&quot;
does not affect imported templated wpt tests that may match that condition, such as
&quot;.../pbkdf2.https.any.worker.html.&quot;

A unittest for SVG results was added as well, since the initial patch was reverted due to this case.

Based on rolled out patch authored by J Pascoe  &lt;j_pascoe@apple.com&gt;.

* LayoutTests/fast/harness/results.html:
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer.py:
(TestResultWriter.output_filename):
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py:
(TestResultWriterTest.test_output_filename):
(TestResultWriterTest):
(TestResultWriterTest.test_output_filename_worker_variant):
(TestResultWriterTest.test_output_filename_variant):
(TestResultWriterTest.test_output_svg_filename):

Canonical link: <a href="https://commits.webkit.org/256703@main">https://commits.webkit.org/256703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c079afebcbb4dca64715e2267397dcf53c46cfe6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106113 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6037 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34581 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102824 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4498 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83190 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31471 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100178 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40312 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37975 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21115 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4244 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40391 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->