### PR TITLE
run-benchmark should allow profiles to be taken during browser benchmark runs

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py
@@ -23,10 +23,11 @@ _log = logging.getLogger(__name__)
 class BenchmarkBuilder(object):
     LOCAL_GIT_ARCHIVE_SCHEMA = re.compile(r'\A(?P<path>.+)@(?P<reference>[0-9a-zA-z.\-]+)\Z')
 
-    def __init__(self, name, plan, driver):
+    def __init__(self, name, plan, driver, enable_signposts=False):
         self._name = name
         self._plan = plan
         self._driver = driver
+        self._enable_signposts = enable_signposts
 
     def __enter__(self):
         self._web_root = tempfile.mkdtemp(dir="/tmp")
@@ -51,6 +52,11 @@ class BenchmarkBuilder(object):
             patch_file_key = "{driver}_benchmark_patch".format(driver=self._driver)
             if patch_file_key in self._plan:
                 self._apply_patch(self._plan[patch_file_key])
+            if self._enable_signposts:
+                if 'signpost_patch' in self._plan:
+                    self._apply_patch(self._plan['signpost_patch'])
+                else:
+                    _log.warning('Signposts are enabled but a signpost patch was not found in the test plan. Skipping.')
             return self._web_root
         except Exception:
             self._clean()

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -48,6 +48,10 @@ class BrowserDriver(object):
     def prevent_sleep(self, timeout):
         yield
 
+    @contextmanager
+    def profile(self, timeout):
+        yield
+
     @property
     def webdriver_binary_path(self):
         return get_driver_binary_path(self.browser_name)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
@@ -20,30 +20,27 @@ class OSXSafariDriver(OSXBrowserDriver):
         self._safari_process = None
         self._safari_preferences = ["-HomePage", "about:blank", "-WarnAboutFraudulentWebsites", "0", "-ExtensionsEnabled", "0", "-ShowStatusBar", "0", "-NewWindowBehavior", "1", "-NewTabBehavior", "1", "-AlwaysRestoreSessionAtLaunch", "0", "-ApplePersistenceIgnoreStateQuietly", "1"]
         super(OSXSafariDriver, self).prepare_env(config)
+        self._enable_signposts = config["enable_signposts"]
         self._maximize_window()
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        if browser_build_path or browser_path:
-            self._launch_url_with_custom_path(url, options, browser_build_path, browser_path)
-            return
-
         env = {}
         for key, value in os.environ.items():
-            if re.match(r"^__XPC_", key):
+            if re.match(r'^__XPC_', key):
                 env[key] = value
+        if self._enable_signposts:
+            env['__XPC_WEBKIT_SIGNPOSTS_ENABLED'] = '1'
+            env['__XPC_JSC_exposeProfilersOnGlobalObject'] = '1'
+        if browser_build_path or browser_path:
+            self._launch_url_with_custom_path(url, options, browser_build_path, browser_path, env)
+            return
+        self._safari_process = self._launch_process(None, 'Safari.app', url, ['--url', url, '--args'] + self._safari_preferences, env=env)
 
-        self._safari_process = self._launch_process(None, "Safari.app", url, ["--url", url, "--args"] + self._safari_preferences, env=env)
-
-    def _launch_url_with_custom_path(self, url, options, browser_build_path, browser_path):
+    def _launch_url_with_custom_path(self, url, options, browser_build_path, browser_path, env):
         safari_app_path = '/Applications/Safari.app'
         safari_binary_path = os.path.join(safari_app_path, 'Contents/MacOS/Safari')
 
-        _log.info("WARNING: Using custom paths to launch Safari (--browser-path or --build-directory) can return inaccurate results if the test is run remotely.")
-
-        env = {}
-        for key, value in os.environ.items():
-            if re.match(r"^__XPC_", key):
-                env[key] = value
+        _log.info('WARNING: Using custom paths to launch Safari (--browser-path or --build-directory) can return inaccurate results if the test is run remotely.')
 
         if browser_build_path:
             browser_build_absolute_path = os.path.abspath(browser_build_path)
@@ -66,7 +63,7 @@ class OSXSafariDriver(OSXBrowserDriver):
             if os.path.exists(safari_binary_path):
                 safari_app_path = browser_path
             else:
-                raise Exception('Could not find Safari.app at {}'.format(safari_app_path))
+                raise Exception('Could not find Safari.app at {}'.format(browser_path))
 
         args = [safari_binary_path] + self._safari_preferences
         _log.info('Launching safari: %s with url: %s' % (safari_binary_path, url))
@@ -93,7 +90,7 @@ class OSXSafariDriver(OSXBrowserDriver):
             if contains_frameworks:
                 assert '.framework' in output, 'No framework is loaded from "{}"'.format(browser_build_path)
 
-        subprocess.Popen(['open', '-a', safari_app_path, url])
+        subprocess.Popen(['open', '-a', safari_app_path, url], env=env)
 
     def launch_driver(self, url, options, browser_build_path):
         from selenium import webdriver
@@ -104,7 +101,7 @@ class OSXSafariDriver(OSXBrowserDriver):
     def close_browsers(self):
         super(OSXSafariDriver, self).close_browsers()
         if self._safari_process and self._safari_process.returncode:
-            sys.exit('Browser crashed with exitcode %d' % self._process.returncode)
+            sys.exit('Browser crashed with exitcode %d' % self._safari_process.returncode)
 
     @classmethod
     def _maximize_window(cls):

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -55,7 +55,8 @@ def config_argument_parser():
     parser.add_argument('--diagnose-directory', dest='diagnose_dir', default=diagnose_directory, help='Directory for storing diagnose information on test failure. Defaults to {}.'.format(diagnose_directory))
     parser.add_argument('--no-adjust-unit', dest='scale_unit', action='store_false', help="Don't convert to scientific notation.")
     parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
-    parser.add_argument('--generate-profiles', dest='generate_profiles', action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnose directory.")
+    parser.add_argument('--generate-pgo-profiles', '--generate-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
+    parser.add_argument('--profile', action='store_true', help="Collect profiling traces, and copy them to the diagnostic directory.")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--browser-path', help='Specify the path to a non-default copy of the target browser as a path to the .app.')
@@ -77,13 +78,14 @@ def parse_args(parser=None):
     _log.debug('\tbuild directory\t: %s' % args.build_dir)
     _log.debug('\tplan name\t: %s', args.plan)
 
-    if args.generate_profiles and not os.path.isdir(args.diagnose_dir):
-        _log.error("No diagnose directory to dump profiles to: {}".format(args.diagnose_dir))
-        exit()
+    if (args.generate_pgo_profiles or args.profile) and not args.diagnose_dir:
+        raise Exception('Collecting profiles requires a diagnostic directory (--diagnose-directory) to be set.')
 
-    if args.generate_profiles and args.platform != 'osx':
-        _log.error("Profile generation is currently only supported on macOS.")
-        exit()
+    if args.generate_pgo_profiles and args.platform != 'osx':
+        raise Exception('PGO Profile generation is currently only supported on macOS.')
+
+    if args.profile and args.platform != 'osx':
+        raise Exception('Profile collection is currently only supported on macOS.')
 
     return args
 
@@ -94,7 +96,8 @@ def run_benchmark_plan(args, plan):
                                     args.local_copy, args.count, args.build_dir, args.output_file,
                                     args.platform, args.browser, args.browser_path, args.scale_unit,
                                     args.show_iteration_values, args.device_id, args.diagnose_dir,
-                                    args.diagnose_dir if args.generate_profiles else None)
+                                    args.diagnose_dir if args.generate_pgo_profiles else None,
+                                    args.diagnose_dir if args.profile else None)
     runner.execute()
 
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
@@ -14,7 +14,7 @@ class WebDriverBenchmarkRunner(BenchmarkRunner):
         result = driver.execute_script("return window.webdriver_results")
         return result
 
-    def _run_one_test(self, web_root, test_file):
+    def _run_one_test(self, web_root, test_file, iteration):
         from selenium.webdriver.support.ui import WebDriverWait
         try:
             url = 'file://{root}/{plan_name}/{test_file}'.format(root=web_root, plan_name=self._plan_name, test_file=test_file)

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -6,7 +6,7 @@ import signal
 import sys
 import time
 
-from webkitcorepy import Timeout
+from webkitcorepy import NullContext, Timeout
 
 from webkitpy.benchmark_runner.benchmark_runner import BenchmarkRunner
 from webkitpy.benchmark_runner.http_server_driver.http_server_driver_factory import HTTPServerDriverFactory
@@ -22,11 +22,10 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, build_dir, output_file, platform, browser, browser_path, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, profile_output_directory=None):
+    def __init__(self, plan_file, local_copy, count_override, build_dir, output_file, platform, browser, browser_path, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None):
         self._http_server_driver = HTTPServerDriverFactory.create(platform)
         self._http_server_driver.set_device_id(device_id)
-        self._profile_output_directory = profile_output_directory
-        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, build_dir, output_file, platform, browser, browser_path, scale_unit, show_iteration_values, device_id, diagnose_dir, profile_output_directory)
+        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, build_dir, output_file, platform, browser, browser_path, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
 
@@ -34,27 +33,34 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         result = self._browser_driver.add_additional_results(test_url, self._http_server_driver.fetch_result())
         assert(not self._http_server_driver.get_return_code())
 
-        if self._profile_output_directory:
-            _log.info("Getting benchmark profile results for {} and copying them to {}.".format(test_url, self._profile_output_directory))
-            copy_output = subprocess.Popen(r"""log stream --style json --color none | perl -mFile::Basename -mFile::Copy -nle 'if (m/<WEBKIT_LLVM_PROFILE>.*<BEGIN>(.*)<END>/) { (my $l = $1) =~ s/\\\//\//g; my $b = File::Basename::basename($l); my $d = """ + "\"" + self._profile_output_directory + """/$b"; print "Moving $l to $d"; File::Copy::move($l, $d); }'""", shell=True, bufsize=0, preexec_fn=os.setsid)
+        if self._pgo_profile_output_dir:
+            _log.info('Getting benchmark PGO profile results for {} and copying them to {}.'.format(test_url, self._pgo_profile_output_dir))
+            copy_output = subprocess.Popen(r"""log stream --style json --color none | perl -mFile::Basename -mFile::Copy -nle 'if (m/<WEBKIT_LLVM_PROFILE>.*<BEGIN>(.*)<END>/) { (my $l = $1) =~ s/\\\//\//g; my $b = File::Basename::basename($l); my $d = """ + "\"" + self._pgo_profile_output_dir + """/$b"; print "Moving $l to $d"; File::Copy::move($l, $d); }'""", shell=True, bufsize=0, preexec_fn=os.setsid)
             time.sleep(1)
-            subprocess.call(["notifyutil", "-p", "com.apple.WebKit.profiledata"])
+            subprocess.call(['notifyutil', '-p', 'com.apple.WebKit.profiledata'])
             time.sleep(7)
             # We can kill the shell with kill(), but killing children is harder.
             os.killpg(os.getpgid(copy_output.pid), signal.SIGINT)
             copy_output.kill()
             time.sleep(1)
-            _log.debug("Hopefully the benchmark profile has finished writing to disk, moving on.")
+            _log.debug('Hopefully the benchmark profile has finished writing to disk, moving on.')
         return result
 
-    def _run_one_test(self, web_root, test_file):
+    def _run_one_test(self, web_root, test_file, iteration):
+        enable_profiling = True if self._profile_output_dir else False
+        profile_filename = '{}/{}-{}'.format(self._profile_output_dir, self._plan_name, iteration)
         try:
             self._http_server_driver.serve(web_root)
             url = urljoin(self._http_server_driver.base_url(), self._plan_name + '/' + test_file)
-            self._browser_driver.launch_url(url, self._plan['options'], self._build_dir, self._browser_path)
-            timeout = self._plan['timeout']
-            with Timeout(timeout), self._browser_driver.prevent_sleep(timeout):
-                result = self._get_result(url)
+            if enable_profiling:
+                context = self._browser_driver.profile(profile_filename)
+            else:
+                context = NullContext()
+            with context:
+                self._browser_driver.launch_url(url, self._plan['options'], self._build_dir, self._browser_path)
+                timeout = self._plan['timeout']
+                with Timeout(timeout), self._browser_driver.prevent_sleep(timeout):
+                    result = self._get_result(url)
         except Exception as error:
             self._browser_driver.diagnose_test_failure(self._diagnose_dir, error)
             raise error


### PR DESCRIPTION
#### 619e29b635b5478321472aa69a23645a8dd018c2
<pre>
run-benchmark should allow profiles to be taken during browser benchmark runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=247496">https://bugs.webkit.org/show_bug.cgi?id=247496</a>
rdar://101969614

Reviewed by Dewei Zhu.

We&apos;d like the ability to take profiles in browser benchmarks. To do this, we&apos;ll need to add a context (defined in the driver) to take profiles during test iterations, and add an argument to the script that toggles this feature on.

In addition:
 - Added support for signposts in OSX driver, and refactored `_launch_url_with_custom_path` to be able to use a previously modified environment.
 - Added an `iteration` argument to `_run_one_test`, as this information may be useful for labelling profiles later on.
 - Clarify and rename references to PGO profiles - previously, we had use the term &quot;profile generation&quot; across run-benchmark to refer to PGO profile generation (this has since been replaced with the phrase &quot;PGO profile generation&quot;).

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_builder.py:
(BenchmarkBuilder.__init__):
(BenchmarkBuilder.__enter__):
* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
(BenchmarkRunner._run_benchmark):
(BenchmarkRunner.execute):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver):
(BrowserDriver.profile):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py:
(OSXSafariDriver.prepare_env):
(OSXSafariDriver.launch_url):
(OSXSafariDriver._launch_url_with_custom_path):
(OSXSafariDriver.close_browsers):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):
(parse_args):
(run_benchmark_plan):
* Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py:
(WebDriverBenchmarkRunner._run_one_test):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):
(WebServerBenchmarkRunner._get_result):
(WebServerBenchmarkRunner):

Canonical link: <a href="https://commits.webkit.org/256544@main">https://commits.webkit.org/256544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd406d34296e6d67769b584384f2b3b35db4aa7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105326 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165633 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5083 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33760 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101162 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3738 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82362 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30791 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99336 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87507 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73620 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39495 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19045 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4527 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43005 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39613 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->