### PR TITLE
Add signposts to Speedometer

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2-controlled.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2-controlled.patch
@@ -1,0 +1,208 @@
+Index: PerformanceTests/Speedometer/resources/benchmark-runner.js
+===================================================================
+--- a/resources/benchmark-runner.js    (revision 293992)
++++ b/resources/benchmark-runner.js    (working copy)
+@@ -125,21 +125,27 @@ BenchmarkRunner.prototype._runTest = fun
+ 
+     var contentWindow = self._frame.contentWindow;
+     var contentDocument = self._frame.contentDocument;
++    let syncName = suite.name + '.' + test.name + '-sync';
++    let asyncName = suite.name + '.' + test.name + '-async';
+ 
+     self._writeMark(suite.name + '.' + test.name + '-start');
++    __signpostStart(syncName);
+     var startTime = now();
+     test.run(prepareReturnValue, contentWindow, contentDocument);
+     var endTime = now();
++    __signpostStop(syncName);
+     self._writeMark(suite.name + '.' + test.name + '-sync-end');
+ 
+     var syncTime = endTime - startTime;
+ 
++    __signpostStart(asyncName);
+     var startTime = now();
+     setTimeout(function () {
+         // Some browsers don't immediately update the layout for paint.
+         // Force the layout here to ensure we're measuring the layout time.
+         var height = self._frame.contentDocument.body.getBoundingClientRect().height;
+         var endTime = now();
++        __signpostStop(asyncName);
+         self._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
+         self._writeMark(suite.name + '.' + test.name + '-async-end');
+         callback(syncTime, endTime - startTime, height);
+Index: PerformanceTests/Speedometer/resources/tests.js
+===================================================================
+--- a/resources/tests.js    (revision 293992)
++++ b/resources/tests.js    (working copy)
+@@ -11,6 +11,7 @@ var triggerEnter = function (element, ty
+     element.dispatchEvent(event);
+ }
+ 
++for (let i = 0; i < 8; ++i) {
+ Suites.push({
+     name: 'VanillaJS-TodoMVC',
+     url: 'todomvc/vanilla-examples/vanillajs/index.html',
+@@ -40,7 +41,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 6; ++i) {
+ Suites.push({
+     name: 'Vanilla-ES2015-TodoMVC',
+     url: 'todomvc/vanilla-examples/es2015/index.html',
+@@ -70,7 +73,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 7; ++i) {
+ Suites.push({
+     name: 'Vanilla-ES2015-Babel-Webpack-TodoMVC',
+     url: 'todomvc/vanilla-examples/es2015-babel-webpack/dist/index.html',
+@@ -100,7 +105,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 5; ++i) {
+ Suites.push({
+     name: 'React-TodoMVC',
+     url: 'todomvc/architecture-examples/react/index.html',
+@@ -134,7 +141,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 3; ++i) {
+ Suites.push({
+     name: 'React-Redux-TodoMVC',
+     url: 'todomvc/architecture-examples/react-redux/dist/index.html',
+@@ -163,7 +172,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 3; ++i) {
+ Suites.push({
+     name: 'EmberJS-TodoMVC',
+     url: 'todomvc/architecture-examples/emberjs/dist/index.html',
+@@ -192,7 +203,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 1; ++i) {
+ Suites.push({
+     name: 'EmberJS-Debug-TodoMVC',
+     url: 'todomvc/architecture-examples/emberjs-debug/index.html',
+@@ -221,7 +234,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 7; ++i) {
+ Suites.push({
+     name: 'BackboneJS-TodoMVC',
+     url: 'todomvc/architecture-examples/backbone/index.html',
+@@ -252,7 +267,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 3; ++i) {
+ Suites.push({
+     name: 'AngularJS-TodoMVC',
+     url: 'todomvc/architecture-examples/angularjs/index.html',
+@@ -285,7 +302,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 9; ++i) {
+ Suites.push({
+     name: 'Angular2-TypeScript-TodoMVC',
+     url: 'todomvc/architecture-examples/angular/dist/index.html',
+@@ -318,7 +337,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 12; ++i) {
+ Suites.push({
+     name: 'VueJS-TodoMVC',
+     url: 'todomvc/architecture-examples/vuejs-cli/dist/index.html',
+@@ -351,7 +372,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 2; ++i) {
+ Suites.push({
+     name: 'jQuery-TodoMVC',
+     url: 'todomvc/architecture-examples/jquery/index.html',
+@@ -380,7 +403,9 @@ Suites.push({
+         }),
+     ]
+ })
++}
+ 
++for (let i = 0; i < 22; ++i) {
+ Suites.push({
+     name: 'Preact-TodoMVC',
+     url: 'todomvc/architecture-examples/preact/dist/index.html',
+@@ -409,7 +434,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 6; ++i) {
+ Suites.push({
+     name: 'Inferno-TodoMVC',
+     url: 'todomvc/architecture-examples/inferno/index.html',
+@@ -442,6 +469,7 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
+ function processElmWorkQueue(contentWindow)
+ {
+@@ -455,6 +483,7 @@ function processElmWorkQueue(contentWind
+     contentWindow.rAFCallbackList = [];
+ }
+ 
++for (let i = 0; i < 3; ++i) {
+ Suites.push({
+     name: 'Elm-TodoMVC',
+     url: 'todomvc/functional-prog-examples/elm/index.html',
+@@ -492,7 +521,9 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
++for (let i = 0; i < 6; ++i) {
+ Suites.push({
+     name: 'Flight-TodoMVC',
+     url: 'todomvc/dependency-examples/flight/flight/index.html',
+@@ -522,6 +553,7 @@ Suites.push({
+         }),
+     ]
+ });
++}
+ 
+ var actionCount = 50;
+ Suites.push({

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2.patch
@@ -1,0 +1,32 @@
+Index: PerformanceTests/Speedometer/resources/benchmark-runner.js
+===================================================================
+--- a/resources/benchmark-runner.js    (revision 293992)
++++ b/resources/benchmark-runner.js    (working copy)
+@@ -125,21 +125,27 @@ BenchmarkRunner.prototype._runTest = fun
+ 
+     var contentWindow = self._frame.contentWindow;
+     var contentDocument = self._frame.contentDocument;
++    let syncName = suite.name + '.' + test.name + '-sync';
++    let asyncName = suite.name + '.' + test.name + '-async';
+ 
+     self._writeMark(suite.name + '.' + test.name + '-start');
++    __signpostStart(syncName);
+     var startTime = now();
+     test.run(prepareReturnValue, contentWindow, contentDocument);
+     var endTime = now();
++    __signpostStop(syncName);
+     self._writeMark(suite.name + '.' + test.name + '-sync-end');
+ 
+     var syncTime = endTime - startTime;
+ 
++    __signpostStart(asyncName);
+     var startTime = now();
+     setTimeout(function () {
+         // Some browsers don't immediately update the layout for paint.
+         // Force the layout here to ensure we're measuring the layout time.
+         var height = self._frame.contentDocument.body.getBoundingClientRect().height;
+         var endTime = now();
++        __signpostStop(asyncName);
+         self._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
+         self._writeMark(suite.name + '.' + test.name + '-async-end');
+         callback(syncTime, endTime - startTime, height);

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan
@@ -3,6 +3,7 @@
     "count": 4,
     "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Speedometer/@r226694",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer2.patch",
+    "signpost_patch": "data/patches/signposts/Speedometer2-controlled.patch",
     "entry_point": "index.html",
     "output_file": "speedometer2.result"
 }

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.1.plan
@@ -3,6 +3,7 @@
     "count": 4,
     "svn_source": "https://svn.webkit.org/repository/webkit/trunk/PerformanceTests/Speedometer/@r290664",
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer2.patch",
+    "signpost_patch": "data/patches/signposts/Speedometer2-controlled.patch",
     "entry_point": "index.html",
     "output_file": "speedometer2.result"
 }


### PR DESCRIPTION
#### 44ec92796f5c148f067ce4288c82022d614ae080
<pre>
Add signposts to Speedometer
<a href="https://bugs.webkit.org/show_bug.cgi?id=247591">https://bugs.webkit.org/show_bug.cgi?id=247591</a>
&lt;rdar://problem/102061752&gt;

Reviewed by NOBODY (OOPS!).

This patch adds signpost patches to Speedometer plans, which will  allow us to annotate generated profiles (--profile).

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2-controlled.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer2.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.0.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer2.1.plan:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44ec92796f5c148f067ce4288c82022d614ae080

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/4996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105318 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165626 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5074 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33754 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101156 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3732 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82356 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30785 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99328 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39487 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19036 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37180 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20353 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43000 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39604 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->