### PR TITLE
Ensure AddAllowedFirstPartyForCookies message is processed before ScheduleResourceLoad

### DIFF
--- a/LayoutTests/platform/gtk/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
+++ b/LayoutTests/platform/gtk/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
@@ -1,0 +1,48 @@
+CONSOLE MESSAGE: Provisional navigation started.
+CONSOLE MESSAGE: No trusted events should be logged and the input element should have the value "".
+CONSOLE MESSAGE: Dispatching untrusted keypress event.
+CONSOLE MESSAGE: keypressevent dispatched (isTrusted: false).
+CONSOLE MESSAGE: Pressing tab.
+CONSOLE MESSAGE: Active element after pressing tab: [object HTMLInputElement].
+CONSOLE MESSAGE: Pressing "a".
+CONSOLE MESSAGE: Setting marked text to "b".
+CONSOLE MESSAGE: Inserting text "c".
+CONSOLE MESSAGE: Pasting text "d".
+CONSOLE MESSAGE: Input element value after text input events: "".
+CONSOLE MESSAGE: Pressing "z" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.
+CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: keyupevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: Finished navigating to resources/keyboard-events-after-navigation.html.
+CONSOLE MESSAGE: Trusted events should be logged and the input element should have the value "acd".
+CONSOLE MESSAGE: Dispatching untrusted keypress event.
+CONSOLE MESSAGE: keypressevent dispatched (isTrusted: false).
+CONSOLE MESSAGE: Pressing tab.
+CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: keyupevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: Active element after pressing tab: [object HTMLInputElement].
+CONSOLE MESSAGE: Pressing "a".
+CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: keypressevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: keyupevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: Setting marked text to "b".
+CONSOLE MESSAGE: compositionstartevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: compositionupdateevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: Inserting text "c".
+CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: compositionendevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: Pasting text "d".
+CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: beforeinputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: inputevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: Input element value after text input events: "acd".
+

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -328,7 +328,7 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
     m_ftpEnabled = parameters.ftpEnabled;
 
     for (auto [processIdentifier, domain] : parameters.allowedFirstPartiesForCookies)
-        addAllowedFirstPartyForCookies(processIdentifier, WTFMove(domain));
+        addAllowedFirstPartyForCookies(processIdentifier, WTFMove(domain), [] { });
 
     for (auto& supplement : m_supplements.values())
         supplement->initialize(parameters);
@@ -386,11 +386,12 @@ void NetworkProcess::createNetworkConnectionToWebProcess(ProcessIdentifier ident
         session->storageManager().startReceivingMessageFromConnection(connection.connection());
 }
 
-void NetworkProcess::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain&& firstPartyForCookies)
+void NetworkProcess::addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain&& firstPartyForCookies, CompletionHandler<void()>&& completionHandler)
 {
     m_allowedFirstPartiesForCookies.ensure(processIdentifier, [] {
         return HashSet<RegistrableDomain> { };
     }).iterator->value.add(WTFMove(firstPartyForCookies));
+    completionHandler();
 }
 
 bool NetworkProcess::allowsFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, const URL& firstParty)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -400,7 +400,7 @@ public:
     void deleteWebsiteDataForOrigins(PAL::SessionID, OptionSet<WebsiteDataType>, const Vector<WebCore::SecurityOriginData>& origins, const Vector<String>& cookieHostNames, const Vector<String>& HSTSCacheHostnames, const Vector<RegistrableDomain>&, CompletionHandler<void()>&&);
 
     bool allowsFirstPartyForCookies(WebCore::ProcessIdentifier, const URL&);
-    void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, WebCore::RegistrableDomain&&);
+    void addAllowedFirstPartyForCookies(WebCore::ProcessIdentifier, WebCore::RegistrableDomain&&, CompletionHandler<void()>&&);
 
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -25,7 +25,7 @@ messages -> NetworkProcess LegacyReceiver {
 
     CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID) -> (std::optional<IPC::Connection::Handle> connectionHandle, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy)
 
-    AddAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain firstPartyForCookies)
+    AddAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain firstPartyForCookies) -> ()
 
 #if USE(SOUP)
     SetIgnoreTLSErrors(PAL::SessionID sessionID, bool ignoreTLSErrors)

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -662,7 +662,7 @@ SWServer& NetworkSession::ensureSWServer()
                 completionHandler();
             }, 0);
         }, WTFMove(appBoundDomainsCallback), [this](auto webProcessIdentifier, auto&& firstPartyForCookies) {
-            m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies));
+            m_networkProcess->addAllowedFirstPartyForCookies(webProcessIdentifier, WTFMove(firstPartyForCookies), [] { });
         });
     }
     return *m_swServer;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -142,7 +142,7 @@ void WebSharedWorkerServer::createContextConnection(const WebCore::RegistrableDo
         RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::createContextConnection should now have created a connection");
 
         // FIXME: Add a check that the process this firstPartyForCookies came from was allowed to use it as a firstPartyForCookies.
-        m_session.networkProcess().addAllowedFirstPartyForCookies(remoteProcessIdentifier, WebCore::RegistrableDomain(firstPartyForCookies));
+        m_session.networkProcess().addAllowedFirstPartyForCookies(remoteProcessIdentifier, WebCore::RegistrableDomain(firstPartyForCookies), [] { });
 
         ASSERT(m_pendingContextConnectionDomains.contains(registrableDomain));
         m_pendingContextConnectionDomains.remove(registrableDomain);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -3217,6 +3217,7 @@ TEST(ProcessSwap, NavigateCrossSiteBeforePageLoadEnd)
     [webViewConfiguration setProcessPool:processPool.get()];
     auto handler = adoptNS([[PSONScheme alloc] init]);
     [handler addMappingFromURLString:@"pson://www.webkit.org/main.html" toData:navigateBeforePageLoadEndBytes];
+    [handler setShouldRespondAsynchronously:YES];
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);


### PR DESCRIPTION
#### 3d4ebd0d31cdcbb0984e106d0acb8130e5007071
<pre>
Ensure AddAllowedFirstPartyForCookies message is processed before ScheduleResourceLoad
<a href="https://bugs.webkit.org/show_bug.cgi?id=247582">https://bugs.webkit.org/show_bug.cgi?id=247582</a>
rdar://102056030

Reviewed by Chris Dumez.

The API test ProcessSwap.NavigateCrossSiteBeforePageLoadEnd was so sensitive to the reordering of messages
that it started failing, so I made it respond asynchronously to give the network process time to respond
to these new roundtrip messages.  Otherwise, no change in behavior.  It&apos;s taking something that&apos;s async
and adding an async step.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
(WebKit::NetworkProcess::addAllowedFirstPartyForCookies):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::ensureSWServer):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::createContextConnection):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):

Canonical link: <a href="https://commits.webkit.org/256488@main">https://commits.webkit.org/256488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a815502ce2f291c7c17ff634f4133a4dbf544e99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105518 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5314 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33970 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101345 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101620 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82566 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39699 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37379 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2160 "Built successfully and passed tests") | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43799 "Reverted pull request changes (failure)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/39804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->