### PR TITLE
RE-SYNC(255459@main): [ iOS iPadOS ] 7X imported/w3c/web-platform-tests/screen-orientation/(Layout tests) are constant/flaky failures

### DIFF
--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -120,11 +120,3 @@ webkit.org/b/229656 fast/forms/ios/ipad/open-picker-using-keyboard.html [ Pass T
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-databases-opaque-origin.html [ Pass Failure ]
 webkit.org/b/244674 [ Release ] imported/w3c/web-platform-tests/IndexedDB/idbfactory-deleteDatabase-opaque-origin.html [ Pass Failure ]
 
-# webkit.org/b/246701 Constant failure only on iPad
-imported/w3c/web-platform-tests/screen-orientation/active-lock.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/lock-basic.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/onchange-event.html [ Failure ]

--- a/Tools/WebKitTestRunner/WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist
+++ b/Tools/WebKitTestRunner/WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist
@@ -14,8 +14,6 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
-	<key>UILaunchStoryboardName</key>
-	<string>Launch</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -26,21 +24,25 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
#### 3e020b585a846c1504e6850e54dc388c4bffdf52
<pre>
RE-SYNC(255459@main): [ iOS iPadOS ] 7X imported/w3c/web-platform-tests/screen-orientation/(Layout tests) are constant/flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=246701">https://bugs.webkit.org/show_bug.cgi?id=246701</a>
rdar://101303037

Reviewed by Wenson Hsieh.

Screen orientation locking is not supported on iPad OS when the client
application supports multi-tasking (split-view). As a result, the tests were
failing on iPad simulator (while passing on iPhone simulator).

To address the issue, I propose we disable multi-tasking support in
WebKitTestRunner. I don&apos;t believe WKTR rely on multi-tasking support currently
and this helps maintain good test coverage for the screen orientation API.

* LayoutTests/platform/ipad/TestExpectations:
* Tools/WebKitTestRunner/WebKitTestRunnerApp/WebKitTestRunnerApp-Info.plist:

Canonical link: <a href="https://commits.webkit.org/256450@main">https://commits.webkit.org/256450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66a5a9028ef6bc06e25320e03966fd1fae638cb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105322 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165630 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5079 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33758 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101160 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3734 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82360 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30788 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73617 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39491 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37184 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20357 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43002 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2145 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39608 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->