### PR TITLE
[MSE] Should not seek with no seekable range

### DIFF
--- a/LayoutTests/media/media-source/media-source-no-seek-with-infinite-duration-expected.txt
+++ b/LayoutTests/media/media-source/media-source-no-seek-with-infinite-duration-expected.txt
@@ -1,0 +1,15 @@
+This test checks if seeking status and currentTime when duration is infinity.
+
+RUN(video.currentTime = 1.0)
+RUN(source = new MediaSource())
+EVENT(sourceopen)
+EXPECTED (mediaElement.readyState == '0') OK
+RUN(source.duration = Infinity)
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+EXPECTED (mediaElement.seekable.length == '0') OK
+EXPECTED (mediaElement.currentTime == '0') OK
+EXPECTED (mediaElement.readyState == '1') OK
+EXPECTED (mediaElement.seeking == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-no-seek-with-infinite-duration.html
+++ b/LayoutTests/media/media-source/media-source-no-seek-with-infinite-duration.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-no-seek-with-infinite-duration</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async() => {
+        findMediaElement();
+
+        run('video.currentTime = 1.0');
+
+        run('source = new MediaSource()');
+
+        const mediaElement = document.createElement('source');
+        mediaElement.type = 'video/mock; codecs=mock';
+        mediaElement.src = URL.createObjectURL(source);
+        video.appendChild(mediaElement);
+        await waitFor(source, 'sourceopen');
+        testExpected('mediaElement.readyState', HTMLMediaElement.HAVE_NOTHING);
+
+        // Test seeking a mediaElement backed by a mediaSource with infinite duration and
+        // empty buffered ranges. These factors trigger special considerations for
+        // HTMLMediaElement.seekable.
+        run('source.duration = Infinity');
+
+        sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock");
+        initSegment = makeAInit(0, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('mediaElement.seekable.length', 0);
+        testExpected('mediaElement.currentTime', 0);
+        testExpected('mediaElement.readyState', HTMLMediaElement.HAVE_METADATA);
+
+        // Seek should not actually occur because seekable is empty.
+        // From https://html.spec.whatwg.org/multipage/media.html#seeking,
+        // "If there are no ranges given in the seekable attribute then set the seeking IDL
+        // attribute to false and abort these steps."
+        testExpected('mediaElement.seeking', false);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <div>This test checks if seeking status and currentTime when duration is infinity.</div>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3505,9 +3505,9 @@ void HTMLMediaElement::seekTask()
         noSeekRequired = true;
 
 #if ENABLE(MEDIA_SOURCE)
-    // Always notify the media engine of a seek if the source is not closed. This ensures that the source is
-    // always in a flushed state when the 'seeking' event fires.
-    if (m_mediaSource && !m_mediaSource->isClosed())
+    // Always notify the media engine of a seek if the source is not closed and there is seekable ranges.
+    // This ensures that the source is always in a flushed state when the 'seeking' event fires.
+    if (m_mediaSource && !m_mediaSource->isClosed() && seekableRanges->length())
         noSeekRequired = false;
 #endif
 


### PR DESCRIPTION
#### ab539817a72136ed0d4a41d1489404ee9a0259dc
<pre>
[MSE] Should not seek with no seekable range

<a href="https://bugs.webkit.org/show_bug.cgi?id=247602">https://bugs.webkit.org/show_bug.cgi?id=247602</a>

Reviewed by Jer Noble.

According <a href="https://html.spec.whatwg.org/multipage/media.html#seeking">https://html.spec.whatwg.org/multipage/media.html#seeking</a>,
&quot;If there are no ranges given in the seekable attribute then set
 the seeking IDL attribute to false and return.&quot;
For live streaming videos, their duration is infinity, then there
is no seekable range. So &apos;seek&apos; should be aborted in this case.

* LayoutTests/media/media-source/media-source-no-seek-with-infinite-duration-expected.txt: Added.
* LayoutTests/media/media-source/media-source-no-seek-with-infinite-duration.html: Test seeking
status and currentTime with an infinite duration.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekTask): Added a condtion to check if there is no seekable range
for for notifying the mdedia engine of a seek.

Canonical link: <a href="https://commits.webkit.org/256759@main">https://commits.webkit.org/256759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5225b74e36fb457714eda8fb61be84f9cfa321d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105355 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165662 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5112 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33786 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101185 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3758 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82388 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73647 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39521 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19065 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20386 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4697 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43024 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39638 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->