### PR TITLE
Port SecItemRequestData to the new serialization format

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -240,6 +240,7 @@ $(PROJECT_DIR)/Shared/WebPushMessage.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteData/WebsiteDataFetchOption.serialization.in
 $(PROJECT_DIR)/Shared/WebsiteDataStoreParameters.serialization.in
 $(PROJECT_DIR)/Shared/ios/InteractionInformationAtPosition.serialization.in
+$(PROJECT_DIR)/Shared/mac/SecItemRequestData.serialization.in
 $(PROJECT_DIR)/Shared/mac/SecItemResponseData.serialization.in
 $(PROJECT_DIR)/UIProcess/Automation/Automation.json
 $(PROJECT_DIR)/UIProcess/Automation/WebAutomationSession.messages.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -490,6 +490,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/WebExtensionControllerParameters.serialization.in \
 	Shared/WebPushDaemonConnectionConfiguration.serialization.in \
 	Shared/WebPushMessage.serialization.in \
+	Shared/mac/SecItemRequestData.serialization.in \
 	Shared/mac/SecItemResponseData.serialization.in \
 	Shared/WebsiteDataStoreParameters.serialization.in \
 	Shared/WebsiteData/WebsiteDataFetchOption.serialization.in \

--- a/Source/WebKit/Shared/mac/SecItemRequestData.cpp
+++ b/Source/WebKit/Shared/mac/SecItemRequestData.cpp
@@ -26,9 +26,6 @@
 #include "config.h"
 #include "SecItemRequestData.h"
 
-#include "ArgumentCoders.h"
-#include "ArgumentCodersCF.h"
-
 namespace WebKit {
 
 SecItemRequestData::SecItemRequestData(Type type, CFDictionaryRef query)
@@ -44,39 +41,11 @@ SecItemRequestData::SecItemRequestData(Type type, CFDictionaryRef query, CFDicti
 {
 }
 
-void SecItemRequestData::encode(IPC::Encoder& encoder) const
+SecItemRequestData::SecItemRequestData(Type type, RetainPtr<CFDictionaryRef>&& query, RetainPtr<CFDictionaryRef>&& attributesToMatch)
+    : m_type(type)
+    , m_queryDictionary(WTFMove(query))
+    , m_attributesToMatch(WTFMove(attributesToMatch))
 {
-    encoder << m_type;
-
-    encoder << static_cast<bool>(m_queryDictionary);
-    if (m_queryDictionary)
-        encoder << m_queryDictionary;
-
-    encoder << static_cast<bool>(m_attributesToMatch);
-    if (m_attributesToMatch)
-        encoder << m_attributesToMatch;
-}
-
-bool SecItemRequestData::decode(IPC::Decoder& decoder, SecItemRequestData& secItemRequestData)
-{
-    if (!decoder.decode(secItemRequestData.m_type))
-        return false;
-
-    bool expectQuery;
-    if (!decoder.decode(expectQuery))
-        return false;
-
-    if (expectQuery && !decoder.decode(secItemRequestData.m_queryDictionary))
-        return false;
-    
-    bool expectAttributes;
-    if (!decoder.decode(expectAttributes))
-        return false;
-    
-    if (expectAttributes && !decoder.decode(secItemRequestData.m_attributesToMatch))
-        return false;
-    
-    return true;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/mac/SecItemRequestData.h
+++ b/Source/WebKit/Shared/mac/SecItemRequestData.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
+#include "ArgumentCoders.h"
 #include <wtf/RetainPtr.h>
 
 namespace IPC {
@@ -37,7 +37,7 @@ namespace WebKit {
     
 class SecItemRequestData {
 public:
-    enum Type {
+    enum class Type : uint8_t {
         Invalid,
         CopyMatching,
         Add,
@@ -48,9 +48,7 @@ public:
     SecItemRequestData() = default;
     SecItemRequestData(Type, CFDictionaryRef query);
     SecItemRequestData(Type, CFDictionaryRef query, CFDictionaryRef attributesToMatch);
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, SecItemRequestData&);
+    SecItemRequestData(Type, RetainPtr<CFDictionaryRef>&& query, RetainPtr<CFDictionaryRef>&& attributesToMatch);
 
     Type type() const { return m_type; }
 
@@ -58,24 +56,11 @@ public:
     CFDictionaryRef attributesToMatch() const { return m_attributesToMatch.get(); }
 
 private:
-    Type m_type { Invalid };
+    friend struct IPC::ArgumentCoder<WebKit::SecItemRequestData, void>;
+
+    Type m_type { Type::Invalid };
     RetainPtr<CFDictionaryRef> m_queryDictionary;
     RetainPtr<CFDictionaryRef> m_attributesToMatch;
 };
     
 } // namespace WebKit
-
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::SecItemRequestData::Type> {
-    using values = EnumValues<
-        WebKit::SecItemRequestData::Type,
-        WebKit::SecItemRequestData::Type::Invalid,
-        WebKit::SecItemRequestData::Type::CopyMatching,
-        WebKit::SecItemRequestData::Type::Add,
-        WebKit::SecItemRequestData::Type::Update,
-        WebKit::SecItemRequestData::Type::Delete
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/mac/SecItemRequestData.serialization.in
+++ b/Source/WebKit/Shared/mac/SecItemRequestData.serialization.in
@@ -1,0 +1,37 @@
+# Copyright (C) 2022 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+header: <WebKit/SecItemRequestData.h>
+[Nested, CustomHeader] enum class WebKit::SecItemRequestData::Type : uint8_t {
+    Invalid,
+    CopyMatching,
+    Add,
+    Update,
+    Delete,
+};
+
+class WebKit::SecItemRequestData {
+    WebKit::SecItemRequestData::Type type();
+    RetainPtr<CFDictionaryRef> m_queryDictionary;
+    RetainPtr<CFDictionaryRef> m_attributesToMatch;
+};

--- a/Source/WebKit/Shared/mac/SecItemShim.cpp
+++ b/Source/WebKit/Shared/mac/SecItemShim.cpp
@@ -95,7 +95,7 @@ static std::optional<SecItemResponseData> sendSecItemRequest(SecItemRequestData:
 
 static OSStatus webSecItemCopyMatching(CFDictionaryRef query, CFTypeRef* result)
 {
-    auto response = sendSecItemRequest(SecItemRequestData::CopyMatching, query);
+    auto response = sendSecItemRequest(SecItemRequestData::Type::CopyMatching, query);
     if (!response)
         return errSecInteractionNotAllowed;
 
@@ -112,7 +112,7 @@ static OSStatus webSecItemAdd(CFDictionaryRef query, CFTypeRef* unusedResult)
         return errSecParam;
     }
 
-    auto response = sendSecItemRequest(SecItemRequestData::Add, query);
+    auto response = sendSecItemRequest(SecItemRequestData::Type::Add, query);
     if (!response)
         return errSecInteractionNotAllowed;
 
@@ -121,7 +121,7 @@ static OSStatus webSecItemAdd(CFDictionaryRef query, CFTypeRef* unusedResult)
 
 static OSStatus webSecItemUpdate(CFDictionaryRef query, CFDictionaryRef attributesToUpdate)
 {
-    auto response = sendSecItemRequest(SecItemRequestData::Update, query, attributesToUpdate);
+    auto response = sendSecItemRequest(SecItemRequestData::Type::Update, query, attributesToUpdate);
     if (!response)
         return errSecInteractionNotAllowed;
     
@@ -130,7 +130,7 @@ static OSStatus webSecItemUpdate(CFDictionaryRef query, CFDictionaryRef attribut
 
 static OSStatus webSecItemDelete(CFDictionaryRef query)
 {
-    auto response = sendSecItemRequest(SecItemRequestData::Delete, query);
+    auto response = sendSecItemRequest(SecItemRequestData::Type::Delete, query);
     if (!response)
         return errSecInteractionNotAllowed;
     

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp
@@ -64,19 +64,19 @@ void SecItemShimProxy::initializeConnection(IPC::Connection& connection)
 void SecItemShimProxy::secItemRequest(const SecItemRequestData& request, CompletionHandler<void(std::optional<SecItemResponseData>&&)>&& response)
 {
     switch (request.type()) {
-    case SecItemRequestData::Invalid:
+    case SecItemRequestData::Type::Invalid:
         LOG_ERROR("SecItemShimProxy::secItemRequest received an invalid data request. Please file a bug if you know how you caused this.");
         response(SecItemResponseData { errSecParam, nullptr });
         break;
 
-    case SecItemRequestData::CopyMatching: {
+    case SecItemRequestData::Type::CopyMatching: {
         CFTypeRef resultObject = nullptr;
         OSStatus resultCode = SecItemCopyMatching(request.query(), &resultObject);
         response(SecItemResponseData { resultCode, adoptCF(resultObject) });
         break;
     }
 
-    case SecItemRequestData::Add: {
+    case SecItemRequestData::Type::Add: {
         // Return value of SecItemAdd is often ignored. Even if it isn't, we don't have the ability to
         // serialize SecKeychainItemRef.
         OSStatus resultCode = SecItemAdd(request.query(), nullptr);
@@ -84,13 +84,13 @@ void SecItemShimProxy::secItemRequest(const SecItemRequestData& request, Complet
         break;
     }
 
-    case SecItemRequestData::Update: {
+    case SecItemRequestData::Type::Update: {
         OSStatus resultCode = SecItemUpdate(request.query(), request.attributesToMatch());
         response(SecItemResponseData { resultCode, nullptr });
         break;
     }
 
-    case SecItemRequestData::Delete: {
+    case SecItemRequestData::Type::Delete: {
         OSStatus resultCode = SecItemDelete(request.query());
         response(SecItemResponseData { resultCode, nullptr });
         break;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5176,6 +5176,7 @@
 		51D124851E734AE3002B2820 /* WKHTTPCookieStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKHTTPCookieStore.mm; sourceTree = "<group>"; };
 		51D124861E734AE3002B2820 /* WKHTTPCookieStoreInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHTTPCookieStoreInternal.h; sourceTree = "<group>"; };
 		51D1304F1382EAC000351EDD /* SecItemRequestData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SecItemRequestData.cpp; sourceTree = "<group>"; };
+		86E6E357291959C3006C25CA /* SecItemRequestData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SecItemRequestData.serialization.in; sourceTree = "<group>"; };
 		51D130501382EAC000351EDD /* SecItemRequestData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SecItemRequestData.h; sourceTree = "<group>"; };
 		51D130511382EAC000351EDD /* SecItemResponseData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SecItemResponseData.serialization.in; sourceTree = "<group>"; };
 		51D130521382EAC000351EDD /* SecItemResponseData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SecItemResponseData.h; sourceTree = "<group>"; };
@@ -5427,13 +5428,13 @@
 		5ABF2BEC2862353F000DCE74 /* GPUProcessPreferences.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GPUProcessPreferences.cpp; sourceTree = "<group>"; };
 		5ABF2BED2862353F000DCE74 /* GPUProcessPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessPreferences.h; sourceTree = "<group>"; };
 		5C00993B2417FB7E00D53C25 /* ResourceLoadStatisticsParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsParameters.h; sourceTree = "<group>"; };
+		5C03D5DD28F765F800D096AF /* SessionState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SessionState.serialization.in; sourceTree = "<group>"; };
 		5C046A17290B268500FF7820 /* GPUProcessSessionParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUProcessSessionParameters.serialization.in; sourceTree = "<group>"; };
 		5C046A18290B26A900FF7820 /* RemoteRenderingBackendCreationParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteRenderingBackendCreationParameters.serialization.in; sourceTree = "<group>"; };
 		5C046A19290B26CE00FF7820 /* MediaDescriptionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaDescriptionInfo.h; sourceTree = "<group>"; };
 		5C046A1A290B26CF00FF7820 /* MediaDescriptionInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = MediaDescriptionInfo.serialization.in; sourceTree = "<group>"; };
 		5C046A1B290B26CF00FF7820 /* InitializationSegmentInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = InitializationSegmentInfo.serialization.in; sourceTree = "<group>"; };
 		5C046A1C290B26CF00FF7820 /* TextTrackPrivateRemoteConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextTrackPrivateRemoteConfiguration.serialization.in; sourceTree = "<group>"; };
-		5C03D5DD28F765F800D096AF /* SessionState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SessionState.serialization.in; sourceTree = "<group>"; };
 		5C05FDF227AB4FA5003A2487 /* PrivateRelayed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateRelayed.h; sourceTree = "<group>"; };
 		5C0A10C1235241A30053E2CA /* NetworkSchemeRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkSchemeRegistry.cpp; sourceTree = "<group>"; };
 		5C0B17741E7C879C00E9123C /* NetworkSocketStreamMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = NetworkSocketStreamMessageReceiver.cpp; path = DerivedSources/WebKit/NetworkSocketStreamMessageReceiver.cpp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6041,6 +6042,7 @@
 		86DD518F28EF28E800DF2A58 /* WebEventModifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebEventModifier.h; sourceTree = "<group>"; };
 		86E67A21190F411800004AB7 /* ProcessThrottler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessThrottler.h; sourceTree = "<group>"; };
 		86E67A22190F411800004AB7 /* ProcessThrottler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessThrottler.cpp; sourceTree = "<group>"; };
+		86E6E357291959C3006C25CA /* SecItemRequestData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SecItemRequestData.serialization.in; sourceTree = "<group>"; };
 		86F9536018FF4FD4001DB2EF /* ProcessAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessAssertion.h; sourceTree = "<group>"; };
 		8CFECE931490F140002AAA32 /* EditorState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EditorState.cpp; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -12793,6 +12795,7 @@
 				2D65D194274B8E73009C4101 /* ScrollingAccelerationCurveMac.mm */,
 				51D1304F1382EAC000351EDD /* SecItemRequestData.cpp */,
 				51D130501382EAC000351EDD /* SecItemRequestData.h */,
+				86E6E357291959C3006C25CA /* SecItemRequestData.serialization.in */,
 				51D130521382EAC000351EDD /* SecItemResponseData.h */,
 				51D130511382EAC000351EDD /* SecItemResponseData.serialization.in */,
 				E18E6947169B77C8009B6670 /* SecItemShim.cpp */,


### PR DESCRIPTION
#### c4d183b6065b4aa9d51a5a182456eea9498749cc
<pre>
Port SecItemRequestData to the new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=247571">https://bugs.webkit.org/show_bug.cgi?id=247571</a>
rdar://102043673

Reviewed by Alex Christensen.

Port SecItemRequestData and SecItemRequestData::Type to the new
serialization format.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/mac/SecItemRequestData.cpp:
(WebKit::SecItemRequestData::SecItemRequestData):
(WebKit::SecItemRequestData::encode const): Deleted.
(WebKit::SecItemRequestData::decode): Deleted.
* Source/WebKit/Shared/mac/SecItemRequestData.h:
* Source/WebKit/Shared/mac/SecItemRequestData.serialization.in: Added.
* Source/WebKit/Shared/mac/SecItemShim.cpp:
(WebKit::webSecItemCopyMatching):
(WebKit::webSecItemAdd):
(WebKit::webSecItemUpdate):
(WebKit::webSecItemDelete):
* Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp:
(WebKit::SecItemShimProxy::secItemRequest):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/256412@main">https://commits.webkit.org/256412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21f9e4392c763fa9f7ba76ed4801aaca4a570607

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105256 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5010 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33694 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101104 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3682 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82297 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30736 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39427 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/18993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37125 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20306 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41121 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/42955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2123 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39557 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->