### PR TITLE
[WK2][GLib] Clean up GLib ArgumentCoders specializations

### DIFF
--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -35,7 +35,7 @@
 
 namespace IPC {
 
-void ArgumentCoder<GRefPtr<GVariant>>::encode(Encoder& encoder, GRefPtr<GVariant> variant)
+void ArgumentCoder<GRefPtr<GVariant>>::encode(Encoder& encoder, const GRefPtr<GVariant>& variant)
 {
     if (!variant) {
         encoder << CString();
@@ -67,8 +67,7 @@ std::optional<GRefPtr<GVariant>> ArgumentCoder<GRefPtr<GVariant>>::decode(Decode
     return std::optional<GRefPtr<GVariant> >(g_variant_new_from_bytes(variantType.get(), bytes.get(), FALSE));
 }
 
-template<typename Encoder>
-void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, GRefPtr<GTlsCertificate> certificate)
+void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, const GRefPtr<GTlsCertificate>& certificate)
 {
     if (!certificate) {
         encoder << 0;
@@ -106,9 +105,7 @@ void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode(Encoder& encoder, GRefPtr<G
         encoder << IPC::DataReference(certificateData->data, certificateData->len);
     }
 }
-template void ArgumentCoder<GRefPtr<GTlsCertificate>>::encode<Encoder>(Encoder&, GRefPtr<GTlsCertificate>);
 
-template<typename Decoder>
 std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>::decode(Decoder& decoder)
 {
     std::optional<uint32_t> chainLength;
@@ -162,7 +159,6 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
 
     return certificate;
 }
-template std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>::decode<Decoder>(Decoder&);
 
 void ArgumentCoder<GRefPtr<GUnixFDList>>::encode(Encoder& encoder, const GRefPtr<GUnixFDList>& fdList)
 {

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
@@ -35,14 +35,12 @@ typedef struct _GVariant GVariant;
 namespace IPC {
 
 template<> struct ArgumentCoder<GRefPtr<GVariant>> {
-    static void encode(Encoder&, GRefPtr<GVariant>);
+    static void encode(Encoder&, const GRefPtr<GVariant>&);
     static std::optional<GRefPtr<GVariant>> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
-    template<typename Encoder>
-    static void encode(Encoder&, GRefPtr<GTlsCertificate>);
-    template<typename Decoder>
+    static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
     static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
 };
 


### PR DESCRIPTION
#### b842b3761eaf73ad3c9d28ad08c34c81e77b0b94
<pre>
[WK2][GLib] Clean up GLib ArgumentCoders specializations
<a href="https://bugs.webkit.org/show_bug.cgi?id=247561">https://bugs.webkit.org/show_bug.cgi?id=247561</a>

Reviewed by Carlos Garcia Campos.

In ArgumentCoder specializations for GVariant and GTlsCertificate objects
managed through GRefPtrs, have the encode methods accept simple references to
the GRefPtrs, avoiding unnecessary refcounting churn.

Drop the encoder and decoder type templates on the GTlsCertificate
specialization of ArgumentCoder and subsequently-necessary specializations
for the IPC::Encoder and IPC::Decoder methods. We can enforce those two types
without the template, and support for other encoders and decoders likely won&apos;t
be necessary.

* Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp:
(IPC::ArgumentCoder&lt;GRefPtr&lt;GVariant&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;GRefPtr&lt;GTlsCertificate&gt;&gt;::decode):
* Source/WebKit/Shared/glib/ArgumentCodersGLib.h:

Canonical link: <a href="https://commits.webkit.org/256389@main">https://commits.webkit.org/256389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/330545c1b512867515f5bb5a9cf349409bd696dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105222 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4970 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33660 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101071 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3646 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82262 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87422 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73539 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39394 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37093 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20276 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41089 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39527 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->