### PR TITLE
CRASH at WebKit::VideoFullscreenManager::ensureModelAndInterface

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -385,6 +385,13 @@ void VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVideo
         m_videoElementInPictureInPicture = nullptr;
 
     auto contextId = m_videoElements.get(&videoElement);
+    if (!contextId.isValid()) {
+        // We have somehow managed to be asked to exit video fullscreen
+        // for a video element which was either never in fullscreen or
+        // has already been removed. Bail.
+        ASSERT_NOT_REACHED();
+        return;
+    }
     auto& interface = ensureInterface(contextId);
 
     setCurrentlyInFullscreen(interface, false);


### PR DESCRIPTION
#### 1513963400a6fab88f9f5420b8a96c32a1e10cd6
<pre>
CRASH at WebKit::VideoFullscreenManager::ensureModelAndInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=247520">https://bugs.webkit.org/show_bug.cgi?id=247520</a>
rdar://67069959

Reviewed by Eric Carlson.

In VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(), the HTMLVideoElement
parameter is search for in a HashMap storing those media element&apos;s matching contextIDs. If,
however, the media element was never in that HashMap, or if it was already removed from that
hash map, (or more unlikely, if an invalid contextID was inserted into that HashMap), attempting
to use that invalid contextID as the key to other HashMaps will cause failures, as the map will
treat that contextID as the &quot;deleted value&quot; key.

In this exceptional scenario, just bail out.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):

Canonical link: <a href="https://commits.webkit.org/256409@main">https://commits.webkit.org/256409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c1034a3891c2dc79195c7f3f9a9a142bc1efddf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105113 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4829 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33532 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100964 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3521 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82144 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30606 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73442 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39285 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/36986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4432 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/40982 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42835 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/SharedWorkerGlobalScope/name/getting.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39433 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->