### PR TITLE
Use std::remove_cvref where possible

### DIFF
--- a/Source/WTF/wtf/CrossThreadCopier.h
+++ b/Source/WTF/wtf/CrossThreadCopier.h
@@ -216,20 +216,20 @@ template<typename... Types> struct CrossThreadCopierBase<false, false, std::vari
     static std::variant<Types...> copy(const Type& source)
     {
         return std::visit([] (auto& type) -> std::variant<Types...> {
-            return CrossThreadCopier<std::remove_const_t<std::remove_reference_t<decltype(type)>>>::copy(type);
+            return CrossThreadCopier<std::remove_cvref_t<decltype(type)>>::copy(type);
         }, source);
     }
     static std::variant<Types...> copy(Type&& source)
     {
         return std::visit([] (auto&& type) -> std::variant<Types...> {
-            return CrossThreadCopier<std::remove_const_t<std::remove_reference_t<decltype(type)>>>::copy(std::forward<decltype(type)>(type));
+            return CrossThreadCopier<std::remove_cvref_t<decltype(type)>>::copy(std::forward<decltype(type)>(type));
         }, WTFMove(source));
     }
 };
 
 template<typename T> auto crossThreadCopy(T&& source)
 {
-    return CrossThreadCopier<std::remove_cv_t<std::remove_reference_t<T>>>::copy(std::forward<T>(source));
+    return CrossThreadCopier<std::remove_cvref_t<T>>::copy(std::forward<T>(source));
 }
     
 } // namespace WTF

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -457,11 +457,6 @@ struct IsBaseOfTemplate : public std::integral_constant<bool, Detail::IsBaseOfTe
 template<typename, typename = void> inline constexpr bool IsTypeComplete = false;
 template<typename T> inline constexpr bool IsTypeComplete<T, std::void_t<decltype(sizeof(T))>> = true;
 
-template <class T>
-struct RemoveCVAndReference  {
-    typedef typename std::remove_cv<typename std::remove_reference<T>::type>::type type;
-};
-
 template<typename IteratorTypeLeft, typename IteratorTypeRight, typename IteratorTypeDst>
 IteratorTypeDst mergeDeduplicatedSorted(IteratorTypeLeft leftBegin, IteratorTypeLeft leftEnd, IteratorTypeRight rightBegin, IteratorTypeRight rightEnd, IteratorTypeDst dstBegin)
 {

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1430,7 +1430,7 @@ bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendSlow
     static_assert(action == FailureAction::Crash || action == FailureAction::Report);
     ASSERT(size() == capacity());
 
-    auto ptr = const_cast<typename std::remove_const<typename std::remove_reference<U>::type>::type*>(std::addressof(value));
+    auto ptr = const_cast<std::remove_cvref_t<U>*>(std::addressof(value));
     ptr = expandCapacity<action>(size() + 1, ptr);
     if constexpr (action == FailureAction::Report) {
         if (UNLIKELY(!ptr))
@@ -1535,7 +1535,7 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::ins
 {
     ASSERT_WITH_SECURITY_IMPLICATION(position <= size());
 
-    auto ptr = const_cast<typename std::remove_const<typename std::remove_reference<U>::type>::type*>(std::addressof(value));
+    auto ptr = const_cast<std::remove_cvref_t<U>*>(std::addressof(value));
     if (size() == capacity()) {
         ptr = expandCapacity<FailureAction::Crash>(size() + 1, ptr);
         ASSERT(begin());

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -196,7 +196,7 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
                 if (returnValue)
                     return;
                 
-                using Type = typename WTF::RemoveCVAndReference<decltype(type)>::type::type;
+                using Type = typename std::remove_cvref_t<decltype(type)>::type;
                 using ImplementationType = typename Type::ImplementationType;
                 using RawType = typename Type::RawType;
 
@@ -269,7 +269,7 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
                 if (returnValue)
                     return;
 
-                using Type = typename WTF::RemoveCVAndReference<decltype(type)>::type::type;
+                using Type = typename std::remove_cvref_t<decltype(type)>::type;
                 using ImplementationType = typename Type::ImplementationType;
                 using WrapperType = typename Converter<Type>::WrapperType;
 
@@ -393,7 +393,7 @@ template<typename... T> struct JSConverter<IDLUnion<T...>> {
 
         std::optional<JSC::JSValue> returnValue;
         brigand::for_each<Sequence>([&](auto&& type) {
-            using I = typename WTF::RemoveCVAndReference<decltype(type)>::type::type;
+            using I = typename std::remove_cvref_t<decltype(type)>::type;
             if (I::value == index) {
                 ASSERT(!returnValue);
                 returnValue = toJS<brigand::at<TypeList, I>>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -273,7 +273,7 @@ public:
             && (std::is_same_v<Args, Ref<const DataSegment>> &&...))
             return adoptRef(*new SharedBuffer(std::forward<Args>(args)...));
         else if constexpr (sizeof...(Args) == 1
-            && (std::is_same_v<std::remove_const_t<std::remove_reference_t<Args>>, DataSegment> &&...))
+            && (std::is_same_v<std::remove_cvref_t<Args>, DataSegment> &&...))
             return adoptRef(*new SharedBuffer(std::forward<Args>(args)...));
         else {
             auto buffer = FragmentedSharedBuffer::create(std::forward<Args>(args)...);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
@@ -616,7 +616,7 @@ bool ItemHandle::safeCopy(ItemType itemType, ItemHandle destination) const
 bool safeCopy(ItemHandle destination, const DisplayListItem& source)
 {
     return std::visit([&](const auto& source) {
-        using DisplayListItemType = typename WTF::RemoveCVAndReference<decltype(source)>::type;
+        using DisplayListItemType = std::remove_cvref_t<decltype(source)>;
         constexpr auto itemType = DisplayListItemType::itemType;
         destination.data[0] = static_cast<uint8_t>(itemType);
         auto itemOffset = destination.data + sizeof(uint64_t);

--- a/Source/WebKit/Platform/IPC/DaemonDecoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonDecoder.h
@@ -45,7 +45,7 @@ public:
     template<typename T>
     std::optional<T> decode()
     {
-        return Coder<std::remove_const_t<std::remove_reference_t<T>>>::decode(*this);
+        return Coder<std::remove_cvref_t<T>>::decode(*this);
     }
 
     template<typename T>

--- a/Source/WebKit/Platform/IPC/DaemonEncoder.h
+++ b/Source/WebKit/Platform/IPC/DaemonEncoder.h
@@ -35,7 +35,7 @@ public:
     template<typename T>
     Encoder& operator<<(T&& t)
     {
-        Coder<std::remove_const_t<std::remove_reference_t<T>>>::encode(*this, std::forward<T>(t));
+        Coder<std::remove_cvref_t<T>>::encode(*this, std::forward<T>(t));
         return *this;
     }
 

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -92,7 +92,7 @@ public:
     template<typename T>
     WARN_UNUSED_RETURN bool decode(T& t)
     {
-        using Impl = ArgumentCoder<std::remove_const_t<std::remove_reference_t<T>>, void>;
+        using Impl = ArgumentCoder<std::remove_cvref_t<T>, void>;
         if constexpr(HasLegacyDecoder<T, Impl>::value) {
             if (UNLIKELY(!Impl::decode(*this, t))) {
                 markInvalid();
@@ -121,7 +121,7 @@ public:
     template<typename T>
     std::optional<T> decode()
     {
-        using Impl = ArgumentCoder<std::remove_const_t<std::remove_reference_t<T>>, void>;
+        using Impl = ArgumentCoder<std::remove_cvref_t<T>, void>;
         if constexpr(HasModernDecoder<T, Impl>::value) {
             std::optional<T> t { Impl::decode(*this) };
             if (UNLIKELY(!t))

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -69,7 +69,7 @@ public:
     template<typename T>
     Encoder& operator<<(T&& t)
     {
-        ArgumentCoder<std::remove_const_t<std::remove_reference_t<T>>, void>::encode(*this, std::forward<T>(t));
+        ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
         return *this;
     }
 

--- a/Source/WebKit/Platform/IPC/HandleMessage.h
+++ b/Source/WebKit/Platform/IPC/HandleMessage.h
@@ -240,12 +240,12 @@ struct CompletionHandlerValidation::ValidCompletionHandlerType<CompletionHandler
 
 template<typename T>
 struct CodingType {
-    typedef std::remove_const_t<std::remove_reference_t<T>> Type;
+    using Type = std::remove_cvref_t<T>;
 };
 
 template<typename... Ts>
 struct CodingType<std::tuple<Ts...>> {
-    typedef std::tuple<typename CodingType<Ts>::Type...> Type;
+    using Type = std::tuple<typename CodingType<Ts>::Type...>;
 };
 
 template<typename T, typename C, typename MF>

--- a/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionEncoder.h
@@ -71,7 +71,7 @@ public:
     template<typename T>
     StreamConnectionEncoder& operator<<(T&& t)
     {
-        ArgumentCoder<std::remove_const_t<std::remove_reference_t<T>>, void>::encode(*this, std::forward<T>(t));
+        ArgumentCoder<std::remove_cvref_t<T>, void>::encode(*this, std::forward<T>(t));
         return *this;
     }
 

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -275,7 +275,7 @@ def check_type_members(type):
     for member in type.members:
         if member.condition is not None:
             result.append('#if ' + member.condition)
-        result.append('    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.' + member.name + ')>>, ' + member.type + '>);')
+        result.append('    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.' + member.name + ')>, ' + member.type + '>);')
         if member.condition is not None:
             result.append('#endif')
     return result

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -57,11 +57,11 @@ template<> struct ArgumentCoder<Namespace::OtherClass> {
 
 void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder, const Namespace::Subnamespace::StructName& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.firstMemberName)>>, FirstMemberType>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.firstMemberName)>, FirstMemberType>);
 #if ENABLE(SECOND_MEMBER)
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.secondMemberName)>>, SecondMemberType>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMemberName)>, SecondMemberType>);
 #endif
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.nullableTestMember)>>, RetainPtr<CFTypeRef>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.nullableTestMember)>, RetainPtr<CFTypeRef>>);
     encoder << instance.firstMemberName;
 #if ENABLE(SECOND_MEMBER)
     encoder << instance.secondMemberName;
@@ -73,11 +73,11 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder
 
 void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& encoder, const Namespace::Subnamespace::StructName& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.firstMemberName)>>, FirstMemberType>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.firstMemberName)>, FirstMemberType>);
 #if ENABLE(SECOND_MEMBER)
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.secondMemberName)>>, SecondMemberType>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMemberName)>, SecondMemberType>);
 #endif
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.nullableTestMember)>>, RetainPtr<CFTypeRef>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.nullableTestMember)>, RetainPtr<CFTypeRef>>);
     encoder << instance.firstMemberName;
 #if ENABLE(SECOND_MEMBER)
     encoder << instance.secondMemberName;
@@ -129,10 +129,10 @@ std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subn
 
 void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namespace::OtherClass& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.isNull)>>, bool>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.a)>>, int>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.b)>>, bool>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.dataDetectorResults)>>, RetainPtr<NSArray>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.isNull)>, bool>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, bool>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.dataDetectorResults)>, RetainPtr<NSArray>>);
     encoder << instance.isNull;
     if (instance.isNull)
         return;
@@ -178,9 +178,9 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
 
 void ArgumentCoder<Namespace::ReturnRefClass>::encode(Encoder& encoder, const Namespace::ReturnRefClass& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.functionCall().member1)>>, double>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.functionCall().member2)>>, double>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.uniqueMember)>>, std::unique_ptr<int>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.functionCall().member1)>, double>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.functionCall().member2)>, double>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.uniqueMember)>, std::unique_ptr<int>>);
     encoder << instance.functionCall().member1;
     encoder << instance.functionCall().member2;
     encoder << !!instance.uniqueMember;
@@ -226,8 +226,8 @@ std::optional<Ref<Namespace::ReturnRefClass>> ArgumentCoder<Namespace::ReturnRef
 
 void ArgumentCoder<Namespace::EmptyConstructorStruct>::encode(Encoder& encoder, const Namespace::EmptyConstructorStruct& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.m_int)>>, int>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.m_double)>>, double>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_int)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_double)>, double>);
     encoder << instance.m_int;
     encoder << instance.m_double;
 }
@@ -253,12 +253,12 @@ std::optional<Namespace::EmptyConstructorStruct> ArgumentCoder<Namespace::EmptyC
 
 void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder, const Namespace::EmptyConstructorNullable& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.m_isNull)>>, bool>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_isNull)>, bool>);
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.m_type)>>, MemberType>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_type)>, MemberType>);
 #endif
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.m_value)>>, OtherMemberType>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_value)>, OtherMemberType>);
 #endif
     encoder << instance.m_isNull;
     if (instance.m_isNull)
@@ -308,7 +308,7 @@ std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::Empt
 
 void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutNamespace& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.a)>>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
     encoder << instance.a;
 }
 
@@ -329,13 +329,13 @@ std::optional<WithoutNamespace> ArgumentCoder<WithoutNamespace>::decode(Decoder&
 
 void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(Encoder& encoder, const WithoutNamespaceWithAttributes& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.a)>>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
     encoder << instance.a;
 }
 
 void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(OtherEncoder& encoder, const WithoutNamespaceWithAttributes& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.a)>>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
     encoder << instance.a;
 }
 
@@ -356,8 +356,8 @@ std::optional<WithoutNamespaceWithAttributes> ArgumentCoder<WithoutNamespaceWith
 
 void ArgumentCoder<WebCore::InheritsFrom>::encode(Encoder& encoder, const WebCore::InheritsFrom& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.a)>>, int>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.b)>>, float>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, float>);
     encoder << instance.a;
     encoder << instance.b;
 }
@@ -388,9 +388,9 @@ std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decod
 
 void ArgumentCoder<WebCore::InheritanceGrandchild>::encode(Encoder& encoder, const WebCore::InheritanceGrandchild& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.a)>>, int>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.b)>>, float>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.c)>>, double>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, float>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.c)>, double>);
     encoder << instance.a;
     encoder << instance.b;
     encoder << instance.c;
@@ -431,7 +431,7 @@ std::optional<WebCore::InheritanceGrandchild> ArgumentCoder<WebCore::Inheritance
 
 void ArgumentCoder<WTF::Seconds>::encode(Encoder& encoder, const WTF::Seconds& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.value())>>, double>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value())>, double>);
     encoder << instance.value();
 }
 
@@ -452,7 +452,7 @@ std::optional<WTF::Seconds> ArgumentCoder<WTF::Seconds>::decode(Decoder& decoder
 
 void ArgumentCoder<WTF::CreateUsingClass>::encode(Encoder& encoder, const WTF::CreateUsingClass& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.value)>>, double>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, double>);
     encoder << instance.value;
 }
 
@@ -473,10 +473,10 @@ std::optional<WTF::CreateUsingClass> ArgumentCoder<WTF::CreateUsingClass>::decod
 
 void ArgumentCoder<WebCore::FloatBoxExtent>::encode(Encoder& encoder, const WebCore::FloatBoxExtent& instance)
 {
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.top())>>, float>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.right())>>, float>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.bottom())>>, float>);
-    static_assert(std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype(instance.left())>>, float>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.top())>, float>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.right())>, float>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.bottom())>, float>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.left())>, float>);
     encoder << instance.top();
     encoder << instance.right();
     encoder << instance.bottom();


### PR DESCRIPTION
#### d51d63b0938d48756a22d42c0b80f7d0c0ad12b6
<pre>
Use std::remove_cvref where possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=247542">https://bugs.webkit.org/show_bug.cgi?id=247542</a>

Reviewed by Fujii Hironori.

C++20 introduces the std::remove_cvref type alias which can be used in place of
combinations of std::remove_reference and std::remove_const or std::remove_cv.

Older versions of GCC&apos;s standard library are covered by an already-existing
fallback. WTF::RemoveCVAndReference is basically the same thing and can be
replaced completely.

* Source/WTF/wtf/CrossThreadCopier.h:
(WTF::crossThreadCopy):
* Source/WTF/wtf/StdLibExtras.h:
* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::appendSlowCase):
(WTF::Malloc&gt;::insert):
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBuffer::create):
* Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp:
(WebCore::DisplayList::safeCopy):
* Source/WebKit/Platform/IPC/DaemonDecoder.h:
(WebKit::Daemon::Decoder::decode):
* Source/WebKit/Platform/IPC/DaemonEncoder.h:
(WebKit::Daemon::Encoder::operator&lt;&lt;):
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::decode):
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/HandleMessage.h:
* Source/WebKit/Platform/IPC/StreamConnectionEncoder.h:
* Source/WebKit/Scripts/generate-serializers.py:
(check_type_members):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ReturnRefClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorStruct&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::encode):
(IPC::ArgumentCoder&lt;WithoutNamespace&gt;::encode):
(IPC::ArgumentCoder&lt;WithoutNamespaceWithAttributes&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::InheritsFrom&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::InheritanceGrandchild&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::Seconds&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::CreateUsingClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::FloatBoxExtent&gt;::encode):

Canonical link: <a href="https://commits.webkit.org/256377@main">https://commits.webkit.org/256377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f349bb7d079bbf29544f4b5b9ed72c287415f073

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105169 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165448 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4899 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33603 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101020 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3582 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82202 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30650 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99176 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73487 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86652 "Found 6 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-no-ftl (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39341 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/81956 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20229 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28149 "Found 5 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-no-ftl (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4406 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42877 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84634 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39480 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19116 "Passed tests") | 
<!--EWS-Status-Bubble-End-->