### PR TITLE
[WK2][GLib] Add ArgumentCoder<GRefPtr<GUnixFDList>> specialization

### DIFF
--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
@@ -28,8 +28,9 @@
 #include "ArgumentCoders.h"
 #include <wtf/glib/GRefPtr.h>
 
-typedef struct _GVariant GVariant;
 typedef struct _GTlsCertificate GTlsCertificate;
+typedef struct _GUnixFDList GUnixFDList;
+typedef struct _GVariant GVariant;
 
 namespace IPC {
 
@@ -43,6 +44,11 @@ template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
     static void encode(Encoder&, GRefPtr<GTlsCertificate>);
     template<typename Decoder>
     static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {
+    static void encode(Encoder&, const GRefPtr<GUnixFDList>&);
+    static std::optional<GRefPtr<GUnixFDList>> decode(Decoder&);
 };
 
 } // namespace IPC


### PR DESCRIPTION
#### 96ebc7619894c35e64d5155eaf81d2963d4bd4a8
<pre>
[WK2][GLib] Add ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt; specialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=247522">https://bugs.webkit.org/show_bug.cgi?id=247522</a>

Reviewed by Michael Catanzaro.

Move encoding and decoding logic for GUnixFDList objects into a separate
ArgumentCoder specialization, removing the logic from the UserMessage
class&apos;s encoding and decoding methods.

Nullness of a GRefPtr&lt;GUnixFDList&gt; is preserved, and a file descriptor
leak during decoding is fixed. When encoding, the gathered UnixFileDescriptor
objects should be moved through the encoder to avoid further duplication,
but this will only work later once other specific ArgumentCoder specializations
properly handle rvalues.

* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GUnixFDList&gt;&gt;::decode):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:
* Source/WebKit/Shared/glib/UserMessage.cpp:
(WebKit::UserMessage::encode const):
(WebKit::UserMessage::decode):

Canonical link: <a href="https://commits.webkit.org/256374@main">https://commits.webkit.org/256374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f0e56e5adfbfe6f44591d540698974ecd30225c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105132 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4851 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33556 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100983 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3541 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82164 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30620 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73457 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39304 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4405 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42849 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/42989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39449 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->