### PR TITLE
Apple.com/apple-events: Unable to enable subtitles on first watch of the keynote

### DIFF
--- a/LayoutTests/media/track/video-track-add-visible-expected.txt
+++ b/LayoutTests/media/track/video-track-add-visible-expected.txt
@@ -1,0 +1,10 @@
+
+RUN(video.src = findMediaFile("video", "../content/test"))
+EVENT(canplay)
+RUN(track = video.addTextTrack("subtitles"))
+RUN(track.mode = "showing")
+RUN(cue = new VTTCue(0, video.duration, "cue text"))
+RUN(track.addCue(cue))
+EXPECTED (internals.shadowRoot(video).querySelector(".media-controls-container").innerText == 'cue text') OK
+END OF TEST
+

--- a/LayoutTests/media/track/video-track-add-visible.html
+++ b/LayoutTests/media/track/video-track-add-visible.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <script>
+    window.addEventListener('load', async event => {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "../content/test")');
+        await waitFor(video, 'canplay');
+        run('track = video.addTextTrack("subtitles")');
+        run('track.mode = "showing"');
+        run('cue = new VTTCue(0, video.duration, "cue text")');
+        run('track.addCue(cue)');
+        await testExpectedEventually('internals.shadowRoot(video).querySelector(".media-controls-container").innerText', 'cue text');
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video muted></video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4861,8 +4861,6 @@ void HTMLMediaElement::configureTextTrackGroup(const TrackGroup& group)
         if (!webkitClosedCaptionsVisible() && closedCaptionsVisible() && displayMode == CaptionUserPreferences::AlwaysOn)
             m_webkitLegacyClosedCaptionOverride = true;
     }
-
-    m_processingPreferenceChange = false;
 }
 
 static JSC::JSValue controllerJSValue(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, HTMLMediaElement& media)
@@ -4967,6 +4965,9 @@ void HTMLMediaElement::layoutSizeChanged()
     auto task = [this] {
         if (auto root = userAgentShadowRoot())
             root->dispatchEvent(Event::create(eventNames().resizeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+
+        if (m_mediaControlsHost)
+            m_mediaControlsHost->updateCaptionDisplaySizes();
     };
     queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, WTFMove(task));
 
@@ -5105,6 +5106,8 @@ void HTMLMediaElement::configureTextTracks()
         configureTextTrackGroup(metadataTracks);
     if (otherTracks.tracks.size())
         configureTextTrackGroup(otherTracks);
+
+    m_processingPreferenceChange = false;
 
     updateCaptionContainer();
     configureTextTrackDisplay();


### PR DESCRIPTION
#### 7ff585820d47faa4b1845617e6328c4d3d7c41ac
<pre>
Apple.com/apple-events: Unable to enable subtitles on first watch of the keynote
<a href="https://bugs.webkit.org/show_bug.cgi?id=247549">https://bugs.webkit.org/show_bug.cgi?id=247549</a>
rdar://101785175

Reviewed by Eric Carlson.

Two interlocking bugs prevent captions from being visible if tracks are added after the video is
loaded: 1) `m_processingPreferenceChange` is set to `true` in
`markCaptionAndSubtitleTracksAsUnconfigured()` and is only set to `false` if at least one text
track is present and therefore `configureTextTrackGroup()` is called. 2) the MediaControlsHost is
not notified that the video element&apos;s videoBox has changed, as it&apos;s only notified during style
updates, and will not necessarily have a RenderVideo attached at that point.

Clear `m_processingPreferenceChange` unconditionally at the end of `configureTextTracks()`. And call
the MediaControlsHost&apos;s `updateCaptionDisplaySizes()` when the media element is resized.

* LayoutTests/media/track/video-track-add-visible-expected.txt: Added.
* LayoutTests/media/track/video-track-add-visible.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::configureTextTrackGroup):
(WebCore::HTMLMediaElement::layoutSizeChanged):
(WebCore::HTMLMediaElement::configureTextTracks):

Canonical link: <a href="https://commits.webkit.org/256408@main">https://commits.webkit.org/256408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75b96c60ac17c8e01d4196401f03cb297f09650b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105209 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165506 "Found 1 new test failure: fast/images/pagewide-play-pause-offscreen-animations.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99616 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4954 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33645 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101058 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3631 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82248 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30689 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73525 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39381 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37080 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42916 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39514 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->