### PR TITLE
[GStreamer] Rebrand colorspace handling to common facilities

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -23,6 +23,7 @@
 #include "FloatSize.h"
 #include "GRefPtrGStreamer.h"
 #include "GUniquePtrGStreamer.h"
+#include "PlatformVideoColorSpace.h"
 #include <gst/gst.h>
 #include <gst/video/video-format.h>
 #include <gst/video/video-info.h>
@@ -338,7 +339,11 @@ GstClockTime webkitGstElementGetCurrentRunningTime(GstElement*);
 #define gst_element_get_current_running_time webkitGstElementGetCurrentRunningTime
 #endif
 
-}
+PlatformVideoColorSpace videoColorSpaceFromCaps(const GstCaps*);
+PlatformVideoColorSpace videoColorSpaceFromInfo(const GstVideoInfo&);
+void fillVideoInfoColorimetryFromColorSpace(GstVideoInfo*, const PlatformVideoColorSpace&);
+
+} // namespace WebCore
 
 #ifndef GST_BUFFER_DTS_OR_PTS
 #define GST_BUFFER_DTS_OR_PTS(buffer) (GST_BUFFER_DTS_IS_VALID(buffer) ? GST_BUFFER_DTS(buffer) : GST_BUFFER_PTS(buffer))

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -113,64 +113,7 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromCaps()
         }
         configuration.width = GST_VIDEO_INFO_WIDTH(&info);
         configuration.height = GST_VIDEO_INFO_HEIGHT(&info);
-
-#ifndef GST_DISABLE_GST_DEBUG
-        GUniquePtr<char> colorimetry(gst_video_colorimetry_to_string(&GST_VIDEO_INFO_COLORIMETRY(&info)));
-#endif
-        PlatformVideoColorSpace colorSpace;
-        switch (GST_VIDEO_INFO_COLORIMETRY(&info).matrix) {
-        case GST_VIDEO_COLOR_MATRIX_RGB:
-            colorSpace.matrix = PlatformVideoMatrixCoefficients::Rgb;
-            break;
-        case GST_VIDEO_COLOR_MATRIX_BT709:
-            colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt709;
-            break;
-        case GST_VIDEO_COLOR_MATRIX_BT601:
-            colorSpace.matrix = PlatformVideoMatrixCoefficients::Bt470bg;
-            break;
-        default:
-#ifndef GST_DISABLE_GST_DEBUG
-            GST_DEBUG("Unhandled colorspace matrix from %s", colorimetry.get());
-#endif
-            break;
-        }
-
-        switch (GST_VIDEO_INFO_COLORIMETRY(&info).transfer) {
-        case GST_VIDEO_TRANSFER_SRGB:
-            colorSpace.transfer = PlatformVideoTransferCharacteristics::Iec6196621;
-            break;
-        case GST_VIDEO_TRANSFER_BT709:
-            colorSpace.transfer = PlatformVideoTransferCharacteristics::Bt709;
-            break;
-#if GST_CHECK_VERSION(1, 18, 0)
-        case GST_VIDEO_TRANSFER_BT601:
-            colorSpace.transfer = PlatformVideoTransferCharacteristics::Smpte170m;
-            break;
-#endif
-        default:
-#ifndef GST_DISABLE_GST_DEBUG
-            GST_DEBUG("Unhandled colorspace transfer from %s", colorimetry.get());
-#endif
-            break;
-        }
-
-        switch (GST_VIDEO_INFO_COLORIMETRY(&info).primaries) {
-        case GST_VIDEO_COLOR_PRIMARIES_BT709:
-            colorSpace.primaries = PlatformVideoColorPrimaries::Bt709;
-            break;
-        case GST_VIDEO_COLOR_PRIMARIES_BT470BG:
-            colorSpace.primaries = PlatformVideoColorPrimaries::Bt470bg;
-            break;
-        case GST_VIDEO_COLOR_PRIMARIES_SMPTE170M:
-            colorSpace.primaries = PlatformVideoColorPrimaries::Smpte170m;
-            break;
-        default:
-#ifndef GST_DISABLE_GST_DEBUG
-            GST_DEBUG("Unhandled colorspace primaries from %s", colorimetry.get());
-#endif
-            break;
-        }
-        configuration.colorSpace = WTFMove(colorSpace);
+        configuration.colorSpace = videoColorSpaceFromInfo(info);
     }
 
 #if GST_CHECK_VERSION(1, 20, 0)


### PR DESCRIPTION
#### 2a9d6e23045c352a05def5c4da6f2d2a4a07a20e
<pre>
[GStreamer] Rebrand colorspace handling to common facilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=247524">https://bugs.webkit.org/show_bug.cgi?id=247524</a>

Reviewed by Xabier Rodriguez-Calvar.

We had some basic GstVideoInfo -&gt; PlatformVideoColorSpace conversion in VideoTrackPrivateGStreamer.
This now lives in GStreamerCommon along with a GstCaps -&gt; PlatformVideoColorSpace and
PlatformVideoColorSpace -&gt; GstCaps utilities. Those will be useful to improve the
VideoFrameGStreamer implementation for the WebCodecs backend.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::videoColorSpaceFromCaps):
(WebCore::videoColorSpaceFromInfo):
(WebCore::fillVideoInfoColorimetryFromColorSpace):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromCaps):

Canonical link: <a href="https://commits.webkit.org/256396@main">https://commits.webkit.org/256396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9afbbfd7cfa58ced7b43059a3cfce44ceafbbb67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105236 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4987 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33674 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101084 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101318 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82276 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87434 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39407 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4423 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41102 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39539 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->