### PR TITLE
Add additional logging to imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html to investigate iOS simulator flakiness

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js
@@ -40,7 +40,7 @@ promise_test(async t => {
     output(frame) {
       assert_equals(frame.visibleRect.width, w, "visibleRect.width");
       assert_equals(frame.visibleRect.height, h, "visibleRect.height");
-      assert_equals(frame.timestamp, next_ts++, "timestamp");
+      assert_equals(frame.timestamp, next_ts++, "decode timestamp");
       frames_decoded++;
       assert_true(validateBlackDots(frame, frame.timestamp),
         "frame doesn't match. ts: " + frame.timestamp);
@@ -51,6 +51,7 @@ promise_test(async t => {
     }
   });
 
+  let next_encode_ts = 0;
   const encoder_init = {
     output(chunk, metadata) {
       let config = metadata.decoderConfig;
@@ -60,6 +61,7 @@ promise_test(async t => {
       }
       decoder.decode(chunk);
       frames_encoded++;
+      assert_equals(chunk.timestamp, next_encode_ts++, "encode timestamp");
     },
     error(e) {
       assert_unreached(e.message);
@@ -79,7 +81,7 @@ promise_test(async t => {
   await decoder.flush();
   encoder.close();
   decoder.close();
-  assert_equals(frames_encoded, frames_to_encode);
-  assert_equals(frames_decoded, frames_to_encode);
+  assert_equals(frames_encoded, frames_to_encode, "frames_encoded");
+  assert_equals(frames_decoded, frames_to_encode, "frames_decoded");
 }, 'Encoding and decoding cycle');
 


### PR DESCRIPTION
#### 24de22c96ba4e89c499e0422ec78be4f05c5df88
<pre>
Add additional logging to imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html to investigate iOS simulator flakiness
<a href="https://bugs.webkit.org/show_bug.cgi?id=247567">https://bugs.webkit.org/show_bug.cgi?id=247567</a>
rdar://problem/102035679

Reviewed by Eric Carlson.

Add more asserts and add assert names to help diagnosing the timestamp issues seen in iOS sim bots.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.js:
(promise_test.async t):

Canonical link: <a href="https://commits.webkit.org/256421@main">https://commits.webkit.org/256421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e73d5c2a1ed3ad69cf0e403018252b3fb464c7a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105244 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165544 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/4996 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33682 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101092 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101326 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3666 "Found 1 new test failure: fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82284 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30726 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85531 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73557 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39415 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20296 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4441 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42944 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39547 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->