### PR TITLE
Replaced elements with aspect ratio and size in one dimension should respect min-max constraints in opposite dimension.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-039-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-039-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Replaced element honors transferred max-height</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="SVG item with aspect ratio + intrinsic width + no intrinsic height honors transferred max-height." />
+
+<style>
+    div {
+        width: 100px;
+        height:100px;
+        background-color: green;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-039.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-039.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Replaced element honors transferred max-height</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="SVG item with aspect ratio + intrinsic width + no intrinsic height honors transferred max-height." />
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' width='200'%3E%3Crect width='100%25' height='100%25' fill='green'/%3E%3C/svg%3E" style="max-height: 100px; flex: 0 0 auto; background: red;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-040-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-040-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Replaced element honors transferred max-height</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="SVG item with aspect ratio + intrinsic width + no intrinsic height honors transferred max-height." />
+
+<style>
+    div {
+        width: 100px;
+        height:100px;
+        background-color: green;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-040.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-040.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Replaced element honors transferred max-width</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<meta name="assert" content="SVG item with aspect ratio + intrinsic height + no intrinsic width honors transferred max-width." />
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' height='200'%3E%3Crect width='100%25' height='100%25' fill='green'/%3E%3C/svg%3E" style="max-width: 100px; flex: 0 0 auto; background: red;">

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2428,7 +2428,7 @@ void RenderBlock::computeChildPreferredLogicalWidths(RenderObject& child, Layout
         auto& box = downcast<RenderBox>(child);
         if (box.shouldComputeLogicalHeightFromAspectRatio() && box.style().logicalWidth().isFixed()) {
             LayoutUnit logicalWidth = LayoutUnit(box.style().logicalWidth().value());
-            minPreferredLogicalWidth = maxPreferredLogicalWidth = blockSizeFromAspectRatio(box.horizontalBorderAndPaddingExtent(), box.verticalBorderAndPaddingExtent(), LayoutUnit(box.style().logicalAspectRatio()), box.style().boxSizingForAspectRatio(), logicalWidth);
+            minPreferredLogicalWidth = maxPreferredLogicalWidth = blockSizeFromAspectRatio(box.horizontalBorderAndPaddingExtent(), box.verticalBorderAndPaddingExtent(), LayoutUnit(box.style().logicalAspectRatio()), box.style().boxSizingForAspectRatio(), logicalWidth, style().aspectRatioType(), isRenderReplaced());
             return;
         }
         minPreferredLogicalWidth = maxPreferredLogicalWidth = box.computeLogicalHeightWithoutLayout();
@@ -3202,7 +3202,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         // Only grid is expected to be in a state where it is calculating pref width and having unknown logical width.
         if (isRenderGrid() && preferredLogicalWidthsDirty() && !style().logicalWidth().isSpecified())
             return availableHeight;
-        availableHeight = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit(style().logicalAspectRatio()), style().boxSizingForAspectRatio(), logicalWidth());
+        availableHeight = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit(style().logicalAspectRatio()), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatioType(), isRenderReplaced());
     } else if (isOutOfFlowPositionedWithSpecifiedHeight) {
         // Don't allow this to affect the block' size() member variable, since this
         // can get called while the block is still laying out its kids.

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -736,7 +736,9 @@ protected:
 
     void incrementVisuallyNonEmptyPixelCountIfNeeded(const IntSize&);
 
+    std::optional<double> resolveAspectRatio() const;
     bool shouldIgnoreAspectRatio() const;
+    bool isRenderReplacedWithIntrinsicRatio() const;
     bool shouldComputeLogicalWidthFromAspectRatio() const;
     LayoutUnit computeLogicalWidthFromAspectRatioInternal() const;
     LayoutUnit computeLogicalWidthFromAspectRatio(RenderFragmentContainer* = nullptr) const;
@@ -746,9 +748,9 @@ protected:
     enum class MinimumSizeIsAutomaticContentBased { Yes, No };
     void constrainLogicalMinMaxSizesByAspectRatio(LayoutUnit& minSize, LayoutUnit& maxSize, LayoutUnit computedSize, MinimumSizeIsAutomaticContentBased, ConstrainDimension) const;
 
-    static LayoutUnit blockSizeFromAspectRatio(LayoutUnit borderPaddingInlineSum, LayoutUnit borderPaddingBlockSum, double aspectRatio, BoxSizing boxSizing, LayoutUnit inlineSize)
+    static LayoutUnit blockSizeFromAspectRatio(LayoutUnit borderPaddingInlineSum, LayoutUnit borderPaddingBlockSum, double aspectRatio, BoxSizing boxSizing, LayoutUnit inlineSize, AspectRatioType aspectRatioType, bool isRenderReplaced)
     {
-        if (boxSizing == BoxSizing::BorderBox)
+        if (boxSizing == BoxSizing::BorderBox && aspectRatioType == AspectRatioType::Ratio && !isRenderReplaced)
             return std::max(borderPaddingBlockSum, LayoutUnit(inlineSize / aspectRatio));
         return LayoutUnit((inlineSize - borderPaddingInlineSum) / aspectRatio) + borderPaddingBlockSum;
     }

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -414,7 +414,7 @@ public:
     // rest of the rendering tree will move to a similar model.
     virtual bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction);
 
-    bool hasIntrinsicAspectRatio() const { return isReplacedOrInlineBlock() && (isImage() || isVideo() || isCanvas()); }
+    virtual bool hasIntrinsicAspectRatio() const { return isReplacedOrInlineBlock() && (isImage() || isVideo() || isCanvas()); }
     bool isAnonymous() const { return m_bitfields.isAnonymous(); }
     bool isAnonymousBlock() const;
     bool isBlockContainer() const;

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -105,6 +105,7 @@ private:
 
     LayoutRect selectionRectForRepaint(const RenderLayerModelObject* repaintContainer, bool clipToVisibleContent = true) final;
     void computeAspectRatioInformationForRenderBox(RenderBox*, FloatSize& constrainedSize, FloatSize& intrinsicRatio) const;
+    void computeIntrinsicSizesConstrainedByTransferredMinMaxSizes(RenderBox* contentRenderer, FloatSize& constrainedSize, FloatSize& intrinsicRatio) const;
 
     virtual bool shouldDrawSelectionTint() const;
     
@@ -114,6 +115,7 @@ private:
     bool hasReplacedLogicalHeight() const;
 
     mutable LayoutSize m_intrinsicSize;
+    mutable FloatSize m_intrinsicRatio;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -69,6 +69,11 @@ SVGSVGElement& LegacyRenderSVGRoot::svgSVGElement() const
     return downcast<SVGSVGElement>(nodeForNonAnonymous());
 }
 
+bool LegacyRenderSVGRoot::hasIntrinsicAspectRatio() const
+{
+    return computeIntrinsicAspectRatio();
+}
+
 void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const
 {
     ASSERT(!shouldApplySizeContainment());

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
@@ -44,6 +44,7 @@ public:
     bool isEmbeddedThroughFrameContainingSVGDocument() const;
 
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const override;
+    bool hasIntrinsicAspectRatio() const final;
 
     bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
     bool isInLayout() const { return m_inLayout; }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -82,6 +82,11 @@ RenderSVGViewportContainer* RenderSVGRoot::viewportContainer() const
     return dynamicDowncast<RenderSVGViewportContainer>(child);
 }
 
+bool RenderSVGRoot::hasIntrinsicAspectRatio() const
+{
+    return computeIntrinsicAspectRatio();
+}
+
 void RenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const
 {
     ASSERT(!shouldApplySizeContainment());

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -47,6 +47,7 @@ public:
     bool isEmbeddedThroughFrameContainingSVGDocument() const;
 
     void computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const final;
+    bool hasIntrinsicAspectRatio() const final;
 
     bool isLayoutSizeChanged() const { return m_isLayoutSizeChanged; }
     bool didTransformToRootUpdate() const { return m_didTransformToRootUpdate; }


### PR DESCRIPTION
#### 036e53a548a5852a4a59f49298cb45e8c8e0a2ce
<pre>
Replaced elements with aspect ratio and size in one dimension should respect min-max constraints in opposite dimension.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247507">https://bugs.webkit.org/show_bug.cgi?id=247507</a>
rdar://101979495

Reviewed by Alan Baradlay.

There are certain scenarios where a replaced element may have a
specified aspect ratio, but will not have intrinsic sizes in both
dimensions. One such examples is a SVG with only a specified width
and aspect ratio.

To help facilitate this, the logic in
RenderReplaced::computeAspectRatioInformationForRenderBox has been
separated out since it was doing too much before. It was both computing
the intrinsic size/ratio and constraining the intrinsic size. The logic
for constraining the intrinsic size has been refactored out into a new
method called
RenderReplaced::computeIntrinsicSizesConstrainedByTransferredMinMaxSizes.
This method will call

In these scenarios, we must use the specified aspect ratio to do any
sort of sizing since it is not possible to compute it from the
dimensions of the box. computeAspectRatioInformationForRenderBox to get
the intrinsic size/ratio and then constrain it. This new method will
also constrain the sizes in each dimension by the transferred sizes.
This size may be then potentially constrained even further in
RenderReplaced::computeReplacedLogicalWidthRespectingMinMaxWidth (and
height) by any definite min/max sizes in that dimension. There was an
attempt to consolidate all constraining logic into that method, but
that was causing some unexpected results. That may need to be done in
a future patch.

A few of the CSS aspect ratio methods have also been modified to help
with this logic. Since a lot of the logic is shared, these methods
can determine if a replaced element is being used and use the correct
aspect ratio in that case.

A new member variable to RenderReplaced has been added:
m_intrinsicRatioSize. This is used to keep track of the width and height
sizes associated with the aspect ratio. This is because there were some
precision issues that this patch exposed. Certain tests were starting
to fail because the computed width/height from the aspect ratio was
slightly off. To help with this, we can store the intrinsic ratio sizes
until we actually need to use them to compute the width/height. The
goal here is to hopefully reduce the number of floating point operations
that are needed to compute a size. It may be possible to replace all
instances where the computed intrinsicRatio double is being used, but
that is probably a little too risky for this patch. Instead, this patch
only uses it in the call to resolveHeightForRatio within
RenderReplaced::computeReplacedLogicalHeight. It is probably best
to update all uses of intrinsicRatio to m_intrinsicRatioSize in another
patch. To compute the intrinsic ratio size we needed to keep track of
a new variable inside the computeIntrinsicRatioInformation logic and
then update the member variable once it was computed.

Spec references:
<a href="https://www.w3.org/TR/CSS22/visudet.html#min-max-widths">https://www.w3.org/TR/CSS22/visudet.html#min-max-widths</a>
<a href="https://www.w3.org/TR/CSS22/visudet.html#min-max-heights">https://www.w3.org/TR/CSS22/visudet.html#min-max-heights</a>
<a href="https://w3c.github.io/csswg-drafts/css-sizing-4/#aspect-ratio">https://w3c.github.io/csswg-drafts/css-sizing-4/#aspect-ratio</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-039-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-039.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-040-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-040.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeChildPreferredLogicalWidths const):
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainLogicalMinMaxSizesByAspectRatio const):
(WebCore::RenderBox::constrainLogicalHeightByMinMax const):
(WebCore::inlineSizeFromAspectRatio):
Two extra arguments have been added to provide some context when
determining the box type to use (content box or border box). These
arguments are the aspect-ratio type being used for the box along with
whether or not the box is a replaced element with an intrinsic ratio.
css-sizing-4 specifies which box type to use depending on whether the
aspect-ratio property is auto, &lt;ratio&gt;, or auto &amp;&amp; &lt;ratio&gt;. If the item
is a replaced element, then it should always work with the content box.

(WebCore::RenderBox::computeLogicalHeight const):
(WebCore::RenderBox::availableLogicalHeightUsing const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::computeLogicalWidthFromAspectRatioInternal const):
(WebCore::RenderBox::isRenderReplacedWithIntrinsicRatio const):
(WebCore::RenderBox::resolveAspectRatio const):
A new helper method to determine which aspect ratio to use depending on
the type of the box. Since RenderReplaced objects have slightly
different logic to compute their aspect ratio, this method does the
work of finding on the aspect ratio that needs to be used and performs
the appropriate calls to compute it. If the object is a RenderReplaced
object, then we need the compute its aspect ratio, otherwise we should
be able to get the box&apos;s aspect ratio from its style.

(WebCore::RenderBox::computeMinMaxLogicalWidthFromAspectRatio const):
(WebCore::RenderBox::computeMinMaxLogicalHeightFromAspectRatio const):
horizontalBorderAndPaddingExtent and verticalBorderAndPaddingExtent
were replaced with borderAndPaddingLogicalWidth and
borderAndPaddingLogicalHeight since both blockSizeFromAspectRatio and
inlineSizeFromAspectRatio were expecting the inline and block sizes.
Before, these methods were being passed in the values for the physical
directions and were causing certain tests to fail (e.g.
css/css-flexbox/flex-aspect-ratio-img-column-008.html and
css/css-flexbox/image-as-flexitem-size-007v.html).

* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::blockSizeFromAspectRatio):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::hasIntrinsicAspectRatio const):
This method was made virtual because it was difficult to provide a valid
answer for SVG elements at this high of an abstraction. Since SVG
elements may not have an aspect ratio, we need those elements to
override this method and provide the answer themselves.

* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeAspectRatioInformationForRenderBox const):
(WebCore::RenderReplaced::computeIntrinsicSizesConstrainedByTransferredMinMaxSizes const):
(WebCore::RenderReplaced::computeIntrinsicRatioInformation const):
(WebCore::RenderReplaced::computeReplacedLogicalWidth const):
(WebCore::RenderReplaced::computeReplacedLogicalHeight const):
* Source/WebCore/rendering/RenderReplaced.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::hasIntrinsicAspectRatio const):
* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::hasIntrinsicAspectRatio const):
* Source/WebCore/rendering/svg/RenderSVGRoot.h:

Canonical link: <a href="https://commits.webkit.org/257434@main">https://commits.webkit.org/257434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42e8fd285790dec7926e86070efbfe5935b28476

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108406 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168658 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8758 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91523 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/106366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104719 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2107 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2011 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6974 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/42551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->