### PR TITLE
Adopt new ARQL scene API when possible

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h
@@ -37,6 +37,10 @@
 #import <AssetViewer/ASVInlinePreview.h>
 #endif
 
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
+#import <AssetViewer/ASVLaunchPreview.h>
+#endif
+
 #else
 
 #import <UIKit/UIKit.h>
@@ -122,6 +126,11 @@ typedef void (^ASVSetIsPlayingReplyBlock) (BOOL isPlaying, NSError * _Nullable e
 @property (nonatomic, retain, nullable) NSURL *canonicalWebPageURL;
 @property (nonatomic, retain, nullable) NSString *urlFragment;
 
+@end
+
+@interface ASVLaunchPreview : NSObject
++ (void)beginPreviewApplicationWithURLs:(nonnull NSArray *)urls is3DContent:(BOOL)is3DContent completion:(nonnull void (^)(NSError * _Nullable))handler;
++ (void)launchPreviewApplicationWithURLs:(nonnull NSArray *)urls completion:(nonnull void (^)(NSError * _Nullable))handler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -165,6 +165,8 @@ void LegacyDownloadClient::didCreateDestination(DownloadProxy& downloadProxy, co
 #if USE(SYSTEM_PREVIEW)
     if (downloadProxy.isSystemPreviewDownload()) {
         downloadProxy.setDestinationFilename(destination);
+        if (auto* controller = systemPreviewController(downloadProxy))
+            controller->setDestinationURL(URL::fileURLWithFileSystemPath(downloadProxy.destinationFilename()));
         return;
     }
 #endif

--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -51,6 +51,7 @@ public:
     bool canPreview(const String& mimeType) const;
 
     void start(URL originatingPageURL, const String& mimeType, const WebCore::SystemPreviewInfo&);
+    void setDestinationURL(URL);
     void updateProgress(float);
     void finish(URL);
     void cancel();
@@ -66,6 +67,7 @@ public:
 private:
     WebPageProxy& m_webPageProxy;
     WebCore::SystemPreviewInfo m_systemPreviewInfo;
+    URL m_destinationURL;
 #if USE(QUICK_LOOK)
     RetainPtr<QLPreviewController> m_qlPreviewController;
     RetainPtr<_WKPreviewControllerDelegate> m_qlPreviewControllerDelegate;


### PR DESCRIPTION
#### 9626f28c4f960793e9efcd05937293dd62cb930b
<pre>
Adopt new ARQL scene API when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=247511">https://bugs.webkit.org/show_bug.cgi?id=247511</a>
rdar://101981518

Reviewed by Sam Weinig.

AR Quick Look are exposing a new API to launch scenes.
Add support for it when the right compile-time flags
are set.

* Source/WebCore/PAL/pal/spi/ios/SystemPreviewSPI.h:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::didCreateDestination):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/SystemPreviewController.h:

Canonical link: <a href="https://commits.webkit.org/256671@main">https://commits.webkit.org/256671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88800c3a8fe7fa9dcd53fa694d7160d660cc9726

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106017 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5913 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34475 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88855 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102150 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83079 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40206 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37878 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/4147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2213 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/959 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->