### PR TITLE
Tweak canvas-createImageBitmap-video-resize.html so it passes on iOS

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-video-resize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-video-resize.html
@@ -24,7 +24,7 @@ function checkLowResult(imageBitmap, bw, bh, video, sx, sy, sw, sh)
     for (var i = 0; i < data1.length; i++) {
         // data1[i] is strictly the same as data2[i] on software rendering.
         // But on GPU, the difference could be quite significant.
-        if (Math.abs(data1[i] - data2[i]) > 18) {
+        if (Math.abs(data1[i] - data2[i]) > 33) {
             dataMatched = false;
             break;
         }
@@ -52,8 +52,10 @@ var t = async_test('createImageBitmap(HTMLVideoElement) with resize option');
 // HTMLVideoElement
 var video = document.createElement("video");
 video.preload = "auto";
-video.oncanplaythrough = t.step_func(function() {
-    return generateTest();
-});
+if (video.requestVideoFrameCallback) {
+    video.requestVideoFrameCallback(t.step_func(() => generateTest()));
+} else {
+    video.oncanplaythrough = t.step_func(() => generateTest());
+}
 video.src = '/media/counting.' + (video.canPlayType('video/ogg') ? 'ogv' : 'mp4');
 </script>


### PR DESCRIPTION
#### 3c5d90c46ca5b1bb42993250fae451d81981c950
<pre>
Tweak canvas-createImageBitmap-video-resize.html so it passes on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=247558">https://bugs.webkit.org/show_bug.cgi?id=247558</a>
rdar://100330154

Reviewed by Jer Noble.

1. Use requestVideoFrameCallback when available, so that we&apos;re not
   subject to the flakiness of video frame data being available when
   using oncanplaythrough.
2. Bump up the hard coded fuzziness for the image comparison.

* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-video-resize.html:

Canonical link: <a href="https://commits.webkit.org/256422@main">https://commits.webkit.org/256422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a46d13bf0f56f7d097c858c91e696f041368647c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105210 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165505 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4955 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33650 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101059 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3633 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82249 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30691 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73527 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39382 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37081 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20263 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42917 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2129 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39512 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->