### PR TITLE
[MobileMiniBrowser] Settings popover throws exception on iPad simulator

### DIFF
--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/Base.lproj/Main.storyboard
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/Base.lproj/Main.storyboard
@@ -126,6 +126,7 @@
                     </view>
                     <connections>
                         <outlet property="progressView" destination="2bJ-bG-4SW" id="epj-Uv-45U"/>
+                        <outlet property="settingsButton" destination="yi7-p4-xpL" id="qEx-EB-V7c"/>
                         <outlet property="tabButton" destination="riZ-ip-Qee" id="c25-vk-MxM"/>
                         <outlet property="urlField" destination="n4f-v4-gO4" id="6y7-b7-P81"/>
                         <outlet property="webViewContainer" destination="719-Zt-fvZ" id="UaF-fa-bAe"/>
@@ -178,30 +179,46 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rVm-uk-liS" userLabel="Default URL Button">
-                                <rect key="frame" x="62" y="154" width="267" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="filled" title="Set Current URL As Default URL"/>
-                                <connections>
-                                    <action selector="setDefaultURLToCurrentURL:" destination="aJ5-0L-JDf" eventType="touchUpInside" id="6ge-wG-0Vi"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ua5-lh-IpN">
-                                <rect key="frame" x="16" y="55" width="40" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <buttonConfiguration key="configuration" style="plain"/>
-                                <connections>
-                                    <action selector="closeModal:" destination="aJ5-0L-JDf" eventType="touchUpInside" id="h5A-RA-TNO"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="UK0-Lb-N0g">
+                                <rect key="frame" x="55" y="341" width="280" height="170.33333333333337"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Eu-Zz-uaZ">
+                                        <rect key="frame" x="0.0" y="0.0" width="280" height="128"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="close" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ua5-lh-IpN">
+                                                <rect key="frame" x="0.0" y="0.0" width="40" height="128"/>
+                                                <buttonConfiguration key="configuration" style="plain"/>
+                                                <connections>
+                                                    <action selector="closeModal:" destination="aJ5-0L-JDf" eventType="touchUpInside" id="h5A-RA-TNO"/>
+                                                </connections>
+                                            </button>
+                                            <view contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="V0B-v2-13O">
+                                                <rect key="frame" x="40" y="0.0" width="240" height="128"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            </view>
+                                        </subviews>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rVm-uk-liS" userLabel="Default URL Button">
+                                        <rect key="frame" x="0.0" y="136" width="280" height="34.333333333333343"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="filled" title="Set Current URL As Default URL"/>
+                                        <connections>
+                                            <action selector="setDefaultURLToCurrentURL:" destination="aJ5-0L-JDf" eventType="touchUpInside" id="6ge-wG-0Vi"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="UK0-Lb-N0g" firstAttribute="centerX" secondItem="EDp-dN-mqp" secondAttribute="centerX" id="PGf-NI-Zxi"/>
+                            <constraint firstItem="UK0-Lb-N0g" firstAttribute="top" secondItem="OVt-56-WEs" secondAttribute="bottom" constant="50" id="vSb-Yl-4Ei"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jS8-Pw-4A3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1451" y="293"/>
+            <point key="canvasLocation" x="1451" y="319"/>
         </scene>
     </scenes>
     <resources>

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
@@ -139,8 +139,9 @@ void* URLContext = &URLContext;
 
 - (IBAction)showSettings:(id)sender
 {
+    UIPopoverPresentationController *presentationController = [self.settingsViewController popoverPresentationController];
+    presentationController.barButtonItem = self.settingsButton;
     [self presentViewController:self.settingsViewController animated:YES completion:nil];
-    self.settingsViewController.popoverPresentationController.barButtonItem = self.settingsButton;
 }
 
 #pragma mark Public methods


### PR DESCRIPTION
#### 1713bed5d0c732d56f06c5947117844dbdc4f765
<pre>
[MobileMiniBrowser] Settings popover throws exception on iPad simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=247597">https://bugs.webkit.org/show_bug.cgi?id=247597</a>
rdar://102067010

Reviewed by Simon Fraser.

This fixes the presentation of the settings view to follow the popover API and
makes the settings view work with autolayout.

We will now anchor the view to the settings button so that iPad can correctly display
it as a popover.

* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/Base.lproj/Main.storyboard:
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m:
(-[WebViewController showSettings:]):

Canonical link: <a href="https://commits.webkit.org/256436@main">https://commits.webkit.org/256436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/542ba2209b4c4a9acd1f0939bf01101ef1089067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105328 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5084 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33761 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88132 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/101163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101412 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82363 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73621 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39496 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37189 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4449 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/41254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/43221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39616 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->