### PR TITLE
Assertion hit under EventTarget::fireEventListeners()

### DIFF
--- a/LayoutTests/svg/use-element-updateUserAgentShadowTree-crash-expected.txt
+++ b/LayoutTests/svg/use-element-updateUserAgentShadowTree-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/svg/use-element-updateUserAgentShadowTree-crash.html
+++ b/LayoutTests/svg/use-element-updateUserAgentShadowTree-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function subtreeModifiedEventhandler() {
+}
+
+onload = () => {
+    useElement.setAttribute("attributeType", "CSS");
+    useElement.lastElementChild.textContent = "foo";
+    menuItemElement.addEventListener("DOMSubtreeModified", subtreeModifiedEventhandler);
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+</script>
+<p>This test passes if it doesn't crash.</p>
+<svg skewX(0)">
+<use id="useElement">
+<animate onend="" />
+</use>
+<use xlink:href="#useElement" />
+<menuitem id="menuItemElement" ismap="ismap">
+</body>
+</html>

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -285,7 +285,12 @@ static const AtomString& legacyType(const Event& event)
 // https://dom.spec.whatwg.org/#concept-event-listener-invoke
 void EventTarget::fireEventListeners(Event& event, EventInvokePhase phase)
 {
-    ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::isScriptAllowedInMainThread());
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    if (auto* node = dynamicDowncast<Node>(*this))
+        ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(*node));
+    else
+        ASSERT_WITH_SECURITY_IMPLICATION(ScriptDisallowedScope::isScriptAllowedInMainThread());
+#endif
     ASSERT(event.isInitialized());
 
     auto* data = eventTargetData();


### PR DESCRIPTION
#### 0c1b973a7433fde1d87c8c81e835ba31fc30fe96
<pre>
Assertion hit under EventTarget::fireEventListeners()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247580">https://bugs.webkit.org/show_bug.cgi?id=247580</a>
rdar://98238259

Reviewed by Ryosuke Niwa.

We were hitting the `ScriptDisallowedScope::isScriptAllowedInMainThread()`
assertion under EventTarget::fireEventListeners(). However, the caller is
SVGUseElement::updateUserAgentShadowTree() which has a EventAllowedScope to
allow event dispatch in the shadow root subtree.

I updated the assertion in fireEventListeners() to rely on
isEventDispatchAllowedInSubtree() instead when the EventTarget is a Node,
so that the ScriptDisallowedScope is taken into account.

* LayoutTests/svg/use-element-updateUserAgentShadowTree-crash-expected.txt: Added.
* LayoutTests/svg/use-element-updateUserAgentShadowTree-crash.html: Added.
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::fireEventListeners):

Canonical link: <a href="https://commits.webkit.org/256451@main">https://commits.webkit.org/256451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/459ea0084fe0ca3b7ec317652d6677ebe1e453fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95703 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105283 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165592 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5038 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33722 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101127 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3705 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82323 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30759 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73589 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39452 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20329 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42978 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2146 "Failed to close bug 247580") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39580 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->