### PR TITLE
[Cocoa] Mac Catalyst builds don't correctly replace JS_IOS_TBA/WK_IOS_TBA in headers

### DIFF
--- a/Source/JavaScriptCore/Scripts/postprocess-header-rule
+++ b/Source/JavaScriptCore/Scripts/postprocess-header-rule
@@ -50,9 +50,17 @@ function rewrite_headers () {
 
     if [[ "${PLATFORM_NAME}" == "macosx" ]]; then
         [[ -n ${OSX_VERSION} ]] || OSX_VERSION=${MACOSX_DEPLOYMENT_TARGET}
-        [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
         [[ -n ${OSX_VERSION_NUMBER} ]] || OSX_VERSION_NUMBER=${TARGET_MAC_OS_X_VERSION_MAJOR}
-        [[ -n ${IOS_VERSION_NUMBER} ]] || IOS_VERSION_NUMBER="0"
+
+        if [[ "${WK_PLATFORM_NAME}" == "maccatalyst" && "${LLVM_TARGET_TRIPLE_OS_VERSION}" == ios* ]]; then
+            # On Mac Catalyst `LLVM_TARGET_TRIPLE_OS_VERSION` will be in the format `ios{major}.{minor}`.
+            local ALIGNED_IOS_VERSION="${LLVM_TARGET_TRIPLE_OS_VERSION#ios}"
+            [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${ALIGNED_IOS_VERSION}
+            [[ -n ${IOS_VERSION_NUMBER} ]] || IOS_VERSION_NUMBER=${ALIGNED_IOS_VERSION%%.*}
+        else
+            [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
+            [[ -n ${IOS_VERSION_NUMBER} ]] || IOS_VERSION_NUMBER="0"
+        fi
     elif [[ "${PLATFORM_NAME}" =~ "iphone" ]]; then
         [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}
         [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"

--- a/Source/WebKit/Scripts/postprocess-header-rule
+++ b/Source/WebKit/Scripts/postprocess-header-rule
@@ -47,10 +47,16 @@ process_definitions "${BUILT_PRODUCTS_DIR}/${DEFINITIONS_PATH}" || process_defin
 # FIXME: rdar://90704735 (Run unifdef more uniformly on all WebKit.framework headers)
 
 if [[ "${WK_FRAMEWORK_HEADER_POSTPROCESSING_DISABLED}" != "YES" ]]; then
-    if [[ "${WK_PLATFORM_NAME}" == "macosx" ]]; then
+    if [[ "${PLATFORM_NAME}" == "macosx" ]]; then
         [[ -n ${OSX_VERSION} ]] || OSX_VERSION=${MACOSX_DEPLOYMENT_TARGET}
-        [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
-    elif [[ "${WK_PLATFORM_NAME}" =~ "iphone" ]]; then
+
+        if [[ "${WK_PLATFORM_NAME}" == "maccatalyst" && "${LLVM_TARGET_TRIPLE_OS_VERSION}" == ios* ]]; then
+            # On Mac Catalyst `LLVM_TARGET_TRIPLE_OS_VERSION` will be in the format `ios{major}.{minor}`.
+            [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${LLVM_TARGET_TRIPLE_OS_VERSION#ios}
+        else
+            [[ -n ${IOS_VERSION} ]] || IOS_VERSION="NA"
+        fi
+    elif [[ "${PLATFORM_NAME}" =~ "iphone" ]]; then
         [[ -n ${IOS_VERSION} ]] || IOS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}
         [[ -n ${OSX_VERSION} ]] || OSX_VERSION="NA"
     fi


### PR DESCRIPTION
#### cf442de8dfd0db8743997344098054ddd962157b
<pre>
[Cocoa] Mac Catalyst builds don&apos;t correctly replace JS_IOS_TBA/WK_IOS_TBA in headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=247516">https://bugs.webkit.org/show_bug.cgi?id=247516</a>
rdar://101889288

Reviewed by Elliott Williams.

Currently on Mac Catalyst we replace JS_IOS_TBA/WK_IOS_TBA with &quot;NA&quot; instead of a real version number. For Catalyst
builds `LLVM_TARGET_TRIPLE_OS_VERSION` will contain the iOS version number we need. We also need to use the
`PLATFORM_NAME` and not the `WK_PLATFORM_NAME` for WebKit in order to replace the macOS version placeholder correctly,
since `WK_PLATFORM_NAME` will be `maccatalyst` for Catalyst, but we want to replace the Mac placeholder for all Mac
build styles, even Catalyst. We can then use the `WK_PLATFORM_NAME` as part of determining if we are building for
Catalyst.

* Source/JavaScriptCore/Scripts/postprocess-header-rule:
* Source/WebKit/Scripts/postprocess-header-rule:

Canonical link: <a href="https://commits.webkit.org/256419@main">https://commits.webkit.org/256419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c75a53194cc513a42eecd92d606722c734b0b96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105103 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165362 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4817 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33520 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100954 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3511 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82134 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30592 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99111 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87317 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73429 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86587 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39275 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81891 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20173 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4439 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42824 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84569 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39422 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19097 "Passed tests") | 
<!--EWS-Status-Bubble-End-->