### PR TITLE
CAAudioStreamDescription::format() is hard to understand

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.cpp
@@ -94,52 +94,41 @@ AudioStreamDescription::PCMFormat CAAudioStreamDescription::format() const
 {
     if (m_format != None)
         return m_format;
-
     if (m_streamDescription.mFormatID != kAudioFormatLinearPCM)
         return None;
     if (m_streamDescription.mFramesPerPacket != 1)
         return None;
     if (m_streamDescription.mBytesPerFrame != m_streamDescription.mBytesPerPacket)
         return None;
-    if (m_streamDescription.mBitsPerChannel / sizeof(double) > m_streamDescription.mBytesPerFrame)
-        return None;
     if (!m_streamDescription.mChannelsPerFrame)
         return None;
-
-    unsigned wordsize = m_streamDescription.mBytesPerFrame;
-    if (isInterleaved()) {
-        if (wordsize % m_streamDescription.mChannelsPerFrame)
-            return None;
-
-        wordsize /= m_streamDescription.mChannelsPerFrame;
+    if (!isNativeEndian())
+        return None;
+    if (m_streamDescription.mBitsPerChannel % 8)
+        return None;
+    uint32_t bytesPerSample = m_streamDescription.mBitsPerChannel / 8;
+    uint32_t numChannelsPerFrame = numberOfInterleavedChannels();
+    if (m_streamDescription.mBytesPerFrame % numChannelsPerFrame)
+        return None;
+    if (m_streamDescription.mBytesPerFrame / numChannelsPerFrame != bytesPerSample)
+        return None;
+    std::optional<PCMFormat> format;
+    auto asbdFormat = m_streamDescription.mFormatFlags & (kLinearPCMFormatFlagIsFloat | kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagsSampleFractionMask);
+    if (asbdFormat == kLinearPCMFormatFlagIsFloat) {
+        if (bytesPerSample == sizeof(float))
+            format = Float32;
+        else if (bytesPerSample == sizeof(double))
+            format = Float64;
+    } else if (asbdFormat == kLinearPCMFormatFlagIsSignedInteger) {
+        if (bytesPerSample == sizeof(int16_t))
+            format = Int16;
+        else if (bytesPerSample == sizeof(int32_t))
+            format = Int32;
     }
-
-    if (isNativeEndian() && wordsize * sizeof(double) == m_streamDescription.mBitsPerChannel) {
-        // Packed and native endian, good
-        if (m_streamDescription.mFormatFlags & kLinearPCMFormatFlagIsFloat) {
-            if (m_streamDescription.mFormatFlags & (kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagsSampleFractionMask))
-                return None;
-
-            if (wordsize == sizeof(float))
-                return m_format = Float32;
-            if (wordsize == sizeof(double))
-                return m_format = Float64;
-
-            return None;
-        }
-
-        if (m_streamDescription.mFormatFlags & kLinearPCMFormatFlagIsSignedInteger) {
-            unsigned fractionBits = (m_streamDescription.mFormatFlags & kLinearPCMFormatFlagsSampleFractionMask) >> kLinearPCMFormatFlagsSampleFractionShift;
-            if (!fractionBits) {
-                if (wordsize == sizeof(int16_t))
-                    return m_format = Int16;
-                if (wordsize == sizeof(int32_t))
-                    return m_format = Int32;
-            }
-        }
-    }
-
-    return None;
+    if (!format)
+        return None;
+    m_format = *format;
+    return m_format;
 }
 
 bool operator==(const AudioStreamBasicDescription& a, const AudioStreamBasicDescription& b)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		7BA3936C271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BA3936B271EDFCA0015911C /* TestGraphicsContextGLCocoa.mm */; };
 		7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */; };
 		7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */; };
+		7BE876032919457B00B15289 /* AudioStreamDescriptionCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */; };
 		7BF5017828E55F7A0008BB16 /* StackTraceTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */; };
 		7C3965061CDD74F90094DBB8 /* ColorTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C3965051CDD74F90094DBB8 /* ColorTests.cpp */; };
 		7C486BA11AA12567003F6F9B /* bundle-file.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7C486BA01AA1254B003F6F9B /* bundle-file.html */; };
@@ -2723,6 +2724,7 @@
 		7BB754AF274E39A100D00EC1 /* WebCoreTestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebCoreTestUtilities.h; sourceTree = "<group>"; };
 		7BB754B0274E39A100D00EC1 /* WebCoreTestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebCoreTestUtilities.cpp; sourceTree = "<group>"; };
 		7BB8BDDC28F0781A00129836 /* CompletionHandlerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompletionHandlerTests.cpp; sourceTree = "<group>"; };
+		7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioStreamDescriptionCocoa.mm; sourceTree = "<group>"; };
 		7BF5017028E55F7A0008BB16 /* StackTraceTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackTraceTest.cpp; sourceTree = "<group>"; };
 		7C1AF7931E8DCBAB002645B9 /* PrepareForMoveToWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PrepareForMoveToWindow.mm; sourceTree = "<group>"; };
 		7C3965051CDD74F90094DBB8 /* ColorTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColorTests.cpp; sourceTree = "<group>"; };
@@ -5476,6 +5478,7 @@
 		CD89D0371C4EDB1300040A04 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				7BE875FB2919457B00B15289 /* AudioStreamDescriptionCocoa.mm */,
 				0711DF51226A95FB003DD2F7 /* AVFoundationSoftLinkTest.mm */,
 				31F865E526701E73003BFC6D /* CoreCryptoSPI.h */,
 				510A667A27D2FC7A00D22629 /* CoreMediaUtilities.mm */,
@@ -6110,6 +6113,7 @@
 				7CCE7EB41A411A7E00447C4C /* AttributedString.mm in Sources */,
 				F4FA2A4F24D1F05700618A46 /* AttributedSubstringForProposedRange.mm in Sources */,
 				CDC8E48D1BC5CB4500594FEC /* AudioSessionCategoryIOS.mm in Sources */,
+				7BE876032919457B00B15289 /* AudioStreamDescriptionCocoa.mm in Sources */,
 				F42D634422A1729F00D2FB3A /* AutocorrectionTestsIOS.mm in Sources */,
 				510A667C27D301C600D22629 /* AVFoundationSoftLinkTest.mm in Sources */,
 				7CCE7EB51A411A7E00447C4C /* BackForwardList.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioStreamDescriptionCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioStreamDescriptionCocoa.mm
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(COCOA)
+#import "Test.h"
+#import <WebCore/CAAudioStreamDescription.h>
+
+namespace {
+
+template<typename T> inline constexpr AudioFormatFlags formatFlag = 0;
+template<> inline constexpr AudioFormatFlags formatFlag<float> = kAudioFormatFlagIsFloat;
+template<> inline constexpr AudioFormatFlags formatFlag<double> = kAudioFormatFlagIsFloat;
+template<> inline constexpr AudioFormatFlags formatFlag<int32_t> = kAudioFormatFlagIsSignedInteger;
+template<> inline constexpr AudioFormatFlags formatFlag<int16_t> = kAudioFormatFlagIsSignedInteger;
+
+template<typename T> inline constexpr WebCore::AudioStreamDescription::PCMFormat pcmFormat = WebCore::AudioStreamDescription::None;
+template<> inline constexpr WebCore::AudioStreamDescription::PCMFormat pcmFormat<float> = WebCore::AudioStreamDescription::Float32;
+template<> inline constexpr WebCore::AudioStreamDescription::PCMFormat pcmFormat<double> = WebCore::AudioStreamDescription::Float64;
+template<> inline constexpr WebCore::AudioStreamDescription::PCMFormat pcmFormat<int16_t> = WebCore::AudioStreamDescription::Int16;
+template<> inline constexpr WebCore::AudioStreamDescription::PCMFormat pcmFormat<int32_t> = WebCore::AudioStreamDescription::Int32;
+
+template<typename T> AudioStreamBasicDescription createASBD(uint32_t numChannels = 1)
+{
+    AudioStreamBasicDescription asbd { };
+    asbd.mFormatID = kAudioFormatLinearPCM;
+    asbd.mSampleRate = 44000;
+    asbd.mFramesPerPacket = 1;
+    asbd.mChannelsPerFrame = numChannels;
+    asbd.mBitsPerChannel = 8 * sizeof(T);
+    asbd.mBytesPerFrame = sizeof(T) * asbd.mChannelsPerFrame;
+    asbd.mBytesPerPacket = asbd.mBytesPerFrame;
+    asbd.mFormatFlags = static_cast<AudioFormatFlags>(kAudioFormatFlagsNativeEndian) | static_cast<AudioFormatFlags>(kAudioFormatFlagIsPacked) | formatFlag<T>;
+    asbd.mReserved = 0;
+    return asbd;
+}
+
+
+template <typename T>
+class EachSampleTypeTest : public testing::Test {
+
+};
+
+static constexpr uint32_t failPropertyIncrements[] = {
+    1, static_cast<uint32_t>(-1), 8, static_cast<uint32_t>(-8), 16, static_cast<uint32_t>(-16), 32, static_cast<uint32_t>(-32), 60, 5000
+};
+
+}
+
+
+TYPED_TEST_SUITE_P(EachSampleTypeTest);
+
+TYPED_TEST_P(EachSampleTypeTest, CreateWorks)
+{
+    WebCore::CAAudioStreamDescription d = createASBD<TypeParam>();
+    EXPECT_EQ(d.format(), pcmFormat<TypeParam>);
+}
+
+TYPED_TEST_P(EachSampleTypeTest, FormatFailsBytesPerFrame)
+{
+    for (auto increment : failPropertyIncrements) {
+        auto asbd = createASBD<TypeParam>();
+        asbd.mBytesPerFrame += increment;
+        WebCore::CAAudioStreamDescription d = asbd;
+        EXPECT_EQ(d.format(), WebCore::AudioStreamDescription::None) << increment;
+    }
+}
+
+TYPED_TEST_P(EachSampleTypeTest, FormatFailsBitsPerChannel)
+{
+    for (auto increment : failPropertyIncrements) {
+        auto asbd = createASBD<TypeParam>();
+        asbd.mBitsPerChannel += increment;
+        WebCore::CAAudioStreamDescription d = asbd;
+        EXPECT_EQ(d.format(), WebCore::AudioStreamDescription::None) << increment;
+    }
+}
+
+TYPED_TEST_P(EachSampleTypeTest, FormatFailsChannelsPerFrame)
+{
+    for (auto increment : failPropertyIncrements) {
+        auto asbd = createASBD<TypeParam>();
+        asbd.mChannelsPerFrame += increment;
+        WebCore::CAAudioStreamDescription d = asbd;
+        EXPECT_EQ(d.format(), WebCore::AudioStreamDescription::None) << increment;
+    }
+}
+
+
+using SampleTypes = ::testing::Types<float, double, int16_t, int32_t>;
+
+REGISTER_TYPED_TEST_SUITE_P(EachSampleTypeTest,
+    CreateWorks, FormatFailsBytesPerFrame, FormatFailsBitsPerChannel, FormatFailsChannelsPerFrame);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(AudioStreamDescriptionCocoa, EachSampleTypeTest, SampleTypes);
+
+#endif


### PR DESCRIPTION
#### f55c4602a771e8ca0900054cdc05fe2b60a94f1c
<pre>
CAAudioStreamDescription::format() is hard to understand
<a href="https://bugs.webkit.org/show_bug.cgi?id=247605">https://bugs.webkit.org/show_bug.cgi?id=247605</a>
rdar://problem/102080347

Reviewed by Eric Carlson.

An attempt to make the function more understandable:
 - Have only one success exit
 - Use &quot;bits / 8&quot; to compute &quot;bytes&quot; instead of surprising &quot;bits / sizeof(double)&quot;
 - Compute bytesPerSample as &quot;bitsPerSample / 8&quot; instead of &quot;bytesPerFrame / ... &quot;
   Validate bytesPerFrame based on bytesPerSample.

Add rudimentary tests exercising the function.

No change in functionality.

* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.cpp:
(WebCore::CAAudioStreamDescription::format const):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioStreamDescriptionCocoa.mm: Added.
(TYPED_TEST_P):

Canonical link: <a href="https://commits.webkit.org/256480@main">https://commits.webkit.org/256480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce8a12b618e7f08fdd5e5970b63f357c24fb58d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105356 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165663 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5113 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33788 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101186 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3759 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82389 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30817 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73648 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39522 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37212 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4481 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43026 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39641 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->