### PR TITLE
Simplify MessagePort garbage collection logic

### DIFF
--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -67,7 +67,7 @@ void MessagePort::ref() const
 void MessagePort::deref() const
 {
     // This custom deref() function ensures that as long as the lock to allMessagePortsLock is taken, no MessagePort will be destroyed.
-    // This allows isExistingMessagePortLocallyReachable and notifyMessageAvailable to easily query the map and manipulate MessagePort instances.
+    // This allows notifyMessageAvailable to easily query the map and manipulate MessagePort instances.
 
     if (!--m_refCount) {
         Locker locker { allMessagePortsLock };
@@ -83,13 +83,6 @@ void MessagePort::deref() const
 
         delete this;
     }
-}
-
-bool MessagePort::isExistingMessagePortLocallyReachable(const MessagePortIdentifier& identifier)
-{
-    Locker locker { allMessagePortsLock };
-    auto* port = allMessagePorts().get(identifier);
-    return port && port->isLocallyReachable();
 }
 
 bool MessagePort::isMessagePortAliveForTesting(const MessagePortIdentifier& identifier)
@@ -168,8 +161,6 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
 {
     LOG(MessagePorts, "Attempting to post message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
-    registerLocalActivity();
-
     Vector<RefPtr<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports);
     if (messageData.hasException())
@@ -206,8 +197,6 @@ TransferredMessagePort MessagePort::disentangle()
     ASSERT(m_entangled);
     m_entangled = false;
 
-    registerLocalActivity();
-
     auto& context = *scriptExecutionContext();
     MessagePortChannelProvider::fromContext(context).messagePortDisentangled(m_identifier);
 
@@ -221,13 +210,6 @@ TransferredMessagePort MessagePort::disentangle()
     return { identifier(), remoteIdentifier() };
 }
 
-void MessagePort::registerLocalActivity()
-{
-    // Any time certain local operations happen, we dirty our own state to delay GC.
-    m_hasHadLocalActivitySinceLastCheck = true;
-    m_mightBeEligibleForGC = false;
-}
-
 // Invoked to notify us that there are messages available for this port.
 // This code may be called from another thread, and so should not call any non-threadsafe APIs (i.e. should not call into the entangled channel or access mutable variables).
 void MessagePort::messageAvailable()
@@ -238,7 +220,7 @@ void MessagePort::messageAvailable()
     if (!context || context->activeDOMObjectsAreSuspended())
         return;
 
-    context->processMessageWithMessagePortsSoon();
+    context->processMessageWithMessagePortsSoon([pendingActivity = makePendingActivity(*this)] { });
 }
 
 void MessagePort::start()
@@ -247,20 +229,16 @@ void MessagePort::start()
     if (!isEntangled())
         return;
 
-    registerLocalActivity();
-
     ASSERT(scriptExecutionContext());
     if (m_started)
         return;
 
     m_started = true;
-    scriptExecutionContext()->processMessageWithMessagePortsSoon();
+    scriptExecutionContext()->processMessageWithMessagePortsSoon([pendingActivity = makePendingActivity(*this)] { });
 }
 
 void MessagePort::close()
 {
-    m_mightBeEligibleForGC = true;
-
     if (m_isDetached)
         return;
     m_isDetached = true;
@@ -290,20 +268,14 @@ void MessagePort::dispatchMessages()
     if (!context || context->activeDOMObjectsAreSuspended() || !isEntangled())
         return;
 
-    auto messagesTakenHandler = [this, weakThis = WeakPtr { *this }](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& completionCallback) mutable {
+    auto messagesTakenHandler = [this, protectedThis = makePendingActivity(*this)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& completionCallback) mutable {
         auto scopeExit = makeScopeExit(WTFMove(completionCallback));
-
-        if (!weakThis)
-            return;
 
         LOG(MessagePorts, "MessagePort %s (%p) dispatching %zu messages", m_identifier.logString().utf8().data(), this, messages.size());
 
         auto* context = scriptExecutionContext();
         if (!context)
             return;
-
-        if (!messages.isEmpty())
-            registerLocalActivity();
 
         ASSERT(context->isContextThread());
 
@@ -333,70 +305,19 @@ void MessagePort::dispatchEvent(Event& event)
     EventTarget::dispatchEvent(event);
 }
 
-void MessagePort::updateActivity(MessagePortChannelProvider::HasActivity hasActivity)
-{
-    bool hasHadLocalActivity = m_hasHadLocalActivitySinceLastCheck;
-    m_hasHadLocalActivitySinceLastCheck = false;
-
-    if (hasActivity == MessagePortChannelProvider::HasActivity::No && !hasHadLocalActivity)
-        m_isRemoteEligibleForGC = true;
-
-    if (hasActivity == MessagePortChannelProvider::HasActivity::Yes)
-        m_isRemoteEligibleForGC = false;
-
-    m_isAskingRemoteAboutGC = false;
-}
-
+// https://html.spec.whatwg.org/multipage/web-messaging.html#ports-and-garbage-collection
 bool MessagePort::virtualHasPendingActivity() const
 {
-    m_mightBeEligibleForGC = true;
-
     // If the ScriptExecutionContext has been shut down on this object close()'ed, we can GC.
     auto* context = scriptExecutionContext();
     if (!context || m_isDetached)
         return false;
 
-    // If this MessagePort has no message event handler then the existence of remote activity cannot keep it alive.
+    // If this MessagePort has no message event handler then there is no point in keeping it alive.
     if (!m_hasMessageEventListener)
         return false;
 
-    if (m_entangled)
-        return true;
-
-    // If this object has been idle since the remote port declared itself eligible for GC, we can GC.
-    if (!m_hasHadLocalActivitySinceLastCheck && m_isRemoteEligibleForGC)
-        return false;
-
-    // If we're not in the middle of asking the remote port about collectability, do so now.
-    if (!m_isAskingRemoteAboutGC) {
-        RefPtr<WorkerOrWorkletThread> workerOrWorkletThread;
-        if (is<WorkerOrWorkletGlobalScope>(*context))
-            workerOrWorkletThread = downcast<WorkerOrWorkletGlobalScope>(*context).workerOrWorkletThread();
-
-        callOnMainThread([remoteIdentifier = m_remoteIdentifier, weakThis = WeakPtr { *this }, workerOrWorkletThread = WTFMove(workerOrWorkletThread)]() mutable {
-            MessagePortChannelProvider::singleton().checkRemotePortForActivity(remoteIdentifier, [weakThis = WTFMove(weakThis), workerOrWorkletThread = WTFMove(workerOrWorkletThread)](auto hasActivity) mutable {
-                if (!workerOrWorkletThread) {
-                    if (weakThis)
-                        weakThis->updateActivity(hasActivity);
-                    return;
-                }
-
-                workerOrWorkletThread->runLoop().postTaskForMode([weakThis = WTFMove(weakThis), hasActivity](auto&) mutable {
-                    if (weakThis)
-                        weakThis->updateActivity(hasActivity);
-                }, WorkerRunLoop::defaultMode());
-            });
-        });
-        m_isAskingRemoteAboutGC = true;
-    }
-
-    // Since we need an answer from the remote object, we have to pretend we have pending activity for now.
-    return true;
-}
-
-bool MessagePort::isLocallyReachable() const
-{
-    return !m_mightBeEligibleForGC;
+    return m_entangled;
 }
 
 MessagePort* MessagePort::locallyEntangledPort() const
@@ -449,7 +370,6 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
         if (listener->isAttribute())
             start();
         m_hasMessageEventListener = true;
-        registerLocalActivity();
     }
 
     return EventTarget::addEventListener(eventType, WTFMove(listener), options);

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -65,7 +65,6 @@ public:
     static Vector<RefPtr<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
 
     WEBCORE_EXPORT static bool isMessagePortAliveForTesting(const MessagePortIdentifier&);
-    WEBCORE_EXPORT static bool isExistingMessagePortLocallyReachable(const MessagePortIdentifier&);
     WEBCORE_EXPORT static void notifyMessageAvailable(const MessagePortIdentifier&);
 
     WEBCORE_EXPORT void messageAvailable();
@@ -84,8 +83,6 @@ public:
 
     WEBCORE_EXPORT void ref() const;
     WEBCORE_EXPORT void deref() const;
-
-    WEBCORE_EXPORT bool isLocallyReachable() const;
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return MessagePortEventTargetInterfaceType; }
@@ -110,22 +107,12 @@ private:
     void stop() final { close(); }
     bool virtualHasPendingActivity() const final;
 
-    void registerLocalActivity();
-
     // A port starts out its life entangled, and remains entangled until it is detached or is cloned.
     bool isEntangled() const { return !m_isDetached && m_entangled; }
-
-    void updateActivity(MessagePortChannelProvider::HasActivity);
 
     bool m_started { false };
     bool m_isDetached { false };
     bool m_entangled { true };
-
-    // Flags to manage querying the remote port for GC purposes
-    mutable bool m_mightBeEligibleForGC { false };
-    mutable bool m_hasHadLocalActivitySinceLastCheck { false };
-    mutable bool m_isRemoteEligibleForGC { false };
-    mutable bool m_isAskingRemoteAboutGC { false };
     bool m_hasMessageEventListener { false };
 
     MessagePortIdentifier m_identifier;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -186,6 +186,10 @@ ScriptExecutionContext::~ScriptExecutionContext()
     for (auto& callback : callbacks.values())
         callback();
 
+    auto postMessageCompletionHandlers = WTFMove(m_processMessageWithMessagePortsSoonHandlers);
+    for (auto& completionHandler : postMessageCompletionHandlers)
+        completionHandler();
+
 #if ENABLE(SERVICE_WORKER)
     setActiveServiceWorker(nullptr);
 #endif
@@ -198,9 +202,11 @@ ScriptExecutionContext::~ScriptExecutionContext()
 #endif
 }
 
-void ScriptExecutionContext::processMessageWithMessagePortsSoon()
+void ScriptExecutionContext::processMessageWithMessagePortsSoon(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(isContextThread());
+    m_processMessageWithMessagePortsSoonHandlers.append(WTFMove(completionHandler));
+
     if (m_willprocessMessageWithMessagePortsSoon)
         return;
 
@@ -219,6 +225,8 @@ void ScriptExecutionContext::dispatchMessagePortEvents()
     ASSERT(m_willprocessMessageWithMessagePortsSoon);
     m_willprocessMessageWithMessagePortsSoon = false;
 
+    auto completionHandlers = std::exchange(m_processMessageWithMessagePortsSoonHandlers, Vector<CompletionHandler<void()>> { });
+
     // Make a frozen copy of the ports so we can iterate while new ones might be added or destroyed.
     for (auto* messagePort : copyToVector(m_messagePorts)) {
         // The port may be destroyed, and another one created at the same address,
@@ -227,6 +235,9 @@ void ScriptExecutionContext::dispatchMessagePortEvents()
         if (m_messagePorts.contains(messagePort) && messagePort->started())
             messagePort->dispatchMessages();
     }
+
+    for (auto& completionHandler : completionHandlers)
+        completionHandler();
 }
 
 void ScriptExecutionContext::createdMessagePort(MessagePort& messagePort)
@@ -330,7 +341,7 @@ void ScriptExecutionContext::resumeActiveDOMObjects(ReasonForSuspension why)
 
     // In case there were pending messages at the time the script execution context entered the BackForwardCache,
     // make sure those get dispatched shortly after restoring from the BackForwardCache.
-    processMessageWithMessagePortsSoon();
+    processMessageWithMessagePortsSoon([] { });
 }
 
 void ScriptExecutionContext::stopActiveDOMObjects()

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -168,8 +168,7 @@ public:
     void willDestroyDestructionObserver(ContextDestructionObserver&);
 
     // MessagePort is conceptually a kind of ActiveDOMObject, but it needs to be tracked separately for message dispatch.
-    void processMessageWithMessagePortsSoon();
-    void dispatchMessagePortEvents();
+    void processMessageWithMessagePortsSoon(CompletionHandler<void()>&&);
     void createdMessagePort(MessagePort&);
     void destroyedMessagePort(MessagePort&);
 
@@ -362,6 +361,8 @@ private:
     virtual void refScriptExecutionContext() = 0;
     virtual void derefScriptExecutionContext() = 0;
 
+    void dispatchMessagePortEvents();
+
     enum class ShouldContinue { No, Yes };
     void forEachActiveDOMObject(const Function<ShouldContinue(ActiveDOMObject&)>&) const;
 
@@ -393,6 +394,7 @@ private:
     bool m_inDispatchErrorEvent { false };
     mutable bool m_activeDOMObjectAdditionForbidden { false };
     bool m_willprocessMessageWithMessagePortsSoon { false };
+    Vector<CompletionHandler<void()>> m_processMessageWithMessagePortsSoonHandlers;
 
 #if ASSERT_ENABLED
     bool m_inScriptExecutionContextDestructor { false };

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -54,7 +54,6 @@ public:
     bool postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget);
 
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
-    void checkRemotePortForActivity(const MessagePortIdentifier&, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&& callback);
 
     WEBCORE_EXPORT bool hasAnyMessagesPendingOrInFlight() const;
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
@@ -52,27 +52,6 @@ public:
     virtual void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) = 0;
 
     virtual void postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget) = 0;
-
-    enum class HasActivity {
-        Yes,
-        No,
-    };
-    virtual void checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(HasActivity)>&& callback) = 0;
-
-private:
-
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::MessagePortChannelProvider::HasActivity> {
-    using values = EnumValues<
-        WebCore::MessagePortChannelProvider::HasActivity,
-        WebCore::MessagePortChannelProvider::HasActivity::No,
-        WebCore::MessagePortChannelProvider::HasActivity::Yes
-    >;
-};
-
-}

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
@@ -32,16 +32,7 @@
 
 namespace WebCore {
 
-static inline MessagePortChannelRegistry::CheckProcessLocalPortForActivityCallback checkActivityCallback()
-{
-    return [](auto& messagePortIdentifier, auto, auto&& callback) {
-        ASSERT(isMainThread());
-        callback(MessagePort::isExistingMessagePortLocallyReachable(messagePortIdentifier) ? MessagePortChannelProvider::HasActivity::Yes : MessagePortChannelProvider::HasActivity::No);
-    };
-}
-
 MessagePortChannelProviderImpl::MessagePortChannelProviderImpl()
-    : m_registry(checkActivityCallback())
 {
 }
 
@@ -96,18 +87,6 @@ void MessagePortChannelProviderImpl::takeAllMessagesForPort(const MessagePortIde
 
     ensureOnMainThread([registry = &m_registry, port, callback = WTFMove(callback)]() mutable {
         registry->takeAllMessagesForPort(port, WTFMove(callback));
-    });
-}
-
-void MessagePortChannelProviderImpl::checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(HasActivity)>&& outerCallback)
-{
-    auto callback = Function<void(HasActivity)> { [outerCallback = WTFMove(outerCallback)](HasActivity hasActivity) mutable {
-        ASSERT(isMainThread());
-        outerCallback(hasActivity);
-    } };
-
-    ensureOnMainThread([registry = &m_registry, remoteTarget, callback = WTFMove(callback)]() mutable {
-        registry->checkRemotePortForActivity(remoteTarget, WTFMove(callback));
     });
 }
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h
@@ -42,7 +42,6 @@ private:
     void messagePortClosed(const MessagePortIdentifier& local) final;
     void postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget) final;
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) final;
-    void checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(HasActivity)>&& callback) final;
 
     MessagePortChannelRegistry m_registry;
 };

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp
@@ -32,10 +32,7 @@
 
 namespace WebCore {
 
-MessagePortChannelRegistry::MessagePortChannelRegistry(CheckProcessLocalPortForActivityCallback&& checkProcessLocalPortForActivityCallback)
-    : m_checkProcessLocalPortForActivityCallback(WTFMove(checkProcessLocalPortForActivityCallback))
-{
-}
+MessagePortChannelRegistry::MessagePortChannelRegistry() = default;
 
 MessagePortChannelRegistry::~MessagePortChannelRegistry()
 {
@@ -157,30 +154,11 @@ void MessagePortChannelRegistry::takeAllMessagesForPort(const MessagePortIdentif
     channel->takeAllMessagesForPort(port, WTFMove(callback));
 }
 
-void MessagePortChannelRegistry::checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&& callback)
-{
-    ASSERT(isMainThread());
-
-    // The channel might be gone if the remote side was closed.
-    auto* channel = m_openChannels.get(remoteTarget);
-    if (!channel) {
-        callback(MessagePortChannelProvider::HasActivity::No);
-        return;
-    }
-
-    channel->checkRemotePortForActivity(remoteTarget, WTFMove(callback));
-}
-
 MessagePortChannel* MessagePortChannelRegistry::existingChannelContainingPort(const MessagePortIdentifier& port)
 {
     ASSERT(isMainThread());
 
     return m_openChannels.get(port);
-}
-
-void MessagePortChannelRegistry::checkProcessLocalPortForActivity(const MessagePortIdentifier& messagePortIdentifier, ProcessIdentifier processIdentifier, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&& callback)
-{
-    m_checkProcessLocalPortForActivityCallback(messagePortIdentifier, processIdentifier, WTFMove(callback));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -35,8 +35,7 @@ namespace WebCore {
 
 class MessagePortChannelRegistry {
 public:
-    using CheckProcessLocalPortForActivityCallback = Function<void(const MessagePortIdentifier&, ProcessIdentifier, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&&)>;
-    WEBCORE_EXPORT explicit MessagePortChannelRegistry(CheckProcessLocalPortForActivityCallback&&);
+    WEBCORE_EXPORT MessagePortChannelRegistry();
 
     WEBCORE_EXPORT ~MessagePortChannelRegistry();
     
@@ -46,18 +45,14 @@ public:
     WEBCORE_EXPORT void didCloseMessagePort(const MessagePortIdentifier& local);
     WEBCORE_EXPORT bool didPostMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget);
     WEBCORE_EXPORT void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
-    WEBCORE_EXPORT void checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&& callback);
 
     WEBCORE_EXPORT MessagePortChannel* existingChannelContainingPort(const MessagePortIdentifier&);
 
     WEBCORE_EXPORT void messagePortChannelCreated(MessagePortChannel&);
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 
-    void checkProcessLocalPortForActivity(const MessagePortIdentifier&, ProcessIdentifier, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&&);
-
 private:
     HashMap<MessagePortIdentifier, MessagePortChannel*> m_openChannels;
-    CheckProcessLocalPortForActivityCallback m_checkProcessLocalPortForActivityCallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -47,13 +47,11 @@ private:
     void messagePortClosed(const MessagePortIdentifier& local) final;
     void postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget) final;
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) final;
-    void checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(HasActivity)>&& callback) final;
 
     WorkerOrWorkletGlobalScope& m_scope;
 
     uint64_t m_lastCallbackIdentifier { 0 };
     HashMap<uint64_t, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, Function<void()>&&)>> m_takeAllMessagesCallbacks;
-    HashMap<uint64_t, CompletionHandler<void(HasActivity)>> m_activityCallbacks;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1383,18 +1383,6 @@ void NetworkConnectionToWebProcess::postMessageToRemote(MessageWithMessagePorts&
     }
 }
 
-void NetworkConnectionToWebProcess::checkRemotePortForActivity(const WebCore::MessagePortIdentifier port, CompletionHandler<void(bool)>&& callback)
-{
-    networkProcess().messagePortChannelRegistry().checkRemotePortForActivity(port, [callback = WTFMove(callback)](auto hasActivity) mutable {
-        callback(hasActivity == MessagePortChannelProvider::HasActivity::Yes);
-    });
-}
-
-void NetworkConnectionToWebProcess::checkProcessLocalPortForActivity(const MessagePortIdentifier& port, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&& callback)
-{
-    connection().sendWithAsyncReply(Messages::NetworkProcessConnection::CheckProcessLocalPortForActivity { port }, WTFMove(callback), 0);
-}
-
 void NetworkConnectionToWebProcess::broadcastConsoleMessage(JSC::MessageSource source, JSC::MessageLevel level, const String& message)
 {
     connection().send(Messages::NetworkProcessConnection::BroadcastConsoleMessage(source, level, message), 0);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -185,8 +185,6 @@ public:
 
     WebCore::ProcessIdentifier webProcessIdentifier() const { return m_webProcessIdentifier; }
 
-    void checkProcessLocalPortForActivity(const WebCore::MessagePortIdentifier&, CompletionHandler<void(WebCore::MessagePortChannelProvider::HasActivity)>&&);
-
 #if ENABLE(SERVICE_WORKER)
     void serviceWorkerServerToContextConnectionNoLongerNeeded();
     WebSWServerConnection* swConnection();
@@ -291,7 +289,6 @@ private:
     void messagePortClosed(const WebCore::MessagePortIdentifier&);
     void takeAllMessagesForPort(const WebCore::MessagePortIdentifier&, CompletionHandler<void(Vector<WebCore::MessageWithMessagePorts>&&, uint64_t)>&&);
     void postMessageToRemote(WebCore::MessageWithMessagePorts&&, const WebCore::MessagePortIdentifier&);
-    void checkRemotePortForActivity(const WebCore::MessagePortIdentifier, CompletionHandler<void(bool)>&&);
     void didDeliverMessagePortMessages(uint64_t messageBatchIdentifier);
 
     void setCORSDisablingPatterns(WebCore::PageIdentifier, Vector<String>&&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -103,7 +103,6 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     MessagePortClosed(struct WebCore::MessagePortIdentifier local)
     TakeAllMessagesForPort(struct WebCore::MessagePortIdentifier port) -> (Vector<WebCore::MessageWithMessagePorts> messages, uint64_t messageBatchIdentifier)
     PostMessageToRemote(struct WebCore::MessageWithMessagePorts message, struct WebCore::MessagePortIdentifier remote)
-    CheckRemotePortForActivity(struct WebCore::MessagePortIdentifier port) -> (bool hasActivity)
     DidDeliverMessagePortMessages(uint64_t messageBatchIdentifier)
     RegisterURLSchemesAsCORSEnabled(Vector<String> schemes);
     SetCORSDisablingPatterns(WebCore::PageIdentifier pageIdentifier, Vector<String> patterns)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -142,19 +142,6 @@ static void callExitSoon(IPC::Connection*)
     });
 }
 
-static inline MessagePortChannelRegistry createMessagePortChannelRegistry(NetworkProcess& networkProcess)
-{
-    return MessagePortChannelRegistry { [&networkProcess](auto& messagePortIdentifier, auto processIdentifier, auto&& completionHandler) {
-        auto* connection = networkProcess.webProcessConnection(processIdentifier);
-        if (!connection) {
-            completionHandler(MessagePortChannelProvider::HasActivity::No);
-            return;
-        }
-
-        connection->checkProcessLocalPortForActivity(messagePortIdentifier, WTFMove(completionHandler));
-    } };
-}
-
 NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parameters)
     : m_downloadManager(*this)
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -163,7 +150,6 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
 #if PLATFORM(IOS_FAMILY)
     , m_webSQLiteDatabaseTracker([this](bool isHoldingLockedFiles) { setIsHoldingLockedFiles(isHoldingLockedFiles); })
 #endif
-    , m_messagePortChannelRegistry(createMessagePortChannelRegistry(*this))
 {
     NetworkProcessPlatformStrategies::initialize();
 

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -333,11 +333,6 @@ void NetworkProcessConnection::messagesAvailableForPort(const WebCore::MessagePo
     WebProcess::singleton().messagesAvailableForPort(messagePortIdentifier);
 }
 
-void NetworkProcessConnection::checkProcessLocalPortForActivity(const WebCore::MessagePortIdentifier& messagePortIdentifier, CompletionHandler<void(MessagePortChannelProvider::HasActivity)>&& callback)
-{
-    callback(WebCore::MessagePort::isExistingMessagePortLocallyReachable(messagePortIdentifier) ? MessagePortChannelProvider::HasActivity::Yes : MessagePortChannelProvider::HasActivity::No);
-}
-
 void NetworkProcessConnection::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> dataTypes, const Vector<WebCore::SecurityOriginData>& origins, CompletionHandler<void()>&& completionHandler)
 {
     WebProcess::singleton().deleteWebsiteDataForOrigins(dataTypes, origins, WTFMove(completionHandler));

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -105,7 +105,6 @@ private:
     void setOnLineState(bool isOnLine);
     void cookieAcceptPolicyChanged(WebCore::HTTPCookieAcceptPolicy);
 
-    void checkProcessLocalPortForActivity(const WebCore::MessagePortIdentifier&, CompletionHandler<void(WebCore::MessagePortChannelProvider::HasActivity)>&&);
     void messagesAvailableForPort(const WebCore::MessagePortIdentifier&);
 
 #if ENABLE(SHAREABLE_RESOURCE)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
@@ -41,7 +41,6 @@ messages -> NetworkProcessConnection LegacyReceiver {
     ConnectToRTCDataChannelRemoteSource(struct WebCore::RTCDataChannelIdentifier source, struct WebCore::RTCDataChannelIdentifier handler) -> (std::optional<bool> result)
 #endif
 
-    CheckProcessLocalPortForActivity(struct WebCore::MessagePortIdentifier port) -> (WebCore::MessagePortChannelProvider::HasActivity hasActivity)
     MessagesAvailableForPort(struct WebCore::MessagePortIdentifier port)
 
     BroadcastConsoleMessage(enum:uint8_t JSC::MessageSource messageSource, enum:uint8_t JSC::MessageLevel messageLevel, String message)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -116,16 +116,4 @@ void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&
     networkProcessConnection().send(Messages::NetworkConnectionToWebProcess::PostMessageToRemote { message, remoteTarget }, 0);
 }
 
-void WebMessagePortChannelProvider::checkRemotePortForActivity(const MessagePortIdentifier& remoteTarget, CompletionHandler<void(HasActivity)>&& completionHandler)
-{
-    networkProcessConnection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CheckRemotePortForActivity { remoteTarget }, [completionHandler = WTFMove(completionHandler), remoteTarget](bool hasActivity) mutable {
-        if (!hasActivity) {
-            auto& inProcessPorts = WebMessagePortChannelProvider::singleton().m_inProcessPortMessages;
-            auto iterator = inProcessPorts.find(remoteTarget);
-            hasActivity = iterator != inProcessPorts.end() && iterator->value.size();
-        }
-        completionHandler(hasActivity ? HasActivity::Yes : HasActivity::No);
-    }, 0);
-}
-
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -46,7 +46,6 @@ private:
     void messagePortClosed(const WebCore::MessagePortIdentifier& local) final;
     void takeAllMessagesForPort(const WebCore::MessagePortIdentifier&, CompletionHandler<void(Vector<WebCore::MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) final;
     void postMessageToRemote(WebCore::MessageWithMessagePorts&&, const WebCore::MessagePortIdentifier& remoteTarget) final;
-    void checkRemotePortForActivity(const WebCore::MessagePortIdentifier& remoteTarget, CompletionHandler<void(HasActivity)>&& callback) final;
 
     HashMap<WebCore::MessagePortIdentifier, Vector<WebCore::MessageWithMessagePorts>> m_inProcessPortMessages;
 };


### PR DESCRIPTION
#### 69660ff46e158c50ff8248f7d10d12db74ef71ff
<pre>
Simplify MessagePort garbage collection logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=247528">https://bugs.webkit.org/show_bug.cgi?id=247528</a>

Reviewed by Geoffrey Garen.

Simplify MessagePort garbage collection logic and align with the specification:
- <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#ports-and-garbage-collection">https://html.spec.whatwg.org/multipage/web-messaging.html#ports-and-garbage-collection</a>

Drop all logic to track remote port activity since this is not per specification.

* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::deref const):
(WebCore::MessagePort::postMessage):
(WebCore::MessagePort::disentangle):
(WebCore::MessagePort::messageAvailable):
(WebCore::MessagePort::start):
(WebCore::MessagePort::close):
(WebCore::MessagePort::dispatchMessages):
(WebCore::MessagePort::virtualHasPendingActivity const):
(WebCore::MessagePort::addEventListener):
(WebCore::MessagePort::isExistingMessagePortLocallyReachable): Deleted.
(WebCore::MessagePort::registerLocalActivity): Deleted.
(WebCore::MessagePort::updateActivity): Deleted.
(WebCore::MessagePort::isLocallyReachable const): Deleted.
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::~ScriptExecutionContext):
(WebCore::ScriptExecutionContext::processMessageWithMessagePortsSoon):
(WebCore::ScriptExecutionContext::dispatchMessagePortEvents):
(WebCore::ScriptExecutionContext::resumeActiveDOMObjects):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::MessagePortChannel::checkRemotePortForActivity): Deleted.
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelProvider.h:
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp:
(WebCore::MessagePortChannelProviderImpl::MessagePortChannelProviderImpl):
(WebCore::checkActivityCallback): Deleted.
(WebCore::MessagePortChannelProviderImpl::checkRemotePortForActivity): Deleted.
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.h:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.cpp:
(WebCore::MessagePortChannelRegistry::MessagePortChannelRegistry): Deleted.
(WebCore::MessagePortChannelRegistry::checkRemotePortForActivity): Deleted.
(WebCore::MessagePortChannelRegistry::checkProcessLocalPortForActivity): Deleted.
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp:
(WebCore::WorkerMessagePortChannelProvider::~WorkerMessagePortChannelProvider):
(WebCore::WorkerMessagePortChannelProvider::checkRemotePortForActivity): Deleted.
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::checkRemotePortForActivity): Deleted.
(WebKit::NetworkConnectionToWebProcess::checkProcessLocalPortForActivity): Deleted.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::createMessagePortChannelRegistry): Deleted.
(WebKit::m_messagePortChannelRegistry): Deleted.
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::checkProcessLocalPortForActivity): Deleted.
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::checkRemotePortForActivity): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/256452@main">https://commits.webkit.org/256452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d88b40cd61b287a06a39bd4f7a4c76ff87725c45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105143 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165411 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4865 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33570 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100994 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3553 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82175 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30629 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87352 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73466 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39316 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/18906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20208 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42857 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2148 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39459 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->