### PR TITLE
[run-webkit-tests] Reduce shard size

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
@@ -327,6 +327,17 @@ class SharderTests(unittest.TestCase):
              ('.', ['ietestcenter/Javascript/11.1.5_4-4-c-1.html']),
              ('.', ['dom/html/level2/html/HTMLAnchorElement06.html'])])
 
+    def test_large_shard(self):
+        shards = self.get_shards(
+            num_workers=2,
+            fully_parallel=False,
+            test_list=['fast/css/test-{}'.format(i) for i in range(255)],
+        )
+        self.assertEqual(len(shards), 3)
+        self.assertEqual(len(shards[0].test_inputs), 64)
+        self.assertEqual(len(shards[1].test_inputs), 64)
+        self.assertEqual(len(shards[2].test_inputs), 127)
+
 
 class ShardTests(unittest.TestCase):
     def test_pickle(self):


### PR DESCRIPTION
#### 27cad66929529cfcb8e4c92de1f37eb1623d5fc1
<pre>
[run-webkit-tests] Reduce shard size
<a href="https://bugs.webkit.org/show_bug.cgi?id=247501">https://bugs.webkit.org/show_bug.cgi?id=247501</a>
<a href="https://rdar.apple.com/101973633">rdar://101973633</a>

Reviewed by NOBODY (OOPS!).

Establish an explicit ceiling on shard size by taking directories greater than 128 tests and then
seperate each file into a bucket based on path. Continue recurisvely spliting each bucket unit either
the bucket is smaller than 128 tests we&apos;ve run out of crc32 bits to bucket tests into.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(Sharder.shards_for_directory): Recursively break up shards greater than 128 tests.
(Sharder._shard_by_directory): Pass every directory to shards_for_directory to be recursively splilt.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(SharderTests.test_large_shard):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27cad66929529cfcb8e4c92de1f37eb1623d5fc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41526 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22646 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/50831 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1177 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/9422 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55833 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48935 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48058 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->