### PR TITLE
Fix some style mishaps in MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/mac/BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/BrowserWindowController.m
@@ -280,12 +280,12 @@
     return proposedServices;
 }
 
-- (nullable id <NSSharingServiceDelegate>)sharingServicePicker:(NSSharingServicePicker *)sharingServicePicker delegateForSharingService:(NSSharingService *)sharingService
+- (id <NSSharingServiceDelegate>)sharingServicePicker:(NSSharingServicePicker *)sharingServicePicker delegateForSharingService:(NSSharingService *)sharingService
 {
     return self;
 }
 
-- (void)sharingServicePicker:(NSSharingServicePicker *)sharingServicePicker didChooseSharingService:(nullable NSSharingService *)service
+- (void)sharingServicePicker:(NSSharingServicePicker *)sharingServicePicker didChooseSharingService:(NSSharingService *)service
 {
 }
 
@@ -321,7 +321,7 @@ static CGRect coreGraphicsScreenRectForAppKitScreenRect(NSRect rect)
     return image;
 }
 
-- (nullable NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope
+- (NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope
 {
     *sharingContentScope = NSSharingContentScopeFull;
     return self.window;

--- a/Tools/MiniBrowser/mac/ExtensionManagerWindowController.m
+++ b/Tools/MiniBrowser/mac/ExtensionManagerWindowController.m
@@ -34,11 +34,10 @@
 {
     self = [self initWithWindowNibName:@"ExtensionManagerWindowController"];
     if (self) {
-        NSArray* installedContentExtensions = [[NSUserDefaults standardUserDefaults] arrayForKey:@"InstalledContentExtensions"];
+        NSArray *installedContentExtensions = [[NSUserDefaults standardUserDefaults] arrayForKey:@"InstalledContentExtensions"];
         if (installedContentExtensions) {
             for (NSString *identifier in installedContentExtensions) {
-                [[WKContentRuleListStore defaultStore] lookUpContentRuleListForIdentifier:identifier completionHandler:^(WKContentRuleList *list, NSError *error)
-                {
+                [[WKContentRuleListStore defaultStore] lookUpContentRuleListForIdentifier:identifier completionHandler:^(WKContentRuleList *list, NSError *error) {
                     if (error) {
                         NSLog(@"Extension store got out of sync with system defaults.");
                         return;
@@ -58,7 +57,7 @@
 {
     [super windowDidLoad];
 
-    NSArray* installedContentExtensions = [[NSUserDefaults standardUserDefaults] arrayForKey:@"InstalledContentExtensions"];
+    NSArray *installedContentExtensions = [[NSUserDefaults standardUserDefaults] arrayForKey:@"InstalledContentExtensions"];
     if (installedContentExtensions) {
         for (NSString *extension in installedContentExtensions)
             [arrayController addObject:extension];
@@ -73,8 +72,7 @@
     openPanel.allowedFileTypes = @[ @"public.json" ];
 #pragma clang diagnostic pop
     
-    [openPanel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result)
-    {
+    [openPanel beginSheetModalForWindow:self.window completionHandler:^(NSInteger result) {
         if (result != NSModalResponseOK)
             return;
 
@@ -82,8 +80,7 @@
         NSString *identifier = url.lastPathComponent;
         NSString *jsonString = [[NSString alloc] initWithContentsOfURL:url encoding:NSUTF8StringEncoding error:nil];
 
-        [[WKContentRuleListStore defaultStore] compileContentRuleListForIdentifier:identifier encodedContentRuleList:jsonString completionHandler:^(WKContentRuleList *list, NSError *error)
-        {
+        [[WKContentRuleListStore defaultStore] compileContentRuleListForIdentifier:identifier encodedContentRuleList:jsonString completionHandler:^(WKContentRuleList *list, NSError *error) {
             
             if (error) {
                 NSAlert *alert = [NSAlert alertWithError:error];
@@ -93,7 +90,7 @@
 
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
-            NSArray* installedContentExtensions = [defaults arrayForKey:@"InstalledContentExtensions"];
+            NSArray *installedContentExtensions = [defaults arrayForKey:@"InstalledContentExtensions"];
             NSMutableArray *mutableInstalledContentExtensions;
             if (installedContentExtensions)
                 mutableInstalledContentExtensions = [installedContentExtensions mutableCopy];
@@ -105,7 +102,7 @@
 
             [self->arrayController addObject:identifier];
 
-            BrowserAppDelegate* appDelegate = [[NSApplication sharedApplication] browserAppDelegate];
+            BrowserAppDelegate *appDelegate = [[NSApplication sharedApplication] browserAppDelegate];
             [appDelegate.userContentContoller addContentRuleList:list];
         }];
     }];
@@ -118,8 +115,7 @@
 
     NSString *identifierToRemove = arrayController.arrangedObjects[index];
 
-    [[WKContentRuleListStore defaultStore] removeContentRuleListForIdentifier:identifierToRemove completionHandler:^(NSError *error)
-    {
+    [[WKContentRuleListStore defaultStore] removeContentRuleListForIdentifier:identifierToRemove completionHandler:^(NSError *error) {
         if (error) {
             NSAlert *alert = [NSAlert alertWithError:error];
             [alert runModal];
@@ -133,7 +129,7 @@
         [defaults setObject:installedContentExtensions forKey:@"InstalledContentExtensions"];
 
         [self->arrayController removeObjectAtArrangedObjectIndex:index];
-        BrowserAppDelegate* appDelegate = [[NSApplication sharedApplication] browserAppDelegate];
+        BrowserAppDelegate *appDelegate = [[NSApplication sharedApplication] browserAppDelegate];
         [appDelegate.userContentContoller _removeUserContentFilter:identifierToRemove];
     }];
 }

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -623,11 +623,7 @@ static BOOL areEssentiallyEqual(double a, double b)
     }];
 }
 
-#if __has_feature(objc_generics)
 - (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray<NSURL *> * URLs))completionHandler
-#else
-- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray *URLs))completionHandler
-#endif
 {
     NSOpenPanel *openPanel = [NSOpenPanel openPanel];
 


### PR DESCRIPTION
#### 54167ed189ac3aecd06895b4be1f1e5150434904
<pre>
Fix some style mishaps in MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=247531">https://bugs.webkit.org/show_bug.cgi?id=247531</a>

Reviewed by Wenson Hsieh.

* Tools/MiniBrowser/mac/BrowserWindowController.m:
(-[BrowserWindowController sharingServicePicker:delegateForSharingService:]):
(-[BrowserWindowController sharingServicePicker:didChooseSharingService:]):
(-[BrowserWindowController sharingService:sourceWindowForShareItems:sharingContentScope:]):
* Tools/MiniBrowser/mac/ExtensionManagerWindowController.m:
(-[ExtensionManagerWindowController init]):
(-[ExtensionManagerWindowController windowDidLoad]):
(-[ExtensionManagerWindowController add:]):
(-[ExtensionManagerWindowController remove:]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):
(-[WK2BrowserWindowController webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/256364@main">https://commits.webkit.org/256364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a481b8f37556931836efb76a398197440ae86bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95570 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105150 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4872 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33576 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101001 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82182 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30633 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87357 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39322 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37022 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20213 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4398 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41019 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43007 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39464 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->