### PR TITLE
[WinCairo][CMake] Propagate MediaFoundation target

### DIFF
--- a/Source/WebCore/PlatformWinCairo.cmake
+++ b/Source/WebCore/PlatformWinCairo.cmake
@@ -9,7 +9,6 @@ if (USE_DAWN)
 endif ()
 
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
-    "${WEBKIT_LIBRARIES_DIR}/include"
     "${WEBCORE_DIR}/loader/archive/cf"
     "${WEBCORE_DIR}/platform/cf"
     "${WEBCORE_DIR}/platform/graphics/wc"
@@ -74,6 +73,8 @@ if (ENABLE_VIDEO AND USE_MEDIA_FOUNDATION)
         /DELAYLOAD:mf.dll
         /DELAYLOAD:mfplat.dll
     )
+
+    list(APPEND WebCore_PRIVATE_LIBRARIES MediaFoundation)
 endif ()
 
 if (USE_WOFF2)

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -192,7 +192,6 @@ if (${WTF_PLATFORM_WIN_CAIRO})
     )
 
     list(APPEND WebKit_PRIVATE_LIBRARIES
-        MediaFoundation
         comctl32
     )
 endif ()

--- a/Source/WebKitLegacy/PlatformWin.cmake
+++ b/Source/WebKitLegacy/PlatformWin.cmake
@@ -9,7 +9,6 @@ if (${WTF_PLATFORM_WIN_CAIRO})
     )
     list(APPEND WebKitLegacy_PRIVATE_LIBRARIES
         $<TARGET_OBJECTS:WebCore>
-        MediaFoundation
     )
 else ()
     list(APPEND WebKitLegacy_SOURCES_Classes

--- a/Tools/TestWebKitAPI/PlatformWin.cmake
+++ b/Tools/TestWebKitAPI/PlatformWin.cmake
@@ -47,14 +47,6 @@ list(APPEND TestWebCore_LIBRARIES
 )
 
 if (${WTF_PLATFORM_WIN_CAIRO})
-    list(APPEND TestWebCore_LIBRARIES
-        Cairo::Cairo
-        MediaFoundation
-        OpenSSL::SSL
-        mfuuid
-        strmiids
-        vcruntime
-    )
     list(APPEND TestWebCore_SOURCES
         Tests/WebCore/CryptoDigest.cpp
 


### PR DESCRIPTION
#### 7c870a9654097f448a35441d26405d91d66c24d8
<pre>
[WinCairo][CMake] Propagate MediaFoundation target
<a href="https://bugs.webkit.org/show_bug.cgi?id=247599">https://bugs.webkit.org/show_bug.cgi?id=247599</a>

Reviewed by Fujii Hironori.

Add `MediaFoundation` to `WebCore_PRIVATE_LIBRARIES` and remove
libraries that are already propagated by CMake to dependencies.

* Source/WebCore/PlatformWinCairo.cmake:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKitLegacy/PlatformWin.cmake:
* Tools/TestWebKitAPI/PlatformWin.cmake:

Canonical link: <a href="https://commits.webkit.org/256523@main">https://commits.webkit.org/256523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d68221a503decf66284f404e467a8d5f15b9c1a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105576 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165897 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5386 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34033 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101394 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101685 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82629 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87729 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39766 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4512 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42038 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39863 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->