### PR TITLE
@font-face src must serialize specified URLs, not URLs resolved against the base

### DIFF
--- a/LayoutTests/fast/css/font-face-src-parsing-expected.txt
+++ b/LayoutTests/fast/css/font-face-src-parsing-expected.txt
@@ -7,9 +7,9 @@ Valid rules from the stylesheet:
 @font-face { src: url("font.svg#id"); }
 @font-face { src: url("font.ttf") format("truetype"); }
 @font-face { src: url("font.woff") format("woff"), local("font2"); }
-@font-face { src: url("font2.ttf"); }
-@font-face { src: url("font2.ttf") format("truetype"); }
-@font-face { src: url("font3.otf") format("opentype"), local("foo bar"); }
+@font-face { src: url("font.ttf") format("truetype"), url("font2.ttf"); }
+@font-face { src: url("font.ttf"), url("font2.ttf") format("truetype"); }
+@font-face { src: url("font.ttf"), local("font2"), url("font3.otf") format("opentype"), local("foo bar"); }
 @font-face { src: local("foo"); }
 @font-face { src: local("font"), local("foo bar"); }
 @font-face { src: local("foo"); }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-family-src-quoted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-family-src-quoted-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL font-family-src-quoted assert_not_equals: got disallowed value -1
+PASS font-family-src-quoted
 

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -60,28 +60,20 @@ template<typename T> void iterateClients(HashSet<CSSFontFace::Client*>& clients,
 
 void CSSFontFace::appendSources(CSSFontFace& fontFace, CSSValueList& srcList, ScriptExecutionContext* context, bool isInitiatingElementInUserAgentShadowTree)
 {
+    bool allowDownloading = context && context->settingsValues().downloadableBinaryFontsEnabled;
     for (auto& src : srcList) {
         // An item in the list either specifies a string (local font name) or a URL (remote font to download).
-        CSSFontFaceSrcValue& item = downcast<CSSFontFaceSrcValue>(src.get());
-        std::unique_ptr<CSSFontFaceSource> source;
-        SVGFontFaceElement* fontFaceElement = nullptr;
-        bool foundSVGFont = false;
-
-        foundSVGFont = item.isSVGFontFaceSrc() || item.svgFontFaceElement();
-        fontFaceElement = item.svgFontFaceElement();
-        bool allowDownloading = context && context->settingsValues().downloadableBinaryFontsEnabled;
-        if (!item.isLocal()) {
-            if (allowDownloading && item.isSupportedFormat()) {
-                if (auto fontRequest = item.fontLoadRequest(context, foundSVGFont, isInitiatingElementInUserAgentShadowTree))
-                    source = makeUnique<CSSFontFaceSource>(fontFace, item.resource(), *context->cssFontSelector(), makeUniqueRefFromNonNullUniquePtr(WTFMove(fontRequest)));
+        if (auto local = dynamicDowncast<CSSFontFaceSrcLocalValue>(src.get())) {
+            if (!local->svgFontFaceElement())
+                fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, local->fontFaceName()));
+            else if (allowDownloading)
+                fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, local->fontFaceName(), *local->svgFontFaceElement()));
+        } else {
+            if (allowDownloading) {
+                if (auto request = downcast<CSSFontFaceSrcResourceValue>(src.get()).fontLoadRequest(*context, isInitiatingElementInUserAgentShadowTree))
+                    fontFace.adoptSource(makeUnique<CSSFontFaceSource>(fontFace, *context->cssFontSelector(), makeUniqueRefFromNonNullUniquePtr(WTFMove(request))));
             }
-        } else if (allowDownloading && fontFaceElement)
-            source = makeUnique<CSSFontFaceSource>(fontFace, item.resource(), *fontFaceElement);
-        else if (!fontFaceElement)
-            source = makeUnique<CSSFontFaceSource>(fontFace, item.resource());
-
-        if (source)
-            fontFace.adoptSource(WTFMove(source));
+        }
     }
     fontFace.sourcesPopulated();
 }

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -109,7 +109,7 @@ void CSSFontFaceSet::updateStyleIfNeeded()
         m_owningFontSelector->updateStyleIfNeeded();
 }
 
-void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const String& familyName)
+void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& familyName)
 {
     ASSERT(m_owningFontSelector);
     if (m_locallyInstalledFacesLookupTable.contains(familyName))
@@ -117,8 +117,8 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const String& famil
 
     if (!m_owningFontSelector->scriptExecutionContext())
         return;
-    AllowUserInstalledFonts allowUserInstalledFonts = m_owningFontSelector->scriptExecutionContext()->settingsValues().shouldAllowUserInstalledFonts ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
-    Vector<FontSelectionCapabilities> capabilities = FontCache::forCurrentThread().getFontSelectionCapabilitiesInFamily(AtomString { familyName }, allowUserInstalledFonts);
+    auto allowUserInstalledFonts = m_owningFontSelector->scriptExecutionContext()->settingsValues().shouldAllowUserInstalledFonts ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
+    auto capabilities = FontCache::forCurrentThread().getFontSelectionCapabilitiesInFamily(familyName, allowUserInstalledFonts);
     if (capabilities.isEmpty())
         return;
 
@@ -177,7 +177,7 @@ void CSSFontFaceSet::addToFacesLookupTable(CSSFontFace& face)
     }
 
     for (auto& item : *families) {
-        String familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item.get()));
+        auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item.get())) };
         if (familyName.isEmpty())
             continue;
 

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -105,7 +105,7 @@ private:
     void fontStateChanged(CSSFontFace&, CSSFontFace::Status oldState, CSSFontFace::Status newState) final;
     void fontPropertyChanged(CSSFontFace&, CSSValueList* oldFamilies = nullptr) final;
 
-    void ensureLocalFontFacesForFamilyRegistered(const String&);
+    void ensureLocalFontFacesForFamilyRegistered(const AtomString&);
 
     static String familyNameFromPrimitive(const CSSPrimitiveValue&);
 

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -36,25 +36,21 @@ class CSSFontFace;
 class CSSFontSelector;
 class SharedBuffer;
 class Document;
-class WeakPtrImplWithEventTargetData;
 class Font;
 class FontCreationContext;
-struct FontCustomPlatformData;
 class FontDescription;
-struct FontSelectionSpecifiedCapabilities;
-struct FontVariantSettings;
 class SVGFontFaceElement;
+class WeakPtrImplWithEventTargetData;
 
-template <typename T> class FontTaggedSettings;
-typedef FontTaggedSettings<int> FontFeatureSettings;
+struct FontCustomPlatformData;
 
 class CSSFontFaceSource final : public FontLoadRequestClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    CSSFontFaceSource(CSSFontFace& owner, const String& familyNameOrURI);
-    CSSFontFaceSource(CSSFontFace& owner, const String& familyNameOrURI, CSSFontSelector&, UniqueRef<FontLoadRequest>&&);
-    CSSFontFaceSource(CSSFontFace& owner, const String& familyNameOrURI, SVGFontFaceElement&);
-    CSSFontFaceSource(CSSFontFace& owner, const String& familyNameOrURI, Ref<JSC::ArrayBufferView>&&);
+    CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName);
+    CSSFontFaceSource(CSSFontFace& owner, AtomString fontFaceName, SVGFontFaceElement&);
+    CSSFontFaceSource(CSSFontFace& owner, CSSFontSelector&, UniqueRef<FontLoadRequest>);
+    CSSFontFaceSource(CSSFontFace& owner, Ref<JSC::ArrayBufferView>&&);
     virtual ~CSSFontFaceSource();
 
     //                      => Success
@@ -69,8 +65,6 @@ public:
         Failure
     };
     Status status() const { return m_status; }
-
-    const AtomString& familyNameOrURI() const { return m_familyNameOrURI; }
 
     void opportunisticallyStartFontDataURLLoading();
 
@@ -89,10 +83,10 @@ private:
 
     void setStatus(Status);
 
-    AtomString m_familyNameOrURI; // URI for remote, built-in font name for local.
+    AtomString m_fontFaceName; // Font name for local fonts
     CSSFontFace& m_face; // Our owning font face.
     WeakPtr<CSSFontSelector> m_fontSelector; // For remote fonts, to orchestrate loading.
-    std::unique_ptr<FontLoadRequest> m_fontRequest; // Also for remote fonts, a pointer to the resource request.
+    const std::unique_ptr<FontLoadRequest> m_fontRequest; // Also for remote fonts, a pointer to the resource request.
 
     RefPtr<SharedBuffer> m_generatedOTFBuffer;
     RefPtr<JSC::ArrayBufferView> m_immediateSource;

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -145,7 +145,11 @@ String serializeString(const String& string)
 
 String serializeURL(const String& string)
 {
-    return "url(" + serializeString(string) + ")";
+    StringBuilder builder;
+    builder.append("url(");
+    serializeString(string, builder);
+    builder.append(')');
+    return builder.toString();
 }
 
 String serializeFontFamily(const String& string)

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -123,8 +123,10 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFilterImageValue>(*this));
     case FontClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontValue>(*this));
-    case FontFaceSrcClass:
-        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFaceSrcValue>(*this));
+    case FontFaceSrcLocalClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFaceSrcLocalValue>(*this));
+    case FontFaceSrcResourceClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFaceSrcResourceValue>(*this));
     case FontFeatureClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSFontFeatureValue>(*this));
     case FontPaletteValuesOverrideColorsClass:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -66,7 +66,8 @@ public:
     bool isFontFeatureValue() const { return m_classType == FontFeatureClass; }
     bool isFontVariationValue() const { return m_classType == FontVariationClass; }
     bool isFontVariantAlternatesValue() const { return m_classType == FontVariantAlternatesClass; }
-    bool isFontFaceSrcValue() const { return m_classType == FontFaceSrcClass; }
+    bool isFontFaceSrcLocalValue() const { return m_classType == FontFaceSrcLocalClass; }
+    bool isFontFaceSrcResourceValue() const { return m_classType == FontFaceSrcResourceClass; }
     bool isFontPaletteValuesOverrideColorsValue() const { return m_classType == FontPaletteValuesOverrideColorsClass; }
     bool isFontValue() const { return m_classType == FontClass; }
     bool isFontStyleRangeValue() const { return m_classType == FontStyleRangeClass; }
@@ -186,7 +187,8 @@ protected:
         FontClass,
         FontStyleRangeClass,
         FontStyleWithAngleClass,
-        FontFaceSrcClass,
+        FontFaceSrcLocalClass,
+        FontFaceSrcResourceClass,
         FontPaletteValuesOverrideColorsClass,
         FunctionClass,
 

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 
 static bool populateFontFaceWithArrayBuffer(CSSFontFace& fontFace, Ref<JSC::ArrayBufferView>&& arrayBufferView)
 {
-    auto source = makeUnique<CSSFontFaceSource>(fontFace, String(), WTFMove(arrayBufferView));
+    auto source = makeUnique<CSSFontFaceSource>(fontFace, WTFMove(arrayBufferView));
     fontFace.adoptSource(WTFMove(source));
     return false;
 }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -2265,7 +2265,7 @@ static RefPtr<CSSValue> consumePaintStroke(CSSParserTokenRange& range, const CSS
 {
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
-    RefPtr<CSSPrimitiveValue> url = consumeUrl(range);
+    auto url = consumeURL(range);
     if (url) {
         RefPtr<CSSValue> parsedValue;
         if (range.peek().id() == CSSValueNone)
@@ -2348,7 +2348,7 @@ static RefPtr<CSSValue> consumeNoneOrURI(CSSParserTokenRange& range)
 {
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
-    return consumeUrl(range);
+    return consumeURL(range);
 }
 
 static bool isFlexBasisIdent(const WebCore::CSSValueID id, const CSSParserContext& context)
@@ -2915,7 +2915,7 @@ static RefPtr<CSSValue> consumePathOperation(CSSParserTokenRange& range, const C
 {
     if (range.peek().id() == CSSValueNone)
         return consumeIdent(range);
-    if (RefPtr<CSSPrimitiveValue> url = consumeUrl(range))
+    if (auto url = consumeURL(range))
         return url;
 
     if (consumeRay == ConsumeRay::Include) {
@@ -3808,10 +3808,10 @@ static bool consumeGridTrackRepeatFunction(CSSParserTokenRange& range, CSSParser
     else {
         // We clamp the repetitions to a multiple of the repeat() track list's size, while staying below the max grid size.
         repetitions = std::min(repetitions, GridPosition::max() / numberOfTracks);
-        RefPtr<CSSValueList> integerRepeatedValues = CSSGridIntegerRepeatValue::create(repetitions);
-        for (size_t i = 0; i < repeatedValues->length(); ++i)
-            integerRepeatedValues->append(*repeatedValues->itemWithoutBoundsCheck(i));
-        list.append(integerRepeatedValues.releaseNonNull());
+        auto integerRepeatedValues = CSSGridIntegerRepeatValue::create(repetitions);
+        for (auto& item : *repeatedValues)
+            integerRepeatedValues->append(item.get());
+        list.append(WTFMove(integerRepeatedValues));
     }
     return true;
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1638,7 +1638,7 @@ RefPtr<CSSPrimitiveValue> consumeString(CSSParserTokenRange& range)
     return CSSValuePool::singleton().createValue(range.consumeIncludingWhitespace().value().toString(), CSSUnitType::CSS_STRING);
 }
 
-StringView consumeUrlAsStringView(CSSParserTokenRange& range)
+StringView consumeURLRaw(CSSParserTokenRange& range)
 {
     const CSSParserToken& token = range.peek();
     if (token.type() == UrlToken) {
@@ -1660,9 +1660,9 @@ StringView consumeUrlAsStringView(CSSParserTokenRange& range)
     return { };
 }
 
-RefPtr<CSSPrimitiveValue> consumeUrl(CSSParserTokenRange& range)
+RefPtr<CSSPrimitiveValue> consumeURL(CSSParserTokenRange& range)
 {
-    StringView url = consumeUrlAsStringView(range);
+    StringView url = consumeURLRaw(range);
     if (url.isNull())
         return nullptr;
     return CSSValuePool::singleton().createValue(url.toString(), CSSUnitType::CSS_URI);
@@ -4481,7 +4481,7 @@ RefPtr<CSSValue> consumeFilter(CSSParserTokenRange& range, const CSSParserContex
     bool referenceFiltersAllowed = allowedFunctions == AllowedFilterFunctions::PixelFilters;
     auto list = CSSValueList::createSpaceSeparated();
     do {
-        RefPtr<CSSValue> filterValue = referenceFiltersAllowed ? consumeUrl(range) : nullptr;
+        RefPtr<CSSValue> filterValue = referenceFiltersAllowed ? consumeURL(range) : nullptr;
         if (!filterValue) {
             filterValue = consumeFilterFunction(range, context, allowedFunctions);
             if (!filterValue)
@@ -4578,7 +4578,7 @@ RefPtr<CSSValue> consumeImage(CSSParserTokenRange& range, const CSSParserContext
     }
 
     if (allowedImageTypes.contains(AllowedImageType::URLFunction)) {
-        if (auto string = consumeUrlAsStringView(range); !string.isNull()) {
+        if (auto string = consumeURLRaw(range); !string.isNull()) {
             return CSSImageValue::create(context.completeURL(string.toAtomString().string()),
                 context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
         }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -120,8 +120,8 @@ template<CSSValueID... allowedIdents> RefPtr<CSSPrimitiveValue> consumeIdentWork
 RefPtr<CSSPrimitiveValue> consumeCustomIdent(CSSParserTokenRange&, bool shouldLowercase = false);
 RefPtr<CSSPrimitiveValue> consumeDashedIdent(CSSParserTokenRange&, bool shouldLowercase = false);
 RefPtr<CSSPrimitiveValue> consumeString(CSSParserTokenRange&);
-StringView consumeUrlAsStringView(CSSParserTokenRange&);
-RefPtr<CSSPrimitiveValue> consumeUrl(CSSParserTokenRange&);
+StringView consumeURLRaw(CSSParserTokenRange&);
+RefPtr<CSSPrimitiveValue> consumeURL(CSSParserTokenRange&);
 
 Color consumeColorWorkerSafe(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSPrimitiveValue> consumeColor(CSSParserTokenRange&, const CSSParserContext&, bool acceptQuirkyColors = false, OptionSet<StyleColor::CSSColorType> = { StyleColor::CSSColorType::Absolute, StyleColor::CSSColorType::Current, StyleColor::CSSColorType::System });

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -601,7 +601,7 @@ CSSParserToken CSSTokenizer::consumeIdentLikeToken()
             m_input.advanceUntilNonWhitespace();
             UChar next = m_input.peek(0);
             if (next != '"' && next != '\'')
-                return consumeUrlToken();
+                return consumeURLToken();
         }
         return blockStart(LeftParenthesisToken, FunctionToken, name);
     }
@@ -655,7 +655,7 @@ static bool isNonPrintableCodePoint(UChar cc)
 }
 
 // http://dev.w3.org/csswg/css-syntax/#consume-url-token
-CSSParserToken CSSTokenizer::consumeUrlToken()
+CSSParserToken CSSTokenizer::consumeURLToken()
 {
     m_input.advanceUntilNonWhitespace();
 

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -70,7 +70,7 @@ private:
     CSSParserToken consumeIdentLikeToken();
     CSSParserToken consumeNumber();
     CSSParserToken consumeStringTokenUntil(UChar);
-    CSSParserToken consumeUrlToken();
+    CSSParserToken consumeURLToken();
 
     void consumeBadUrlRemnants();
     void consumeSingleWhitespaceIfNext();

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3138,7 +3138,7 @@ void Document::implicitOpen()
     setReadyState(Loading);
 }
 
-std::unique_ptr<FontLoadRequest> Document::fontLoadRequest(String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
+std::unique_ptr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
     auto* cachedFont = m_fontLoader->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
     return cachedFont ? makeUnique<CachedFontLoadRequest>(*cachedFont) : nullptr;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1750,7 +1750,7 @@ private:
 
     // ScriptExecutionContext
     CSSFontSelector* cssFontSelector() final { return m_fontSelector.ptr(); }
-    std::unique_ptr<FontLoadRequest> fontLoadRequest(String&, bool, bool, LoadedFromOpaqueSource) final;
+    std::unique_ptr<FontLoadRequest> fontLoadRequest(const String&, bool, bool, LoadedFromOpaqueSource) final;
     void beginLoadingFontSoon(FontLoadRequest&) final;
 
     // FontSelectorClient

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -252,7 +252,7 @@ CSSValuePool& ScriptExecutionContext::cssValuePool()
     return CSSValuePool::singleton();
 }
 
-std::unique_ptr<FontLoadRequest> ScriptExecutionContext::fontLoadRequest(String&, bool, bool, LoadedFromOpaqueSource)
+std::unique_ptr<FontLoadRequest> ScriptExecutionContext::fontLoadRequest(const String&, bool, bool, LoadedFromOpaqueSource)
 {
     return nullptr;
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -177,7 +177,7 @@ public:
 
     virtual CSSFontSelector* cssFontSelector() { return nullptr; }
     virtual CSSValuePool& cssValuePool();
-    virtual std::unique_ptr<FontLoadRequest> fontLoadRequest(String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource);
+    virtual std::unique_ptr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource);
     virtual void beginLoadingFontSoon(FontLoadRequest&) { }
 
     WEBCORE_EXPORT static void setCrossOriginMode(CrossOriginMode);

--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -52,8 +52,8 @@ public:
     virtual bool isLoading() const = 0;
     virtual bool errorOccurred() const = 0;
 
-    virtual bool ensureCustomFontData(const AtomString& remoteURI) = 0;
-    virtual RefPtr<Font> createFont(const FontDescription&, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) = 0;
+    virtual bool ensureCustomFontData() = 0;
+    virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) = 0;
 
     virtual void setClient(FontLoadRequestClient*) = 0;
 

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -85,7 +85,7 @@ void CachedFont::beginLoadIfNeeded(CachedResourceLoader& loader)
     }
 }
 
-bool CachedFont::ensureCustomFontData(const AtomString&)
+bool CachedFont::ensureCustomFontData()
 {
     if (!m_data)
         return ensureCustomFontData(nullptr);
@@ -119,7 +119,7 @@ std::unique_ptr<FontCustomPlatformData> CachedFont::createCustomFontData(SharedB
     return buffer ? createFontCustomPlatformData(*buffer, itemInCollection) : nullptr;
 }
 
-RefPtr<Font> CachedFont::createFont(const FontDescription& fontDescription, const AtomString&, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
+RefPtr<Font> CachedFont::createFont(const FontDescription& fontDescription, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
 {
     return Font::create(platformDataFromCustomData(fontDescription, syntheticBold, syntheticItalic, fontCreationContext), Font::Origin::Remote);
 }

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -53,11 +53,11 @@ public:
     void beginLoadIfNeeded(CachedResourceLoader&);
     bool stillNeedsLoad() const override { return !m_loadInitiated; }
 
-    virtual bool ensureCustomFontData(const AtomString& remoteURI);
+    virtual bool ensureCustomFontData();
     static std::unique_ptr<FontCustomPlatformData> createCustomFontData(SharedBuffer&, const String& itemInCollection, bool& wrapping);
     static FontPlatformData platformDataFromCustomData(FontCustomPlatformData&, const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
-    virtual RefPtr<Font> createFont(const FontDescription&, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext&);
+    virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&);
 
 protected:
     FontPlatformData platformDataFromCustomData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -58,10 +58,10 @@ private:
     bool isLoading() const final { return m_font->isLoading(); }
     bool errorOccurred() const final { return m_font->errorOccurred(); }
 
-    bool ensureCustomFontData(const AtomString& remoteURI) final { return m_font->ensureCustomFontData(remoteURI); }
-    RefPtr<Font> createFont(const FontDescription& description, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext) final
+    bool ensureCustomFontData() final { return m_font->ensureCustomFontData(); }
+    RefPtr<Font> createFont(const FontDescription& description, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext) final
     {
-        return m_font->createFont(description, remoteURI, syntheticBold, syntheticItalic, fontCreationContext);
+        return m_font->createFont(description, syntheticBold, syntheticItalic, fontCreationContext);
     }
 
     void setClient(FontLoadRequestClient* client) final

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -55,10 +55,10 @@ CachedSVGFont::CachedSVGFont(CachedResourceRequest&& request, CachedSVGFont& res
 {
 }
 
-RefPtr<Font> CachedSVGFont::createFont(const FontDescription& fontDescription, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
+RefPtr<Font> CachedSVGFont::createFont(const FontDescription& fontDescription, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
 {
-    ASSERT(firstFontFace(remoteURI));
-    return CachedFont::createFont(fontDescription, remoteURI, syntheticBold, syntheticItalic, fontCreationContext);
+    ASSERT(firstFontFace());
+    return CachedFont::createFont(fontDescription, syntheticBold, syntheticItalic, fontCreationContext);
 }
 
 FontPlatformData CachedSVGFont::platformDataFromCustomData(const FontDescription& fontDescription, bool bold, bool italic, const FontCreationContext& fontCreationContext)
@@ -68,7 +68,7 @@ FontPlatformData CachedSVGFont::platformDataFromCustomData(const FontDescription
     return CachedFont::platformDataFromCustomData(fontDescription, bold, italic, fontCreationContext);
 }
 
-bool CachedSVGFont::ensureCustomFontData(const AtomString& remoteURI)
+bool CachedSVGFont::ensureCustomFontData()
 {
     if (!m_externalSVGDocument && !errorOccurred() && !isLoading() && m_data) {
         bool sawError = false;
@@ -88,8 +88,8 @@ bool CachedSVGFont::ensureCustomFontData(const AtomString& remoteURI)
         if (sawError)
             m_externalSVGDocument = nullptr;
         if (m_externalSVGDocument)
-            maybeInitializeExternalSVGFontElement(remoteURI);
-        if (!m_externalSVGFontElement || !firstFontFace(remoteURI))
+            maybeInitializeExternalSVGFontElement();
+        if (!m_externalSVGFontElement || !firstFontFace())
             return false;
         if (auto convertedFont = convertSVGToOTFFont(*m_externalSVGFontElement))
             m_convertedFont = SharedBuffer::create(WTFMove(convertedFont.value()));
@@ -118,21 +118,17 @@ SVGFontElement* CachedSVGFont::getSVGFontById(const AtomString& fontName) const
     return nullptr;
 }
 
-SVGFontElement* CachedSVGFont::maybeInitializeExternalSVGFontElement(const AtomString& remoteURI)
+SVGFontElement* CachedSVGFont::maybeInitializeExternalSVGFontElement()
 {
     if (m_externalSVGFontElement)
         return m_externalSVGFontElement;
-    AtomString fragmentIdentifier;
-    size_t start = remoteURI.find('#');
-    if (start != notFound)
-        fragmentIdentifier = StringView(remoteURI).substring(start + 1).toAtomString();
-    m_externalSVGFontElement = getSVGFontById(fragmentIdentifier);
+    m_externalSVGFontElement = getSVGFontById(url().fragmentIdentifier().toAtomString());
     return m_externalSVGFontElement;
 }
 
-SVGFontFaceElement* CachedSVGFont::firstFontFace(const AtomString& remoteURI)
+SVGFontFaceElement* CachedSVGFont::firstFontFace()
 {
-    if (!maybeInitializeExternalSVGFontElement(remoteURI))
+    if (!maybeInitializeExternalSVGFontElement())
         return nullptr;
 
     if (auto* firstFontFace = childrenOfType<SVGFontFaceElement>(*m_externalSVGFontElement).first())

--- a/Source/WebCore/loader/cache/CachedSVGFont.h
+++ b/Source/WebCore/loader/cache/CachedSVGFont.h
@@ -38,17 +38,16 @@ public:
     CachedSVGFont(CachedResourceRequest&&, PAL::SessionID, const CookieJar*, const Settings&);
     CachedSVGFont(CachedResourceRequest&&, CachedSVGFont&);
 
-    bool ensureCustomFontData(const AtomString& remoteURI) override;
-
-    RefPtr<Font> createFont(const FontDescription&, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) override;
+    bool ensureCustomFontData() final;
+    RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) final;
 
 private:
     FontPlatformData platformDataFromCustomData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
     SVGFontElement* getSVGFontById(const AtomString&) const;
 
-    SVGFontElement* maybeInitializeExternalSVGFontElement(const AtomString& remoteURI);
-    SVGFontFaceElement* firstFontFace(const AtomString& remoteURI);
+    SVGFontElement* maybeInitializeExternalSVGFontElement();
+    SVGFontFaceElement* firstFontFace();
 
     RefPtr<SharedBuffer> m_convertedFont;
     RefPtr<SVGDocument> m_externalSVGDocument;

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -274,11 +274,11 @@ void SVGFontFaceElement::rebuildFontFace()
         m_fontElement = downcast<SVGFontElement>(parentNode());
 
         list = CSSValueList::createCommaSeparated();
-        list->append(CSSFontFaceSrcValue::createLocal(fontFamily()));
+        list->append(CSSFontFaceSrcLocalValue::create(AtomString { fontFamily() }));
     } else {
         m_fontElement = nullptr;
         if (srcElement)
-            list = srcElement->srcValue();
+            list = srcElement->createSrcValue();
     }
 
     if (!list || !list->length())
@@ -288,14 +288,10 @@ void SVGFontFaceElement::rebuildFontFace()
     m_fontFaceRule->mutableProperties().addParsedProperty(CSSProperty(CSSPropertySrc, list));
 
     if (describesParentFont) {    
-        // Traverse parsed CSS values and associate CSSFontFaceSrcValue elements with ourselves.
-        RefPtr<CSSValue> src = m_fontFaceRule->properties().getPropertyCSSValue(CSSPropertySrc);
-        CSSValueList* srcList = downcast<CSSValueList>(src.get());
-
-        unsigned srcLength = srcList ? srcList->length() : 0;
-        for (unsigned i = 0; i < srcLength; ++i) {
-            if (RefPtr item = downcast<CSSFontFaceSrcValue>(srcList->itemWithoutBoundsCheck(i)))
-                item->setSVGFontFaceElement(this);
+        // Traverse parsed CSS values and associate CSSFontFaceSrcLocalValue elements with ourselves.
+        if (auto* srcList = downcast<CSSValueList>(m_fontFaceRule->properties().getPropertyCSSValue(CSSPropertySrc).get())) {
+            for (auto& item : *srcList)
+                downcast<CSSFontFaceSrcLocalValue>(item.get()).setSVGFontFaceElement(*this);
         }
     }
 

--- a/Source/WebCore/svg/SVGFontFaceNameElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceNameElement.cpp
@@ -40,9 +40,9 @@ Ref<SVGFontFaceNameElement> SVGFontFaceNameElement::create(const QualifiedName& 
     return adoptRef(*new SVGFontFaceNameElement(tagName, document));
 }
 
-Ref<CSSFontFaceSrcValue> SVGFontFaceNameElement::srcValue() const
+Ref<CSSFontFaceSrcLocalValue> SVGFontFaceNameElement::createSrcValue() const
 {
-    return CSSFontFaceSrcValue::createLocal(attributeWithoutSynchronization(SVGNames::nameAttr));
+    return CSSFontFaceSrcLocalValue::create(attributeWithoutSynchronization(SVGNames::nameAttr));
 }
 
 }

--- a/Source/WebCore/svg/SVGFontFaceNameElement.h
+++ b/Source/WebCore/svg/SVGFontFaceNameElement.h
@@ -23,14 +23,14 @@
 
 namespace WebCore {
 
-class CSSFontFaceSrcValue;
+class CSSFontFaceSrcLocalValue;
 
 class SVGFontFaceNameElement final : public SVGElement {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceNameElement);
 public:
     static Ref<SVGFontFaceNameElement> create(const QualifiedName&, Document&);
     
-    Ref<CSSFontFaceSrcValue> srcValue() const;
+    Ref<CSSFontFaceSrcLocalValue> createSrcValue() const;
 
 private:
     SVGFontFaceNameElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
@@ -47,17 +47,17 @@ Ref<SVGFontFaceSrcElement> SVGFontFaceSrcElement::create(const QualifiedName& ta
     return adoptRef(*new SVGFontFaceSrcElement(tagName, document));
 }
 
-Ref<CSSValueList> SVGFontFaceSrcElement::srcValue() const
+Ref<CSSValueList> SVGFontFaceSrcElement::createSrcValue() const
 {
-    Ref<CSSValueList> list = CSSValueList::createCommaSeparated();
+    auto list = CSSValueList::createCommaSeparated();
     for (auto& child : childrenOfType<SVGElement>(*this)) {
-        RefPtr<CSSFontFaceSrcValue> srcValue;
-        if (is<SVGFontFaceUriElement>(child))
-            srcValue = downcast<SVGFontFaceUriElement>(child).srcValue();
-        else if (is<SVGFontFaceNameElement>(child))
-            srcValue = downcast<SVGFontFaceNameElement>(child).srcValue();
-        if (srcValue && srcValue->resource().length())
-            list->append(srcValue.releaseNonNull());
+        if (auto* element = dynamicDowncast<SVGFontFaceUriElement>(child)) {
+            if (auto srcValue = element->createSrcValue(); !srcValue->isEmpty())
+                list->append(WTFMove(srcValue));
+        } else if (auto* element = dynamicDowncast<SVGFontFaceNameElement>(child)) {
+            if (auto srcValue = element->createSrcValue(); !srcValue->isEmpty())
+                list->append(WTFMove(srcValue));
+        }
     }
     return list;
 }

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.h
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.h
@@ -30,7 +30,7 @@ class SVGFontFaceSrcElement final : public SVGElement {
 public:
     static Ref<SVGFontFaceSrcElement> create(const QualifiedName&, Document&);
 
-    Ref<CSSValueList> srcValue() const;
+    Ref<CSSValueList> createSrcValue() const;
     
 private:
     SVGFontFaceSrcElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -25,7 +25,7 @@
 
 namespace WebCore {
 
-class CSSFontFaceSrcValue;
+class CSSFontFaceSrcResourceValue;
 
 class SVGFontFaceUriElement final : public SVGElement, public CachedFontClient {
     WTF_MAKE_ISO_ALLOCATED(SVGFontFaceUriElement);
@@ -34,7 +34,7 @@ public:
 
     virtual ~SVGFontFaceUriElement();
 
-    Ref<CSSFontFaceSrcValue> srcValue() const;
+    Ref<CSSFontFaceSrcResourceValue> createSrcValue() const;
 
 private:
     SVGFontFaceUriElement(const QualifiedName&, Document&);

--- a/Source/WebCore/workers/WorkerFontLoadRequest.cpp
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.cpp
@@ -74,7 +74,7 @@ void WorkerFontLoadRequest::load(WorkerGlobalScope& workerGlobalScope)
     WorkerThreadableLoader::loadResourceSynchronously(workerGlobalScope, WTFMove(request), *this, options);
 }
 
-bool WorkerFontLoadRequest::ensureCustomFontData(const AtomString&)
+bool WorkerFontLoadRequest::ensureCustomFontData()
 {
     if (!m_fontCustomPlatformData && !m_errorOccurred && !m_isLoading) {
         RefPtr<SharedBuffer> contiguousData;
@@ -92,7 +92,7 @@ bool WorkerFontLoadRequest::ensureCustomFontData(const AtomString&)
     return m_fontCustomPlatformData.get();
 }
 
-RefPtr<Font> WorkerFontLoadRequest::createFont(const FontDescription& fontDescription, const AtomString&, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
+RefPtr<Font> WorkerFontLoadRequest::createFont(const FontDescription& fontDescription, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext)
 {
     ASSERT(m_fontCustomPlatformData);
     ASSERT(m_context);

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -55,8 +55,8 @@ private:
     bool isLoading() const final { return m_isLoading; }
     bool errorOccurred() const final { return m_errorOccurred; }
 
-    bool ensureCustomFontData(const AtomString& remoteURI) final;
-    RefPtr<Font> createFont(const FontDescription&, const AtomString& remoteURI, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) final;
+    bool ensureCustomFontData() final;
+    RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&) final;
 
     void setClient(FontLoadRequestClient*) final;
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -562,7 +562,7 @@ Ref<FontFaceSet> WorkerGlobalScope::fonts()
     return cssFontSelector()->fontFaceSet();
 }
 
-std::unique_ptr<FontLoadRequest> WorkerGlobalScope::fontLoadRequest(String& url, bool, bool, LoadedFromOpaqueSource loadedFromOpaqueSource)
+std::unique_ptr<FontLoadRequest> WorkerGlobalScope::fontLoadRequest(const String& url, bool, bool, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
     return makeUnique<WorkerFontLoadRequest>(completeURL(url), loadedFromOpaqueSource);
 }

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -152,7 +152,7 @@ public:
     CSSValuePool& cssValuePool() final;
     CSSFontSelector* cssFontSelector() final;
     Ref<FontFaceSet> fonts();
-    std::unique_ptr<FontLoadRequest> fontLoadRequest(String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource) final;
+    std::unique_ptr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource) final;
     void beginLoadingFontSoon(FontLoadRequest&) final;
 
     const Settings::Values& settingsValues() const final { return m_settingsValues; }


### PR DESCRIPTION
#### 443de8e8e9716b164f0a25da35e9235efd72d4dd
<pre>
@font-face src must serialize specified URLs, not URLs resolved against the base
<a href="https://bugs.webkit.org/show_bug.cgi?id=247547">https://bugs.webkit.org/show_bug.cgi?id=247547</a>
rdar://problem/102012585

Reviewed by Sam Weinig.

* LayoutTests/fast/css/font-face-src-parsing-expected.txt: Updated to expect successful
parsing of all the values for src. The old code expected some to be skipped, and
they are not skipped any more.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-family-src-quoted-expected.txt:
Expect PASS.

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::appendSources): Updated since CSSFontFaceSrcLocalValue and
CSSFontFaceSrcResourceValue are now two separate classes and CSSFontFaceSource gets the URL from
the FontLoadRequest rather than taking a separate URL argument.

* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered): Take AtomString.
(WebCore::CSSFontFaceSet::addToFacesLookupTable): Use AtomString.
* Source/WebCore/css/CSSFontFaceSet.h: Updated for above.

* Source/WebCore/css/CSSFontFaceSource.cpp:
(WebCore::CSSFontFaceSource::CSSFontFaceSource): Updated the argument name since this now takes
only a font face name, not a URL. Also, a font face name is *not* the same thing as a family name,
so don&apos;t call it a family name. Change argument types for things we take ownership of to the
appropriate owning type: AtomString and UniqueRef.
(WebCore::CSSFontFaceSource::opportunisticallyStartFontDataURLLoading): Check the length of URL
from the font request itself to decide if it&apos;s short enough, rather than using m_familyNameOrURI.
(WebCore::CSSFontFaceSource::fontLoaded): Removed the argument from ensureCustomFontData. We don&apos;t
need to pass the URL back to the object which supplied the URL in the first place.
(WebCore::CSSFontFaceSource::load): Updated for the name change of m_fontFaceName.
(WebCore::CSSFontFaceSource::font): Ditto. Also removed the argument from ensureCustomFontData
and createFont.

* Source/WebCore/css/CSSFontFaceSource.h: Changed the constructors: We don’t need to pass in a
URL along with a FontLoadRequest, which contains the URL. The font face name is not the
same thing as a family name, so let&apos;s not call it that.  Change argument types for things we take
ownership of to the appropriate owning type: AtomString and UniqueRef. There is not font face name
or URL when creating from an ArrayBufferView, so don&apos;t require the caller to pass a null one in.
Removed the familyNameOrURI function, which was unneeded. Replaced m_familyNameOrURI with
m_fontFaceName. Made m_fontRequest const to emphasize it&apos;s never changed after construction.

* Source/WebCore/css/CSSFontFaceSrcValue.cpp: Broke the CSSFontFaceSrcValue into two classes,
CSSFontFaceSrcLocalValue and CSSFontFaceSrcResourceValue. Otherwise this class would have mostly
been variant processing, since there are basically no data members in common.
(WebCore::CSSFontFaceSrcLocalValue::CSSFontFaceSrcLocalValue): Added.
(WebCore::CSSFontFaceSrcLocalValue::create): Added.
(WebCore::CSSFontFaceSrcLocalValue::svgFontFaceElement const): Added.
(WebCore::CSSFontFaceSrcLocalValue::setSVGFontFaceElement): Added.
(WebCore::CSSFontFaceSrcLocalValue::customCSSText const): Added.
(WebCore::CSSFontFaceSrcLocalValue::equals const): Added.
(WebCore::CSSFontFaceSrcResourceValue::CSSFontFaceSrcResourceValue): Added. Stores the location
as a ResolvedURL, the same way CSSImageValue does.
(WebCore::CSSFontFaceSrcResourceValue::create): Added.
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest): Added. Besides what the old version
of this function did, this now checks if the format is one we can load and returns nullptr if not.
(WebCore::CSSFontFaceSrcResourceValue::customTraverseSubresources const): Added.
(WebCore::CSSFontFaceSrcResourceValue::customCSSText const): Added. Here is where the core of the
bug fix is: we serialize the specified URL string, not the resolved URL.
(WebCore::CSSFontFaceSrcResourceValue::equals const): Added.

* Source/WebCore/css/CSSFontFaceSrcValue.h: Broke the CSSFontFaceSrcValue class into two classes,
CSSFontFaceSrcLocalValue and CSSFontFaceSrcResourceValue. Removed unneeded functions resource,
format, isLocal, setFormat, isSupportedFormat, isSVGFontFaceSrc, abd isSVGFontTarget. Added
fontFaceName and isEmpty functions to CSSFontFaceSrcLocalValue. Changed CSSFontFaceSrcResourceValue
to take and store a ResolvedURL. Added isEmpty and isFormatSVG functions to
CSSFontFaceSrcResourceValue. Changed fontLoadRequest to take a ScriptExecutionContext&amp; and also
removed the isSVG argument since CSSFontFaceSrcResourceValue itself is the where the answer to that
question comes from.

* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived): Updated for the two classes that replace CSSFontFaceSrcValue.
* Source/WebCore/css/CSSValue.h: Ditto.

* Source/WebCore/css/FontFace.cpp:
(WebCore::populateFontFaceWithArrayBuffer): Remove unneeded null URL string argument.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumePaintStroke): Updated to call consumeURL.
(WebCore::consumeNoneOrURI): Ditto.
(WebCore::consumePathOperation): Ditto.
(WebCore::consumeGridTrackRepeatFunction): Updated to use a rangee-based for loop.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeURLRaw): Renamed from consumeUrlAsStringView.
(WebCore::CSSPropertyParserHelpers::consumeURL): Renamed from consumeUrl.
(WebCore::CSSPropertyParserHelpers::consumeFilter): Updated to call consumeURL.
(WebCore::CSSPropertyParserHelpers::consumeImage): Ditto.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h: Updated for the name changes.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI): Use the ResolvedURL
instead of immediately turning it into a string. Call the new
CSSFontFaceSrcResourceValue::create.
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcLocal): Call the new
CSSFontFaceSrcLocalValue::create.

* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::consumeIdentLikeToken): Use consumeURLToken.
(WebCore::CSSTokenizer::consumeURLToken): Renamed from consumeUrlToken.
* Source/WebCore/css/parser/CSSTokenizer.h: Updated for the name change.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fontLoadRequest): Changed the URL argument to a const String&amp;.
It was String&amp; before by accident.
* Source/WebCore/dom/Document.h: Ditto.
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::fontLoadRequest): Ditto.
* Source/WebCore/dom/ScriptExecutionContext.h: Ditto.

* Source/WebCore/loader/FontLoadRequest.h: Took out the unnneded remoteURI arguments
from the ensureCustomFontData and createFont functions. These involve the font load
request passing the URI back to the object it came from, so they aren&apos;t needed.

* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::ensureCustomFontData): Removed remoteURI argument.
(WebCore::CachedFont::createFont): Ditto.
* Source/WebCore/loader/cache/CachedFont.h: Ditto.
* Source/WebCore/loader/cache/CachedFontLoadRequest.h: Ditto.
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::createFont): Ditto.
(WebCore::CachedSVGFont::ensureCustomFontData): Ditto.
(WebCore::CachedSVGFont::maybeInitializeExternalSVGFontElement): Ditto.
The logic here got simpler becuase when we have an already-parsed URL instead of
just an atom string we can take advantage of member functions.
(WebCore::CachedSVGFont::firstFontFace): Ditto.
* Source/WebCore/loader/cache/CachedSVGFont.h: Ditto.

* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::rebuildFontFace): Use CSSFontFaceSrcLocalValue::create,
a range-based for loop, and pass a reference instead of a pointer. Call createSrcValue.

* Source/WebCore/svg/SVGFontFaceNameElement.cpp:
(WebCore::SVGFontFaceNameElement::createSrcValue const): Renamed from srcValue, and return a
CSSFontFaceSrcLocalValue.
* Source/WebCore/svg/SVGFontFaceNameElement.h: Ditto.

* Source/WebCore/svg/SVGFontFaceSrcElement.cpp:
(WebCore::SVGFontFaceSrcElement::createSrcValue const): Renamed from srcValue, and updated to work
with the two different createSrcValue functions that now have different return types.

* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::createSrcValue const): Renamed from srcValue, and return a
CSSFontFaceSrcResourceValue.
(WebCore::isSVGFontTarget): Check if the font is an SVG font without creating and destroying a
CSSFontFaceSrcValue, which is overkill since we can check the format attribute directly.
* Source/WebCore/svg/SVGFontFaceUriElement.h: Return a CSSFontFaceSrcResourceValue.

* Source/WebCore/workers/WorkerFontLoadRequest.cpp:
(WebCore::WorkerFontLoadRequest::ensureCustomFontData): Removed remoteURI argument.
(WebCore::WorkerFontLoadRequest::createFont): Ditto.
* Source/WebCore/workers/WorkerFontLoadRequest.h: Ditto.

* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::fontLoadRequest): Changed the URL argument to a const String&amp;.
It was String&amp; before by accident.
* Source/WebCore/workers/WorkerGlobalScope.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/256387@main">https://commits.webkit.org/256387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3719250ddaa4aee8455f17f1941765cb450455c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105214 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4962 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101063 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101297 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82253 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73529 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39386 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4414 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41081 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39517 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->