### PR TITLE
Array.prototype.indexOf constant-folding should account for non-numeric index

### DIFF
--- a/JSTests/stress/array-indexof-constant-folding-index-coercion.js
+++ b/JSTests/stress/array-indexof-constant-folding-index-coercion.js
@@ -1,0 +1,50 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+(function() {
+    const int32Array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const doubleArray = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5];
+
+    const indexOfInt32Cell = index => int32Array.indexOf("test", index);
+    const indexOfInt32Other = index => int32Array.indexOf(null, index);
+    const indexOfInt32Boolean = index => int32Array.indexOf(true, index);
+    const indexOfDoubleCell = index => doubleArray.indexOf(Symbol(), index);
+    const indexOfDoubleOther = index => doubleArray.indexOf(undefined, index);
+    const indexOfDoubleBoolean = index => doubleArray.indexOf(false, index);
+
+    noInline(indexOfInt32Cell);
+    noInline(indexOfInt32Other);
+    noInline(indexOfInt32Boolean);
+    noInline(indexOfDoubleCell);
+    noInline(indexOfDoubleOther);
+    noInline(indexOfDoubleBoolean);
+
+    for (var i = 0; i < 1e6; ++i) {
+        shouldBe(indexOfInt32Cell(0), -1);
+        shouldBe(indexOfInt32Other(0), -1);
+        shouldBe(indexOfInt32Boolean(0), -1);
+        shouldBe(indexOfDoubleCell(0), -1);
+        shouldBe(indexOfDoubleOther(0), -1);
+        shouldBe(indexOfDoubleBoolean(0), -1);
+    }
+
+    let coercibleIndexCalls = 0;
+    const coercibleIndex = {
+        valueOf: () => {
+            coercibleIndexCalls++;
+            return 0;
+        },
+    };
+
+    shouldBe(indexOfInt32Cell(coercibleIndex), -1);
+    shouldBe(indexOfInt32Other(coercibleIndex), -1);
+    shouldBe(indexOfInt32Boolean(coercibleIndex), -1);
+    shouldBe(indexOfDoubleCell(coercibleIndex), -1);
+    shouldBe(indexOfDoubleOther(coercibleIndex), -1);
+    shouldBe(indexOfDoubleBoolean(coercibleIndex), -1);
+
+    shouldBe(coercibleIndexCalls, 6);
+})();


### PR DESCRIPTION
#### 77b468c0b1d1db870032d003bc9cd33d2012b6e4
<pre>
Array.prototype.indexOf constant-folding should account for non-numeric index
<a href="https://bugs.webkit.org/show_bug.cgi?id=246275">https://bugs.webkit.org/show_bug.cgi?id=246275</a>
&lt;rdar://problem/101242631&gt;

Reviewed by Yusuke Suzuki.

With this change, a Check DFG node is emitted when Array.prototype.indexOf is
constant-folded to ensure an OSR exit for non-numeric index, whose coercion
might be observable.

* JSTests/stress/array-indexof-constant-folding-index-coercion.js: Added.
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArrayIndexOf):

Canonical link: <a href="https://commits.webkit.org/256590@main">https://commits.webkit.org/256590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebb71f7e68517f234e5e884088e0352a104b08bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105797 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5628 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88629 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101922 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31192 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/87250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39984 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82630 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37661 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28276 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4569 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/80 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85310 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/88 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19249 "Passed tests") | 
<!--EWS-Status-Bubble-End-->