### PR TITLE
[WK2] Allow moving objects into ArgumentCoder encoding functions

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <memory>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <wtf/Assertions.h>
 #include <wtf/CheckedArithmetic.h>
@@ -645,6 +646,27 @@ struct remove_cvref {
 
 template <typename T>
 using remove_cvref_t = typename remove_cvref<T>::type;
+}
+#endif
+
+#if !(defined(__cpp_lib_forward_like) && __cpp_lib_forward_like >= 202207L)
+namespace std {
+template<typename T, typename U>
+constexpr auto&& forward_like(U&& value)
+{
+    constexpr bool is_adding_const = std::is_const_v<std::remove_reference_t<T>>;
+    if constexpr (std::is_lvalue_reference_v<T&&>) {
+        if constexpr (is_adding_const)
+            return std::as_const(value);
+        else
+            return static_cast<U&>(value);
+    } else {
+        if constexpr (is_adding_const)
+            return std::move(std::as_const(value));
+        else
+            return std::move(value);
+    }
+}
 }
 #endif
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		2D4CF8BD1D8360CC0001CE8D /* WKThumbnailView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D4CF8BC1D8360CC0001CE8D /* WKThumbnailView.mm */; };
 		2D51A0C71C8BF00C00765C45 /* DOMHTMLVideoElementWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D51A0C51C8BF00400765C45 /* DOMHTMLVideoElementWrapper.mm */; };
 		2D70059921EDA4D0003463CB /* OffscreenWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2D70059721EDA4D0003463CB /* OffscreenWindow.mm */; };
+		2D83D08B29194B0100C5C051 /* ArgumentCoderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2D83D08A29194B0100C5C051 /* ArgumentCoderTests.cpp */; };
 		2DC9451724D8AC0200430376 /* WebThreadLock.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2DC9451624D8AC0200430376 /* WebThreadLock.mm */; };
 		2DD7D3AF178227B30026E1E3 /* lots-of-text-vertical-lr.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 2DD7D3AE178227AC0026E1E3 /* lots-of-text-vertical-lr.html */; };
 		2DD87145265F23B4005F997C /* BifurcatedGraphicsContextTestsCG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2DD87144265F23B4005F997C /* BifurcatedGraphicsContextTestsCG.cpp */; };
@@ -2104,6 +2105,7 @@
 		2D7FD19222419087007887F1 /* DocumentEditingContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DocumentEditingContext.mm; sourceTree = "<group>"; };
 		2D8104CB1BEC13E70020DA46 /* FindInPage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FindInPage.mm; sourceTree = "<group>"; };
 		2D838B1E1EEF3A5B009B980E /* WKContentViewEditingActions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKContentViewEditingActions.mm; sourceTree = "<group>"; };
+		2D83D08A29194B0100C5C051 /* ArgumentCoderTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ArgumentCoderTests.cpp; sourceTree = "<group>"; };
 		2D9846FB28AE0F2F00CBA70C /* TextFragments.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextFragments.mm; sourceTree = "<group>"; };
 		2D9A53AE1B31FA8D0074D5AA /* ShrinkToFit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ShrinkToFit.mm; sourceTree = "<group>"; };
 		2DA2586E225C67DC00B45C1C /* OverrideViewportArguments.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OverrideViewportArguments.mm; sourceTree = "<group>"; };
@@ -4381,6 +4383,7 @@
 		7B9FC58228A26544007570E7 /* IPC */ = {
 			isa = PBXGroup;
 			children = (
+				2D83D08A29194B0100C5C051 /* ArgumentCoderTests.cpp */,
 				7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */,
 				7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */,
 				7B7392EA28F849F3007297FC /* IPCTestUtilities.h */,
@@ -5949,6 +5952,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D83D08B29194B0100C5C051 /* ArgumentCoderTests.cpp in Sources */,
 				7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */,
 				7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */,
 				7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "ArgumentCoders.h"
+#include "Decoder.h"
+#include "Encoder.h"
+#include "Test.h"
+
+namespace TestWebKitAPI {
+
+struct EncodingCounter {
+    struct CounterValues {
+        CounterValues() = default;
+        CounterValues(unsigned encodingLValue, unsigned encodingRValue)
+            : encodingLValue(encodingLValue)
+            , encodingRValue(encodingRValue)
+        { }
+
+        unsigned encodingLValue { 0 };
+        unsigned encodingRValue { 0 };
+
+        bool operator==(const CounterValues& other) const
+        {
+            return encodingLValue == other.encodingLValue && encodingRValue == other.encodingRValue;
+        }
+    };
+
+    EncodingCounter(CounterValues& counterValues)
+        : m_counterValues(counterValues)
+    { }
+
+    void encode(IPC::Encoder& encoder) const & {
+        encoder << uint32_t(0);
+        ++m_counterValues.encodingLValue;
+    }
+
+    void encode(IPC::Encoder& encoder) && {
+        encoder << uint32_t(0);
+        ++m_counterValues.encodingRValue;
+    }
+
+    static std::optional<EncodingCounter> decode(IPC::Decoder&) { return std::nullopt; }
+
+    CounterValues& m_counterValues;
+};
+
+enum class EncodingCounterTestType {
+    LValue,
+    RValue,
+    MovedRValue,
+};
+
+void PrintTo(EncodingCounterTestType value, ::std::ostream* o)
+{
+    switch (value) {
+    case EncodingCounterTestType::LValue:
+        *o << "LValue";
+        return;
+    case EncodingCounterTestType::RValue:
+        *o << "RValue";
+        return;
+    case EncodingCounterTestType::MovedRValue:
+        *o << "MovedRValue";
+        return;
+    default:
+        break;
+    }
+
+    *o << "Unknown";
+}
+
+class ArgumentCoderEncodingCounterTest : public ::testing::TestWithParam<std::tuple<EncodingCounterTestType>> {
+public:
+    ArgumentCoderEncodingCounterTest()
+        : m_encoder(static_cast<IPC::MessageName>(0), 42)
+    { }
+
+    template<typename F>
+    void testEncoding(unsigned expectedEncodingCount, const F& createFunctor)
+    {
+        EncodingCounter::CounterValues counterValues;
+
+        switch (std::get<0>(GetParam())) {
+        case EncodingCounterTestType::LValue: {
+            auto object = createFunctor(counterValues);
+            m_encoder << object;
+
+            ASSERT_EQ(counterValues, EncodingCounter::CounterValues(expectedEncodingCount, 0));
+            break;
+        }
+        case EncodingCounterTestType::RValue: {
+            m_encoder << createFunctor(counterValues);
+
+            ASSERT_EQ(counterValues, EncodingCounter::CounterValues(0, expectedEncodingCount));
+            break;
+        }
+        case EncodingCounterTestType::MovedRValue: {
+            auto object = createFunctor(counterValues);
+            m_encoder << WTFMove(object);
+
+            ASSERT_EQ(counterValues, EncodingCounter::CounterValues(0, expectedEncodingCount));
+            break;
+        }
+        }
+    }
+
+private:
+    IPC::Encoder m_encoder;
+};
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodeRawObject)
+{
+    testEncoding(1,
+        [](auto& counterValues)
+        {
+            return EncodingCounter { counterValues };
+        });
+}
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodeOptional)
+{
+    testEncoding(1,
+        [](auto& counterValues)
+        {
+            return std::optional<EncodingCounter> { EncodingCounter { counterValues } };
+        });
+}
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodePair)
+{
+    testEncoding(1,
+        [](auto& counterValues)
+        {
+            return std::pair<unsigned, EncodingCounter> { 0, EncodingCounter { counterValues } };
+        });
+}
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodeTuple)
+{
+    testEncoding(2,
+        [](auto& counterValues)
+        {
+            return std::tuple<EncodingCounter, unsigned, EncodingCounter> {
+                EncodingCounter { counterValues }, 0,
+                EncodingCounter { counterValues },
+            };
+        });
+}
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodeArray)
+{
+    testEncoding(4,
+        [](auto& counterValues)
+        {
+            return std::array<EncodingCounter, 4> {
+                EncodingCounter { counterValues },
+                EncodingCounter { counterValues },
+                EncodingCounter { counterValues },
+                EncodingCounter { counterValues },
+            };
+        });
+}
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodeVector)
+{
+    testEncoding(16,
+        [](auto& counterValues)
+        {
+            Vector<EncodingCounter> counters;
+            for (unsigned i = 0; i < 16; ++i)
+                counters.append(EncodingCounter { counterValues });
+            return counters;
+        });
+}
+
+TEST_P(ArgumentCoderEncodingCounterTest, EncodeVariant)
+{
+    testEncoding(1,
+        [](auto& counterValues)
+        {
+            return std::variant<EncodingCounter, unsigned> { EncodingCounter { counterValues } };
+        });
+}
+
+INSTANTIATE_TEST_SUITE_P(ArgumentCoderTest,
+    ArgumentCoderEncodingCounterTest,
+    testing::Values(EncodingCounterTestType::LValue, EncodingCounterTestType::RValue, EncodingCounterTestType::MovedRValue),
+    TestParametersToStringFormatter());
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### afff11b97280d9bb26274dfad5ca123f8bffffae
<pre>
[WK2] Allow moving objects into ArgumentCoder encoding functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247525">https://bugs.webkit.org/show_bug.cgi?id=247525</a>

Reviewed by Alex Christensen and Kimmo Kinnunen.

Adjust current encode() functions for different ArgumentCoder
specializations so that rvalue references to a given object can be
passed in, enabling different resources to be more optimally handled.
This mostly concerns containers and other wrapper types like
std::optional&lt;&gt; and std::variant&lt;&gt;. In changed encode() functions,
universal references are used to accept the passed-in value, and
std::forward_like&lt;&gt; is used to apply the value category from the
universal reference to the contained object that&apos;s passed forward into
the encoding process.

std::forward_like&lt;&gt; is a C++23 feature, so not in line yet with the
current C++ standard in use in the project. A fallback implementation is
added in StdLibExtras.h, properly guarded with the relevant feature-test
macro.

As an example, this can simplify encoding of Unix file descriptors or
containers of such items. When such objects can be consumed through
these rvalue references, the underlying resources can completely avoid
any otherwise-necessary duplication.

Testing facilities are added, covering different types that now support
encoding of objects passed through rvalue references. For each type,
testing is done for lvalues, rvalues and moved-in rvalues of that type.
HashTable-based types are skipped for now because of issues in
constructing appropriate values of those types.

* Source/WTF/wtf/StdLibExtras.h:
(std::forward_like):
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;std::optional&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;std::optional&lt;T&gt;&gt;::decode):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp: Added.
(TestWebKitAPI::EncodingCounter::CounterValues::CounterValues):
(TestWebKitAPI::EncodingCounter::CounterValues::operator== const):
(TestWebKitAPI::EncodingCounter::EncodingCounter):
(TestWebKitAPI::EncodingCounter::encode const):
(TestWebKitAPI::EncodingCounter::encode):
(TestWebKitAPI::EncodingCounter::decode):
(TestWebKitAPI::PrintTo):
(TestWebKitAPI::ArgumentCoderEncodingCounterTest::ArgumentCoderEncodingCounterTest):
(TestWebKitAPI::ArgumentCoderEncodingCounterTest::testEncoding):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/257073@main">https://commits.webkit.org/257073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c9ac55c7b301dbddfd79682263d192a9bd47ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97411 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106930 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167194 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6993 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35617 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103603 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5250 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84043 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32251 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75176 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88325 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/683 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20384 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83981 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/668 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21852 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44331 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86807 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41205 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19506 "Passed tests") | 
<!--EWS-Status-Bubble-End-->