### PR TITLE
REGRESSION (iOS 16): AR QuickLook banner tap event no longer propagated to anchor if not attached to DOM

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9120,7 +9120,7 @@ void Document::dispatchSystemPreviewActionEvent(const SystemPreviewInfo& systemP
     if (!is<HTMLAnchorElement>(element))
         return;
 
-    if (!element->isConnected() || &element->document() != this)
+    if (&element->document() != this)
         return;
 
     auto event = MessageEvent::create(message, securityOrigin().toString());

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview-trigger.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview-trigger.html
@@ -2,19 +2,25 @@
 <body>
 <a rel="ar"></a>
 <script>
-window.addEventListener("load", function () {
-    const a = document.querySelector("a");
-
-    const elementID = internals.elementIdentifier(a);
+function runTest(element, message, loadedMessage) {
+    const elementID = internals.elementIdentifier(element);
     const pageID = internals.pageIdentifier(document);
     const documentID = internals.documentIdentifier(document);
 
-    a.addEventListener("message", function (event) {
-        window.webkit.messageHandlers.testSystemPreview.postMessage({ message: "triggered", action: event.data });
+    element.addEventListener("message", function (event) {
+        window.webkit.messageHandlers.testSystemPreview.postMessage({ message: message, action: event.data });
     });
 
-    const msg = { message: "loaded", elementID, pageID, documentID };
+    const msg = { message: loadedMessage, elementID, pageID, documentID };
     window.webkit.messageHandlers.testSystemPreview.postMessage(msg);
+}
+
+window.addEventListener("load", function () {
+    const attachedElement = document.querySelector("a");
+    runTest(attachedElement, "triggered", "loaded_triggered");
+
+    const detachedElement = document.createElement("a");
+    runTest(detachedElement, "triggered_detached", "loaded_triggered_detached");
 });
 
 


### PR DESCRIPTION
#### a203e214d6b8191acdc2aeb7a7430ff5f761cdce
<pre>
REGRESSION (iOS 16): AR QuickLook banner tap event no longer propagated to anchor if not attached to DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=245959">https://bugs.webkit.org/show_bug.cgi?id=245959</a>
rdar://100952298

Reviewed by Wenson Hsieh.

The commit <a href="https://commits.webkit.org/251042@main">https://commits.webkit.org/251042@main</a> added a check `!element-&gt;isConnected()`
in `Document::dispatchSystemPreviewActionEvent` to ensure the element is part
of the DOM before sending the `_apple_ar_quicklook_button_tapped` event.

However, this broke behavior in the case of a detached element, and so this PR
reverts that check to maintain the existing behavior.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::dispatchSystemPreviewActionEvent):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(-[TestSystemPreviewTriggeredHandler userContentController:didReceiveScriptMessage:]):
(-[TestSystemPreviewTriggeredOnDetachedElementHandler userContentController:didReceiveScriptMessage:]):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview-trigger.html:

Canonical link: <a href="https://commits.webkit.org/256462@main">https://commits.webkit.org/256462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2fc55f5ad893c65f522cd7803ca53d8ab1b7638

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105305 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165615 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5062 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33743 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101146 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3721 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82345 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30777 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39474 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19026 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20342 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4464 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/42994 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39593 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->