### PR TITLE
Fix form association behavior when a form and a control with form= are removed from a document together

### DIFF
--- a/LayoutTests/fast/forms/form-disassociation-attributes-expected.txt
+++ b/LayoutTests/fast/forms/form-disassociation-attributes-expected.txt
@@ -1,0 +1,13 @@
+This test checks the form attribute of the form-associated elements.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+- Check if a form and a control are disassociated when they are removed from the document together.
+PASS owner.elements.length is 1
+PASS owner.elements.length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/form-disassociation-attributes.html
+++ b/LayoutTests/fast/forms/form-disassociation-attributes.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../../resources/js-test.js"></script>
+    </head>
+    <body>
+        <p id="description"></p>
+        <div id="console"></div>
+        <script>
+            description("This test checks the form attribute of the form-associated elements.");
+
+            var container = document.createElement('div');
+            document.body.appendChild(container);
+
+
+            debug('');
+            debug('- Check if a form and a control are disassociated when they are removed from the document together.');
+            container.innerHTML = '<div><input form=owner><form id=owner></form></div>';
+            owner = document.getElementById('owner');
+            shouldBe('owner.elements.length', '1');
+            container.firstChild.remove();
+            shouldBe('owner.elements.length', '0');
+
+            container.remove();
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -89,9 +89,14 @@ void FormAssociatedElement::insertedIntoAncestor(Node::InsertionType insertionTy
         resetFormAttributeTargetObserver();
 }
 
-void FormAssociatedElement::removedFromAncestor(Node::RemovalType, ContainerNode&)
+void FormAssociatedElement::removedFromAncestor(Node::RemovalType, Node::InsertionType insertionType, ContainerNode&)
 {
-    m_formAttributeTargetObserver = nullptr;
+    HTMLElement& element = asHTMLElement();
+    if (!insertionType.connectedToDocument && element.hasAttributeWithoutSynchronization(formAttr)) {
+        m_formAttributeTargetObserver = nullptr;
+        resetFormOwner();
+        return;
+    }
 
     // If the form and element are both in the same tree, preserve the connection to the form.
     // Otherwise, null out our form and remove ourselves from the form's list of elements.

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -94,7 +94,7 @@ protected:
     FormAssociatedElement(HTMLFormElement*);
 
     void insertedIntoAncestor(Node::InsertionType, ContainerNode&);
-    void removedFromAncestor(Node::RemovalType, ContainerNode&);
+    void removedFromAncestor(Node::RemovalType, Node::InsertionType, ContainerNode&);
     void didMoveToNewDocument(Document& oldDocument);
 
     void clearForm() { setForm(nullptr); }

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -304,10 +304,10 @@ void HTMLObjectElement::didFinishInsertingNode()
     resetFormOwner();
 }
 
-void HTMLObjectElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+void HTMLObjectElement::removedFromAncestor(RemovalType removalType, InsertionType insertionType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLPlugInImageElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    FormAssociatedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    FormAssociatedElement::removedFromAncestor(removalType, insertionType, oldParentOfRemovedTree);
 }
 
 void HTMLObjectElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -68,7 +68,7 @@ private:
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
-    void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void removedFromAncestor(RemovalType, InsertionType, ContainerNode&) final;
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 


### PR DESCRIPTION
<pre>
Fix form association behavior when a form and a control with form= are removed from a document together
<a href="https://bugs.webkit.org/show_bug.cgi?id=247593">https://bugs.webkit.org/show_bug.cgi?id=247593</a>

Reviewed by NOBODY (OOPS!).

This is to align Webkit behavior with Gecko / Firefox and Blink / Chromium.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=197887&view=revision">https://src.chromium.org/viewvc/blink?revision=197887&view=revision</a>

We missed to call resetFormOwner() if they are in the single sub-tree even after they were removed from the document.

* Source/WebCore/html/FormAssociatedElement.h: Added arguments of "Node::InsertionType" for "removedFromAncestor"
* Source/WebCore/html/FormAssociatedElement.cpp: Added logic to resetFormOwner upon disassociation
* LayoutTests/fast/forms/form-disassociation-attributes.html: Added Test Case
* LayoutTests/fast/forms/form-disassociation-attributes-expected.txt: Added Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e455b3a94f507a01099ad472f991584600bc4ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95863 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/5111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/105425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/99845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5207 "Hash 5e455b3a for PR 6229 does not build (failure)") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/101256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101523 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/5207 "Hash 5e455b3a for PR 6229 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/88238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/5207 "Hash 5e455b3a for PR 6229 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39604 "Hash 5e455b3a for PR 6229 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/37287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/41361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/43455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->