### PR TITLE
Adopt UniformTypeIdentifiers framework in MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig
+++ b/Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig
@@ -29,5 +29,5 @@ INFOPLIST_FILE = mac/Info.plist
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphone*] = *
 EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_PLATFORM_NAME))
 EXCLUDED_SOURCE_FILE_NAMES_maccatalyst = *
-OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Cocoa -framework WebKit
+OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Cocoa -framework UniformTypeIdentifiers -framework WebKit
 STRIP_STYLE = debugging;

--- a/Tools/MiniBrowser/mac/ExtensionManagerWindowController.m
+++ b/Tools/MiniBrowser/mac/ExtensionManagerWindowController.m
@@ -26,6 +26,7 @@
 #import "ExtensionManagerWindowController.h"
 
 #import "AppDelegate.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
 
 @implementation ExtensionManagerWindowController
@@ -67,10 +68,7 @@
 - (IBAction)add:(id)sender
 {
     NSOpenPanel *openPanel = [NSOpenPanel openPanel];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    openPanel.allowedFileTypes = @[ @"public.json" ];
-#pragma clang diagnostic pop
+    openPanel.allowedContentTypes = @[ UTTypeJSON ];
     
     [openPanel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result != NSModalResponseOK)

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -28,6 +28,7 @@
 #import "AppDelegate.h"
 #import "SettingsController.h"
 #import <SecurityInterface/SFCertificateTrustPanel.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebKit/WKFrameInfo.h>
 #import <WebKit/WKNavigationActionPrivate.h>
 #import <WebKit/WKNavigationDelegate.h>
@@ -910,10 +911,8 @@ static BOOL isJavaScriptURL(NSURL *url)
 - (IBAction)saveAsPDF:(id)sender
 {
     NSSavePanel *panel = [NSSavePanel savePanel];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    panel.allowedFileTypes = @[ @"pdf" ];
-#pragma clang diagnostic pop
+    panel.allowedContentTypes = @[ UTTypePDF ];
+
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK) {
             [self->_webView createPDFWithConfiguration:nil completionHandler:^(NSData *pdfSnapshotData, NSError *error) {
@@ -926,11 +925,8 @@ static BOOL isJavaScriptURL(NSURL *url)
 - (IBAction)saveAsWebArchive:(id)sender
 {
     NSSavePanel *panel = [NSSavePanel savePanel];
+    panel.allowedContentTypes = @[ UTTypeWebArchive ];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    panel.allowedFileTypes = @[ @"webarchive" ];
-#pragma clang diagnostic pop
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result == NSModalResponseOK) {
             [self->_webView createWebArchiveDataWithCompletionHandler:^(NSData *archiveData, NSError *error) {


### PR DESCRIPTION
#### 4452a79f90bf2151963ca639f45d54f23202144b
<pre>
Adopt UniformTypeIdentifiers framework in MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=247529">https://bugs.webkit.org/show_bug.cgi?id=247529</a>

Reviewed by Wenson Hsieh.

* Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig:
* Tools/MiniBrowser/mac/ExtensionManagerWindowController.m:
(-[ExtensionManagerWindowController add:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController saveAsPDF:]):
(-[WK2BrowserWindowController saveAsWebArchive:]):
Adopt UTI API to replace some deprecated constants and methods.

Canonical link: <a href="https://commits.webkit.org/256367@main">https://commits.webkit.org/256367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec02a5714d3a30b5b7776eab7b0b9fd03cc2b7c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105147 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165415 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4869 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/100998 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3557 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82179 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87356 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39319 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20212 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41016 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39463 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->