### PR TITLE
[GStreamer] Refactor video frame painting to VideoFrameGStreamer

### DIFF
--- a/Source/WebCore/platform/VideoFrame.cpp
+++ b/Source/WebCore/platform/VideoFrame.cpp
@@ -95,12 +95,14 @@ RefPtr<JSC::Uint8ClampedArray> VideoFrame::getRGBAImageData() const
     // FIXME: Add support.
     return nullptr;
 }
+#endif // !PLATFORM(COCOA)
 
-void VideoFrame::paintInContext(GraphicsContext&, const FloatRect&, bool)
+#if !PLATFORM(COCOA) && !USE(GSTREAMER)
+void VideoFrame::paintInContext(GraphicsContext&, const FloatRect&, const ImageOrientation&, bool)
 {
     // FIXME: Add support.
 }
-#endif
+#endif // !PLATFORM(COCOA) && !USE(GSTREAMER)
 
 }
 

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -42,6 +42,7 @@ namespace WebCore {
 
 class FloatRect;
 class GraphicsContext;
+struct ImageOrientation;
 class NativeImage;
 class ProcessIdentity;
 #if USE(AVFOUNDATION) && PLATFORM(COCOA)
@@ -103,7 +104,7 @@ public:
 
     void initializeCharacteristics(MediaTime presentationTime, bool isMirrored, Rotation);
 
-    void paintInContext(GraphicsContext&, const FloatRect&, bool shouldDiscardAlpha);
+    void paintInContext(GraphicsContext&, const FloatRect&, const ImageOrientation&, bool shouldDiscardAlpha);
 
     const PlatformVideoColorSpace& colorSpace() const { return m_colorSpace; }
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -33,6 +33,7 @@
 #include "FloatRoundedRect.h"
 #include "Gradient.h"
 #include "ImageBuffer.h"
+#include "ImageOrientation.h"
 #include "IntRect.h"
 #include "MediaPlayer.h"
 #include "MediaPlayerPrivate.h"
@@ -609,7 +610,7 @@ void GraphicsContext::paintFrameForMedia(MediaPlayer& player, const FloatRect& d
 #if ENABLE(WEB_CODECS)
 void GraphicsContext::paintVideoFrame(VideoFrame& frame, const FloatRect& destination, bool shouldDiscardAlpha)
 {
-    frame.paintInContext(*this, destination, shouldDiscardAlpha);
+    frame.paintInContext(*this, destination, ImageOrientation::None, shouldDiscardAlpha);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -383,10 +383,13 @@ void VideoFrame::copyTo(Span<uint8_t> span, VideoPixelFormat format, Vector<Comp
     callback({ });
 }
 
-void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& destination, bool shouldDiscardAlpha)
+void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& destination, const ImageOrientation& destinationImageRotation, bool shouldDiscardAlpha)
 {
     // FIXME: Handle alpha discarding.
     UNUSED_PARAM(shouldDiscardAlpha);
+
+    // FIXME: destination image rotation handling.
+    UNUSED_PARAM(destinationImageRotation);
 
     // FIXME: It is not efficient to create a conformer everytime. We might want to make it more efficient, for instance by storing it in GraphicsContext.
     auto conformer = makeUnique<PixelBufferConformerCV>((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA) });

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp
@@ -574,6 +574,26 @@ template <> void derefGPtr<GstEGLImage>(GstEGLImage* ptr)
         gst_egl_image_unref(ptr);
 }
 
+template<> GRefPtr<GstGLColorConvert> adoptGRef(GstGLColorConvert* ptr)
+{
+    ASSERT(!ptr || !g_object_is_floating(ptr));
+    return GRefPtr<GstGLColorConvert>(ptr, GRefPtrAdopt);
+}
+
+template<> GstGLColorConvert* refGPtr<GstGLColorConvert>(GstGLColorConvert* ptr)
+{
+    if (ptr)
+        gst_object_ref_sink(GST_OBJECT(ptr));
+
+    return ptr;
+}
+
+template<> void derefGPtr<GstGLColorConvert>(GstGLColorConvert* ptr)
+{
+    if (ptr)
+        gst_object_unref(GST_OBJECT(ptr));
+}
+
 #endif // USE(GSTREAMER_GL)
 
 template <>

--- a/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h
@@ -32,6 +32,7 @@ struct WebKitWebSrc;
 typedef struct _GstGLDisplay GstGLDisplay;
 typedef struct _GstGLContext GstGLContext;
 typedef struct _GstEGLImage GstEGLImage;
+typedef struct _GstGLColorConvert GstGLColorConvert;
 #endif
 
 #if USE(GSTREAMER_WEBRTC)
@@ -156,6 +157,11 @@ template<> void derefGPtr<GstGLContext>(GstGLContext* ptr);
 template<> GRefPtr<GstEGLImage> adoptGRef(GstEGLImage* ptr);
 template<> GstEGLImage* refGPtr<GstEGLImage>(GstEGLImage* ptr);
 template<> void derefGPtr<GstEGLImage>(GstEGLImage* ptr);
+
+template<> GRefPtr<GstGLColorConvert> adoptGRef(GstGLColorConvert* ptr);
+template<> GstGLColorConvert* refGPtr<GstGLColorConvert>(GstGLColorConvert* ptr);
+template<> void derefGPtr<GstGLColorConvert>(GstGLColorConvert* ptr);
+
 #endif
 
 template<> GRefPtr<GstEncodingProfile> adoptGRef(GstEncodingProfile*);

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -64,7 +64,7 @@ private:
     ImageDecoderGStreamerSample(GRefPtr<GstSample>&& sample, const FloatSize& presentationSize)
         : MediaSampleGStreamer(WTFMove(sample), presentationSize, { })
     {
-        m_image = ImageGStreamer::createImage(platformSample().sample.gstSample);
+        m_image = ImageGStreamer::createImage(GRefPtr<GstSample>(platformSample().sample.gstSample));
     }
 
     RefPtr<ImageGStreamer> m_image;

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h
@@ -37,15 +37,13 @@ class IntSize;
 
 class ImageGStreamer : public RefCounted<ImageGStreamer> {
 public:
-    static RefPtr<ImageGStreamer> createImage(GstSample* sample)
+    static RefPtr<ImageGStreamer> createImage(GRefPtr<GstSample>&& sample)
     {
-        auto image = adoptRef(new ImageGStreamer(sample));
-        if (!image->m_image)
-            return nullptr;
-
-        return image;
+        return adoptRef(new ImageGStreamer(WTFMove(sample)));
     }
     ~ImageGStreamer();
+
+    operator bool() const { return !!m_image; }
 
     BitmapImage& image()
     {
@@ -65,7 +63,8 @@ public:
     bool hasAlpha() const { return m_hasAlpha; }
 
 private:
-    ImageGStreamer(GstSample*);
+    ImageGStreamer(GRefPtr<GstSample>&&);
+    GRefPtr<GstSample> m_sample;
     RefPtr<BitmapImage> m_image;
     FloatRect m_cropRect;
 #if USE(CAIRO)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp
@@ -31,9 +31,10 @@
 
 namespace WebCore {
 
-ImageGStreamer::ImageGStreamer(GstSample* sample)
+ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
+    : m_sample(WTFMove(sample))
 {
-    GstCaps* caps = gst_sample_get_caps(sample);
+    GstCaps* caps = gst_sample_get_caps(m_sample.get());
     GstVideoInfo videoInfo;
     gst_video_info_init(&videoInfo);
     if (!gst_video_info_from_caps(&videoInfo, caps))
@@ -42,7 +43,7 @@ ImageGStreamer::ImageGStreamer(GstSample* sample)
     // The frame has to RGB so we can paint it.
     ASSERT(GST_VIDEO_INFO_IS_RGB(&videoInfo));
 
-    GstBuffer* buffer = gst_sample_get_buffer(sample);
+    GstBuffer* buffer = gst_sample_get_buffer(m_sample.get());
     if (UNLIKELY(!GST_IS_BUFFER(buffer)))
         return;
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -383,9 +383,6 @@ protected:
 
 #if USE(GSTREAMER_GL)
     std::unique_ptr<VideoTextureCopierGStreamer> m_videoTextureCopier;
-    GRefPtr<GstGLColorConvert> m_colorConvert;
-    GRefPtr<GstCaps> m_colorConvertInputCaps;
-    GRefPtr<GstCaps> m_colorConvertOutputCaps;
 #endif
 
     ImageOrientation m_videoSourceOrientation;

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -19,16 +19,129 @@
 
 
 #include "config.h"
+
 #include "VideoFrameGStreamer.h"
 
 #include "GStreamerCommon.h"
+#include "GraphicsContext.h"
+#include "ImageGStreamer.h"
+#include "ImageOrientation.h"
 #include "PixelBuffer.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/TypedArrayInlines.h>
 
+#if USE(GSTREAMER_GL)
+#include <gst/gl/gstglcolorconvert.h>
+#include <gst/gl/gstglmemory.h>
+#endif
+
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
 namespace WebCore {
+
+class GstSampleColorConverter {
+public:
+    static GstSampleColorConverter& singleton();
+
+    RefPtr<ImageGStreamer> convertSampleToImage(const GRefPtr<GstSample>&);
+    GRefPtr<GstSample> convertSample(const GRefPtr<GstSample>&, const GRefPtr<GstCaps>&);
+
+private:
+#if USE(GSTREAMER_GL)
+    GRefPtr<GstGLColorConvert> m_glColorConvert;
+#endif
+    GUniquePtr<GstVideoConverter> m_colorConvert;
+    GRefPtr<GstCaps> m_colorConvertInputCaps;
+    GRefPtr<GstCaps> m_colorConvertOutputCaps;
+};
+
+GstSampleColorConverter& GstSampleColorConverter::singleton()
+{
+    static NeverDestroyed<GstSampleColorConverter> sharedInstance;
+    return sharedInstance;
+}
+
+GRefPtr<GstSample> GstSampleColorConverter::convertSample(const GRefPtr<GstSample>& sample, const GRefPtr<GstCaps>& outputCaps)
+{
+    auto* buffer = gst_sample_get_buffer(sample.get());
+    if (UNLIKELY(!GST_IS_BUFFER(buffer)))
+        return nullptr;
+
+    auto* caps = gst_sample_get_caps(sample.get());
+
+    GstVideoInfo videoInfo;
+    gst_video_info_init(&videoInfo);
+    if (!gst_video_info_from_caps(&videoInfo, caps))
+        return nullptr;
+
+    GRefPtr<GstBuffer> outputBuffer;
+    auto* memory = gst_buffer_peek_memory(buffer, 0);
+#if USE(GSTREAMER_GL)
+    if (gst_is_gl_memory(memory)) {
+        if (!m_colorConvertInputCaps || !gst_caps_is_equal(m_colorConvertInputCaps.get(), caps)) {
+            m_glColorConvert = adoptGRef(gst_gl_color_convert_new(GST_GL_BASE_MEMORY_CAST(memory)->context));
+            m_colorConvertInputCaps = adoptGRef(gst_caps_copy(caps));
+            m_colorConvertOutputCaps = adoptGRef(gst_caps_copy(outputCaps.get()));
+
+            gst_caps_set_features(m_colorConvertOutputCaps.get(), 0, gst_caps_features_new(GST_CAPS_FEATURE_MEMORY_GL_MEMORY, nullptr));
+            gst_caps_set_simple(m_colorConvertOutputCaps.get(), "texture-target", G_TYPE_STRING, GST_GL_TEXTURE_TARGET_2D_STR, nullptr);
+            if (!gst_gl_color_convert_set_caps(m_glColorConvert.get(), caps, m_colorConvertOutputCaps.get())) {
+                m_colorConvertInputCaps.clear();
+                m_colorConvertOutputCaps.clear();
+                return nullptr;
+            }
+        }
+
+        outputBuffer = adoptGRef(gst_gl_color_convert_perform(m_glColorConvert.get(), buffer));
+    } else
+#endif
+    {
+        GstVideoInfo outputInfo;
+        gst_video_info_init(&outputInfo);
+        if (!gst_video_info_from_caps(&outputInfo, outputCaps.get()))
+            return nullptr;
+
+        if (!m_colorConvertOutputCaps || !gst_caps_is_equal(m_colorConvertOutputCaps.get(), outputCaps.get())) {
+            m_colorConvert.reset(gst_video_converter_new(&videoInfo, &outputInfo, nullptr));
+            m_colorConvertOutputCaps = outputCaps;
+        }
+
+        outputBuffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&outputInfo), nullptr));
+        GstMappedFrame inputFrame(buffer, videoInfo, GST_MAP_READ);
+        GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
+        gst_video_converter_frame(m_colorConvert.get(), inputFrame.get(), outputFrame.get());
+    }
+
+    if (UNLIKELY(!GST_IS_BUFFER(outputBuffer.get())))
+        return nullptr;
+
+    const auto* info = gst_sample_get_info(sample.get());
+    auto convertedSample = adoptGRef(gst_sample_new(outputBuffer.get(), m_colorConvertOutputCaps.get(),
+        gst_sample_get_segment(sample.get()), info ? gst_structure_copy(info) : nullptr));
+    return convertedSample;
+}
+
+RefPtr<ImageGStreamer> GstSampleColorConverter::convertSampleToImage(const GRefPtr<GstSample>& sample)
+{
+    GstVideoInfo videoInfo;
+    gst_video_info_init(&videoInfo);
+    if (!gst_video_info_from_caps(&videoInfo, gst_sample_get_caps(sample.get())))
+        return nullptr;
+
+    // These caps must match the internal format of a cairo surface with CAIRO_FORMAT_ARGB32,
+    // so we don't need to perform color conversions when painting the video frame.
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+    const char* formatString = GST_VIDEO_INFO_HAS_ALPHA(&videoInfo) ? "BGRA" : "BGRx";
+#else
+    const char* formatString = GST_VIDEO_INFO_HAS_ALPHA(&videoInfo) ? "ARGB" : "xRGB";
+#endif
+    auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatString, "framerate", GST_TYPE_FRACTION, GST_VIDEO_INFO_FPS_N(&videoInfo), GST_VIDEO_INFO_FPS_D(&videoInfo), "width", G_TYPE_INT, GST_VIDEO_INFO_WIDTH(&videoInfo), "height", G_TYPE_INT, GST_VIDEO_INFO_HEIGHT(&videoInfo), nullptr));
+    auto convertedSample = convertSample(sample, caps);
+    if (!convertedSample)
+        return nullptr;
+
+    return ImageGStreamer::createImage(WTFMove(convertedSample));
+}
 
 static inline void setBufferFields(GstBuffer* buffer, const MediaTime& presentationTime, double frameRate)
 {
@@ -83,22 +196,16 @@ Ref<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<PixelBuf
         height = destinationSize.height();
         auto outputCaps = adoptGRef(gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, formatName, "width", G_TYPE_INT, width,
             "height", G_TYPE_INT, height, "framerate", GST_TYPE_FRACTION, frameRateNumerator, frameRateDenominator, nullptr));
-        GstVideoInfo outputInfo;
-        gst_video_info_from_caps(&outputInfo, outputCaps.get());
 
-        auto outputBuffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&outputInfo), nullptr));
-        {
-            GUniquePtr<GstVideoConverter> converter(gst_video_converter_new(&inputInfo, &outputInfo, nullptr));
-            GstMappedFrame inputFrame(buffer.get(), inputInfo, GST_MAP_READ);
-            GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
-            gst_video_converter_frame(converter.get(), inputFrame.get(), outputFrame.get());
+        auto inputSample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+        sample = GstSampleColorConverter::singleton().convertSample(inputSample, outputCaps);
+        if (sample) {
+            auto* outputBuffer = gst_sample_get_buffer(sample.get());
+            if (metadata)
+                webkitGstBufferSetVideoFrameTimeMetadata(outputBuffer, *metadata);
+
+            setBufferFields(outputBuffer, presentationTime, frameRate);
         }
-
-        if (metadata)
-            webkitGstBufferSetVideoFrameTimeMetadata(outputBuffer.get(), *metadata);
-
-        setBufferFields(outputBuffer.get(), presentationTime, frameRate);
-        sample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
     } else {
         if (metadata)
             buffer = webkitGstBufferSetVideoFrameTimeMetadata(buffer.get(), *metadata);
@@ -127,6 +234,18 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
     : VideoFrame(presentationTime, false, videoRotation)
     , m_sample(sample)
 {
+}
+
+void VideoFrame::paintInContext(GraphicsContext& context, const FloatRect& destination, const ImageOrientation& destinationImageOrientation, bool shouldDiscardAlpha)
+{
+    auto image = GstSampleColorConverter::singleton().convertSampleToImage(downcast<VideoFrameGStreamer>(*this).sample());
+    if (!image)
+        return;
+
+    auto imageRect = image->rect();
+    auto source = destinationImageOrientation.usesWidthAsHeight() ? FloatRect(imageRect.location(), imageRect.size().transposedSize()) : imageRect;
+    auto compositeOperator = !shouldDiscardAlpha && image->hasAlpha() ? CompositeOperator::SourceOver : CompositeOperator::Copy;
+    context.drawImage(image->image(), destination, source, { compositeOperator, destinationImageOrientation });
 }
 
 RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -72,4 +72,8 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::VideoFrameGStreamer)
+static bool isType(const WebCore::VideoFrame& frame) { return frame.isGStreamer(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)


### PR DESCRIPTION
#### 5919cb323ca10a52b6c40b8ce2d408d3a3c956a2
<pre>
[GStreamer] Refactor video frame painting to VideoFrameGStreamer
<a href="https://bugs.webkit.org/show_bug.cgi?id=247523">https://bugs.webkit.org/show_bug.cgi?id=247523</a>

Reviewed by Žan Doberšek.

VideoFrame::paintInContext() is needed for WebCodec VideoFrame rendering, we already had some useful
code for this embedded in the player, it is now refactored in the VideoFrameGStreamer
implementation.

* Source/WebCore/platform/VideoFrame.cpp:
(WebCore::VideoFrame::paintInContext):
* Source/WebCore/platform/VideoFrame.h:
(WebCore::VideoFrame::sample const):
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::paintVideoFrame):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::paintInContext):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.cpp:
(WTF::adoptGRef):
(WTF::refGPtr&lt;GstGLColorConvert&gt;):
(WTF::derefGPtr&lt;GstGLColorConvert&gt;):
* Source/WebCore/platform/graphics/gstreamer/GRefPtrGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamer.h:
(WebCore::ImageGStreamer::createImage):
(WebCore::ImageGStreamer::operator bool const):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerCairo.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::paint):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::GstSampleColorConverter::singleton):
(WebCore::GstSampleColorConverter::convertSample):
(WebCore::GstSampleColorConverter::convertSampleToImage):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrame::paintInContext):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/256533@main">https://commits.webkit.org/256533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c99a6c8b914c9416f744cc20ea758626d3c13672

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105621 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165948 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5435 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34079 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101438 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101730 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82675 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87773 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39811 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37486 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42082 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39907 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->