### PR TITLE
Create RemoteScrollingCoordinatorProxyIOS

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -35,7 +35,7 @@
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeScrollingPerformanceData.h"
 #import "RemoteLayerTreeViews.h"
-#import "RemoteScrollingCoordinatorProxy.h"
+#import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "ScrollingTreeScrollingNodeDelegateIOS.h"
 #import "TapHandlingResult.h"
 #import "UIKitSPI.h"
@@ -1800,7 +1800,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
 #if ENABLE(ASYNC_SCROLLING)
     // FIXME: We will want to detect whether snapping will occur before beginning to drag. See WebPageProxy::didCommitLayerTree.
-    WebKit::RemoteScrollingCoordinatorProxy* coordinator = _page->scrollingCoordinatorProxy();
+    auto* coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy());
     ASSERT(scrollView == _scrollView.get());
     [_scrollView _setDecelerationRateInternal:(coordinator && coordinator->shouldSetScrollViewDecelerationRateFast()) ? UIScrollViewDecelerationRateFast : UIScrollViewDecelerationRateNormal];
 
@@ -1837,7 +1837,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
             targetContentOffset->y = scrollView.contentOffset.y;
     }
 #if ENABLE(ASYNC_SCROLLING)
-    if (WebKit::RemoteScrollingCoordinatorProxy* coordinator = _page->scrollingCoordinatorProxy()) {
+    if (auto* coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy())) {
         // FIXME: Here, I'm finding the maximum horizontal/vertical scroll offsets. There's probably a better way to do this.
         CGSize maxScrollOffsets = CGSizeMake(scrollView.contentSize.width - scrollView.bounds.size.width, scrollView.contentSize.height - scrollView.bounds.size.height);
 
@@ -2514,7 +2514,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
 
 #if ENABLE(ASYNC_SCROLLING)
     if (viewStability.isEmpty()) {
-        WebKit::RemoteScrollingCoordinatorProxy* coordinator = _page->scrollingCoordinatorProxy();
+        auto* coordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy());
         if (coordinator && coordinator->hasActiveSnapPoint()) {
             CGPoint currentPoint = [_scrollView contentOffset];
             CGPoint activePoint = coordinator->nearestActiveContentInsetAdjustedSnapOffset(unobscuredRect.origin.y, currentPoint);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -48,7 +48,7 @@ public:
     const RemoteLayerTreeHost& remoteLayerTreeHost() const { return *m_remoteLayerTreeHost; }
     std::unique_ptr<RemoteLayerTreeHost> detachRemoteLayerTreeHost();
     
-    virtual std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const;
+    virtual std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const = 0;
 
     void acceleratedAnimationDidStart(uint64_t layerID, const String& key, MonotonicTime startTime);
     void acceleratedAnimationDidEnd(uint64_t layerID, const String& key);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -73,11 +73,6 @@ std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemo
     return WTFMove(m_remoteLayerTreeHost);
 }
 
-std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxy::createScrollingCoordinatorProxy() const
-{
-    return makeUnique<RemoteScrollingCoordinatorProxy>(m_webPageProxy);
-}
-
 void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 {
     if (!m_webPageProxy.hasRunningProcess())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -41,6 +41,8 @@ public:
 private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
 
+    std::unique_ptr<RemoteScrollingCoordinatorProxy> createScrollingCoordinatorProxy() const override;
+
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond) override;
     void scheduleDisplayRefreshCallbacks() override;
     void pauseDisplayRefreshCallbacks() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "WebPageProxy.h"
 
 @interface WKDisplayLinkHandler : NSObject {
@@ -157,6 +158,11 @@ RemoteLayerTreeDrawingAreaProxyIOS::RemoteLayerTreeDrawingAreaProxyIOS(WebPagePr
 RemoteLayerTreeDrawingAreaProxyIOS::~RemoteLayerTreeDrawingAreaProxyIOS()
 {
     [m_displayLinkHandler invalidate];
+}
+
+std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxyIOS::createScrollingCoordinatorProxy() const
+{
+    return makeUnique<RemoteScrollingCoordinatorProxyIOS>(m_webPageProxy);
 }
 
 DelegatedScrollingMode RemoteLayerTreeDrawingAreaProxyIOS::delegatedScrollingMode() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)
+
+#include "RemoteScrollingCoordinatorProxy.h"
+
+OBJC_CLASS UIScrollView;
+
+namespace WebKit {
+
+class RemoteScrollingCoordinatorProxyIOS final : public RemoteScrollingCoordinatorProxy {
+public:
+    explicit RemoteScrollingCoordinatorProxyIOS(WebPageProxy&);
+
+    UIScrollView *scrollViewForScrollingNodeID(WebCore::ScrollingNodeID) const;
+
+    OptionSet<WebCore::TouchAction> activeTouchActionsForTouchIdentifier(unsigned touchIdentifier) const;
+    void setTouchActionsForTouchIdentifier(OptionSet<WebCore::TouchAction>, unsigned);
+    void clearTouchActionsForTouchIdentifier(unsigned);
+
+    bool shouldSetScrollViewDecelerationRateFast() const;
+    void setRootNodeIsInUserScroll(bool) override;
+
+    void adjustTargetContentOffsetForSnapping(CGSize maxScrollDimensions, CGPoint velocity, CGFloat topInset, CGPoint currentContentOffset, CGPoint* targetContentOffset);
+    bool hasActiveSnapPoint() const;
+    CGPoint nearestActiveContentInsetAdjustedSnapOffset(CGFloat topInset, const CGPoint&) const;
+
+private:
+    bool propagatesMainFrameScrolls() const override { return false; }
+
+    void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+
+    void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&) override;
+    void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
+
+    WebCore::FloatRect currentLayoutViewport() const;
+
+    bool shouldSnapForMainFrameScrolling(WebCore::ScrollEventAxis) const;
+    std::pair<float, std::optional<unsigned>> closestSnapOffsetForMainFrameScrolling(WebCore::ScrollEventAxis, float currentScrollOffset, WebCore::FloatPoint scrollDestination, float velocity) const;
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    void removeFixedScrollingNodeLayerIDs(const Vector<WebCore::GraphicsLayer::PlatformLayerID>&);
+    const HashSet<WebCore::GraphicsLayer::PlatformLayerID>& fixedScrollingNodeLayerIDs() const { return m_fixedScrollingNodeLayerIDs; }
+#endif
+
+    HashMap<unsigned, OptionSet<WebCore::TouchAction>> m_touchActionsByTouchIdentifier;
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    HashSet<WebCore::GraphicsLayer::PlatformLayerID> m_fixedScrollingNodeLayerIDs;
+#endif
+};
+
+} // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_REMOTE_SCROLLING_COORDINATOR_PROXY(RemoteScrollingCoordinatorProxyIOS, isRemoteScrollingCoordinatorProxyIOS());
+
+#endif // PLATFORM(IOS) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -24,10 +24,9 @@
  */
 
 #import "config.h"
-#import "RemoteScrollingCoordinatorProxy.h"
+#import "RemoteScrollingCoordinatorProxyIOS.h"
 
-#if PLATFORM(IOS_FAMILY)
-#if ENABLE(ASYNC_SCROLLING)
+#if PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)
 
 #import "RemoteLayerTreeHost.h"
 #import "RemoteLayerTreeNode.h"
@@ -51,9 +50,32 @@
 namespace WebKit {
 using namespace WebCore;
 
-UIScrollView *RemoteScrollingCoordinatorProxy::scrollViewForScrollingNodeID(ScrollingNodeID nodeID) const
+RemoteScrollingCoordinatorProxyIOS::RemoteScrollingCoordinatorProxyIOS(WebPageProxy& webPageProxy)
+    : RemoteScrollingCoordinatorProxy(webPageProxy)
 {
-    auto* treeNode = m_scrollingTree->nodeForID(nodeID);
+}
+
+OptionSet<TouchAction> RemoteScrollingCoordinatorProxyIOS::activeTouchActionsForTouchIdentifier(unsigned touchIdentifier) const
+{
+    auto iterator = m_touchActionsByTouchIdentifier.find(touchIdentifier);
+    if (iterator == m_touchActionsByTouchIdentifier.end())
+        return { };
+    return iterator->value;
+}
+
+void RemoteScrollingCoordinatorProxyIOS::setTouchActionsForTouchIdentifier(OptionSet<TouchAction> touchActions, unsigned touchIdentifier)
+{
+    m_touchActionsByTouchIdentifier.set(touchIdentifier, touchActions);
+}
+
+void RemoteScrollingCoordinatorProxyIOS::clearTouchActionsForTouchIdentifier(unsigned touchIdentifier)
+{
+    m_touchActionsByTouchIdentifier.remove(touchIdentifier);
+}
+
+UIScrollView *RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID(ScrollingNodeID nodeID) const
+{
+    auto* treeNode = scrollingTree()->nodeForID(nodeID);
 
     if (is<ScrollingTreeOverflowScrollingNode>(treeNode)) {
         auto* overflowScrollingNode = downcast<ScrollingTreeOverflowScrollingNode>(treeNode);
@@ -73,14 +95,14 @@ UIScrollView *RemoteScrollingCoordinatorProxy::scrollViewForScrollingNodeID(Scro
 }
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-void RemoteScrollingCoordinatorProxy::removeFixedScrollingNodeLayerIDs(const Vector<WebCore::GraphicsLayer::PlatformLayerID>& destroyedLayers)
+void RemoteScrollingCoordinatorProxyIOS::removeFixedScrollingNodeLayerIDs(const Vector<WebCore::GraphicsLayer::PlatformLayerID>& destroyedLayers)
 {
     for (auto layerID : destroyedLayers)
         m_fixedScrollingNodeLayerIDs.remove(layerID);
 }
 #endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 
-void RemoteScrollingCoordinatorProxy::connectStateNodeLayers(ScrollingStateTree& stateTree, const RemoteLayerTreeHost& layerTreeHost)
+void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTree& stateTree, const RemoteLayerTreeHost& layerTreeHost)
 {
     using PlatformLayerID = GraphicsLayer::PlatformLayerID;
 
@@ -136,37 +158,37 @@ void RemoteScrollingCoordinatorProxy::connectStateNodeLayers(ScrollingStateTree&
     }
 }
 
-FloatRect RemoteScrollingCoordinatorProxy::currentLayoutViewport() const
+FloatRect RemoteScrollingCoordinatorProxyIOS::currentLayoutViewport() const
 {
     // FIXME: does this give a different value to the last value pushed onto us?
-    return m_webPageProxy.computeLayoutViewportRect(m_webPageProxy.unobscuredContentRect(), m_webPageProxy.unobscuredContentRectRespectingInputViewBounds(), m_webPageProxy.layoutViewportRect(),
-        m_webPageProxy.displayedContentScale(), FrameView::LayoutViewportConstraint::Unconstrained);
+    return webPageProxy().computeLayoutViewportRect(webPageProxy().unobscuredContentRect(), webPageProxy().unobscuredContentRectRespectingInputViewBounds(), webPageProxy().layoutViewportRect(),
+        webPageProxy().displayedContentScale(), FrameView::LayoutViewportConstraint::Unconstrained);
 }
 
-void RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartPanGesture(ScrollingNodeID nodeID)
+void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartPanGesture(ScrollingNodeID nodeID)
 {
-    m_webPageProxy.scrollingNodeScrollViewWillStartPanGesture(nodeID);
+    webPageProxy().scrollingNodeScrollViewWillStartPanGesture(nodeID);
 }
 
 // This is not called for the main scroll view.
-void RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
+void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
 {
-    m_webPageProxy.scrollingNodeScrollWillStartScroll(nodeID);
+    webPageProxy().scrollingNodeScrollWillStartScroll(nodeID);
 
     m_uiState.addNodeWithActiveUserScroll(nodeID);
     sendUIStateChangedIfNecessary();
 }
 
 // This is not called for the main scroll view.
-void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
+void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
 {
-    m_webPageProxy.scrollingNodeScrollDidEndScroll(nodeID);
+    webPageProxy().scrollingNodeScrollDidEndScroll(nodeID);
 
     m_uiState.removeNodeWithActiveUserScroll(nodeID);
     sendUIStateChangedIfNecessary();
 }
 
-void RemoteScrollingCoordinatorProxy::establishLayerTreeScrollingRelations(const RemoteLayerTreeHost& remoteLayerTreeHost)
+void RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations(const RemoteLayerTreeHost& remoteLayerTreeHost)
 {
     for (auto layerID : m_layersWithScrollingRelations) {
         if (auto* layerNode = remoteLayerTreeHost.nodeForID(layerID)) {
@@ -179,11 +201,11 @@ void RemoteScrollingCoordinatorProxy::establishLayerTreeScrollingRelations(const
     // Usually a scroll view scrolls its descendant layers. In some positioning cases it also controls non-descendants, or doesn't control a descendant.
     // To do overlap hit testing correctly we tell layers about such relations.
     
-    for (auto& positionedNode : m_scrollingTree->activePositionedNodes()) {
+    for (auto& positionedNode : scrollingTree()->activePositionedNodes()) {
         Vector<GraphicsLayer::PlatformLayerID> stationaryScrollContainerIDs;
 
         for (auto overflowNodeID : positionedNode->relatedOverflowScrollingNodes()) {
-            auto* overflowNode = downcast<ScrollingTreeOverflowScrollingNode>(m_scrollingTree->nodeForID(overflowNodeID));
+            auto* overflowNode = downcast<ScrollingTreeOverflowScrollingNode>(scrollingTree()->nodeForID(overflowNodeID));
             if (!overflowNode)
                 continue;
             stationaryScrollContainerIDs.append(RemoteLayerTreeNode::layerID(static_cast<CALayer*>(overflowNode->scrollContainerLayer())));
@@ -195,8 +217,8 @@ void RemoteScrollingCoordinatorProxy::establishLayerTreeScrollingRelations(const
         }
     }
 
-    for (auto& scrollProxyNode : m_scrollingTree->activeOverflowScrollProxyNodes()) {
-        auto* overflowNode = downcast<ScrollingTreeOverflowScrollingNode>(m_scrollingTree->nodeForID(scrollProxyNode->overflowScrollingNodeID()));
+    for (auto& scrollProxyNode : scrollingTree()->activeOverflowScrollProxyNodes()) {
+        auto* overflowNode = downcast<ScrollingTreeOverflowScrollingNode>(scrollingTree()->nodeForID(scrollProxyNode->overflowScrollingNodeID()));
         if (!overflowNode)
             continue;
         if (auto* layerNode = RemoteLayerTreeNode::forCALayer(scrollProxyNode->layer())) {
@@ -206,7 +228,7 @@ void RemoteScrollingCoordinatorProxy::establishLayerTreeScrollingRelations(const
     }
 }
 
-void RemoteScrollingCoordinatorProxy::adjustTargetContentOffsetForSnapping(CGSize maxScrollOffsets, CGPoint velocity, CGFloat topInset, CGPoint currentContentOffset, CGPoint* targetContentOffset)
+void RemoteScrollingCoordinatorProxyIOS::adjustTargetContentOffsetForSnapping(CGSize maxScrollOffsets, CGPoint velocity, CGFloat topInset, CGPoint currentContentOffset, CGPoint* targetContentOffset)
 {
     // The bounds checking with maxScrollOffsets is to ensure that we won't interfere with rubber-banding when scrolling to the edge of the page.
     if (shouldSnapForMainFrameScrolling(WebCore::ScrollEventAxis::Horizontal)) {
@@ -227,60 +249,53 @@ void RemoteScrollingCoordinatorProxy::adjustTargetContentOffsetForSnapping(CGSiz
     }
 }
 
-bool RemoteScrollingCoordinatorProxy::shouldSetScrollViewDecelerationRateFast() const
+bool RemoteScrollingCoordinatorProxyIOS::shouldSetScrollViewDecelerationRateFast() const
 {
     return shouldSnapForMainFrameScrolling(ScrollEventAxis::Horizontal) || shouldSnapForMainFrameScrolling(ScrollEventAxis::Vertical);
 }
 
-void RemoteScrollingCoordinatorProxy::setRootNodeIsInUserScroll(bool value)
+void RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll(bool value)
 {
-    ScrollingTreeNode* root = m_scrollingTree->rootNode();
-    if (!root || !root->isFrameScrollingNode())
+    auto* rootNode = scrollingTree()->rootNode();
+    if (!rootNode)
         return;
 
     if (value)
-        m_uiState.addNodeWithActiveUserScroll(root->scrollingNodeID());
+        m_uiState.addNodeWithActiveUserScroll(rootNode->scrollingNodeID());
     else
-        m_uiState.removeNodeWithActiveUserScroll(root->scrollingNodeID());
+        m_uiState.removeNodeWithActiveUserScroll(rootNode->scrollingNodeID());
 
     sendUIStateChangedIfNecessary();
 }
 
-bool RemoteScrollingCoordinatorProxy::shouldSnapForMainFrameScrolling(ScrollEventAxis axis) const
+bool RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling(ScrollEventAxis axis) const
 {
-    ScrollingTreeNode* root = m_scrollingTree->rootNode();
-    if (root && root->isFrameScrollingNode()) {
-        ScrollingTreeFrameScrollingNode* rootScrollingNode = static_cast<ScrollingTreeFrameScrollingNode*>(root);
-        return rootScrollingNode->snapOffsetsInfo().offsetsForAxis(axis).size();
-    }
+    auto* rootNode = scrollingTree()->rootNode();
+    if (rootNode)
+        return rootNode->snapOffsetsInfo().offsetsForAxis(axis).size();
+
     return false;
 }
 
-std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxy::closestSnapOffsetForMainFrameScrolling(ScrollEventAxis axis, float currentScrollOffset, FloatPoint scrollDestination, float velocity) const
+std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling(ScrollEventAxis axis, float currentScrollOffset, FloatPoint scrollDestination, float velocity) const
 {
-    ScrollingTreeNode* root = m_scrollingTree->rootNode();
-    ASSERT(root && root->isFrameScrollingNode());
-    ScrollingTreeFrameScrollingNode* rootScrollingNode = static_cast<ScrollingTreeFrameScrollingNode*>(root);
-    const auto& snapOffsetsInfo = rootScrollingNode->snapOffsetsInfo();
+    auto* rootNode = scrollingTree()->rootNode();
+    const auto& snapOffsetsInfo = rootNode->snapOffsetsInfo();
 
-    scrollDestination.scale(1.0 / m_webPageProxy.displayedContentScale());
-    float scaledCurrentScrollOffset = currentScrollOffset / m_webPageProxy.displayedContentScale();
-    auto [rawClosestSnapOffset, newIndex] = snapOffsetsInfo.closestSnapOffset(axis, rootScrollingNode->layoutViewport().size(), scrollDestination, velocity, scaledCurrentScrollOffset);
-    return std::make_pair(rawClosestSnapOffset * m_webPageProxy.displayedContentScale(), newIndex);
+    scrollDestination.scale(1.0 / webPageProxy().displayedContentScale());
+    float scaledCurrentScrollOffset = currentScrollOffset / webPageProxy().displayedContentScale();
+    auto [rawClosestSnapOffset, newIndex] = snapOffsetsInfo.closestSnapOffset(axis, rootNode->layoutViewport().size(), scrollDestination, velocity, scaledCurrentScrollOffset);
+    return std::make_pair(rawClosestSnapOffset * webPageProxy().displayedContentScale(), newIndex);
 }
 
-bool RemoteScrollingCoordinatorProxy::hasActiveSnapPoint() const
+bool RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint() const
 {
-    ScrollingTreeNode* root = m_scrollingTree->rootNode();
-    if (!root)
+    auto* rootNode = scrollingTree()->rootNode();
+    if (!rootNode)
         return false;
 
-    if (!is<ScrollingTreeFrameScrollingNode>(root))
-        return false;
-
-    ScrollingTreeFrameScrollingNode& rootScrollingNode = downcast<ScrollingTreeFrameScrollingNode>(*root);
-    const auto& horizontal = rootScrollingNode.snapOffsetsInfo().horizontalSnapOffsets;
-    const auto& vertical = rootScrollingNode.snapOffsetsInfo().verticalSnapOffsets;
+    const auto& horizontal = rootNode->snapOffsetsInfo().horizontalSnapOffsets;
+    const auto& vertical = rootNode->snapOffsetsInfo().verticalSnapOffsets;
 
     if (horizontal.isEmpty() && vertical.isEmpty())
         return false;
@@ -293,22 +308,23 @@ bool RemoteScrollingCoordinatorProxy::hasActiveSnapPoint() const
     return true;
 }
     
-CGPoint RemoteScrollingCoordinatorProxy::nearestActiveContentInsetAdjustedSnapOffset(CGFloat topInset, const CGPoint& currentPoint) const
+CGPoint RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset(CGFloat topInset, const CGPoint& currentPoint) const
 {
     CGPoint activePoint = currentPoint;
 
-    ScrollingTreeNode* root = m_scrollingTree->rootNode();
-    ASSERT(root && is<ScrollingTreeFrameScrollingNode>(root));
-    ScrollingTreeFrameScrollingNode& rootScrollingNode = downcast<ScrollingTreeFrameScrollingNode>(*root);
-    const auto& horizontal = rootScrollingNode.snapOffsetsInfo().horizontalSnapOffsets;
-    const auto& vertical = rootScrollingNode.snapOffsetsInfo().verticalSnapOffsets;
+    auto* rootNode = scrollingTree()->rootNode();
+    if (!rootNode)
+        return CGPointZero;
+
+    const auto& horizontal = rootNode->snapOffsetsInfo().horizontalSnapOffsets;
+    const auto& vertical = rootNode->snapOffsetsInfo().verticalSnapOffsets;
 
     // The bounds checking with maxScrollOffsets is to ensure that we won't interfere with rubber-banding when scrolling to the edge of the page.
     if (!horizontal.isEmpty() && m_currentHorizontalSnapPointIndex && *m_currentHorizontalSnapPointIndex < horizontal.size())
-        activePoint.x = horizontal[*m_currentHorizontalSnapPointIndex].offset * m_webPageProxy.displayedContentScale();
+        activePoint.x = horizontal[*m_currentHorizontalSnapPointIndex].offset * webPageProxy().displayedContentScale();
 
     if (!vertical.isEmpty() && m_currentVerticalSnapPointIndex && *m_currentVerticalSnapPointIndex < vertical.size()) {
-        float potentialSnapPosition = vertical[*m_currentVerticalSnapPointIndex].offset * m_webPageProxy.displayedContentScale();
+        float potentialSnapPosition = vertical[*m_currentVerticalSnapPointIndex].offset * webPageProxy().displayedContentScale();
         potentialSnapPosition -= topInset;
         activePoint.y = potentialSnapPosition;
     }
@@ -318,6 +334,4 @@ CGPoint RemoteScrollingCoordinatorProxy::nearestActiveContentInsetAdjustedSnapOf
 
 } // namespace WebKit
 
-
-#endif // ENABLE(ASYNC_SCROLLING)
-#endif // PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -30,7 +30,7 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(ASYNC_SCROLLING)
 
 #import "RemoteLayerTreeViews.h"
-#import "RemoteScrollingCoordinatorProxy.h"
+#import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "RemoteScrollingTree.h"
 #import "UIKitSPI.h"
 #import "WKScrollView.h"
@@ -402,9 +402,12 @@ UIScrollView *ScrollingTreeScrollingNodeDelegateIOS::findActingScrollParent(UISc
 
 void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)
 {
-    auto& scrollingCoordinatorProxy = downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy();
-    if (auto touchIdentifier = scrollingCoordinatorProxy.webPageProxy().pageClient().activeTouchIdentifierForGestureRecognizer(gestureRecognizer))
-        m_activeTouchActions = scrollingCoordinatorProxy.activeTouchActionsForTouchIdentifier(*touchIdentifier);
+    auto* scrollingCoordinatorProxy = dynamicDowncast<RemoteScrollingCoordinatorProxyIOS>(downcast<RemoteScrollingTree>(scrollingTree()).scrollingCoordinatorProxy());
+    if (!scrollingCoordinatorProxy)
+        return;
+
+    if (auto touchIdentifier = scrollingCoordinatorProxy->webPageProxy().pageClient().activeTouchIdentifierForGestureRecognizer(gestureRecognizer))
+        m_activeTouchActions = scrollingCoordinatorProxy->activeTouchActionsForTouchIdentifier(*touchIdentifier);
 }
 
 void ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -40,8 +40,13 @@ private:
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     void hasNodeWithAnimatedScrollChanged(bool) override;
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
+
+    void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&) override;
+    void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_REMOTE_SCROLLING_COORDINATOR_PROXY(RemoteScrollingCoordinatorProxyMac, isRemoteScrollingCoordinatorProxyMac());
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1166,13 +1166,8 @@ void WebPageProxy::setDrawingArea(std::unique_ptr<DrawingAreaProxy>&& drawingAre
     m_drawingArea->setSize(viewSize());
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(COCOA)
-    if (is<RemoteLayerTreeDrawingAreaProxy>(m_drawingArea)) {
+    if (is<RemoteLayerTreeDrawingAreaProxy>(m_drawingArea))
         m_scrollingCoordinatorProxy = downcast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea).createScrollingCoordinatorProxy();
-#if PLATFORM(IOS_FAMILY)
-        // On iOS, main frame scrolls are sent in terms of visible rect updates.
-        m_scrollingCoordinatorProxy->setPropagatesMainFrameScrolls(false);
-#endif
-    }
 #endif
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -41,7 +41,7 @@
 #import "PageClient.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeViews.h"
-#import "RemoteScrollingCoordinatorProxy.h"
+#import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "RevealItem.h"
 #import "SmartMagnificationController.h"
 #import "TextChecker.h"
@@ -258,7 +258,6 @@ static bool canAttemptTextRecognitionForNonImageElements(const WebKit::Interacti
 
 namespace WebKit {
 using namespace WebCore;
-using namespace WebKit;
 
 WKSelectionDrawingInfo::WKSelectionDrawingInfo()
     : type(SelectionType::None)
@@ -1835,7 +1834,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
 #if ENABLE(TOUCH_EVENTS)
 - (void)_handleTouchActionsForTouchEvent:(const WebKit::NativeWebTouchEvent&)touchEvent
 {
-    auto* scrollingCoordinator = _page->scrollingCoordinatorProxy();
+    auto* scrollingCoordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy());
     if (!scrollingCoordinator)
         return;
 
@@ -2320,7 +2319,7 @@ static NSValue *nsSizeForTapHighlightBorderRadius(WebCore::IntSize borderRadius,
     [_textInteractionAssistant didEndScrollingOverflow];
 
     UIScrollView *targetScrollView = nil;
-    if (auto* scrollingCoordinator = _page->scrollingCoordinatorProxy())
+    if (auto* scrollingCoordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy()))
         targetScrollView = scrollingCoordinator->scrollViewForScrollingNodeID(scrollingNodeID);
 
     [_webView _didFinishScrolling:targetScrollView];
@@ -8439,7 +8438,7 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
 - (void)_updateTargetedPreviewScrollViewUsingContainerScrollingNodeID:(WebCore::ScrollingNodeID)scrollingNodeID
 {
     if (scrollingNodeID) {
-        if (auto* scrollingCoordinator = _page->scrollingCoordinatorProxy()) {
+        if (auto* scrollingCoordinator = downcast<WebKit::RemoteScrollingCoordinatorProxyIOS>(_page->scrollingCoordinatorProxy())) {
             if (UIScrollView *scrollViewForScrollingNode = scrollingCoordinator->scrollViewForScrollingNodeID(scrollingNodeID))
                 _scrollViewForTargetedPreview = scrollViewForScrollingNode;
         }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3055,6 +3055,7 @@
 		0F0C365718C051BA00F607D7 /* RemoteLayerTreeHostIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerTreeHostIOS.mm; sourceTree = "<group>"; };
 		0F0C365B18C05CA100F607D7 /* RemoteScrollingCoordinatorProxyIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteScrollingCoordinatorProxyIOS.mm; sourceTree = "<group>"; };
 		0F11781422E39BE6008BD570 /* TransactionID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TransactionID.h; sourceTree = "<group>"; };
+		0F11C59B29157C69001832D9 /* RemoteScrollingCoordinatorProxyIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteScrollingCoordinatorProxyIOS.h; sourceTree = "<group>"; };
 		0F174AA2142A4CB60039250F /* APIGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIGeometry.h; sourceTree = "<group>"; };
 		0F174AA6142AAC610039250F /* WKGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKGeometry.cpp; sourceTree = "<group>"; };
 		0F189CAB24749F2F00E58D81 /* DisplayLinkObserverID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplayLinkObserverID.h; sourceTree = "<group>"; };
@@ -9361,6 +9362,7 @@
 				0F0C365718C051BA00F607D7 /* RemoteLayerTreeHostIOS.mm */,
 				2DC18FB1218A6E9E0025A88D /* RemoteLayerTreeViews.h */,
 				2DC18FB2218A6E9E0025A88D /* RemoteLayerTreeViews.mm */,
+				0F11C59B29157C69001832D9 /* RemoteScrollingCoordinatorProxyIOS.h */,
 				0F0C365B18C05CA100F607D7 /* RemoteScrollingCoordinatorProxyIOS.mm */,
 				0FF7CE882901FDA500EA62D6 /* RemoteScrollingTreeIOS.cpp */,
 				0FF7CE892901FDA500EA62D6 /* RemoteScrollingTreeIOS.h */,


### PR DESCRIPTION
#### e618b68f1b6a688be17db4c3b2b23de8f940bf45
<pre>
Create RemoteScrollingCoordinatorProxyIOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=247518">https://bugs.webkit.org/show_bug.cgi?id=247518</a>
rdar://101987258

Reviewed by Sam Weinig.

macOS subclassed RemoteScrollingCoordinatorProxy into RemoteScrollingCoordinatorProxyMac, so do the same
for iOS. This cleans up some #ifdeffed code.

The RemoteLayerTreeDrawingAreaProxy subclasses instantiate the correct type of RemoteScrollingCoordinatorProxy.

Define SPECIALIZE_TYPE_TRAITS so we can use downcast&lt;&gt; etc but have the predicate be compile-time.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewWillBeginDragging:]):
(-[WKWebView scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKWebView _updateVisibleContentRects]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::createScrollingCoordinatorProxy const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::layerTreeHost const):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingCoordinatorProxy::connectStateNodeLayers): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::establishLayerTreeScrollingRelations): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::activeTouchActionsForTouchIdentifier const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::setTouchActionsForTouchIdentifier): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::clearTouchActionsForTouchIdentifier): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::isRemoteScrollingCoordinatorProxyIOS const):
(WebKit::RemoteScrollingCoordinatorProxy::isRemoteScrollingCoordinatorProxyMac const):
(WebKit::RemoteScrollingCoordinatorProxy::propagatesMainFrameScrolls const):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartPanGesture):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidEndScroll):
(WebKit::RemoteScrollingCoordinatorProxy::setRootNodeIsInUserScroll):
(WebKit::RemoteScrollingCoordinatorProxy::setPropagatesMainFrameScrolls): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::fixedScrollingNodeLayerIDs const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::createScrollingCoordinatorProxy const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::RemoteScrollingCoordinatorProxyIOS):
(WebKit::RemoteScrollingCoordinatorProxyIOS::activeTouchActionsForTouchIdentifier const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::setTouchActionsForTouchIdentifier):
(WebKit::RemoteScrollingCoordinatorProxyIOS::clearTouchActionsForTouchIdentifier):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::removeFixedScrollingNodeLayerIDs):
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
(WebKit::RemoteScrollingCoordinatorProxyIOS::currentLayoutViewport const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartPanGesture):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll):
(WebKit::RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations):
(WebKit::RemoteScrollingCoordinatorProxyIOS::adjustTargetContentOffsetForSnapping):
(WebKit::RemoteScrollingCoordinatorProxyIOS::shouldSetScrollViewDecelerationRateFast const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll):
(WebKit::RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset const):
(WebKit::RemoteScrollingCoordinatorProxy::scrollViewForScrollingNodeID const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::removeFixedScrollingNodeLayerIDs): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::connectStateNodeLayers): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::currentLayoutViewport const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartPanGesture): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillStartScroll): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidEndScroll): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::establishLayerTreeScrollingRelations): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::adjustTargetContentOffsetForSnapping): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::shouldSetScrollViewDecelerationRateFast const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::setRootNodeIsInUserScroll): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::shouldSnapForMainFrameScrolling const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::closestSnapOffsetForMainFrameScrolling const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::hasActiveSnapPoint const): Deleted.
(WebKit::RemoteScrollingCoordinatorProxy::nearestActiveContentInsetAdjustedSnapOffset const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers):
(WebKit::RemoteScrollingCoordinatorProxyMac::establishLayerTreeScrollingRelations):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setDrawingArea):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _handleTouchActionsForTouchEvent:]):
(-[WKContentView _scrollingNodeScrollingDidEnd:]):
(-[WKContentView _updateTargetedPreviewScrollViewUsingContainerScrollingNodeID:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/256372@main">https://commits.webkit.org/256372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dc687611571f354f9fea2c2afe27d5230560009

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105145 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4866 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33571 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100996 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3554 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82177 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30636 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39317 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37017 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41014 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39461 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->