### PR TITLE
[JSC] Implement growable SharedArrayBuffer part 1

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -13,13 +13,13 @@ flags:
   ShadowRealm: useShadowRealm
   import-assertions: useImportAssertion
   json-modules: useImportAssertion
+  resizable-arraybuffer: useResizableArrayBuffer
 skip:
   features:
     - Atomics.waitAsync
     # https://bugs.webkit.org/show_bug.cgi?id=174931
     - regexp-lookbehind
     - regexp-v-flag
-    - resizable-arraybuffer
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - decorators

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -603,12 +603,318 @@ test/annexB/language/global-code/switch-dflt-global-skip-early-err-try.js:
   default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
 test/annexB/language/global-code/switch-dflt-global-skip-early-err.js:
   default: "SyntaxError: Cannot declare a function that shadows a let/const/class/function variable 'f' in strict mode."
+test/built-ins/Array/prototype/every/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/filter/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/find/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/findIndex/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/findLast/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/findLastIndex/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/forEach/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/map/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/Array/prototype/some/callbackfn-resize-arraybuffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/options-maxbytelength-diminuitive.js:
+  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/options-maxbytelength-excessive.js:
+  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/options-maxbytelength-negative.js:
+  default: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a RangeError to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/options-maxbytelength-object.js:
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/options-maxbytelength-poisoned.js:
+  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/options-maxbytelength-undefined.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «false») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «false») to be true'
+test/built-ins/ArrayBuffer/options-non-object.js:
+  default: 'Test262Error: null Expected SameValue(«undefined», «false») to be true'
+  strict mode: 'Test262Error: null Expected SameValue(«undefined», «false») to be true'
+test/built-ins/ArrayBuffer/prototype/maxByteLength/detached-buffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «0») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «0») to be true'
+test/built-ins/ArrayBuffer/prototype/maxByteLength/invoked-as-accessor.js:
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/prototype/maxByteLength/invoked-as-func.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+test/built-ins/ArrayBuffer/prototype/maxByteLength/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'desc.get')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'desc.get')"
+test/built-ins/ArrayBuffer/prototype/maxByteLength/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'desc.get')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'desc.get')"
+test/built-ins/ArrayBuffer/prototype/maxByteLength/prop-desc.js:
+  default: "TypeError: undefined is not an object (evaluating 'desc.set')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'desc.set')"
+test/built-ins/ArrayBuffer/prototype/maxByteLength/return-maxbytelength-non-resizable.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «0») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «0») to be true'
+test/built-ins/ArrayBuffer/prototype/maxByteLength/return-maxbytelength-resizable.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «0») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «0») to be true'
+test/built-ins/ArrayBuffer/prototype/maxByteLength/this-has-no-arraybufferdata-internal.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+test/built-ins/ArrayBuffer/prototype/maxByteLength/this-is-not-object.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+test/built-ins/ArrayBuffer/prototype/maxByteLength/this-is-sharedarraybuffer.js:
+  default: "TypeError: undefined is not an object (evaluating 'maxByteLength.get')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'maxByteLength.get')"
+test/built-ins/ArrayBuffer/prototype/resizable/detached-buffer.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «false») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «false») to be true'
+test/built-ins/ArrayBuffer/prototype/resizable/invoked-as-accessor.js:
+  default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+  strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
+test/built-ins/ArrayBuffer/prototype/resizable/invoked-as-func.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+test/built-ins/ArrayBuffer/prototype/resizable/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'desc.get')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'desc.get')"
+test/built-ins/ArrayBuffer/prototype/resizable/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'desc.get')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'desc.get')"
+test/built-ins/ArrayBuffer/prototype/resizable/prop-desc.js:
+  default: "TypeError: undefined is not an object (evaluating 'desc.set')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'desc.set')"
+test/built-ins/ArrayBuffer/prototype/resizable/return-resizable.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «false») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «false») to be true'
+test/built-ins/ArrayBuffer/prototype/resizable/this-has-no-arraybufferdata-internal.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+test/built-ins/ArrayBuffer/prototype/resizable/this-is-not-object.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor("
+test/built-ins/ArrayBuffer/prototype/resizable/this-is-sharedarraybuffer.js:
+  default: "TypeError: undefined is not an object (evaluating 'resizable.get')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'resizable.get')"
+test/built-ins/ArrayBuffer/prototype/resize/descriptor.js:
+  default: 'Test262Error: obj should have an own property resize'
+  strict mode: 'Test262Error: obj should have an own property resize'
+test/built-ins/ArrayBuffer/prototype/resize/extensible.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/built-ins/ArrayBuffer/prototype/resize/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/ArrayBuffer/prototype/resize/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/ArrayBuffer/prototype/resize/new-length-excessive.js:
+  default: 'Test262Error: Expected a RangeError but got a TypeError'
+  strict mode: 'Test262Error: Expected a RangeError but got a TypeError'
+test/built-ins/ArrayBuffer/prototype/resize/new-length-negative.js:
+  default: 'Test262Error: Expected a RangeError but got a TypeError'
+  strict mode: 'Test262Error: Expected a RangeError but got a TypeError'
+test/built-ins/ArrayBuffer/prototype/resize/new-length-non-number.js:
+  default: 'Test262Error: Expected SameValue(«0», «2») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «2») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/nonconstructor.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.resize, 'prototype')')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.resize, 'prototype')')"
+test/built-ins/ArrayBuffer/prototype/resize/resize-grow.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/resize-same-size-zero-explicit.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/resize-same-size-zero-implicit.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/resize-same-size.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/resize-shrink-zero-explicit.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/resize-shrink-zero-implicit.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/resize-shrink.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/this-is-detached.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/this-is-not-arraybuffer-object.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/this-is-not-object.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/resize/this-is-not-resizable-arraybuffer-object.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/transfer/descriptor.js:
+  default: 'Test262Error: obj should have an own property transfer'
+  strict mode: 'Test262Error: obj should have an own property transfer'
+test/built-ins/ArrayBuffer/prototype/transfer/extensible.js:
+  default: 'Test262Error: Expected true but got false'
+  strict mode: 'Test262Error: Expected true but got false'
+test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-larger.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer(5)', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer(5)', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-same.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer()', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer()', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-smaller.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer(3)', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer(3)', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-fixed-to-zero.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer(0)', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer(0)', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-larger.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer(5)', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer(5)', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-same.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer()', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer()', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-smaller.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer(3)', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer(3)', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/from-resizable-to-zero.js:
+  default: "TypeError: source.transfer is not a function. (In 'source.transfer(0)', 'source.transfer' is undefined)"
+  strict mode: "TypeError: source.transfer is not a function. (In 'source.transfer(0)', 'source.transfer' is undefined)"
+test/built-ins/ArrayBuffer/prototype/transfer/length.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/ArrayBuffer/prototype/transfer/name.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.getOwnPropertyDescriptor(obj, name)')"
+test/built-ins/ArrayBuffer/prototype/transfer/new-length-excessive.js:
+  default: 'Test262Error: Expected a RangeError but got a TypeError'
+  strict mode: 'Test262Error: Expected a RangeError but got a TypeError'
+test/built-ins/ArrayBuffer/prototype/transfer/new-length-non-number.js:
+  default: 'Test262Error: Expected SameValue(«0», «2») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«0», «2») to be true'
+test/built-ins/ArrayBuffer/prototype/transfer/nonconstructor.js:
+  default: "TypeError: undefined is not an object (evaluating 'Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.transfer, 'prototype')')"
+  strict mode: "TypeError: undefined is not an object (evaluating 'Object.prototype.hasOwnProperty.call(ArrayBuffer.prototype.transfer, 'prototype')')"
+test/built-ins/ArrayBuffer/prototype/transfer/this-is-detached.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/transfer/this-is-not-arraybuffer-object.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/ArrayBuffer/prototype/transfer/this-is-not-object.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
 test/built-ins/AsyncGeneratorPrototype/return/return-suspendedStart-broken-promise.js:
   default: 'Error: broken promise'
   strict mode: 'Error: broken promise'
 test/built-ins/AsyncGeneratorPrototype/return/return-suspendedYield-broken-promise-try-catch.js:
   default: 'Test262:AsyncTestFailure:Error: broken promise'
   strict mode: 'Test262:AsyncTestFailure:Error: broken promise'
+test/built-ins/DataView/custom-proto-access-resizes-buffer-invalid-by-length.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/custom-proto-access-resizes-buffer-invalid-by-offset.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/custom-proto-access-resizes-buffer-valid-by-length.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/custom-proto-access-resizes-buffer-valid-by-offset.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/byteLength/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/byteLength/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/byteOffset/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/byteOffset/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getBigInt64/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getBigUint64/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getFloat32/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getFloat64/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getInt16/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getInt32/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getInt8/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getUint16/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getUint32/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/getUint8/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setBigInt64/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setBigUint64/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setFloat32/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setFloat64/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setInt16/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setInt32/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setInt8/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setUint16/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setUint32/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/DataView/prototype/setUint8/resizable-buffer.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
 test/built-ins/Function/internals/Construct/derived-return-val-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
@@ -1122,6 +1428,243 @@ test/built-ins/Temporal/PlainDateTime/prototype/with/overflow-wrong-type.js:
 test/built-ins/Temporal/getOwnPropertyNames.js:
   default: 'Test262Error: ZonedDateTime'
   strict mode: 'Test262Error: ZonedDateTime'
+test/built-ins/TypedArray/prototype/at/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/at/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteLength/BigInt/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteLength/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteLength/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteOffset/BigInt/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteOffset/BigInt/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/byteOffset/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/copyWithin/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/copyWithin/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/entries/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/entries/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/every/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/every/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/every/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/fill/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/fill/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/filter/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/filter/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/filter/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/find/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/find/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/find/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findIndex/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findIndex/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findIndex/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findLast/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findLast/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findLast/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findLastIndex/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findLastIndex/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/findLastIndex/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/forEach/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/forEach/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/forEach/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/includes/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/includes/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/indexOf/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/indexOf/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/join/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/join/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/keys/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/keys/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/lastIndexOf/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/lastIndexOf/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/length/BigInt/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/length/BigInt/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/length/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/length/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/map/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/map/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/map/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/reduce/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/reduce/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/reduceRight/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/reduceRight/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/reverse/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/reverse/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-resized.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/set/BigInt/typedarray-arg-target-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-same-type-resized.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/set/typedarray-arg-target-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/slice/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/slice/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/some/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/some/callbackfn-resize.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/some/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/sort/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/sort/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/toLocaleString/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/toLocaleString/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/values/BigInt/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArray/prototype/values/return-abrupt-from-this-out-of-bounds.js:
+  default: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: implements ArrayBuffer.prototype.resize Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArrayConstructors/internals/HasProperty/resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArrayConstructors/internals/HasProperty/resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArrayConstructors/internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+test/built-ins/TypedArrayConstructors/internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
+  strict mode: 'Test262Error: Expected SameValue(«undefined», «function») to be true'
 test/harness/temporalHelpers-one-shift-time-zone.js:
   default: "TypeError: realTz.getOffsetNanosecondsFor is not a function. (In 'realTz.getOffsetNanosecondsFor(shiftInstant)', 'realTz.getOffsetNanosecondsFor' is undefined)"
   strict mode: "TypeError: realTz.getOffsetNanosecondsFor is not a function. (In 'realTz.getOffsetNanosecondsFor(shiftInstant)', 'realTz.getOffsetNanosecondsFor' is undefined)"

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -956,6 +956,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/BooleanObject.h
     runtime/BooleanPrototype.h
     runtime/BrandedStructure.h
+    runtime/BufferMemoryHandle.h
     runtime/Butterfly.h
     runtime/ButterflyInlines.h
     runtime/BytecodeCacheError.h
@@ -1136,6 +1137,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/Lookup.h
     runtime/MatchResult.h
     runtime/MathCommon.h
+    runtime/MemoryMode.h
     runtime/MemoryStatistics.h
     runtime/Microtask.h
     runtime/ModuleProgramExecutable.h
@@ -1152,6 +1154,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/Operations.h
     runtime/Options.h
     runtime/OptionsList.h
+    runtime/PageCount.h
     runtime/ParseInt.h
     runtime/PrivateFieldPutKind.h
     runtime/PrivateName.h
@@ -1268,13 +1271,11 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmLLIntTierUpCounter.h
     wasm/WasmMemory.h
     wasm/WasmMemoryInformation.h
-    wasm/WasmMemoryMode.h
     wasm/WasmModule.h
     wasm/WasmModuleInformation.h
     wasm/WasmName.h
     wasm/WasmNameSection.h
     wasm/WasmOSREntryData.h
-    wasm/WasmPageCount.h
     wasm/WasmSIMDOpcodes.h
     wasm/WasmSections.h
     wasm/WasmTypeDefinition.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1248,7 +1248,6 @@
 		79B00CBF1C6AB07E0088C65D /* ProxyObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 79B00CBB1C6AB07E0088C65D /* ProxyObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		79B1788E1D399B8000B1A567 /* JITMathICForwards.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A899FE1D38612E00D18C73 /* JITMathICForwards.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		79B759751DFA4C600052174C /* WasmMemoryInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 79B759721DFA4C600052174C /* WasmMemoryInformation.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		79B759761DFA4C600052174C /* WasmPageCount.h in Headers */ = {isa = PBXBuildFile; fileRef = 79B759731DFA4C600052174C /* WasmPageCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		79B819931DD25CF500DDC714 /* JSGlobalObjectInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 79B819921DD25CF500DDC714 /* JSGlobalObjectInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		79C4B15E1BA2158F00FD592E /* DFGLiveCatchVariablePreservationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 79C4B15C1BA2158F00FD592E /* DFGLiveCatchVariablePreservationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		79CFC6F01C33B10000C768EA /* LLIntPCRanges.h in Headers */ = {isa = PBXBuildFile; fileRef = 79CFC6EF1C33B10000C768EA /* LLIntPCRanges.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1672,7 +1671,6 @@
 		AD5C36EA1F75AD6A000BCAAF /* JSToWasm.h in Headers */ = {isa = PBXBuildFile; fileRef = AD8DD6CF1F67089F0004EB52 /* JSToWasm.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD5C36EB1F75AD73000BCAAF /* JSWebAssembly.h in Headers */ = {isa = PBXBuildFile; fileRef = ADD09AF31F62482E001313C2 /* JSWebAssembly.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD5C36EC1F75AD7C000BCAAF /* WasmToJS.h in Headers */ = {isa = PBXBuildFile; fileRef = ADD09AEE1F5F623F001313C2 /* WasmToJS.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		AD5C36EF1F7A263A000BCAAF /* WasmMemoryMode.h in Headers */ = {isa = PBXBuildFile; fileRef = AD5C36EE1F7A2629000BCAAF /* WasmMemoryMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD7438C01E0457A400FD0C2A /* WasmTypeDefinition.h in Headers */ = {isa = PBXBuildFile; fileRef = AD7438BF1E04579200FD0C2A /* WasmTypeDefinition.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD7B4B2E1FA3E29800C9DF79 /* WasmNameSection.h in Headers */ = {isa = PBXBuildFile; fileRef = AD7B4B2D1FA3E28600C9DF79 /* WasmNameSection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AD86A93E1AA4D88D002FE77F /* WeakGCMapInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AD86A93D1AA4D87C002FE77F /* WeakGCMapInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1884,6 +1882,7 @@
 		E31C31322511AFD700E7A3A0 /* IntlCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E31C31302511AFD600E7A3A0 /* IntlCache.h */; };
 		E3201C1D1F8E82360076A032 /* JSScriptFetchParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = E38D060B1F8E814100649CF2 /* JSScriptFetchParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3201C1E1F8E824C0076A032 /* ScriptFetchParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E320B66C2912298100E87CDB /* MemoryMode.h in Headers */ = {isa = PBXBuildFile; fileRef = E320B66A2912298000E87CDB /* MemoryMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E322E5A31DA64439006E7709 /* DFGSnippetParams.h in Headers */ = {isa = PBXBuildFile; fileRef = E322E5A11DA64435006E7709 /* DFGSnippetParams.h */; };
 		E322E5A71DA644A8006E7709 /* FTLSnippetParams.h in Headers */ = {isa = PBXBuildFile; fileRef = E322E5A51DA644A4006E7709 /* FTLSnippetParams.h */; };
 		E323116924A1DC3500693DA5 /* IntlNumberFormatInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E323116824A1DC2F00693DA5 /* IntlNumberFormatInlines.h */; };
@@ -1998,6 +1997,7 @@
 		E386FD7E26E867B800E4C28B /* TemporalPlainTime.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7826E867B800E4C28B /* TemporalPlainTime.h */; };
 		E386FD7F26E867B800E4C28B /* TemporalPlainTimePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */; };
 		E3893A1D2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = E3893A1C2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h */; };
+		E389D854291226BC0085C3DC /* PageCount.h in Headers */ = {isa = PBXBuildFile; fileRef = E389D852291226BC0085C3DC /* PageCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E38DB2E727F588F80027BD3F /* ScriptExecutableInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E38DB2E627F588F70027BD3F /* ScriptExecutableInlines.h */; };
 		E38E8790254B978400F6F9E4 /* JSDateMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9788FC221471AD0C0068CE2D /* JSDateMath.cpp */; };
 		E38F091A288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E38F0919288D35CF009FD386 /* ObjectAdaptiveStructureWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2022,6 +2022,7 @@
 		E3A32BC71FC83147007D7E76 /* WeakMapImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A32BC61FC8312E007D7E76 /* WeakMapImpl.h */; };
 		E3A421431D6F58930007C617 /* PreciseJumpTargetsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3AC277721FDB4940024452C /* RegExpCachedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F75EFC151C062F007C9BA3 /* RegExpCachedResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3B24859291224540029C08A /* BufferMemoryHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B24857291224530029C08A /* BufferMemoryHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BD2B7622F275020011765C /* WasmCompilationMode.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BD2B7522F275020011765C /* WasmCompilationMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BF1BAE238AAEDB003A1C2B /* IsoHeapCellType.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BF1BAD238AAED1003A1C2B /* IsoHeapCellType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BF3C4D2390D1E8008BC752 /* JSWebAssemblyGlobal.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BF3C4B2390D1E2008BC752 /* JSWebAssemblyGlobal.h */; };
@@ -4375,7 +4376,6 @@
 		79B00CBB1C6AB07E0088C65D /* ProxyObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProxyObject.h; sourceTree = "<group>"; };
 		79B759711DFA4C600052174C /* WasmMemoryInformation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmMemoryInformation.cpp; sourceTree = "<group>"; };
 		79B759721DFA4C600052174C /* WasmMemoryInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmMemoryInformation.h; sourceTree = "<group>"; };
-		79B759731DFA4C600052174C /* WasmPageCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmPageCount.h; sourceTree = "<group>"; };
 		79B819921DD25CF500DDC714 /* JSGlobalObjectInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGlobalObjectInlines.h; sourceTree = "<group>"; };
 		79C4B15B1BA2158F00FD592E /* DFGLiveCatchVariablePreservationPhase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGLiveCatchVariablePreservationPhase.cpp; path = dfg/DFGLiveCatchVariablePreservationPhase.cpp; sourceTree = "<group>"; };
 		79C4B15C1BA2158F00FD592E /* DFGLiveCatchVariablePreservationPhase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGLiveCatchVariablePreservationPhase.h; path = dfg/DFGLiveCatchVariablePreservationPhase.h; sourceTree = "<group>"; };
@@ -5087,8 +5087,6 @@
 		AD5C36DF1F699EB6000BCAAF /* WasmInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmInstance.h; sourceTree = "<group>"; };
 		AD5C36E31F69EC8B000BCAAF /* WasmTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTable.cpp; sourceTree = "<group>"; };
 		AD5C36E41F69EC8B000BCAAF /* WasmTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmTable.h; sourceTree = "<group>"; };
-		AD5C36EE1F7A2629000BCAAF /* WasmMemoryMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmMemoryMode.h; sourceTree = "<group>"; };
-		AD5C36F01F7A26BF000BCAAF /* WasmMemoryMode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmMemoryMode.cpp; sourceTree = "<group>"; };
 		AD7438BE1E04579200FD0C2A /* WasmTypeDefinition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTypeDefinition.cpp; sourceTree = "<group>"; };
 		AD7438BF1E04579200FD0C2A /* WasmTypeDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmTypeDefinition.h; sourceTree = "<group>"; };
 		AD7B4B2D1FA3E28600C9DF79 /* WasmNameSection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmNameSection.h; sourceTree = "<group>"; };
@@ -5097,7 +5095,6 @@
 		AD8DD6D01F6708A30004EB52 /* JSToWasm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSToWasm.cpp; path = js/JSToWasm.cpp; sourceTree = "<group>"; };
 		AD8FF3951EB5BD850087FF82 /* WasmIndexOrName.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmIndexOrName.h; sourceTree = "<group>"; };
 		AD8FF3961EB5BD850087FF82 /* WasmIndexOrName.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmIndexOrName.cpp; sourceTree = "<group>"; };
-		ADB6F67C1E15D7500082F384 /* WasmPageCount.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmPageCount.cpp; sourceTree = "<group>"; };
 		ADD09AEE1F5F623F001313C2 /* WasmToJS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WasmToJS.h; path = js/WasmToJS.h; sourceTree = "<group>"; };
 		ADD09AEF1F5F623F001313C2 /* WasmToJS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WasmToJS.cpp; path = js/WasmToJS.cpp; sourceTree = "<group>"; };
 		ADD09AF21F624829001313C2 /* JSWebAssembly.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = JSWebAssembly.cpp; path = js/JSWebAssembly.cpp; sourceTree = "<group>"; };
@@ -5345,6 +5342,8 @@
 		E319A3EB28DA84EB00DF18C7 /* IntlDurationFormatPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlDurationFormatPrototype.h; sourceTree = "<group>"; };
 		E31C31302511AFD600E7A3A0 /* IntlCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntlCache.h; sourceTree = "<group>"; };
 		E31C31312511AFD600E7A3A0 /* IntlCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntlCache.cpp; sourceTree = "<group>"; };
+		E320B66A2912298000E87CDB /* MemoryMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryMode.h; sourceTree = "<group>"; };
+		E320B66B2912298000E87CDB /* MemoryMode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryMode.cpp; sourceTree = "<group>"; };
 		E322E5A01DA64435006E7709 /* DFGSnippetParams.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DFGSnippetParams.cpp; path = dfg/DFGSnippetParams.cpp; sourceTree = "<group>"; };
 		E322E5A11DA64435006E7709 /* DFGSnippetParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGSnippetParams.h; path = dfg/DFGSnippetParams.h; sourceTree = "<group>"; };
 		E322E5A41DA644A4006E7709 /* FTLSnippetParams.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FTLSnippetParams.cpp; path = ftl/FTLSnippetParams.cpp; sourceTree = "<group>"; };
@@ -5521,6 +5520,8 @@
 		E386FD7826E867B800E4C28B /* TemporalPlainTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporalPlainTime.h; sourceTree = "<group>"; };
 		E386FD7926E867B800E4C28B /* TemporalPlainTimePrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporalPlainTimePrototype.h; sourceTree = "<group>"; };
 		E3893A1C2203A7C600E79A74 /* AsyncFromSyncIteratorPrototype.lut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AsyncFromSyncIteratorPrototype.lut.h; sourceTree = "<group>"; };
+		E389D851291226BC0085C3DC /* PageCount.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageCount.cpp; sourceTree = "<group>"; };
+		E389D852291226BC0085C3DC /* PageCount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageCount.h; sourceTree = "<group>"; };
 		E38D060B1F8E814100649CF2 /* JSScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060C1F8E814100649CF2 /* ScriptFetchParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptFetchParameters.h; sourceTree = "<group>"; };
 		E38D060D1F8E814100649CF2 /* JSScriptFetchParameters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSScriptFetchParameters.cpp; sourceTree = "<group>"; };
@@ -5555,6 +5556,8 @@
 		E3A32BC51FC8312D007D7E76 /* WeakMapImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeakMapImpl.cpp; sourceTree = "<group>"; };
 		E3A32BC61FC8312E007D7E76 /* WeakMapImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakMapImpl.h; sourceTree = "<group>"; };
 		E3A421421D6F588F0007C617 /* PreciseJumpTargetsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreciseJumpTargetsInlines.h; sourceTree = "<group>"; };
+		E3B24857291224530029C08A /* BufferMemoryHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BufferMemoryHandle.h; sourceTree = "<group>"; };
+		E3B24858291224530029C08A /* BufferMemoryHandle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BufferMemoryHandle.cpp; sourceTree = "<group>"; };
 		E3BD2B7522F275020011765C /* WasmCompilationMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmCompilationMode.h; sourceTree = "<group>"; };
 		E3BF1BAD238AAED1003A1C2B /* IsoHeapCellType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsoHeapCellType.h; sourceTree = "<group>"; };
 		E3BF3C4B2390D1E2008BC752 /* JSWebAssemblyGlobal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = JSWebAssemblyGlobal.h; path = js/JSWebAssemblyGlobal.h; sourceTree = "<group>"; };
@@ -7501,8 +7504,6 @@
 				535557131D9D9EA5006D583B /* WasmMemory.h */,
 				79B759711DFA4C600052174C /* WasmMemoryInformation.cpp */,
 				79B759721DFA4C600052174C /* WasmMemoryInformation.h */,
-				AD5C36F01F7A26BF000BCAAF /* WasmMemoryMode.cpp */,
-				AD5C36EE1F7A2629000BCAAF /* WasmMemoryMode.h */,
 				790081361E95A8EC0052D7CD /* WasmModule.cpp */,
 				790081371E95A8EC0052D7CD /* WasmModule.h */,
 				53E777E11E92E265007CBEC4 /* WasmModuleInformation.cpp */,
@@ -7520,8 +7521,6 @@
 				E3C694B123026873006FBE42 /* WasmOSREntryData.h */,
 				527E6CEA2772B9C5005E0782 /* WasmOSREntryPlan.cpp */,
 				527E6CEB2772B9C5005E0782 /* WasmOSREntryPlan.h */,
-				ADB6F67C1E15D7500082F384 /* WasmPageCount.cpp */,
-				79B759731DFA4C600052174C /* WasmPageCount.h */,
 				53F40E8C1D5901F20099A1B6 /* WasmParser.h */,
 				531374BE1D5CE95000AF7A0B /* WasmPlan.cpp */,
 				531374BC1D5CE67600AF7A0B /* WasmPlan.h */,
@@ -7684,6 +7683,8 @@
 				BC7952350E15EB5600A898AB /* BooleanPrototype.h */,
 				8664967A25D1DD1200516B36 /* BrandedStructure.cpp */,
 				861AF60625D18C9D000B63E1 /* BrandedStructure.h */,
+				E3B24858291224530029C08A /* BufferMemoryHandle.cpp */,
+				E3B24857291224530029C08A /* BufferMemoryHandle.h */,
 				9E72940A190F0514001A91B5 /* BundlePath.h */,
 				9E729409190F0306001A91B5 /* BundlePath.mm */,
 				0FB7F38B15ED8E3800F167B2 /* Butterfly.h */,
@@ -8180,6 +8181,8 @@
 				4340A4831A9051AF00D73CCA /* MathCommon.h */,
 				F692A86A0255597D01FF60F7 /* MathObject.cpp */,
 				F692A86B0255597D01FF60F7 /* MathObject.h */,
+				E320B66B2912298000E87CDB /* MemoryMode.cpp */,
+				E320B66A2912298000E87CDB /* MemoryMode.h */,
 				90213E3B123A40C200D422F3 /* MemoryStatistics.cpp */,
 				90213E3C123A40C200D422F3 /* MemoryStatistics.h */,
 				7C008CE5187631B600955C24 /* Microtask.h */,
@@ -8223,6 +8226,8 @@
 				0FE228EA1436AB2300196C48 /* Options.cpp */,
 				0FE228EB1436AB2300196C48 /* Options.h */,
 				FE3842312324D51B009DD445 /* OptionsList.h */,
+				E389D851291226BC0085C3DC /* PageCount.cpp */,
+				E389D852291226BC0085C3DC /* PageCount.h */,
 				37C738D11EDB5672003F2B0B /* ParseInt.h */,
 				CE20BD02237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.cpp */,
 				CE20BD01237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.h */,
@@ -10010,6 +10015,7 @@
 				996B73191BDA068000331B84 /* BooleanPrototype.lut.h in Headers */,
 				861AF60725D18C9D000B63E1 /* BrandedStructure.h in Headers */,
 				FEA08620182B7A0400F6D851 /* Breakpoint.h in Headers */,
+				E3B24859291224540029C08A /* BufferMemoryHandle.h in Headers */,
 				DE26E9031CB5DD0500D2BE82 /* BuiltinExecutableCreator.h in Headers */,
 				A7D801A51880D66E0026C39B /* BuiltinExecutables.h in Headers */,
 				A75EE9B218AAB7E200AAD043 /* BuiltinNames.h in Headers */,
@@ -10979,6 +10985,7 @@
 				4340A4851A9051AF00D73CCA /* MathCommon.h in Headers */,
 				BC18C43C0E16F5CD00B34460 /* MathObject.h in Headers */,
 				E328C6C71DA4304500D255FD /* MaxFrameExtentForSlowPathCall.h in Headers */,
+				E320B66C2912298100E87CDB /* MemoryMode.h in Headers */,
 				90213E3E123A40C200D422F3 /* MemoryStatistics.h in Headers */,
 				142F16E021558802003D49C9 /* MetadataTable.h in Headers */,
 				0FB5467B14F5C7E1002C2989 /* MethodOfGettingAValueProfile.h in Headers */,
@@ -11034,6 +11041,7 @@
 				0FE228ED1436AB2700196C48 /* Options.h in Headers */,
 				FE3842332324D51B009DD445 /* OptionsList.h in Headers */,
 				E356987222841187008CDCCB /* PackedCellPtr.h in Headers */,
+				E389D854291226BC0085C3DC /* PageCount.h in Headers */,
 				0F9DAA0A1FD1C3D30079C5B2 /* ParallelSourceAdapter.h in Headers */,
 				E34E657520668EAA00FB81AC /* ParseHash.h in Headers */,
 				37C738D21EDB56E4003F2B0B /* ParseInt.h in Headers */,
@@ -11367,7 +11375,6 @@
 				53E9E0AC1EAE83DF00FEE251 /* WasmMachineThreads.h in Headers */,
 				535557141D9D9EA5006D583B /* WasmMemory.h in Headers */,
 				79B759751DFA4C600052174C /* WasmMemoryInformation.h in Headers */,
-				AD5C36EF1F7A263A000BCAAF /* WasmMemoryMode.h in Headers */,
 				790081391E95A8EC0052D7CD /* WasmModule.h in Headers */,
 				53E777E41E92E265007CBEC4 /* WasmModuleInformation.h in Headers */,
 				AD5B416F1EBAFB77008EFA43 /* WasmName.h in Headers */,
@@ -11379,7 +11386,6 @@
 				53B4BD121F68B32500D2BEA3 /* WasmOps.h in Headers */,
 				E3C694B323026877006FBE42 /* WasmOSREntryData.h in Headers */,
 				527E6CEC2772B9CB005E0782 /* WasmOSREntryPlan.h in Headers */,
-				79B759761DFA4C600052174C /* WasmPageCount.h in Headers */,
 				53F40E8D1D5901F20099A1B6 /* WasmParser.h in Headers */,
 				531374BD1D5CE67600AF7A0B /* WasmPlan.h in Headers */,
 				E3A0531C21342B680022EC14 /* WasmSectionParser.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -762,6 +762,7 @@ runtime/BooleanConstructor.cpp
 runtime/BooleanObject.cpp
 runtime/BooleanPrototype.cpp
 runtime/BrandedStructure.cpp
+runtime/BufferMemoryHandle.cpp
 runtime/BytecodeCacheError.cpp
 runtime/CallData.cpp
 runtime/CachePayload.cpp
@@ -964,6 +965,7 @@ runtime/MapPrototype.cpp
 runtime/MatchResult.cpp
 runtime/MathCommon.cpp
 runtime/MathObject.cpp
+runtime/MemoryMode.cpp
 runtime/MemoryStatistics.cpp
 runtime/ModuleProgramExecutable.cpp
 runtime/NarrowingNumberPredictionFuzzerAgent.cpp
@@ -981,6 +983,7 @@ runtime/ObjectInitializationScope.cpp
 runtime/ObjectPrototype.cpp
 runtime/Operations.cpp
 runtime/Options.cpp
+runtime/PageCount.cpp
 runtime/PredictionFileCreatingFuzzerAgent.cpp
 runtime/PrivateFieldPutKind.cpp
 runtime/ProgramExecutable.cpp
@@ -1124,7 +1127,6 @@ wasm/WasmLLIntTierUpCounter.cpp
 wasm/WasmMachineThreads.cpp
 wasm/WasmMemory.cpp
 wasm/WasmMemoryInformation.cpp
-wasm/WasmMemoryMode.cpp
 wasm/WasmModule.cpp
 wasm/WasmModuleInformation.cpp
 wasm/WasmNameSectionParser.cpp
@@ -1132,7 +1134,6 @@ wasm/WasmOMGPlan.cpp
 wasm/WasmOSREntryPlan.cpp
 wasm/WasmOpcodeOrigin.cpp
 wasm/WasmOperations.cpp
-wasm/WasmPageCount.cpp
 wasm/WasmPlan.cpp
 wasm/WasmSectionParser.cpp
 wasm/WasmTypeDefinition.cpp

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -1237,9 +1237,9 @@ void AccessCase::generateWithGuard(
             jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
 #if USE(LARGE_TYPED_ARRAYS)
-        jit.load64(addressOfLength, scratchGPR);
+        jit.load64(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfMaxByteLength()), scratchGPR);
 #else
-        jit.load32(addressOfLength, scratchGPR);
+        jit.load32(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfMaxByteLength()), scratchGPR);
 #endif
         jit.loadPtr(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfVector()), scratch2GPR);
         jit.cageConditionallyAndUntag(Gigacage::Primitive, scratch2GPR, scratchGPR, scratchGPR, false);
@@ -1661,9 +1661,9 @@ void AccessCase::generateWithGuard(
             jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
 #if USE(LARGE_TYPED_ARRAYS)
-        jit.load64(addressOfLength, scratchGPR);
+        jit.load64(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfMaxByteLength()), scratchGPR);
 #else
-        jit.load32(addressOfLength, scratchGPR);
+        jit.load32(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfMaxByteLength()), scratchGPR);
 #endif
         jit.loadPtr(CCallHelpers::Address(baseGPR, JSArrayBufferView::offsetOfVector()), scratch2GPR);
         jit.cageConditionallyAndUntag(Gigacage::Primitive, scratch2GPR, scratchGPR, scratchGPR, false);

--- a/Source/JavaScriptCore/bytecode/ExitKind.cpp
+++ b/Source/JavaScriptCore/bytecode/ExitKind.cpp
@@ -93,6 +93,8 @@ ASCIILiteral exitKindToString(ExitKind kind)
         return "GenericUnwind"_s;
     case BigInt32Overflow:
         return "BigInt32Overflow"_s;
+    case UnexpectedResizableArrayBufferView:
+        return "UnexpectedResizableArrayBufferView"_s;
     }
     RELEASE_ASSERT_NOT_REACHED();
     return "Unknown"_s;

--- a/Source/JavaScriptCore/bytecode/ExitKind.h
+++ b/Source/JavaScriptCore/bytecode/ExitKind.h
@@ -59,6 +59,7 @@ enum ExitKind : uint8_t {
     ExceptionCheck, // We exited because a direct exception check showed that we threw an exception from a C call.
     GenericUnwind, // We exited because we arrived at this OSR exit from genericUnwind.
     BigInt32Overflow, // We exited because of an BigInt32 overflow.
+    UnexpectedResizableArrayBufferView, // We exited because we made an incorrect assumption about what type of ArrayBufferView we would see.
 };
 
 ASCIILiteral exitKindToString(ExitKind);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -195,7 +195,7 @@ char* newTypedArrayWithSize(JSGlobalObject* globalObject, VM& vm, Structure* str
     size_t unsignedSize = static_cast<size_t>(size);
 
     if (vector)
-        return bitwise_cast<char*>(ViewClass::createWithFastVector(globalObject, structure, unsignedSize, untagArrayPtr(vector, unsignedSize)));
+        return bitwise_cast<char*>(ViewClass::createWithFastVector(globalObject, structure, unsignedSize, untagArrayPtr(vector, unsignedSize * ViewClass::elementSize)));
 
     RELEASE_AND_RETURN(scope, bitwise_cast<char*>(ViewClass::create(globalObject, structure, unsignedSize)));
 }

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -88,6 +88,7 @@ namespace JSC { namespace FTL {
     macro(GetterSetter_getter, GetterSetter::offsetOfGetter()) \
     macro(GetterSetter_setter, GetterSetter::offsetOfSetter()) \
     macro(JSArrayBufferView_length, JSArrayBufferView::offsetOfLength()) \
+    macro(JSArrayBufferView_maxByteLength, JSArrayBufferView::offsetOfMaxByteLength()) \
     macro(JSArrayBufferView_mode, JSArrayBufferView::offsetOfMode()) \
     macro(JSArrayBufferView_vector, JSArrayBufferView::offsetOfVector()) \
     macro(JSBigInt_length, JSBigInt::offsetOfLength()) \

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -128,7 +128,9 @@ public:
     static void commitBlock(void* block)
     {
 #if OS(UNIX) && ASSERT_ENABLED
-        mprotect(block, MarkedBlock::blockSize, PROT_READ | PROT_WRITE);
+        constexpr bool readable = true;
+        constexpr bool writable = true;
+        OSAllocator::protect(block, MarkedBlock::blockSize, readable, writable);
 #else
         constexpr bool writable = true;
         constexpr bool executable = false;
@@ -139,8 +141,9 @@ public:
     static void decommitBlock(void* block)
     {
 #if OS(UNIX) && ASSERT_ENABLED
-        // Release the page so we'll crash in debug if we read out of bounds rather than get a fresh page.
-        mprotect(block, MarkedBlock::blockSize, PROT_NONE);
+        constexpr bool readable = false;
+        constexpr bool writable = false;
+        OSAllocator::protect(block, MarkedBlock::blockSize, readable, writable);
 #else
         OSAllocator::decommit(block, MarkedBlock::blockSize);
 #endif

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -48,7 +48,7 @@ namespace JSC {
 
 AssemblyHelpers::Jump AssemblyHelpers::branchIfFastTypedArray(GPRReg baseGPR)
 {
-    return branch32(
+    return branch8(
         Equal,
         Address(baseGPR, JSArrayBufferView::offsetOfMode()),
         TrustedImm32(FastTypedArray));
@@ -56,7 +56,7 @@ AssemblyHelpers::Jump AssemblyHelpers::branchIfFastTypedArray(GPRReg baseGPR)
 
 AssemblyHelpers::Jump AssemblyHelpers::branchIfNotFastTypedArray(GPRReg baseGPR)
 {
-    return branch32(
+    return branch8(
         NotEqual,
         Address(baseGPR, JSArrayBufferView::offsetOfMode()),
         TrustedImm32(FastTypedArray));

--- a/Source/JavaScriptCore/jit/IntrinsicEmitter.cpp
+++ b/Source/JavaScriptCore/jit/IntrinsicEmitter.cpp
@@ -118,8 +118,8 @@ void IntrinsicGetterAccessCase::emitIntrinsicGetter(AccessGenerationState& state
     case TypedArrayByteOffsetIntrinsic: {
         GPRReg scratchGPR = state.scratchGPR;
 
-        CCallHelpers::Jump emptyByteOffset = jit.branch32(
-            MacroAssembler::NotEqual,
+        CCallHelpers::Jump emptyByteOffset = jit.branch8(
+            MacroAssembler::Below,
             MacroAssembler::Address(baseGPR, JSArrayBufferView::offsetOfMode()),
             TrustedImm32(WastefulTypedArray));
 

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1051,7 +1051,7 @@ end)
 wasmOp(current_memory, WasmCurrentMemory, macro(ctx)
     loadp Wasm::Instance::m_memory[wasmInstance], t0
     loadp Wasm::Memory::m_handle[t0], t0
-    loadp Wasm::MemoryHandle::m_size[t0], t0
+    loadp BufferMemoryHandle::m_size[t0], t0
     urshiftp 16, t0
 if JSVALUE64
     returnq(ctx, t0)

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -29,8 +29,12 @@
 #include "JSArrayBufferView.h"
 #include "JSCellInlines.h"
 #include <wtf/Gigacage.h>
+#include <wtf/SafeStrerror.h>
 
 namespace JSC {
+namespace ArrayBufferInternal {
+static constexpr bool verbose = false;
+}
 
 Ref<SharedTask<void(void*)>> ArrayBuffer::primitiveGigacageDestructor()
 {
@@ -42,11 +46,11 @@ Ref<SharedTask<void(void*)>> ArrayBuffer::primitiveGigacageDestructor()
     return destructor.get().copyRef();
 }
 
-void ArrayBufferContents::tryAllocate(size_t numElements, unsigned elementByteSize, InitializationPolicy policy)
+void ArrayBufferContents::tryAllocate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength, InitializationPolicy policy)
 {
     CheckedSize sizeInBytes = numElements;
     sizeInBytes *= elementByteSize;
-    if (sizeInBytes.hasOverflowed() || sizeInBytes.value() > MAX_ARRAY_BUFFER_SIZE) {
+    if (sizeInBytes.hasOverflowed() || sizeInBytes.value() > MAX_ARRAY_BUFFER_SIZE || (maxByteLength && sizeInBytes.value() > maxByteLength.value())) {
         reset();
         return;
     }
@@ -56,30 +60,32 @@ void ArrayBufferContents::tryAllocate(size_t numElements, unsigned elementByteSi
         allocationSize = 1; // Make sure malloc actually allocates something, but not too much. We use null to mean that the buffer is detached.
 
     void* data = Gigacage::tryMalloc(Gigacage::Primitive, allocationSize);
-    m_data = DataType(data, sizeInBytes.value());
+    m_data = DataType(data, maxByteLength.value_or(sizeInBytes.value()));
     if (!data) {
         reset();
         return;
     }
     
-    if (policy == ZeroInitialize)
+    if (policy == InitializationPolicy::ZeroInitialize)
         memset(data, 0, allocationSize);
 
     m_sizeInBytes = sizeInBytes.value();
     RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE);
+    m_maxByteLength = maxByteLength.value_or(m_sizeInBytes);
+    m_hasMaxByteLength = !!maxByteLength;
     m_destructor = ArrayBuffer::primitiveGigacageDestructor();
 }
 
 void ArrayBufferContents::makeShared()
 {
-    m_shared = adoptRef(new SharedArrayBufferContents(data(), sizeInBytes(), WTFMove(m_destructor)));
+    m_shared = SharedArrayBufferContents::create(data(), sizeInBytes(), maxByteLength(), nullptr, WTFMove(m_destructor), SharedArrayBufferContents::Mode::Default);
     m_destructor = nullptr;
 }
 
 void ArrayBufferContents::copyTo(ArrayBufferContents& other)
 {
     ASSERT(!other.m_data);
-    other.tryAllocate(m_sizeInBytes, sizeof(char), ArrayBufferContents::DontInitialize);
+    other.tryAllocate(m_sizeInBytes, sizeof(char), std::nullopt, ArrayBufferContents::InitializationPolicy::DontInitialize);
     if (!other.m_data)
         return;
     memcpy(other.data(), data(), m_sizeInBytes);
@@ -95,6 +101,7 @@ void ArrayBufferContents::shareWith(ArrayBufferContents& other)
     other.m_destructor = nullptr;
     other.m_shared = m_shared;
     other.m_sizeInBytes = m_sizeInBytes;
+    other.m_maxByteLength = m_maxByteLength;
     RELEASE_ASSERT(other.m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE);
 }
 
@@ -145,13 +152,21 @@ Ref<ArrayBuffer> ArrayBuffer::createFromBytes(const void* data, size_t byteLengt
     if (data && !Gigacage::isCaged(Gigacage::Primitive, data))
         Gigacage::disablePrimitiveGigacage();
     
-    ArrayBufferContents contents(const_cast<void*>(data), byteLength, WTFMove(destructor));
+    ArrayBufferContents contents(const_cast<void*>(data), byteLength, std::nullopt, WTFMove(destructor));
     return create(WTFMove(contents));
 }
 
-RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(size_t numElements, unsigned elementByteSize)
+Ref<ArrayBuffer> ArrayBuffer::createShared(Ref<SharedArrayBufferContents>&& shared)
 {
-    return tryCreate(numElements, elementByteSize, ArrayBufferContents::ZeroInitialize);
+    void* memory = shared->data();
+    size_t sizeInBytes = shared->sizeInBytes(std::memory_order_seq_cst);
+    ArrayBufferContents contents(memory, sizeInBytes, shared->maxByteLength(), WTFMove(shared));
+    return create(WTFMove(contents));
+}
+
+RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength)
+{
+    return tryCreate(numElements, elementByteSize, maxByteLength, ArrayBufferContents::InitializationPolicy::ZeroInitialize);
 }
 
 RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(ArrayBuffer& other)
@@ -162,7 +177,7 @@ RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(ArrayBuffer& other)
 RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(const void* source, size_t byteLength)
 {
     ArrayBufferContents contents;
-    contents.tryAllocate(byteLength, 1, ArrayBufferContents::DontInitialize);
+    contents.tryAllocate(byteLength, 1, std::nullopt, ArrayBufferContents::InitializationPolicy::DontInitialize);
     if (!contents.m_data)
         return nullptr;
     return createInternal(WTFMove(contents), source, byteLength);
@@ -170,17 +185,17 @@ RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(const void* source, size_t byteLength
 
 Ref<ArrayBuffer> ArrayBuffer::createUninitialized(size_t numElements, unsigned elementByteSize)
 {
-    return create(numElements, elementByteSize, ArrayBufferContents::DontInitialize);
+    return create(numElements, elementByteSize, ArrayBufferContents::InitializationPolicy::DontInitialize);
 }
 
 RefPtr<ArrayBuffer> ArrayBuffer::tryCreateUninitialized(size_t numElements, unsigned elementByteSize)
 {
-    return tryCreate(numElements, elementByteSize, ArrayBufferContents::DontInitialize);
+    return tryCreate(numElements, elementByteSize, std::nullopt, ArrayBufferContents::InitializationPolicy::DontInitialize);
 }
 
 Ref<ArrayBuffer> ArrayBuffer::create(size_t numElements, unsigned elementByteSize, ArrayBufferContents::InitializationPolicy policy)
 {
-    auto buffer = tryCreate(numElements, elementByteSize, policy);
+    auto buffer = tryCreate(numElements, elementByteSize, std::nullopt, policy);
     if (!buffer)
         CRASH();
     return buffer.releaseNonNull();
@@ -196,10 +211,10 @@ Ref<ArrayBuffer> ArrayBuffer::createInternal(ArrayBufferContents&& contents, con
     return buffer;
 }
 
-RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(size_t numElements, unsigned elementByteSize, ArrayBufferContents::InitializationPolicy policy)
+RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength, ArrayBufferContents::InitializationPolicy policy)
 {
     ArrayBufferContents contents;
-    contents.tryAllocate(numElements, elementByteSize, policy);
+    contents.tryAllocate(numElements, elementByteSize, maxByteLength, policy);
     if (!contents.m_data)
         return nullptr;
     return adoptRef(*new ArrayBuffer(WTFMove(contents)));
@@ -324,6 +339,142 @@ void ArrayBuffer::notifyDetaching(VM& vm)
             view->detach();
     }
     m_detachingWatchpointSet.fireAll(vm, "Array buffer was detached");
+}
+
+Expected<void, GrowFailReason> ArrayBuffer::grow(VM& vm, size_t newByteLength)
+{
+    auto shared = m_contents.m_shared;
+    if (!shared)
+        return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
+    return shared->grow(vm, newByteLength);
+}
+
+template<typename Func>
+static bool tryAllocate(VM& vm, const Func& allocate)
+{
+    unsigned numTries = 2;
+    bool success = false;
+    for (unsigned i = 0; i < numTries && !success; ++i) {
+        switch (allocate()) {
+        case BufferMemoryResult::Success:
+            success = true;
+            break;
+        case BufferMemoryResult::SuccessAndNotifyMemoryPressure:
+            vm.heap.collectAsync(CollectionScope::Full);
+            success = true;
+            break;
+        case BufferMemoryResult::SyncTryToReclaimMemory:
+            if (i + 1 == numTries)
+                break;
+            vm.heap.collectSync(CollectionScope::Full);
+            break;
+        }
+    }
+    return success;
+}
+
+RefPtr<ArrayBuffer> ArrayBuffer::tryCreateShared(VM& vm, size_t numElements, unsigned elementByteSize, size_t maxByteLength)
+{
+    CheckedSize sizeInBytes = numElements;
+    sizeInBytes *= elementByteSize;
+    if (sizeInBytes.hasOverflowed() || sizeInBytes.value() > MAX_ARRAY_BUFFER_SIZE || (sizeInBytes.value() > maxByteLength))
+        return nullptr;
+
+    size_t initialBytes = roundUpToMultipleOf<PageCount::pageSize>(sizeInBytes.value());
+    if (!initialBytes)
+        initialBytes = PageCount::pageSize; // Make sure malloc actually allocates something, but not too much. We use null to mean that the buffer is detached.
+    size_t maximumBytes = roundUpToMultipleOf<PageCount::pageSize>(maxByteLength);
+    if (!maximumBytes)
+        maximumBytes = PageCount::pageSize; // Make sure malloc actually allocates something, but not too much. We use null to mean that the buffer is detached.
+
+    bool done = tryAllocate(vm,
+        [&] () -> BufferMemoryResult::Kind {
+            return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(initialBytes);
+        });
+    if (!done)
+        return nullptr;
+
+    char* slowMemory = nullptr;
+    tryAllocate(vm,
+        [&] () -> BufferMemoryResult::Kind {
+            auto result = BufferMemoryManager::singleton().tryAllocateGrowableBoundsCheckingMemory(maximumBytes);
+            slowMemory = bitwise_cast<char*>(result.basePtr);
+            return result.kind;
+        });
+    if (!slowMemory) {
+        BufferMemoryManager::singleton().freePhysicalBytes(initialBytes);
+        return nullptr;
+    }
+
+    constexpr bool readable = false;
+    constexpr bool writable = false;
+    if (!OSAllocator::protect(slowMemory + initialBytes, maximumBytes - initialBytes, readable, writable)) {
+        dataLog("mprotect failed: ", safeStrerror(errno).data(), "\n");
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    auto handle = adoptRef(*new BufferMemoryHandle(slowMemory, initialBytes, maximumBytes, PageCount::fromBytes(initialBytes), PageCount::fromBytes(maximumBytes), MemorySharingMode::Shared, MemoryMode::BoundsChecking));
+    auto content = SharedArrayBufferContents::create(handle->memory(), sizeInBytes.value(), maxByteLength, WTFMove(handle), nullptr, SharedArrayBufferContents::Mode::Default);
+    return createShared(WTFMove(content));
+}
+
+Expected<void, GrowFailReason> SharedArrayBufferContents::grow(VM& vm, size_t newByteLength)
+{
+    if (!m_hasMaxByteLength)
+        return makeUnexpected(GrowFailReason::GrowSharedUnavailable);
+    ASSERT(m_memoryHandle);
+    return grow(Locker { m_memoryHandle->lock() }, vm, newByteLength);
+}
+
+Expected<void, GrowFailReason> SharedArrayBufferContents::grow(const AbstractLocker&, VM& vm, size_t newByteLength)
+{
+    // Keep in mind that newByteLength may not be page-size-aligned.
+    size_t sizeInBytes = m_sizeInBytes.load(std::memory_order_seq_cst);
+    if (sizeInBytes > newByteLength || m_maxByteLength < newByteLength)
+        return makeUnexpected(GrowFailReason::InvalidGrowSize);
+
+    if (sizeInBytes == newByteLength)
+        return { };
+
+    auto newPageCount = PageCount::fromBytesWithRoundUp(newByteLength);
+    auto oldPageCount = PageCount::fromBytes(m_memoryHandle->size()); // MemoryHandle's size is always page-size aligned.
+    if (newPageCount.bytes() > MAX_ARRAY_BUFFER_SIZE)
+        return makeUnexpected(GrowFailReason::WouldExceedMaximum);
+
+    if (newPageCount != oldPageCount) {
+        ASSERT(m_memoryHandle->maximum() >= newPageCount);
+        size_t desiredSize = newPageCount.bytes();
+        RELEASE_ASSERT(desiredSize <= MAX_ARRAY_BUFFER_SIZE);
+        RELEASE_ASSERT(desiredSize > m_memoryHandle->size());
+
+        size_t extraBytes = desiredSize - m_memoryHandle->size();
+        RELEASE_ASSERT(extraBytes);
+        bool allocationSuccess = tryAllocate(vm,
+            [&] () -> BufferMemoryResult::Kind {
+                return BufferMemoryManager::singleton().tryAllocatePhysicalBytes(extraBytes);
+            });
+        if (!allocationSuccess)
+            return makeUnexpected(GrowFailReason::OutOfMemory);
+
+        void* memory = m_memoryHandle->memory();
+        RELEASE_ASSERT(memory);
+
+        // Signaling memory must have been pre-allocated virtually.
+        uint8_t* startAddress = static_cast<uint8_t*>(memory) + m_memoryHandle->size();
+
+        dataLogLnIf(ArrayBufferInternal::verbose, "Marking memory's ", RawPointer(memory), " as read+write in range [", RawPointer(startAddress), ", ", RawPointer(startAddress + extraBytes), ")");
+        constexpr bool readable = true;
+        constexpr bool writable = true;
+        if (!OSAllocator::protect(startAddress, extraBytes, readable, writable)) {
+            dataLog("mprotect failed: ", safeStrerror(errno).data(), "\n");
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        m_memoryHandle->growToSize(desiredSize);
+    }
+
+    growToSize(newByteLength);
+    return { };
 }
 
 ASCIILiteral errorMesasgeForTransfer(ArrayBuffer* buffer)

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArrayBufferSharingMode.h"
+#include "BufferMemoryHandle.h"
 #include "GCIncomingRefCounted.h"
 #include "Watchpoint.h"
 #include "Weak.h"
@@ -40,16 +41,6 @@
 
 namespace JSC {
 
-#if USE(LARGE_TYPED_ARRAYS)
-static_assert(sizeof(size_t) == sizeof(uint64_t));
-#define MAX_ARRAY_BUFFER_SIZE (1ull << 32)
-#else
-static_assert(sizeof(size_t) == sizeof(uint32_t));
-// Because we are using a size_t to store the size in bytes of array buffers, we cannot support 4GB on 32-bit platforms.
-// So we are sticking with 2GB. It should in theory be possible to support up to (4GB - 1B) if anyone cares.
-#define MAX_ARRAY_BUFFER_SIZE 0x7fffffffu
-#endif
-
 class VM;
 class ArrayBuffer;
 class ArrayBufferView;
@@ -59,12 +50,10 @@ using ArrayBufferDestructorFunction = RefPtr<SharedTask<void(void*)>>;
 
 class SharedArrayBufferContents final : public ThreadSafeRefCounted<SharedArrayBufferContents> {
 public:
-    SharedArrayBufferContents(void* data, size_t size, ArrayBufferDestructorFunction&& destructor)
-        : m_data(data, size)
-        , m_destructor(WTFMove(destructor))
-        , m_sizeInBytes(size)
-    {
-    }
+    enum class Mode : uint8_t {
+        Default,
+        WebAssembly,
+    };
 
     ~SharedArrayBufferContents()
     {
@@ -73,28 +62,88 @@ public:
             m_destructor->run(m_data.getUnsafe());
         }
     }
+
+    static Ref<SharedArrayBufferContents> create(void* data, size_t size, std::optional<size_t> maxByteLength, RefPtr<BufferMemoryHandle> memoryHandle, ArrayBufferDestructorFunction&& destructor, Mode mode)
+    {
+        return adoptRef(*new SharedArrayBufferContents(data, size, maxByteLength, WTFMove(memoryHandle), WTFMove(destructor), mode));
+    }
     
-    void* data() const { return m_data.getMayBeNull(m_sizeInBytes); }
+    void* data() const { return m_data.getMayBeNull(m_maxByteLength); }
+
+    size_t sizeInBytes(std::memory_order order) const
+    {
+        return m_sizeInBytes.load(order);
+    }
+
+    std::optional<size_t> maxByteLength() const
+    {
+        if (m_hasMaxByteLength)
+            return m_maxByteLength;
+        return std::nullopt;
+    }
+
+    Mode mode() const { return m_mode; }
+
+    Expected<void, GrowFailReason> grow(VM&, size_t newByteLength);
+    Expected<void, GrowFailReason> grow(const AbstractLocker&, VM&, size_t newByteLength);
+
+    void growToSize(size_t sizeInBytes, std::memory_order order = std::memory_order_seq_cst)
+    {
+        m_sizeInBytes.store(sizeInBytes, order);
+    }
+
+    BufferMemoryHandle* memoryHandle() const { return m_memoryHandle.get(); }
     
 private:
+    SharedArrayBufferContents(void* data, size_t size, std::optional<size_t> maxByteLength, RefPtr<BufferMemoryHandle> memoryHandle, ArrayBufferDestructorFunction&& destructor, Mode mode)
+        : m_data(data, maxByteLength.value_or(size))
+        , m_destructor(WTFMove(destructor))
+        , m_memoryHandle(WTFMove(memoryHandle))
+        , m_sizeInBytes(size)
+        , m_maxByteLength(maxByteLength.value_or(size))
+        , m_hasMaxByteLength(!!maxByteLength)
+        , m_mode(mode)
+    {
+#if ASSERT_ENABLED
+        if (m_hasMaxByteLength)
+            ASSERT(m_memoryHandle);
+#endif
+    }
+
     using DataType = CagedPtr<Gigacage::Primitive, void, tagCagedPtr>;
     DataType m_data;
     ArrayBufferDestructorFunction m_destructor;
-    size_t m_sizeInBytes;
+    RefPtr<BufferMemoryHandle> m_memoryHandle;
+    std::atomic<size_t> m_sizeInBytes { 0 };
+    size_t m_maxByteLength;
+    bool m_hasMaxByteLength : 1 { false };
+    Mode m_mode : 1 { Mode::Default };
 };
 
 class ArrayBufferContents final {
     WTF_MAKE_NONCOPYABLE(ArrayBufferContents);
 public:
     ArrayBufferContents() = default;
-    ArrayBufferContents(void* data, size_t sizeInBytes, ArrayBufferDestructorFunction&& destructor)
-        : m_data(data, sizeInBytes)
+    ArrayBufferContents(void* data, size_t sizeInBytes, std::optional<size_t> maxByteLength, ArrayBufferDestructorFunction&& destructor)
+        : m_data(data, maxByteLength.value_or(sizeInBytes))
         , m_destructor(WTFMove(destructor))
         , m_sizeInBytes(sizeInBytes)
+        , m_maxByteLength(maxByteLength.value_or(sizeInBytes))
+        , m_hasMaxByteLength(!!maxByteLength)
     {
         RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE);
     }
-    
+
+    ArrayBufferContents(void* data, size_t sizeInBytes, std::optional<size_t> maxByteLength, Ref<SharedArrayBufferContents>&& shared)
+        : m_data(data, maxByteLength.value_or(sizeInBytes))
+        , m_shared(WTFMove(shared))
+        , m_sizeInBytes(sizeInBytes)
+        , m_maxByteLength(maxByteLength.value_or(sizeInBytes))
+        , m_hasMaxByteLength(!!maxByteLength)
+    {
+        RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE);
+    }
+
     ArrayBufferContents(ArrayBufferContents&& other)
     {
         swap(other);
@@ -117,11 +166,25 @@ public:
     
     explicit operator bool() { return !!m_data; }
     
-    void* data() const { return m_data.getMayBeNull(sizeInBytes()); }
+    void* data() const { return m_data.getMayBeNull(m_maxByteLength); }
     void* dataWithoutPACValidation() const { return m_data.getUnsafe(); }
-    size_t sizeInBytes() const { return m_sizeInBytes; }
+    size_t sizeInBytes(std::memory_order order = std::memory_order_seq_cst) const
+    {
+        if (m_hasMaxByteLength) {
+            if (m_shared && m_shared->mode() == SharedArrayBufferContents::Mode::Default)
+                return m_shared->sizeInBytes(order);
+        }
+        return m_sizeInBytes;
+    }
+    std::optional<size_t> maxByteLength() const
+    {
+        if (m_hasMaxByteLength)
+            return m_maxByteLength;
+        return std::nullopt;
+    }
     
     bool isShared() const { return m_shared; }
+    bool isResizable() const { return m_hasMaxByteLength; }
     
     void swap(ArrayBufferContents& other)
     {
@@ -130,6 +193,8 @@ public:
         swap(m_destructor, other.m_destructor);
         swap(m_shared, other.m_shared);
         swap(m_sizeInBytes, other.m_sizeInBytes);
+        swap(m_maxByteLength, other.m_maxByteLength);
+        swap(m_hasMaxByteLength, other.m_hasMaxByteLength);
     }
 
 private:
@@ -139,16 +204,18 @@ private:
         m_destructor = nullptr;
         m_shared = nullptr;
         m_sizeInBytes = 0;
+        m_maxByteLength = 0;
+        m_hasMaxByteLength = false;
     }
 
     friend class ArrayBuffer;
 
-    enum InitializationPolicy {
+    enum class InitializationPolicy : uint8_t {
         ZeroInitialize,
         DontInitialize
     };
 
-    void tryAllocate(size_t numElements, unsigned elementByteSize, InitializationPolicy);
+    void tryAllocate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength, InitializationPolicy);
     
     void makeShared();
     void copyTo(ArrayBufferContents&);
@@ -159,6 +226,8 @@ private:
     ArrayBufferDestructorFunction m_destructor { nullptr };
     RefPtr<SharedArrayBufferContents> m_shared { nullptr };
     size_t m_sizeInBytes { 0 };
+    size_t m_maxByteLength { 0 };
+    bool m_hasMaxByteLength { false };
 };
 
 class ArrayBuffer final : public GCIncomingRefCounted<ArrayBuffer> {
@@ -169,9 +238,11 @@ public:
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> create(ArrayBufferContents&&);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createAdopted(const void* data, size_t byteLength);
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createFromBytes(const void* data, size_t byteLength, ArrayBufferDestructorFunction&&);
-    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize);
+    JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createShared(Ref<SharedArrayBufferContents>&&);
+    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength = std::nullopt);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(ArrayBuffer&);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(const void* source, size_t byteLength);
+    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreateShared(VM&, size_t numElements, unsigned elementByteSize, size_t maxByteLength);
 
     // Only for use by Uint8ClampedArray::tryCreateUninitialized and FragmentedSharedBuffer::tryCreateArrayBuffer.
     JS_EXPORT_PRIVATE static Ref<ArrayBuffer> createUninitialized(size_t numElements, unsigned elementByteSize);
@@ -179,7 +250,8 @@ public:
 
     inline void* data();
     inline const void* data() const;
-    inline size_t byteLength() const;
+    inline size_t byteLength(std::memory_order = std::memory_order_relaxed) const;
+    inline std::optional<size_t> maxByteLength() const;
 
     inline void* dataWithoutPACValidation();
     inline const void* dataWithoutPACValidation() const;
@@ -188,6 +260,7 @@ public:
     void setSharingMode(ArrayBufferSharingMode);
     inline bool isShared() const;
     inline ArrayBufferSharingMode sharingMode() const { return isShared() ? ArrayBufferSharingMode::Shared : ArrayBufferSharingMode::Default; }
+    inline bool isResizable() const { return m_contents.isResizable(); }
 
     inline size_t gcSizeEstimateInBytes() const;
 
@@ -216,10 +289,12 @@ public:
 
     JS_EXPORT_PRIVATE static Ref<SharedTask<void(void*)>> primitiveGigacageDestructor();
 
+    Expected<void, GrowFailReason> grow(VM&, size_t newByteLength);
+
 private:
     static Ref<ArrayBuffer> create(size_t numElements, unsigned elementByteSize, ArrayBufferContents::InitializationPolicy);
     static Ref<ArrayBuffer> createInternal(ArrayBufferContents&&, const void*, size_t);
-    static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, ArrayBufferContents::InitializationPolicy);
+    static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength, ArrayBufferContents::InitializationPolicy);
     ArrayBuffer(ArrayBufferContents&&);
     inline size_t clampIndex(double index) const;
     static inline size_t clampValue(double x, size_t left, size_t right);
@@ -258,9 +333,14 @@ const void* ArrayBuffer::dataWithoutPACValidation() const
     return m_contents.dataWithoutPACValidation();
 }
 
-size_t ArrayBuffer::byteLength() const
+size_t ArrayBuffer::byteLength(std::memory_order order) const
 {
-    return m_contents.sizeInBytes();
+    return m_contents.sizeInBytes(order);
+}
+
+std::optional<size_t> ArrayBuffer::maxByteLength() const
+{
+    return m_contents.maxByteLength();
 }
 
 bool ArrayBuffer::isShared() const
@@ -300,6 +380,29 @@ bool ArrayBuffer::isWasmMemory()
 }
 
 JS_EXPORT_PRIVATE ASCIILiteral errorMesasgeForTransfer(ArrayBuffer*);
+
+// https://tc39.es/proposal-resizablearraybuffer/#sec-makeidempotentarraybufferbytelengthgetter
+class IdempotentArrayBufferByteLengthGetter {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    IdempotentArrayBufferByteLengthGetter(std::memory_order order)
+        : m_order(order)
+    {
+    }
+
+    size_t operator()(ArrayBuffer& buffer)
+    {
+        if (m_byteLength)
+            return m_byteLength.value();
+        size_t result = buffer.byteLength(m_order);
+        m_byteLength = result;
+        return result;
+    }
+
+private:
+    std::memory_order m_order;
+    std::optional<size_t> m_byteLength;
+};
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BufferMemoryHandle.h"
+
+#include "Options.h"
+#include "WasmFaultSignalHandler.h"
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/DataLog.h>
+#include <wtf/Gigacage.h>
+#include <wtf/Lock.h>
+#include <wtf/Platform.h>
+#include <wtf/PrintStream.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/Vector.h>
+
+namespace JSC {
+
+// FIXME: We could be smarter about memset / mmap / madvise. https://bugs.webkit.org/show_bug.cgi?id=170343
+// FIXME: Give up some of the cached fast memories if the GC determines it's easy to get them back, and they haven't been used in a while. https://bugs.webkit.org/show_bug.cgi?id=170773
+// FIXME: Limit slow memory size. https://bugs.webkit.org/show_bug.cgi?id=170825
+
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+size_t BufferMemoryHandle::fastMappedRedzoneBytes()
+{
+    return static_cast<size_t>(PageCount::pageSize) * Options::webAssemblyFastMemoryRedzonePages();
+}
+
+size_t BufferMemoryHandle::fastMappedBytes()
+{
+    static_assert(sizeof(uint64_t) == sizeof(size_t), "We rely on allowing the maximum size of Memory we map to be 2^32 + redzone which is larger than fits in a 32-bit integer that we'd pass to mprotect if this didn't hold.");
+    return (static_cast<size_t>(1) << 32) + fastMappedRedzoneBytes();
+}
+#endif
+
+ASCIILiteral BufferMemoryResult::toString(Kind kind)
+{
+    switch (kind) {
+    case Success:
+        return "Success"_s;
+    case SuccessAndNotifyMemoryPressure:
+        return "SuccessAndNotifyMemoryPressure"_s;
+    case SyncTryToReclaimMemory:
+        return "SyncTryToReclaimMemory"_s;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
+}
+
+void BufferMemoryResult::dump(PrintStream& out) const
+{
+    out.print("{basePtr = ", RawPointer(basePtr), ", kind = ", toString(kind), "}");
+}
+
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+BufferMemoryResult BufferMemoryManager::tryAllocateFastMemory()
+{
+    BufferMemoryResult result = [&] {
+        Locker locker { m_lock };
+        if (m_fastMemories.size() >= m_maxFastMemoryCount)
+            return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
+
+        void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, BufferMemoryHandle::fastMappedBytes());
+        if (!result)
+            return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
+
+        m_fastMemories.append(result);
+
+        return BufferMemoryResult(
+            result,
+            m_fastMemories.size() >= m_maxFastMemoryCount / 2 ? BufferMemoryResult::SuccessAndNotifyMemoryPressure : BufferMemoryResult::Success);
+    }();
+
+    dataLogLnIf(Options::logWebAssemblyMemory(), "Allocated virtual: ", result, "; state: ", *this);
+
+    return result;
+}
+
+void BufferMemoryManager::freeFastMemory(void* basePtr)
+{
+    {
+        Locker locker { m_lock };
+        Gigacage::freeVirtualPages(Gigacage::Primitive, basePtr, BufferMemoryHandle::fastMappedBytes());
+        m_fastMemories.removeFirst(basePtr);
+    }
+
+    dataLogLnIf(Options::logWebAssemblyMemory(), "Freed virtual; state: ", *this);
+}
+#endif
+
+BufferMemoryResult BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory(size_t mappedCapacity)
+{
+    BufferMemoryResult result = [&] {
+        Locker locker { m_lock };
+        void* result = Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, mappedCapacity);
+        if (!result)
+            return BufferMemoryResult(nullptr, BufferMemoryResult::SyncTryToReclaimMemory);
+
+        m_growableBoundsCheckingMemories.insert(std::make_pair(bitwise_cast<uintptr_t>(result), mappedCapacity));
+
+        return BufferMemoryResult(result, BufferMemoryResult::Success);
+    }();
+
+    dataLogLnIf(Options::logWebAssemblyMemory(), "Allocated virtual: ", result, "; state: ", *this);
+
+    return result;
+}
+
+void BufferMemoryManager::freeGrowableBoundsCheckingMemory(void* basePtr, size_t mappedCapacity)
+{
+    {
+        Locker locker { m_lock };
+        Gigacage::freeVirtualPages(Gigacage::Primitive, basePtr, mappedCapacity);
+        m_growableBoundsCheckingMemories.erase(std::make_pair(bitwise_cast<uintptr_t>(basePtr), mappedCapacity));
+    }
+
+    dataLogLnIf(Options::logWebAssemblyMemory(), "Freed virtual; state: ", *this);
+}
+
+bool BufferMemoryManager::isInGrowableOrFastMemory(void* address)
+{
+    // NOTE: This can be called from a signal handler, but only after we proved that we're in JIT code or WasmLLInt code.
+    Locker locker { m_lock };
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    for (void* memory : m_fastMemories) {
+        char* start = static_cast<char*>(memory);
+        if (start <= address && address <= start + BufferMemoryHandle::fastMappedBytes())
+            return true;
+    }
+#endif
+    uintptr_t addressValue = bitwise_cast<uintptr_t>(address);
+    auto iterator = std::upper_bound(m_growableBoundsCheckingMemories.begin(), m_growableBoundsCheckingMemories.end(), std::make_pair(addressValue, 0),
+        [](std::pair<uintptr_t, size_t> a, std::pair<uintptr_t, size_t> b) {
+            return (a.first + a.second) < (b.first + b.second);
+        });
+    if (iterator != m_growableBoundsCheckingMemories.end()) {
+        // Since we never have overlapped range in m_growableBoundsCheckingMemories, just checking one lower-bound range is enough.
+        if (iterator->first <= addressValue && addressValue < (iterator->first + iterator->second))
+            return true;
+    }
+    return false;
+}
+
+// FIXME: Ideally, bmalloc would have this kind of mechanism. Then, we would just forward to that
+// mechanism here.
+BufferMemoryResult::Kind BufferMemoryManager::tryAllocatePhysicalBytes(size_t bytes)
+{
+    BufferMemoryResult::Kind result = [&] {
+        Locker locker { m_lock };
+        if (m_physicalBytes + bytes > memoryLimit())
+            return BufferMemoryResult::SyncTryToReclaimMemory;
+
+        m_physicalBytes += bytes;
+
+        if (m_physicalBytes >= memoryLimit() / 2)
+            return BufferMemoryResult::SuccessAndNotifyMemoryPressure;
+
+        return BufferMemoryResult::Success;
+    }();
+
+    dataLogLnIf(Options::logWebAssemblyMemory(), "Allocated physical: ", bytes, ", ", BufferMemoryResult::toString(result), "; state: ", *this);
+
+    return result;
+}
+
+void BufferMemoryManager::freePhysicalBytes(size_t bytes)
+{
+    {
+        Locker locker { m_lock };
+        m_physicalBytes -= bytes;
+    }
+
+    dataLogLnIf(Options::logWebAssemblyMemory(), "Freed physical: ", bytes, "; state: ", *this);
+}
+
+void BufferMemoryManager::dump(PrintStream& out) const
+{
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    out.print("fast memories =  ", m_fastMemories.size(), "/", m_maxFastMemoryCount, ", bytes = ", m_physicalBytes, "/", memoryLimit());
+#else
+    out.print("fast memories = N.A., bytes = ", m_physicalBytes, "/", memoryLimit());
+#endif
+}
+
+BufferMemoryManager& BufferMemoryManager::singleton()
+{
+    static std::once_flag onceFlag;
+    static LazyNeverDestroyed<BufferMemoryManager> manager;
+    std::call_once(onceFlag, []{
+        manager.construct();
+    });
+    return manager.get();
+}
+
+BufferMemoryHandle::BufferMemoryHandle(void* memory, size_t size, size_t mappedCapacity, PageCount initial, PageCount maximum, MemorySharingMode sharingMode, MemoryMode mode)
+    : m_sharingMode(sharingMode)
+    , m_mode(mode)
+    , m_memory(memory, mappedCapacity)
+    , m_size(size)
+    , m_mappedCapacity(mappedCapacity)
+    , m_initial(initial)
+    , m_maximum(maximum)
+{
+    if (sharingMode == MemorySharingMode::Default && mode == MemoryMode::BoundsChecking)
+        ASSERT(mappedCapacity == size);
+    else {
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+        Wasm::activateSignalingMemory();
+#endif
+    }
+}
+
+BufferMemoryHandle::~BufferMemoryHandle()
+{
+    if (m_memory) {
+        void* memory = this->memory();
+        BufferMemoryManager::singleton().freePhysicalBytes(m_size);
+        switch (m_mode) {
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+        case MemoryMode::Signaling: {
+            constexpr bool readable = true;
+            constexpr bool writable = true;
+            if (!OSAllocator::protect(memory, BufferMemoryHandle::fastMappedBytes(), readable, writable)) {
+                dataLog("mprotect failed: ", safeStrerror(errno).data(), "\n");
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+            BufferMemoryManager::singleton().freeFastMemory(memory);
+            break;
+        }
+#endif
+        case MemoryMode::BoundsChecking: {
+            switch (m_sharingMode) {
+            case MemorySharingMode::Default:
+                Gigacage::freeVirtualPages(Gigacage::Primitive, memory, m_size);
+                break;
+            case MemorySharingMode::Shared: {
+                constexpr bool readable = true;
+                constexpr bool writable = true;
+                if (!OSAllocator::protect(memory, m_mappedCapacity, readable, writable)) {
+                    dataLog("mprotect failed: ", safeStrerror(errno).data(), "\n");
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                BufferMemoryManager::singleton().freeGrowableBoundsCheckingMemory(memory, m_mappedCapacity);
+                break;
+            }
+            }
+            break;
+        }
+        }
+    }
+}
+
+// FIXME: ARM64E clang has a bug and inlining this function makes optimizer run forever.
+// For now, putting NEVER_INLINE to suppress inlining of this.
+NEVER_INLINE void* BufferMemoryHandle::memory() const
+{
+    ASSERT(m_memory.getMayBeNull(m_mappedCapacity) == m_memory.getUnsafe());
+    return m_memory.getMayBeNull(m_mappedCapacity);
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MemoryMode.h"
+#include "Options.h"
+#include "PageCount.h"
+
+#include <wtf/CagedPtr.h>
+#include <wtf/Expected.h>
+#include <wtf/Function.h>
+#include <wtf/RAMSize.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/StdSet.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+namespace WTF {
+class PrintStream;
+}
+
+namespace JSC {
+
+class LLIntOffsetsExtractor;
+
+enum class GrowFailReason : uint8_t {
+    InvalidDelta,
+    InvalidGrowSize,
+    WouldExceedMaximum,
+    OutOfMemory,
+    GrowSharedUnavailable,
+};
+
+struct BufferMemoryResult {
+    enum Kind {
+        Success,
+        SuccessAndNotifyMemoryPressure,
+        SyncTryToReclaimMemory
+    };
+
+    static ASCIILiteral toString(Kind);
+
+    BufferMemoryResult() { }
+
+    BufferMemoryResult(void* basePtr, Kind kind)
+        : basePtr(basePtr)
+        , kind(kind)
+    {
+    }
+
+    void dump(PrintStream&) const;
+
+    void* basePtr;
+    Kind kind;
+};
+
+class BufferMemoryManager {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(BufferMemoryManager);
+public:
+    friend class LazyNeverDestroyed<BufferMemoryManager>;
+
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    BufferMemoryResult tryAllocateFastMemory();
+    void freeFastMemory(void* basePtr);
+#endif
+
+    BufferMemoryResult tryAllocateGrowableBoundsCheckingMemory(size_t mappedCapacity);
+
+    void freeGrowableBoundsCheckingMemory(void* basePtr, size_t mappedCapacity);
+
+    bool isInGrowableOrFastMemory(void* address);
+
+    // We allow people to "commit" more wasm memory than there is on the system since most of the time
+    // people don't actually write to most of that memory. There is some chance that this gets us
+    // jettisoned but that's possible anyway.
+    inline size_t memoryLimit() const
+    {
+        if (productOverflows<size_t>(ramSize(),  3))
+            return std::numeric_limits<size_t>::max();
+        return ramSize() * 3;
+    }
+
+    // FIXME: Ideally, bmalloc would have this kind of mechanism. Then, we would just forward to that
+    // mechanism here.
+    BufferMemoryResult::Kind tryAllocatePhysicalBytes(size_t bytes);
+
+    void freePhysicalBytes(size_t bytes);
+
+    void dump(PrintStream& out) const;
+
+    static BufferMemoryManager& singleton();
+
+private:
+    BufferMemoryManager() = default;
+
+    Lock m_lock;
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    unsigned m_maxFastMemoryCount { Options::maxNumWebAssemblyFastMemories() };
+    Vector<void*> m_fastMemories;
+#endif
+    StdSet<std::pair<uintptr_t, size_t>> m_growableBoundsCheckingMemories;
+    size_t m_physicalBytes { 0 };
+};
+
+class BufferMemoryHandle final : public ThreadSafeRefCounted<BufferMemoryHandle> {
+    WTF_MAKE_NONCOPYABLE(BufferMemoryHandle);
+    WTF_MAKE_FAST_ALLOCATED;
+    friend LLIntOffsetsExtractor;
+public:
+    BufferMemoryHandle(void*, size_t size, size_t mappedCapacity, PageCount initial, PageCount maximum, MemorySharingMode, MemoryMode);
+    JS_EXPORT_PRIVATE ~BufferMemoryHandle();
+
+    void* memory() const;
+    size_t size(std::memory_order order = std::memory_order_seq_cst) const
+    {
+        if (m_sharingMode == MemorySharingMode::Default)
+            return m_size.load(std::memory_order_relaxed);
+        return m_size.load(order);
+    }
+
+    size_t mappedCapacity() const { return m_mappedCapacity; }
+    PageCount initial() const { return m_initial; }
+    PageCount maximum() const { return m_maximum; }
+    MemorySharingMode sharingMode() const { return m_sharingMode; }
+    MemoryMode mode() const { return m_mode; }
+    static ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(BufferMemoryHandle, m_size); }
+    Lock& lock() { return m_lock; }
+
+    void growToSize(size_t size, std::memory_order order = std::memory_order_seq_cst)
+    {
+        m_size.store(size, order);
+    }
+
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    static size_t fastMappedRedzoneBytes();
+    static size_t fastMappedBytes();
+#endif
+
+private:
+    using CagedMemory = CagedPtr<Gigacage::Primitive, void, tagCagedPtr>;
+
+    Lock m_lock;
+    MemorySharingMode m_sharingMode { MemorySharingMode::Default };
+    MemoryMode m_mode { MemoryMode::BoundsChecking };
+    CagedMemory m_memory;
+    std::atomic<size_t> m_size { 0 };
+    size_t m_mappedCapacity { 0 };
+    PageCount m_initial;
+    PageCount m_maximum;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -136,6 +136,8 @@
     macro(go) \
     macro(granularity) \
     macro(groups) \
+    macro(grow) \
+    macro(growable) \
     macro(has) \
     macro(hasIndices) \
     macro(hasOwn) \
@@ -180,6 +182,7 @@
     macro(line) \
     macro(locale) \
     macro(localeMatcher) \
+    macro(maxByteLength) \
     macro(maximumFractionDigits) \
     macro(maximumSignificantDigits) \
     macro(message) \

--- a/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp
@@ -81,27 +81,51 @@ EncodedJSValue JSGenericArrayBufferConstructor<sharingMode>::constructImpl(JSGlo
     Structure* structure = JSC_GET_DERIVED_STRUCTURE(vm, arrayBufferStructureWithSharingMode<sharingMode>, newTarget, callFrame->jsCallee());
     RETURN_IF_EXCEPTION(scope, { });
 
-    size_t length;
+    size_t length = 0;
+    std::optional<size_t> maxByteLength;
     if (callFrame->argumentCount()) {
-        length = callFrame->uncheckedArgument(0).toTypedArrayIndex(globalObject, "length");
-        RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    } else {
-        // Although the documentation doesn't say so, it is in fact correct to say
-        // "new ArrayBuffer()". The result is the same as allocating an array buffer
-        // with a zero length.
-        length = 0;
+        length = callFrame->uncheckedArgument(0).toTypedArrayIndex(globalObject, "length"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if constexpr (sharingMode == ArrayBufferSharingMode::Shared) {
+            if (Options::useResizableArrayBuffer()) {
+                JSValue options = callFrame->argument(1);
+                if (options.isObject()) {
+                    JSValue maxByteLengthValue = asObject(options)->get(globalObject, vm.propertyNames->maxByteLength);
+                    RETURN_IF_EXCEPTION(scope, { });
+                    if (!maxByteLengthValue.isUndefined()) {
+                        maxByteLength = maxByteLengthValue.toTypedArrayIndex(globalObject, "maxByteLength"_s);
+                        RETURN_IF_EXCEPTION(scope, { });
+                    }
+                }
+            }
+        }
     }
 
-    auto buffer = ArrayBuffer::tryCreate(length, 1);
-    if (!buffer)
-        return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
-    
-    if (sharingMode == ArrayBufferSharingMode::Shared)
-        buffer->makeShared();
+    // https://tc39.es/proposal-resizablearraybuffer/#sec-allocatesharedarraybuffer
+    RefPtr<ArrayBuffer> buffer;
+    if constexpr (sharingMode == ArrayBufferSharingMode::Shared) {
+        if (maxByteLength) {
+            if (maxByteLength.value() < length)
+                return throwVMRangeError(globalObject, scope, "ArrayBuffer length exceeds maxByteLength option"_s);
+            ASSERT(sharingMode == ArrayBufferSharingMode::Shared);
+            buffer = ArrayBuffer::tryCreateShared(vm, length, 1, maxByteLength.value());
+            if (!buffer)
+                return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
+        }
+    }
+
+    if (!buffer) {
+        buffer = ArrayBuffer::tryCreate(length, 1, maxByteLength);
+        if (!buffer)
+            return JSValue::encode(throwOutOfMemoryError(globalObject, scope));
+        if (sharingMode == ArrayBufferSharingMode::Shared)
+            buffer->makeShared();
+    }
+
     ASSERT(sharingMode == buffer->sharingMode());
 
-    JSArrayBuffer* result = JSArrayBuffer::create(vm, structure, WTFMove(buffer));
-    return JSValue::encode(result);
+    return JSValue::encode(JSArrayBuffer::create(vm, structure, WTFMove(buffer)));
 }
 
 template<ArrayBufferSharingMode sharingMode>

--- a/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h
@@ -35,8 +35,10 @@ inline bool JSArrayBufferView::isShared()
 {
     switch (m_mode) {
     case WastefulTypedArray:
+    case ResizableWastefulTypedArray:
         return existingBufferInButterfly()->isShared();
     case DataViewMode:
+    case ResizableDataViewMode:
         return jsCast<JSDataView*>(this)->possiblySharedBuffer()->isShared();
     default:
         return false;
@@ -51,8 +53,10 @@ inline ArrayBuffer* JSArrayBufferView::possiblySharedBufferImpl()
 
     switch (m_mode) {
     case WastefulTypedArray:
+    case ResizableWastefulTypedArray:
         return existingBufferInButterfly();
     case DataViewMode:
+    case ResizableDataViewMode:
         return jsCast<JSDataView*>(this)->possiblySharedBuffer();
     case FastTypedArray:
     case OversizeTypedArray:
@@ -69,7 +73,7 @@ inline ArrayBuffer* JSArrayBufferView::possiblySharedBuffer()
 
 inline ArrayBuffer* JSArrayBufferView::existingBufferInButterfly()
 {
-    ASSERT(m_mode == WastefulTypedArray);
+    ASSERT(m_mode == WastefulTypedArray || m_mode == ResizableWastefulTypedArray);
     return butterfly()->indexingHeader()->arrayBuffer();
 }
 

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -305,7 +305,7 @@ public:
     int32_t toInt32(JSGlobalObject*) const;
     uint32_t toUInt32(JSGlobalObject*) const;
     uint32_t toIndex(JSGlobalObject*, const char* errorName) const;
-    size_t toTypedArrayIndex(JSGlobalObject*, const char* errorName) const;
+    size_t toTypedArrayIndex(JSGlobalObject*, ASCIILiteral) const;
     uint64_t toLength(JSGlobalObject*) const;
 
     JS_EXPORT_PRIVATE JSValue toBigInt(JSGlobalObject*) const;

--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -81,7 +81,7 @@ inline uint32_t JSValue::toIndex(JSGlobalObject* globalObject, const char* error
     RELEASE_AND_RETURN(scope, JSC::toInt32(d));
 }
 
-inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, const char* errorName) const
+inline size_t JSValue::toTypedArrayIndex(JSGlobalObject* globalObject, ASCIILiteral errorName) const
 {
     VM& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -174,7 +174,7 @@ public:
         if (isDetached())
             return true;
 
-        if (i >= m_length)
+        if (!inBounds(i))
             return false;
 
         setIndexQuicklyToNativeValue(i, value);
@@ -364,6 +364,7 @@ private:
     template<typename IntegralType>
     void sortFloat()
     {
+        // FIXME: Need to get m_length once.
         ASSERT(sizeof(IntegralType) == sizeof(ElementType));
 
         // Since there might be another view that sets the bits of

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -208,7 +208,7 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
         return result;
     }
 
-    size_t length = firstValue.toTypedArrayIndex(globalObject, "length");
+    size_t length = firstValue.toTypedArrayIndex(globalObject, "length"_s);
     RETURN_IF_EXCEPTION(scope, nullptr);
     RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, length));
 }
@@ -236,14 +236,14 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
     size_t offset = 0;
     std::optional<size_t> length = std::nullopt;
     if (jsDynamicCast<JSArrayBuffer*>(firstValue) && argCount > 1) {
-        offset = callFrame->uncheckedArgument(1).toTypedArrayIndex(globalObject, "byteOffset");
+        offset = callFrame->uncheckedArgument(1).toTypedArrayIndex(globalObject, "byteOffset"_s);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
         if (argCount > 2) {
             // If the length value is present but undefined, treat it as missing.
             JSValue lengthValue = callFrame->uncheckedArgument(2);
             if (!lengthValue.isUndefined()) {
-                length = lengthValue.toTypedArrayIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength" : "length");
+                length = lengthValue.toTypedArrayIndex(globalObject, ViewClass::TypedArrayStorageType == TypeDataView ? "byteLength"_s : "length"_s);
                 RETURN_IF_EXCEPTION(scope, encodedJSValue());
             }
         }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -507,7 +507,7 @@ bool JSGenericTypedArrayView<Adaptor>::deletePropertyByIndex(
 {
     // Integer-indexed elements can't be deleted, so we must return false when the index is valid.
     JSGenericTypedArrayView* thisObject = jsCast<JSGenericTypedArrayView*>(cell);
-    return thisObject->isDetached() || propertyName >= thisObject->m_length;
+    return thisObject->isDetached() || !thisObject->inBounds(propertyName);
 }
 
 template<typename Adaptor>
@@ -570,9 +570,11 @@ void JSGenericTypedArrayView<Adaptor>::visitChildrenImpl(JSCell* cell, Visitor& 
     }
         
     case WastefulTypedArray:
+    case ResizableWastefulTypedArray:
         break;
         
     case DataViewMode:
+    case ResizableDataViewMode:
         RELEASE_ASSERT_NOT_REACHED();
         break;
     }

--- a/Source/JavaScriptCore/runtime/MemoryMode.cpp
+++ b/Source/JavaScriptCore/runtime/MemoryMode.cpp
@@ -24,51 +24,40 @@
  */
 
 #include "config.h"
-#include "WasmMemoryMode.h"
-
-#if ENABLE(WEBASSEMBLY)
+#include "MemoryMode.h"
 
 #include <wtf/Assertions.h>
+#include <wtf/DataLog.h>
 #include <wtf/PrintStream.h>
-
-namespace JSC { namespace Wasm {
-
-const char* makeString(MemoryMode mode)
-{
-    switch (mode) {
-    case MemoryMode::BoundsChecking: return "BoundsChecking";
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-    case MemoryMode::Signaling: return "Signaling";
-#endif
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return "";
-}
-
-const char* makeString(MemorySharingMode sharingMode)
-{
-    switch (sharingMode) {
-    case MemorySharingMode::Default: return "Default";
-    case MemorySharingMode::Shared: return "Shared";
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return "";
-}
-
-} } // namespace JSC::Wasm
 
 namespace WTF {
 
-void printInternal(PrintStream& out, JSC::Wasm::MemoryMode mode)
+void printInternal(PrintStream& out, JSC::MemoryMode mode)
 {
-    out.print(JSC::Wasm::makeString(mode));
+    switch (mode) {
+    case JSC::MemoryMode::BoundsChecking:
+        out.print("BoundsChecking");
+        return;
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    case JSC::MemoryMode::Signaling:
+        out.print("Signaling");
+        return;
+#endif
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-void printInternal(PrintStream& out, JSC::Wasm::MemorySharingMode mode)
+void printInternal(PrintStream& out, JSC::MemorySharingMode mode)
 {
-    out.print(JSC::Wasm::makeString(mode));
+    switch (mode) {
+    case JSC::MemorySharingMode::Default:
+        out.print("Default");
+        return;
+    case JSC::MemorySharingMode::Shared:
+        out.print("Shared");
+        return;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 } // namespace WTF
-
-#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/MemoryMode.h
+++ b/Source/JavaScriptCore/runtime/MemoryMode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,31 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WasmPageCount.h"
+#pragma once
 
-#if ENABLE(WEBASSEMBLY)
+namespace JSC {
 
-#include <wtf/PrintStream.h>
-#include <wtf/text/WTFString.h>
+// FIXME: We should support other modes. see: https://bugs.webkit.org/show_bug.cgi?id=162693
+enum class MemoryMode : uint8_t {
+    BoundsChecking,
+#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
+    Signaling
+#endif
+};
 
-namespace JSC { namespace Wasm {
+static constexpr size_t numberOfMemoryModes = 2;
 
-void PageCount::dump(PrintStream& out) const
-{
-    out.print(String::number(bytes()), "B");
-}
+enum class MemorySharingMode : uint8_t {
+    Default,
+    Shared,
+};
 
 } // namespace JSC
 
-} // namespace Wasm
+namespace WTF {
 
-#endif // ENABLE(WEBASSEMBLY)
+class PrintStream;
+JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::MemoryMode);
+JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::MemorySharingMode);
+
+} // namespace WTF

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -551,6 +551,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useImportAssertion, true, Normal, "Enable import assertion.") \
     v(Bool, useIntlEnumeration, true, Normal, "Expose the Intl enumeration APIs.") \
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
+    v(Bool, useResizableArrayBuffer, false, Normal, "Expose ResizableArrayBuffer feature.") \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object.") \

--- a/Source/JavaScriptCore/runtime/PageCount.cpp
+++ b/Source/JavaScriptCore/runtime/PageCount.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,40 +23,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "PageCount.h"
 
-#if ENABLE(WEBASSEMBLY)
+#include <wtf/PrintStream.h>
+#include <wtf/text/WTFString.h>
 
-#include "JSExportMacros.h"
+namespace JSC {
 
-namespace JSC { namespace Wasm {
+void PageCount::dump(PrintStream& out) const
+{
+    out.print(String::number(bytes()), "B");
+}
 
-// FIXME: We should support other modes. see: https://bugs.webkit.org/show_bug.cgi?id=162693
-enum class MemoryMode : uint8_t {
-    BoundsChecking,
-#if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-    Signaling
-#endif
-};
-
-static constexpr size_t NumberOfMemoryModes = 2;
-JS_EXPORT_PRIVATE const char* makeString(MemoryMode);
-
-enum class MemorySharingMode : uint8_t {
-    Default,
-    Shared,
-};
-
-JS_EXPORT_PRIVATE const char* makeString(MemorySharingMode);
-
-} } // namespace JSC::Wasm
-
-namespace WTF {
-
-class PrintStream;
-void printInternal(PrintStream&, JSC::Wasm::MemoryMode);
-void printInternal(PrintStream&, JSC::Wasm::MemorySharingMode);
-
-} // namespace WTF
-
-#endif // ENABLE(WEBASSEMBLY)
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -258,7 +258,8 @@ inline bool Structure::hasIndexingHeader(const JSCell* cell) const
     if (!isTypedView(m_blob.type()))
         return false;
 
-    return jsCast<const JSArrayBufferView*>(cell)->mode() == WastefulTypedArray;
+    TypedArrayMode mode = jsCast<const JSArrayBufferView*>(cell)->mode();
+    return mode == WastefulTypedArray || mode == ResizableWastefulTypedArray;
 }
 
 inline bool Structure::masqueradesAsUndefined(JSGlobalObject* lexicalGlobalObject)

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp
@@ -1824,10 +1824,10 @@ auto AirIRGenerator::addCurrentMemory(ExpressionType& result) -> PartialResult
 
     RELEASE_ASSERT(Arg::isValidAddrForm(Instance::offsetOfMemory(), Width64));
     RELEASE_ASSERT(Arg::isValidAddrForm(Memory::offsetOfHandle(), Width64));
-    RELEASE_ASSERT(Arg::isValidAddrForm(MemoryHandle::offsetOfSize(), Width64));
+    RELEASE_ASSERT(Arg::isValidAddrForm(BufferMemoryHandle::offsetOfSize(), Width64));
     append(Move, Arg::addr(instanceValue(), Instance::offsetOfMemory()), temp1);
     append(Move, Arg::addr(temp1, Memory::offsetOfHandle()), temp1);
-    append(Move, Arg::addr(temp1, MemoryHandle::offsetOfSize()), temp1);
+    append(Move, Arg::addr(temp1, BufferMemoryHandle::offsetOfSize()), temp1);
     constexpr uint32_t shiftValue = 16;
     static_assert(PageCount::pageSize == 1ull << shiftValue, "This must hold for the code below to be correct.");
     append(Move, Arg::imm(16), temp2);

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -1245,7 +1245,7 @@ auto B3IRGenerator::addCurrentMemory(ExpressionType& result) -> PartialResult
 
     Value* memory = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int64, origin(), instanceValue(), safeCast<int32_t>(Instance::offsetOfMemory()));
     Value* handle = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int64, origin(), memory, safeCast<int32_t>(Memory::offsetOfHandle()));
-    Value* size = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int64, origin(), handle, safeCast<int32_t>(MemoryHandle::offsetOfSize()));
+    Value* size = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, Int64, origin(), handle, safeCast<int32_t>(BufferMemoryHandle::offsetOfSize()));
 
     constexpr uint32_t shiftValue = 16;
     static_assert(PageCount::pageSize == 1ull << shiftValue, "This must hold for the code below to be correct.");

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -321,8 +321,8 @@ private:
     FixedVector<JumpTable> m_jumpTables;
 
 #if ENABLE(WEBASSEMBLY_B3JIT)
-    RefPtr<OptimizingJITCallee> m_replacements[Wasm::NumberOfMemoryModes];
-    RefPtr<OSREntryCallee> m_osrEntryCallees[Wasm::NumberOfMemoryModes];
+    RefPtr<OptimizingJITCallee> m_replacements[numberOfMemoryModes];
+    RefPtr<OSREntryCallee> m_osrEntryCallees[numberOfMemoryModes];
 #endif
     CodePtr<WasmEntryPtrTag> m_entrypoint;
 };

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -166,14 +166,14 @@ bool CalleeGroup::isSafeToRun(MemoryMode memoryMode)
         return false;
 
     switch (m_mode) {
-    case Wasm::MemoryMode::BoundsChecking:
+    case MemoryMode::BoundsChecking:
         return true;
 #if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-    case Wasm::MemoryMode::Signaling:
+    case MemoryMode::Signaling:
         // Code being in Signaling mode means that it performs no bounds checks.
         // Its memory, even if empty, absolutely must also be in Signaling mode
         // because the page protection detects out-of-bounds accesses.
-        return memoryMode == Wasm::MemoryMode::Signaling;
+        return memoryMode == MemoryMode::Signaling;
 #endif
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "MacroAssemblerCodeRef.h"
+#include "MemoryMode.h"
 #include "WasmCallee.h"
 #include "WasmEmbedder.h"
 #include <wtf/CrossThreadCopier.h>
@@ -47,7 +48,6 @@ namespace Wasm {
 class EntryPlan;
 struct ModuleInformation;
 struct UnlinkedWasmToWasmCall;
-enum class MemoryMode : uint8_t;
 
 class CalleeGroup final : public ThreadSafeRefCounted<CalleeGroup> {
 public:

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -31,13 +31,13 @@
 #include "Identifier.h"
 #include "JSString.h"
 #include "MacroAssemblerCodeRef.h"
+#include "PageCount.h"
 #include "RegisterAtOffsetList.h"
 #include "WasmMemoryInformation.h"
 #include "WasmName.h"
 #include "WasmNameSection.h"
 #include "WasmOSREntryData.h"
 #include "WasmOps.h"
-#include "WasmPageCount.h"
 #include "WasmTypeDefinition.h"
 #include <cstdint>
 #include <limits>

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -27,8 +27,9 @@
 
 #if ENABLE(WEBASSEMBLY)
 
-#include "WasmMemoryMode.h"
-#include "WasmPageCount.h"
+#include "ArrayBuffer.h"
+#include "MemoryMode.h"
+#include "PageCount.h"
 
 #include <wtf/CagedPtr.h>
 #include <wtf/Expected.h>
@@ -50,42 +51,6 @@ namespace Wasm {
 
 class Instance;
 
-class MemoryHandle final : public ThreadSafeRefCounted<MemoryHandle> {
-    WTF_MAKE_NONCOPYABLE(MemoryHandle);
-    WTF_MAKE_FAST_ALLOCATED;
-    friend LLIntOffsetsExtractor;
-public:
-    MemoryHandle(void*, size_t size, size_t mappedCapacity, PageCount initial, PageCount maximum, MemorySharingMode, MemoryMode);
-    JS_EXPORT_PRIVATE ~MemoryHandle();
-
-    void* memory() const;
-    size_t size() const { return m_size; }
-    size_t mappedCapacity() const { return m_mappedCapacity; }
-    PageCount initial() const { return m_initial; }
-    PageCount maximum() const { return m_maximum; }
-    MemorySharingMode sharingMode() const { return m_sharingMode; }
-    MemoryMode mode() const { return m_mode; }
-    static ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(MemoryHandle, m_size); }
-    Lock& lock() { return m_lock; }
-
-    void growToSize(size_t size)
-    {
-        m_size = size;
-    }
-
-private:
-    using CagedMemory = CagedPtr<Gigacage::Primitive, void, tagCagedPtr>;
-
-    Lock m_lock;
-    MemorySharingMode m_sharingMode { MemorySharingMode::Default };
-    MemoryMode m_mode { MemoryMode::BoundsChecking };
-    CagedMemory m_memory;
-    size_t m_size { 0 };
-    size_t m_mappedCapacity { 0 };
-    PageCount m_initial;
-    PageCount m_maximum;
-};
-
 class Memory final : public RefCounted<Memory> {
     WTF_MAKE_NONCOPYABLE(Memory);
     WTF_MAKE_FAST_ALLOCATED;
@@ -100,35 +65,30 @@ public:
     enum GrowSuccess { GrowSuccessTag };
 
     static Ref<Memory> create();
-    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<MemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<BufferMemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> create(Ref<SharedArrayBufferContents>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    JS_EXPORT_PRIVATE static Ref<Memory> createZeroSized(MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     static RefPtr<Memory> tryCreate(VM&, PageCount initial, PageCount maximum, MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
 
     JS_EXPORT_PRIVATE ~Memory();
 
 #if ENABLE(WEBASSEMBLY_SIGNALING_MEMORY)
-    static size_t fastMappedRedzoneBytes();
-    static size_t fastMappedBytes(); // Includes redzone.
+    static size_t fastMappedRedzoneBytes() { return BufferMemoryHandle::fastMappedRedzoneBytes(); }
+    static size_t fastMappedBytes() { return BufferMemoryHandle::fastMappedBytes(); } // Includes redzone.
+#else
 #endif
     static bool addressIsInGrowableOrFastMemory(void*);
 
     void* memory() const { return m_handle->memory(); }
     size_t size() const { return m_handle->size(); }
-    PageCount sizeInPages() const { return PageCount::fromBytes(size()); }
     size_t mappedCapacity() const { return m_handle->mappedCapacity(); }
     PageCount initial() const { return m_handle->initial(); }
     PageCount maximum() const { return m_handle->maximum(); }
-    MemoryHandle& handle() { return m_handle.get(); }
+    BufferMemoryHandle& handle() { return m_handle.get(); }
 
     MemorySharingMode sharingMode() const { return m_handle->sharingMode(); }
     MemoryMode mode() const { return m_handle->mode(); }
 
-    enum class GrowFailReason {
-        InvalidDelta,
-        InvalidGrowSize,
-        WouldExceedMaximum,
-        OutOfMemory,
-        GrowSharedUnavailable,
-    };
     Expected<PageCount, GrowFailReason> grow(VM&, PageCount);
     bool fill(uint32_t, uint8_t, uint32_t);
     bool copy(uint32_t, uint32_t, uint32_t);
@@ -140,14 +100,18 @@ public:
 
     static ptrdiff_t offsetOfHandle() { return OBJECT_OFFSETOF(Memory, m_handle); }
 
+    SharedArrayBufferContents* shared() const { return m_shared.get(); }
+
 private:
     Memory();
-    Memory(Ref<MemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(Ref<BufferMemoryHandle>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
+    Memory(Ref<BufferMemoryHandle>&&, Ref<SharedArrayBufferContents>&&, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
     Memory(PageCount initial, PageCount maximum, MemorySharingMode, WTF::Function<void(GrowSuccess, PageCount, PageCount)>&& growSuccessCallback);
 
     Expected<PageCount, GrowFailReason> growShared(VM&, PageCount);
 
-    Ref<MemoryHandle> m_handle;
+    Ref<BufferMemoryHandle> m_handle;
+    RefPtr<SharedArrayBufferContents> m_shared;
     WTF::Function<void(GrowSuccess, PageCount, PageCount)> m_growSuccessCallback;
     Vector<WeakPtr<Instance>> m_instances;
 };
@@ -160,7 +124,6 @@ namespace JSC { namespace Wasm {
 
 class Memory {
 public:
-    static size_t maxFastMemoryCount() { return 0; }
     static bool addressIsInGrowableOrFastMemory(void*) { return false; }
 };
 

--- a/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmMemoryInformation.h
@@ -28,9 +28,9 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "GPRInfo.h"
+#include "PageCount.h"
 #include "RegisterSet.h"
 #include "WasmMemory.h"
-#include "WasmPageCount.h"
 
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -116,7 +116,7 @@ void Module::copyInitialCalleeGroupToAllMemoryModes(MemoryMode initialMode)
     Locker locker { m_lock };
     ASSERT(m_calleeGroups[static_cast<uint8_t>(initialMode)]);
     const CalleeGroup& initialBlock = *m_calleeGroups[static_cast<uint8_t>(initialMode)];
-    for (unsigned i = 0; i < Wasm::NumberOfMemoryModes; i++) {
+    for (unsigned i = 0; i < numberOfMemoryModes; i++) {
         if (i == static_cast<uint8_t>(initialMode))
             continue;
         // We should only try to copy the group here if it hasn't already been created.

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -76,7 +76,7 @@ private:
 
     Module(LLIntPlan&);
     Ref<ModuleInformation> m_moduleInformation;
-    RefPtr<CalleeGroup> m_calleeGroups[Wasm::NumberOfMemoryModes];
+    RefPtr<CalleeGroup> m_calleeGroups[numberOfMemoryModes];
     Ref<LLIntCallees> m_llintCallees;
     MacroAssemblerCodeRef<JITCompilationPtrTag> m_llintEntryThunks;
     Lock m_lock;

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -661,11 +661,11 @@ JSC_DEFINE_JIT_OPERATION(operationGrowMemory, int32_t, (void* callFrame, Instanc
     auto grown = instance->memory()->grow(instance->vm(), PageCount(delta));
     if (!grown) {
         switch (grown.error()) {
-        case Memory::GrowFailReason::InvalidDelta:
-        case Memory::GrowFailReason::InvalidGrowSize:
-        case Memory::GrowFailReason::WouldExceedMaximum:
-        case Memory::GrowFailReason::OutOfMemory:
-        case Memory::GrowFailReason::GrowSharedUnavailable:
+        case GrowFailReason::InvalidDelta:
+        case GrowFailReason::InvalidGrowSize:
+        case GrowFailReason::WouldExceedMaximum:
+        case GrowFailReason::OutOfMemory:
+        case GrowFailReason::GrowSharedUnavailable:
             return -1;
         }
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -385,11 +385,11 @@ std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, const
 
         GPRReg currentInstanceGPR = Context::useFastTLS() ? baseMemory : wasmContextInstanceGPR;
         if (isARM64E()) {
-            if (mode == Wasm::MemoryMode::BoundsChecking)
+            if (mode == MemoryMode::BoundsChecking)
                 size = pinnedRegs.boundsCheckingSizeRegister;
             jit.loadPtr(CCallHelpers::Address(currentInstanceGPR, Wasm::Instance::offsetOfCachedBoundsCheckingSize()), size);
         } else {
-            if (mode == Wasm::MemoryMode::BoundsChecking)
+            if (mode == MemoryMode::BoundsChecking)
                 jit.loadPtr(CCallHelpers::Address(currentInstanceGPR, Wasm::Instance::offsetOfCachedBoundsCheckingSize()), pinnedRegs.boundsCheckingSizeRegister);
         }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -213,8 +213,8 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, JSGlobalObject* 
         auto* jsMemory = JSWebAssemblyMemory::tryCreate(globalObject, vm, globalObject->webAssemblyMemoryStructure());
         RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-        RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, moduleInformation.memory.initial(), moduleInformation.memory.maximum(), moduleInformation.memory.isShared() ? Wasm::MemorySharingMode::Shared: Wasm::MemorySharingMode::Default,
-            [&vm, jsMemory](Wasm::Memory::GrowSuccess, Wasm::PageCount oldPageCount, Wasm::PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); }
+        RefPtr<Wasm::Memory> memory = Wasm::Memory::tryCreate(vm, moduleInformation.memory.initial(), moduleInformation.memory.maximum(), moduleInformation.memory.isShared() ? MemorySharingMode::Shared: MemorySharingMode::Default,
+            [&vm, jsMemory](Wasm::Memory::GrowSuccess, PageCount oldPageCount, PageCount newPageCount) { jsMemory->growSuccessCallback(vm, oldPageCount, newPageCount); }
         );
         if (!memory)
             return exception(createOutOfMemoryError(globalObject));

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -78,7 +78,7 @@ public:
         m_memory.set(vm, this, value);
         instance().setMemory(memory()->memory());
     }
-    Wasm::MemoryMode memoryMode() { return memory()->memory().mode(); }
+    MemoryMode memoryMode() { return memory()->memory().mode(); }
 
     JSWebAssemblyTable* table(unsigned i) { return m_tables[i].get(); }
     void setTable(VM& vm, uint32_t index, JSWebAssemblyTable* value)

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp
@@ -80,70 +80,72 @@ JSArrayBuffer* JSWebAssemblyMemory::buffer(JSGlobalObject* globalObject)
 
     auto* wrapper = m_bufferWrapper.get();
     if (wrapper) {
-        if (m_memory->sharingMode() == Wasm::MemorySharingMode::Default)
-            return wrapper;
-
-        ASSERT(m_memory->sharingMode() == Wasm::MemorySharingMode::Shared);
         // If SharedArrayBuffer's underlying memory is not grown, we continue using cached wrapper.
         if (wrapper->impl()->byteLength() == memory().size())
             return wrapper;
     }
 
-    Ref<Wasm::MemoryHandle> protectedHandle = m_memory->handle();
-    CagedUniquePtr<Gigacage::Primitive, uint8_t> pointerForEmpty;
-
-    void* memory = m_memory->memory();
-    size_t size = m_memory->size();
-    if (!memory) {
-        ASSERT(!size);
-        constexpr unsigned allocationSize = 1;
-        pointerForEmpty = CagedUniquePtr<Gigacage::Primitive, uint8_t>::tryCreate(allocationSize);
-        if (!pointerForEmpty) {
-            throwOutOfMemoryError(globalObject, throwScope);
-            return nullptr;
+    if (m_memory->sharingMode() == MemorySharingMode::Shared && m_memory->shared()) {
+        m_buffer = ArrayBuffer::createShared(*m_memory->shared());
+        m_buffer->makeWasmMemory();
+    } else {
+        Ref<BufferMemoryHandle> protectedHandle = m_memory->handle();
+        void* memory = m_memory->memory();
+        size_t size = m_memory->size();
+        CagedUniquePtr<Gigacage::Primitive, uint8_t> pointerForEmpty;
+        if (!memory) {
+            ASSERT(!size);
+            constexpr unsigned allocationSize = 1;
+            pointerForEmpty = CagedUniquePtr<Gigacage::Primitive, uint8_t>::tryCreate(allocationSize);
+            if (!pointerForEmpty) {
+                throwOutOfMemoryError(globalObject, throwScope);
+                return nullptr;
+            }
+            memory = pointerForEmpty.get(allocationSize);
         }
-        memory = pointerForEmpty.get(allocationSize);
+        ASSERT(memory);
+        auto destructor = createSharedTask<void(void*)>([protectedHandle = WTFMove(protectedHandle), pointerForEmpty = WTFMove(pointerForEmpty)] (void*) { });
+        m_buffer = ArrayBuffer::createFromBytes(memory, size, WTFMove(destructor));
+        m_buffer->makeWasmMemory();
+        if (m_memory->sharingMode() == MemorySharingMode::Shared)
+            m_buffer->makeShared();
     }
-    ASSERT(memory);
-    auto destructor = createSharedTask<void(void*)>([protectedHandle = WTFMove(protectedHandle), pointerForEmpty = WTFMove(pointerForEmpty)] (void*) { });
-    m_buffer = ArrayBuffer::createFromBytes(memory, size, WTFMove(destructor));
-    m_buffer->makeWasmMemory();
-    if (m_memory->sharingMode() == Wasm::MemorySharingMode::Shared)
-        m_buffer->makeShared();
+
     auto* arrayBuffer = JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(m_buffer->sharingMode()), m_buffer.get());
-    if (m_memory->sharingMode() == Wasm::MemorySharingMode::Shared) {
+    if (m_memory->sharingMode() == MemorySharingMode::Shared) {
         objectConstructorFreeze(globalObject, arrayBuffer);
         RETURN_IF_EXCEPTION(throwScope, { });
     }
+
     m_bufferWrapper.set(vm, this, arrayBuffer);
     RELEASE_ASSERT(m_bufferWrapper);
     return m_bufferWrapper.get();
 }
 
-Wasm::PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, uint32_t delta)
+PageCount JSWebAssemblyMemory::grow(VM& vm, JSGlobalObject* globalObject, uint32_t delta)
 {
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    auto grown = memory().grow(vm, Wasm::PageCount(delta));
+    auto grown = memory().grow(vm, PageCount(delta));
     if (!grown) {
         switch (grown.error()) {
-        case Wasm::Memory::GrowFailReason::InvalidDelta:
+        case GrowFailReason::InvalidDelta:
             throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory.grow expects the delta to be a valid page count"_s));
             break;
-        case Wasm::Memory::GrowFailReason::InvalidGrowSize:
+        case GrowFailReason::InvalidGrowSize:
             throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory.grow expects the grown size to be a valid page count"_s));
             break;
-        case Wasm::Memory::GrowFailReason::WouldExceedMaximum:
+        case GrowFailReason::WouldExceedMaximum:
             throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory.grow would exceed the memory's declared maximum size"_s));
             break;
-        case Wasm::Memory::GrowFailReason::OutOfMemory:
+        case GrowFailReason::OutOfMemory:
             throwException(globalObject, throwScope, createOutOfMemoryError(globalObject));
             break;
-        case Wasm::Memory::GrowFailReason::GrowSharedUnavailable:
+        case GrowFailReason::GrowSharedUnavailable:
             throwException(globalObject, throwScope, createRangeError(globalObject, "WebAssembly.Memory.grow for shared memory is unavailable"_s));
             break;
         }
-        return Wasm::PageCount();
+        return PageCount();
     }
 
     return grown.value();
@@ -153,8 +155,8 @@ JSObject* JSWebAssemblyMemory::type(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
 
-    Wasm::PageCount minimum = m_memory->initial();
-    Wasm::PageCount maximum = m_memory->maximum();
+    PageCount minimum = m_memory->initial();
+    PageCount maximum = m_memory->maximum();
 
     JSObject* result;
     if (maximum.isValid()) {
@@ -164,17 +166,17 @@ JSObject* JSWebAssemblyMemory::type(JSGlobalObject* globalObject)
         result = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
 
     result->putDirect(vm, Identifier::fromString(vm, "minimum"_s), jsNumber(minimum.pageCount()));
-    result->putDirect(vm, Identifier::fromString(vm, "shared"_s), jsBoolean(m_memory->sharingMode() == Wasm::MemorySharingMode::Shared));
+    result->putDirect(vm, Identifier::fromString(vm, "shared"_s), jsBoolean(m_memory->sharingMode() == MemorySharingMode::Shared));
 
     return result;
 }
 
 
-void JSWebAssemblyMemory::growSuccessCallback(VM& vm, Wasm::PageCount oldPageCount, Wasm::PageCount newPageCount)
+void JSWebAssemblyMemory::growSuccessCallback(VM& vm, PageCount oldPageCount, PageCount newPageCount)
 {
     // We need to clear out the old array buffer because it might now be pointing to stale memory.
     if (m_buffer) {
-        if (m_memory->sharingMode() == Wasm::MemorySharingMode::Default)
+        if (m_memory->sharingMode() == MemorySharingMode::Default)
             m_buffer->detach(vm);
         m_buffer = nullptr;
         m_bufferWrapper.clear();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h
@@ -57,8 +57,8 @@ public:
     JS_EXPORT_PRIVATE void adopt(Ref<Wasm::Memory>&&);
     Wasm::Memory& memory() { return m_memory.get(); }
     JSArrayBuffer* buffer(JSGlobalObject*);
-    Wasm::PageCount grow(VM&, JSGlobalObject*, uint32_t delta);
-    JS_EXPORT_PRIVATE void growSuccessCallback(VM&, Wasm::PageCount oldPageCount, Wasm::PageCount newPageCount);
+    PageCount grow(VM&, JSGlobalObject*, uint32_t delta);
+    JS_EXPORT_PRIVATE void growSuccessCallback(VM&, PageCount oldPageCount, PageCount newPageCount);
 
     JSObject* type(JSGlobalObject*);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
@@ -30,7 +30,7 @@
 #include "CallLinkInfo.h"
 #include "JSDestructibleObject.h"
 #include "JSObject.h"
-#include "WasmMemoryMode.h"
+#include "MemoryMode.h"
 #include "WasmOps.h"
 #include <wtf/Bag.h>
 #include <wtf/Expected.h>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -141,7 +141,7 @@ bool WebAssemblyFunction::usesTagRegisters() const
 RegisterSet WebAssemblyFunction::calleeSaves() const
 {
     // Pessimistically save callee saves in BoundsChecking mode since the LLInt always bounds checks
-    RegisterSetBuilder result = Wasm::PinnedRegisterInfo::get().toSave(Wasm::MemoryMode::BoundsChecking);
+    RegisterSetBuilder result = Wasm::PinnedRegisterInfo::get().toSave(MemoryMode::BoundsChecking);
     if (usesTagRegisters()) {
         RegisterSetBuilder tagCalleeSaves = RegisterSetBuilder::calleeSaveRegisters();
         tagCalleeSaves.filter(RegisterSetBuilder::runtimeTagRegisters());
@@ -396,13 +396,13 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
         auto mode = instance()->memoryMode();
 
         if (isARM64E()) {
-            if (mode == Wasm::MemoryMode::BoundsChecking)
+            if (mode == MemoryMode::BoundsChecking)
                 scratchOrBoundsCheckingSize = pinnedRegs.boundsCheckingSizeRegister;
             else
                 scratchOrBoundsCheckingSize = stackLimitGPR;
             jit.loadPtr(CCallHelpers::Address(scratchJSR.payloadGPR(), Wasm::Instance::offsetOfCachedBoundsCheckingSize()), scratchOrBoundsCheckingSize);
         } else {
-            if (mode == Wasm::MemoryMode::BoundsChecking)
+            if (mode == MemoryMode::BoundsChecking)
                 jit.loadPtr(CCallHelpers::Address(scratchJSR.payloadGPR(), Wasm::Instance::offsetOfCachedBoundsCheckingSize()), pinnedRegs.boundsCheckingSizeRegister);
         }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyMemoryProtoFuncGrow, (JSGlobalObject* global
     uint32_t delta = toNonWrappingUint32(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(throwScope, { });
 
-    Wasm::PageCount result = memory->grow(vm, globalObject, delta);
+    PageCount result = memory->grow(vm, globalObject, delta);
     RETURN_IF_EXCEPTION(throwScope, { });
 
     return JSValue::encode(jsNumber(result.pageCount()));

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -404,13 +404,13 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             if (!memory)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Memory import", "is not an instance of WebAssembly.Memory")));
 
-            Wasm::PageCount declaredInitial = moduleInformation.memory.initial();
-            Wasm::PageCount importedInitial = memory->memory().initial();
+            PageCount declaredInitial = moduleInformation.memory.initial();
+            PageCount importedInitial = memory->memory().initial();
             if (importedInitial < declaredInitial)
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Memory import", "provided an 'initial' that is smaller than the module's declared 'initial' import memory size")));
 
-            if (Wasm::PageCount declaredMaximum = moduleInformation.memory.maximum()) {
-                Wasm::PageCount importedMaximum = memory->memory().maximum();
+            if (PageCount declaredMaximum = moduleInformation.memory.maximum()) {
+                PageCount importedMaximum = memory->memory().maximum();
                 if (!importedMaximum)
                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Memory import", "did not have a 'maximum' but the module requires that it does")));
 
@@ -418,7 +418,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
                     return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Memory import", "provided a 'maximum' that is larger than the module's declared 'maximum' import memory size")));
             }
 
-            if ((memory->memory().sharingMode() == Wasm::MemorySharingMode::Shared) != moduleInformation.memory.isShared())
+            if ((memory->memory().sharingMode() == MemorySharingMode::Shared) != moduleInformation.memory.isShared())
                 return exception(createJSWebAssemblyLinkError(globalObject, vm, importFailMessage(import, "Memory import", "provided a 'shared' that is different from the module's declared 'shared' import memory attribute")));
 
             // ii. Append v to memories.

--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -79,6 +79,8 @@ public:
 
     // Hint to the OS that an address range is not expected to be accessed anytime soon.
     WTF_EXPORT_PRIVATE static void hintMemoryNotNeededSoon(void*, size_t);
+
+    WTF_EXPORT_PRIVATE static bool protect(void*, size_t, bool readable, bool writable);
 };
 
 inline void* OSAllocator::reserveAndCommit(size_t reserveSize, size_t commitSize, Usage usage, bool writable, bool executable, bool jitCageEnabled)

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -282,4 +282,19 @@ void OSAllocator::releaseDecommitted(void* address, size_t bytes)
         CRASH();
 }
 
+bool OSAllocator::protect(void* address, size_t bytes, bool readable, bool writable)
+{
+    int protection = 0;
+    if (readable) {
+        if (writable)
+            protection = PROT_READ | PROT_WRITE;
+        else
+            protection = PROT_READ;
+    } else {
+        ASSERT(!readable && !writable);
+        protection = PROT_NONE;
+    }
+    return !mprotect(address, bytes, protection);
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -133,4 +133,20 @@ void OSAllocator::hintMemoryNotNeededSoon(void*, size_t)
 {
 }
 
+bool OSAllocator::protect(void* address, size_t bytes, bool readable, bool writable)
+{
+    DWORD protection = 0;
+    if (readable) {
+        if (writable)
+            protection = PAGE_READWRITE;
+        else
+            protection = PAGE_READONLY;
+    } else {
+        ASSERT(!readable && !writable);
+        protection = PAGE_NOACCESS;
+    }
+    DWORD oldProtection = 0;
+    return VirtualProtect(address, bytes, protection, &oldProtection);
+}
+
 } // namespace WTF

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -70,7 +70,7 @@ enum class SerializationForStorage : bool { No, Yes };
 using ArrayBufferContentsArray = Vector<JSC::ArrayBufferContents>;
 #if ENABLE(WEBASSEMBLY)
 using WasmModuleArray = Vector<RefPtr<JSC::Wasm::Module>>;
-using WasmMemoryHandleArray = Vector<RefPtr<JSC::Wasm::MemoryHandle>>;
+using WasmMemoryHandleArray = Vector<RefPtr<JSC::SharedArrayBufferContents>>;
 #endif
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
@@ -236,7 +236,8 @@ RefPtr<SerializedScriptValue> SerializedScriptValue::decode(Decoder& decoder)
                 Gigacage::free(Gigacage::Primitive, buffer);
                 return nullptr;
             }
-            arrayBufferContentsArray->append({ buffer, checkedBufferSize, ArrayBuffer::primitiveGigacageDestructor() });
+            JSC::ArrayBufferDestructorFunction destructor = ArrayBuffer::primitiveGigacageDestructor();
+            arrayBufferContentsArray->append({ buffer, checkedBufferSize, std::nullopt, WTFMove(destructor) });
         }
     }
 


### PR DESCRIPTION
#### 7a292520f6b12e8d4d9001d1480474b5c83cb0f8
<pre>
[JSC] Implement growable SharedArrayBuffer part 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=247541">https://bugs.webkit.org/show_bug.cgi?id=247541</a>
rdar://102006760

Reviewed by Mark Lam.

This patch adds first patch for growable SharedArrayBuffer. This patch does
not add TypedArray&apos;s length tracking (when backing ArrayBuffer is resized,
then TypedArray&apos;s length needs to be changed too).

1. We extract Wasm::MemoryHandle to runtime to use it for non wasm. This offers
   growable memory infrastructure since it was used for growable shared Wasm::Memory.
   This also requires moving MemoryMode, MemorySharingMode, and PageCount from wasm to runtime.
2. We add resizable TypedArrayTypes, and currently DFG does OSR exit when we encounter it.
   We also change it from uint32_t to uint8_t to make room in TypedArray to have more information.
3. This patch adds growable SharedArrayBuffer&apos;s methods.
4. We add OSAllocator::protect to make (1) work on Windows too.

* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* JSTests/wasm/stress/shared-wasm-memory-buffer.js:
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::generateWithGuard):
* Source/JavaScriptCore/bytecode/ExitKind.cpp:
(JSC::exitKindToString):
* Source/JavaScriptCore/bytecode/ExitKind.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::newTypedArrayWithSize):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::jumpForTypedArrayOutOfBounds):
(JSC::DFG::SpeculativeJIT::jumpForTypedArrayIsDetachedIfOutOfBounds):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetTypedArrayLengthAsInt52):
(JSC::DFG::SpeculativeJIT::compileGetTypedArrayByteOffsetAsInt52):
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::emitGetTypedArrayByteOffsetExceptSettingResult):
(JSC::FTL::DFG::LowerDFGToB3::compileGetArrayLength):
(JSC::FTL::DFG::LowerDFGToB3::compileGetTypedArrayLengthAsInt52):
(JSC::FTL::DFG::LowerDFGToB3::emitNewTypedArrayWithSize):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp:
(JSC::StructureMemoryManager::commitBlock):
(JSC::StructureMemoryManager::decommitBlock):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::branchIfFastTypedArray):
(JSC::AssemblyHelpers::branchIfNotFastTypedArray):
* Source/JavaScriptCore/jit/IntrinsicEmitter.cpp:
(JSC::IntrinsicGetterAccessCase::emitIntrinsicGetter):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBufferContents::tryAllocate):
(JSC::ArrayBufferContents::makeShared):
(JSC::ArrayBufferContents::copyTo):
(JSC::ArrayBufferContents::shareWith):
(JSC::ArrayBuffer::createFromBytes):
(JSC::ArrayBuffer::createShared):
(JSC::ArrayBuffer::tryCreate):
(JSC::ArrayBuffer::grow):
(JSC::tryAllocate):
(JSC::ArrayBuffer::tryCreateShared):
(JSC::SharedArrayBufferContents::grow):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
(JSC::ArrayBuffer::byteLength const):
(JSC::ArrayBuffer::maxByteLength const):
(JSC::IdempotentArrayBufferByteLengthGetter::IdempotentArrayBufferByteLengthGetter):
(JSC::IdempotentArrayBufferByteLengthGetter::operator()):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp: Added.
(JSC::BufferMemoryHandle::fastMappedRedzoneBytes):
(JSC::BufferMemoryHandle::fastMappedBytes):
(JSC::BufferMemoryResult::toString):
(JSC::BufferMemoryResult::dump const):
(JSC::BufferMemoryManager::tryAllocateFastMemory):
(JSC::BufferMemoryManager::freeFastMemory):
(JSC::BufferMemoryManager::tryAllocateGrowableBoundsCheckingMemory):
(JSC::BufferMemoryManager::freeGrowableBoundsCheckingMemory):
(JSC::BufferMemoryManager::isInGrowableOrFastMemory):
(JSC::BufferMemoryManager::tryAllocatePhysicalBytes):
(JSC::BufferMemoryManager::freePhysicalBytes):
(JSC::BufferMemoryManager::dump const):
(JSC::BufferMemoryManager::singleton):
(JSC::BufferMemoryHandle::BufferMemoryHandle):
(JSC::BufferMemoryHandle::~BufferMemoryHandle):
(JSC::BufferMemoryHandle::memory const):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h: Added.
(JSC::BufferMemoryResult::BufferMemoryResult):
(JSC::BufferMemoryManager::memoryLimit const):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSArrayBufferConstructor.cpp:
(JSC::JSGenericArrayBufferConstructor&lt;sharingMode&gt;::constructImpl):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::arrayBufferSlice):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSArrayBufferPrototype::finishCreation):
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::ConstructionContext::ConstructionContext):
(JSC::JSArrayBufferView::JSArrayBufferView):
(JSC::JSArrayBufferView::finishCreation):
(JSC::JSArrayBufferView::detach):
(JSC::JSArrayBufferView::slowDownAndWasteMemory):
(JSC::isIntegerIndexedObjectOutOfBounds):
(JSC::integerIndexedObjectLength):
(JSC::integerIndexedObjectByteLength):
(WTF::printInternal):
* Source/JavaScriptCore/runtime/JSArrayBufferView.h:
(JSC::hasArrayBuffer):
(JSC::isResizable):
(JSC::JSArrayBufferView::ConstructionContext::vector const):
(JSC::JSArrayBufferView::ConstructionContext::maxByteLength const):
(JSC::JSArrayBufferView::ConstructionContext::maxByteLengthUnsafe const):
(JSC::JSArrayBufferView::vector const):
(JSC::JSArrayBufferView::maxByteLength const):
(JSC::JSArrayBufferView::offsetOfMaxByteLength):
* Source/JavaScriptCore/runtime/JSArrayBufferViewInlines.h:
(JSC::JSArrayBufferView::isShared):
(JSC::JSArrayBufferView::possiblySharedBufferImpl):
(JSC::JSArrayBufferView::existingBufferInButterfly):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::toTypedArrayIndex const):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewWithArguments):
(JSC::constructGenericTypedArrayViewImpl):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::deletePropertyByIndex):
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::visitChildrenImpl):
* Source/JavaScriptCore/runtime/MemoryMode.cpp: Renamed from Source/JavaScriptCore/wasm/WasmMemoryMode.cpp.
(WTF::printInternal):
* Source/JavaScriptCore/runtime/MemoryMode.h: Renamed from Source/JavaScriptCore/wasm/WasmMemoryMode.h.
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/PageCount.cpp: Renamed from Source/JavaScriptCore/wasm/WasmPageCount.cpp.
(JSC::PageCount::dump const):
* Source/JavaScriptCore/runtime/PageCount.h: Renamed from Source/JavaScriptCore/wasm/WasmPageCount.h.
(JSC::PageCount::PageCount):
(JSC::PageCount::bytes const):
(JSC::PageCount::pageCount const):
(JSC::PageCount::isValid):
(JSC::PageCount::isValid const):
(JSC::PageCount::fromBytes):
(JSC::PageCount::fromBytesWithRoundUp):
(JSC::PageCount::max):
(JSC::PageCount::operator bool const):
(JSC::PageCount::operator&lt; const):
(JSC::PageCount::operator&gt; const):
(JSC::PageCount::operator&gt;= const):
(JSC::PageCount::operator== const):
(JSC::PageCount::operator!= const):
(JSC::PageCount::operator+ const):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::hasIndexingHeader const):
* Source/JavaScriptCore/wasm/WasmAirIRGenerator.cpp:
(JSC::Wasm::AirIRGenerator::addCurrentMemory):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addCurrentMemory):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::isSafeToRun):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::Memory):
(JSC::Wasm::Memory::create):
(JSC::Wasm::Memory::createZeroSized):
(JSC::Wasm::Memory::tryCreate):
(JSC::Wasm::Memory::addressIsInGrowableOrFastMemory):
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::grow):
(JSC::Wasm::Memory::dump const):
(JSC::Wasm::MemoryHandle::MemoryHandle): Deleted.
(JSC::Wasm::MemoryHandle::~MemoryHandle): Deleted.
(JSC::Wasm::MemoryHandle::memory const): Deleted.
(JSC::Wasm::Memory::fastMappedRedzoneBytes): Deleted.
(JSC::Wasm::Memory::fastMappedBytes): Deleted.
* Source/JavaScriptCore/wasm/WasmMemory.h:
(JSC::Wasm::Memory::maxFastMemoryCount): Deleted.
* Source/JavaScriptCore/wasm/WasmMemoryInformation.h:
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::copyInitialCalleeGroupToAllMemoryModes):
* Source/JavaScriptCore/wasm/WasmModule.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.cpp:
(JSC::JSWebAssemblyMemory::buffer):
(JSC::JSWebAssemblyMemory::grow):
(JSC::JSWebAssemblyMemory::type):
(JSC::JSWebAssemblyMemory::growSuccessCallback):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyMemory.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::calleeSaves const):
(JSC::WebAssemblyFunction::jsCallEntrypointSlow):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
* Source/WTF/wtf/OSAllocator.h:
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::protect):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::protect):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readTerminal):
* Source/WebCore/bindings/js/SerializedScriptValue.h:

Canonical link: <a href="https://commits.webkit.org/256524@main">https://commits.webkit.org/256524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c0fc7a7cad2eca648f12a1ae447dc9d82ecf557

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96021 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105575 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165892 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5382 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34029 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88397 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101390 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101681 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82625 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31007 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73841 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87028 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39762 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82396 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37439 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20598 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28240 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42034 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85075 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43924 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39861 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19209 "Passed tests") | 
<!--EWS-Status-Bubble-End-->