### PR TITLE
Fix some non-fatal WebKitLegacy linker warnings about WebPreferences categories

### DIFF
--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -1044,6 +1044,15 @@ public:
 #endif
 }
 
+- (BOOL)isJavaEnabled
+{
+    return NO;
+}
+
+- (void)setJavaEnabled:(BOOL)flag
+{
+}
+
 @end
 
 @implementation WebPreferences (WebPrivate)
@@ -1792,15 +1801,6 @@ static RetainPtr<NSString>& classIBCreatorID()
 - (void)setShowDebugBorders:(BOOL)enabled
 {
     [self _setBoolValue:enabled forKey:WebKitShowDebugBordersPreferenceKey];
-}
-
-- (BOOL)subpixelAntialiasedLayerTextEnabled
-{
-    return NO;
-}
-
-- (void)setSubpixelAntialiasedLayerTextEnabled:(BOOL)enabled
-{
 }
 
 - (BOOL)legacyLineLayoutVisualCoverageEnabled
@@ -3267,7 +3267,7 @@ static RetainPtr<NSString>& classIBCreatorID()
 
 @end
 
-@implementation WebPreferences (WebPrivateObsolete)
+@implementation WebPreferences (WebPrivateDeprecated)
 
 // The preferences in this category are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
@@ -3421,12 +3421,12 @@ static RetainPtr<NSString>& classIBCreatorID()
 {
 }
 
-- (BOOL)isJavaEnabled
+- (BOOL)subpixelAntialiasedLayerTextEnabled
 {
     return NO;
 }
 
-- (void)setJavaEnabled:(BOOL)flag
+- (void)setSubpixelAntialiasedLayerTextEnabled:(BOOL)enabled
 {
 }
 


### PR DESCRIPTION
#### 4c7eca9bea82a58e3a4012aa2d7ff4f80f09e2b6
<pre>
Fix some non-fatal WebKitLegacy linker warnings about WebPreferences categories
<a href="https://bugs.webkit.org/show_bug.cgi?id=247534">https://bugs.webkit.org/show_bug.cgi?id=247534</a>

Reviewed by Alex Christensen.

* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences isJavaEnabled]):
(-[WebPreferences setJavaEnabled:]):
(-[WebPreferences subpixelAntialiasedLayerTextEnabled]):
(-[WebPreferences setSubpixelAntialiasedLayerTextEnabled:]):
250264@main incorrectly moved the Java setting to the `WebPrivateObsolete`
category in the implementation file while leaving it in the main interface
in the header. Move it back to match the header.

Also, `WebPrivateObsolete` doesn&apos;t match the name in the private header,
which is `WebPrivateDeprecated`. Fix the name.

Also, I failed to move `subpixelAntialiasedLayerTextEnabled` to the correct
category in 256201@main, so move it now.

Canonical link: <a href="https://commits.webkit.org/256369@main">https://commits.webkit.org/256369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5455274ba17608861e6c92c46490e1bcf64fd3c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105155 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165425 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4877 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33582 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101006 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3564 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82187 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30637 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73474 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39327 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37027 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4401 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41024 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39470 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->