### PR TITLE
@font-face src descriptor format allows only identifiers for specified formats, others are a parse error

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
@@ -15,20 +15,20 @@ PASS Check that src: url("foo.ttf") format(woff) is valid
 PASS Check that src: url("foo.ttf") format(woff2) is valid
 PASS Check that src: url("foo.ttf") format(opentype, truetype) is invalid
 PASS Check that src: url("foo.ttf") format(opentype truetype) is invalid
-FAIL Check that src: url("foo.ttf") format(auto) is invalid assert_equals: expected false but got true
-FAIL Check that src: url("foo.ttf") format(default) is invalid assert_equals: expected false but got true
-FAIL Check that src: url("foo.ttf") format(inherit) is invalid assert_equals: expected false but got true
-FAIL Check that src: url("foo.ttf") format(initial) is invalid assert_equals: expected false but got true
-FAIL Check that src: url("foo.ttf") format(none) is invalid assert_equals: expected false but got true
-FAIL Check that src: url("foo.ttf") format(normal) is invalid assert_equals: expected false but got true
-FAIL Check that src: url("foo.ttf") format(xyzzy) is invalid assert_equals: expected false but got true
+PASS Check that src: url("foo.ttf") format(auto) is invalid
+PASS Check that src: url("foo.ttf") format(default) is invalid
+PASS Check that src: url("foo.ttf") format(inherit) is invalid
+PASS Check that src: url("foo.ttf") format(initial) is invalid
+PASS Check that src: url("foo.ttf") format(none) is invalid
+PASS Check that src: url("foo.ttf") format(normal) is invalid
+PASS Check that src: url("foo.ttf") format(xyzzy) is invalid
 PASS Check that src: url("foo.ttf") format("embedded-opentype"), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(embedded-opentype), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format("svg"), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(svg), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") format(xyzz 200px), url("bar.html") is invalid
-FAIL Check that src: url("foo.ttf") format(xyzz), url("bar.html") is invalid assert_equals: expected false but got true
+PASS Check that src: url("foo.ttf") format(xyzz), url("bar.html") is invalid
 PASS Check that src: url("foo.ttf") dummy(xyzzy), url("bar.html") is invalid
 PASS Check that src: url("foo.ttf") format(), url("bar.html") is invalid
-FAIL Check that src: url("foo.ttf") format(none), url("bar.html") is invalid assert_equals: expected false but got true
+PASS Check that src: url("foo.ttf") format(none), url("bar.html") is invalid
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1280,6 +1280,13 @@ polygon
 
 // @font-face src
 format
+collection
+embedded-opentype
+opentype
+svg
+truetype
+woff
+woff2
 
 // (-webkit-)filter
 // invert

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -213,7 +213,12 @@ static RefPtr<CSSFontFaceSrcValue> consumeFontFaceSrcURI(CSSParserTokenRange& ra
         // FIXME: We allow any identifier here and convert all to strings; specification calls for only certain identifiers.
         auto args = CSSPropertyParserHelpers::consumeFunction(range);
         auto& arg = args.consumeIncludingWhitespace();
-        if ((arg.type() != StringToken && arg.type() != IdentToken) || !args.atEnd())
+        if (!args.atEnd())
+            return nullptr;
+        if (arg.type() == IdentToken) {
+            if (!identMatches<CSSValueCollection, CSSValueEmbeddedOpentype, CSSValueOpentype, CSSValueSvg, CSSValueTruetype, CSSValueWoff, CSSValueWoff2>(arg.id()))
+                return nullptr;
+        } else if (arg.type() != StringToken)
             return nullptr;
         format = arg.value().toString();
     }


### PR DESCRIPTION
#### 9b942dffc4a2e4391e95ecc49fe00c24d5a5dd06
<pre>
@font-face src descriptor format allows only identifiers for specified formats, others are a parse error
<a href="https://bugs.webkit.org/show_bug.cgi?id=247552">https://bugs.webkit.org/show_bug.cgi?id=247552</a>
rdar://problem/102018015

Reviewed by Sam Weinig.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt:
Expect more PASS.

* Source/WebCore/css/CSSValueKeywords.in: Added the keywords for all the formats in the specification.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI): Allow only keywords for known formats.

Canonical link: <a href="https://commits.webkit.org/256382@main">https://commits.webkit.org/256382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f90d8a0c84b384fe5003aa8ea212f136a5ea8204

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105199 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165493 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4941 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33635 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101049 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3621 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82237 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30684 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87399 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39371 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37071 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4411 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41067 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43055 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39506 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->