### PR TITLE
Extraneous interaction regions for elements inside <button>s

### DIFF
--- a/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
+++ b/LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt
@@ -1,0 +1,25 @@
+
+inner
+button
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (region
+            (rect (2,1) width=46 height=31)
+)
+        (borderRadius 0.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/icon-inside-button-single-region.html
+++ b/LayoutTests/interaction-region/icon-inside-button-single-region.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+</style>
+<body>
+<button><div style="cursor: pointer;" onclick="5">inner</div> button</button>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -27,12 +27,14 @@
 #include "InteractionRegion.h"
 
 #include "Document.h"
+#include "ElementAncestorIterator.h"
 #include "ElementInlines.h"
 #include "Frame.h"
 #include "FrameSnapshotting.h"
 #include "FrameView.h"
 #include "GeometryUtilities.h"
 #include "HTMLAnchorElement.h"
+#include "HTMLButtonElement.h"
 #include "HTMLFieldSetElement.h"
 #include "HTMLFormControlElement.h"
 #include "HitTestResult.h"
@@ -86,6 +88,8 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         element = regionRenderer.node()->parentElement();
     if (auto* linkElement = element->enclosingLinkEventParentOrSelf())
         element = linkElement;
+    if (auto* buttonElement = ancestorsOfType<HTMLButtonElement>(*element).first())
+        element = buttonElement;
 
     if (!element || !element->renderer())
         return std::nullopt;


### PR DESCRIPTION
#### 5f642f0bd561aacd6780b4f736034bbe207d28fb
<pre>
Extraneous interaction regions for elements inside &lt;button&gt;s
<a href="https://bugs.webkit.org/show_bug.cgi?id=247508">https://bugs.webkit.org/show_bug.cgi?id=247508</a>
rdar://101979741

Reviewed by Wenson Hsieh.

* LayoutTests/interaction-region/icon-inside-button-single-region-expected.txt: Added.
* LayoutTests/interaction-region/icon-inside-button-single-region.html: Added.
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Promote interaction regions for elements inside a &lt;button&gt; up to their &lt;button&gt;,
treating that as a grouping hint, like we do for &lt;a&gt;.

Canonical link: <a href="https://commits.webkit.org/256432@main">https://commits.webkit.org/256432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2442984294d959b8a9cbaf678e173214c1886c27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105083 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165343 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4792 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33499 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87868 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100938 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3499 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82110 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30575 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73412 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39260 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18861 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36961 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4447 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42812 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42945 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39409 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->