### PR TITLE
Expose the FONT_FEATURE_VALUES_RULE constant

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt
@@ -13,7 +13,7 @@ PASS CSSFontFaceRule interface: attribute style
 PASS CSSFontFaceRule must be primary interface of cssFontFaceRule
 PASS Stringification of cssFontFaceRule
 PASS CSSFontFaceRule interface: cssFontFaceRule must inherit property "style" with the proper type
-FAIL CSSRule interface: cssFontFaceRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type assert_inherits: property "FONT_FEATURE_VALUES_RULE" not found in prototype chain
+PASS CSSRule interface: cssFontFaceRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type
 PASS CSSFontFeatureValuesRule interface: existence and properties of interface object
 PASS CSSFontFeatureValuesRule interface object length
 PASS CSSFontFeatureValuesRule interface object name
@@ -45,7 +45,7 @@ PASS CSSFontPaletteValuesRule interface: attribute name
 PASS CSSFontPaletteValuesRule interface: attribute fontFamily
 PASS CSSFontPaletteValuesRule interface: attribute basePalette
 PASS CSSFontPaletteValuesRule interface: attribute overrideColors
-FAIL CSSRule interface: constant FONT_FEATURE_VALUES_RULE on interface object assert_own_property: expected property "FONT_FEATURE_VALUES_RULE" missing
-FAIL CSSRule interface: constant FONT_FEATURE_VALUES_RULE on interface prototype object assert_own_property: expected property "FONT_FEATURE_VALUES_RULE" missing
-FAIL CSSRule interface: cssRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type assert_inherits: property "FONT_FEATURE_VALUES_RULE" not found in prototype chain
+PASS CSSRule interface: constant FONT_FEATURE_VALUES_RULE on interface object
+PASS CSSRule interface: constant FONT_FEATURE_VALUES_RULE on interface prototype object
+PASS CSSRule interface: cssRule must inherit property "FONT_FEATURE_VALUES_RULE" with the proper type
 

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.idl
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.idl
@@ -29,4 +29,3 @@ typedef USVString CSSOMString;
     // Like Gecko, we don't expose the children at-rules @styleset,...etc
     // https://searchfox.org/mozilla-central/source/dom/webidl/CSSFontFeatureValuesRule.webidl
 };
-

--- a/Source/WebCore/css/CSSRule.idl
+++ b/Source/WebCore/css/CSSRule.idl
@@ -46,6 +46,7 @@
     [ImplementedAs=Namespace] const unsigned short NAMESPACE_RULE = 10;
     [ImplementedAs=CounterStyle, EnabledBySetting=CSSCounterStyleAtRulesEnabled] const unsigned short COUNTER_STYLE_RULE = 11;
     [ImplementedAs=Supports] const unsigned short SUPPORTS_RULE = 12;
+    [ImplementedAs=FontFeatureValues] const unsigned short FONT_FEATURE_VALUES_RULE = 14;
 
     // Legacy synonyms for the above, kept to avoid breaking existing content.
     [ImplementedAs=Keyframes] const unsigned short WEBKIT_KEYFRAMES_RULE = 7;


### PR DESCRIPTION
#### 713b0baf74e830dd90477f29a852ca4a48093c9d
<pre>
Expose the FONT_FEATURE_VALUES_RULE constant
<a href="https://bugs.webkit.org/show_bug.cgi?id=247551">https://bugs.webkit.org/show_bug.cgi?id=247551</a>
rdar://problem/102017360

Reviewed by Sam Weinig.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/idlharness-expected.txt:
Expect more PASS.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj: Added CSSFontFeatureValuesRule.idl,
which was missing. Not needed for the build, but better for editing and searching.

* Source/WebCore/css/CSSFontFeatureValuesRule.idl: Deleted a trailing blank line.

* Source/WebCore/css/CSSRule.idl: Added FONT_FEATURE_VALUES_RULE.

Canonical link: <a href="https://commits.webkit.org/256380@main">https://commits.webkit.org/256380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6a7b1173aa24cc325abb6bb4538ed4bfa445305

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105201 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165495 "Found 1 new test failure: fast/images/pagewide-play-pause-offscreen-animations.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4943 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33639 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/87995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101051 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3620 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82239 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30685 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87398 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39373 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37073 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20255 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4410 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41069 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39505 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->