### PR TITLE
[SOUP] WebSocketTask: add client authentication support

### DIFF
--- a/Source/WebCore/platform/network/soup/AuthenticationChallenge.h
+++ b/Source/WebCore/platform/network/soup/AuthenticationChallenge.h
@@ -60,6 +60,9 @@ public:
     uint32_t tlsPasswordFlags() const { return m_tlsPasswordFlags; }
     void setTLSPasswordFlags(uint32_t tlsPasswordFlags) { m_tlsPasswordFlags = tlsPasswordFlags; }
 
+    static ProtectionSpace protectionSpaceForClientCertificate(const URL&);
+    static ProtectionSpace protectionSpaceForClientCertificatePassword(const URL&, GTlsPassword*);
+
 private:
     friend class AuthenticationChallengeBase;
     static bool platformCompare(const AuthenticationChallenge&, const AuthenticationChallenge&);

--- a/Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp
+++ b/Source/WebCore/platform/network/soup/AuthenticationChallengeSoup.cpp
@@ -37,9 +37,9 @@ namespace WebCore {
 
 static ProtectionSpace::ServerType protectionSpaceServerTypeFromURL(const URL& url, bool isForProxy)
 {
-    if (url.protocolIs("https"_s))
+    if (url.protocolIs("https"_s) || url.protocolIs("wss"_s))
         return isForProxy ? ProtectionSpace::ServerType::ProxyHTTPS : ProtectionSpace::ServerType::HTTPS;
-    if (url.protocolIs("http"_s))
+    if (url.protocolIs("http"_s) || url.protocolIs("ws"_s))
         return isForProxy ? ProtectionSpace::ServerType::ProxyHTTP : ProtectionSpace::ServerType::HTTP;
     if (url.protocolIs("ftp"_s))
         return isForProxy ? ProtectionSpace::ServerType::ProxyFTP : ProtectionSpace::ServerType::FTP;
@@ -90,7 +90,7 @@ AuthenticationChallenge::AuthenticationChallenge(SoupMessage* soupMessage, SoupA
 {
 }
 
-static ProtectionSpace protectionSpaceForClientCertificate(const URL& url)
+ProtectionSpace AuthenticationChallenge::protectionSpaceForClientCertificate(const URL& url)
 {
     auto port = url.port();
     if (!port)
@@ -108,7 +108,7 @@ AuthenticationChallenge::AuthenticationChallenge(SoupMessage* soupMessage, GTlsC
 {
 }
 
-static ProtectionSpace protectionSpaceForClientCertificatePassword(GTlsPassword* tlsPassword, const URL& url)
+ProtectionSpace AuthenticationChallenge::protectionSpaceForClientCertificatePassword(const URL& url, GTlsPassword* tlsPassword)
 {
     auto port = url.port();
     if (!port)
@@ -118,7 +118,7 @@ static ProtectionSpace protectionSpaceForClientCertificatePassword(GTlsPassword*
 }
 
 AuthenticationChallenge::AuthenticationChallenge(SoupMessage* soupMessage, GTlsPassword* tlsPassword)
-    : AuthenticationChallengeBase(protectionSpaceForClientCertificatePassword(tlsPassword, soupURIToURL(soup_message_get_uri(soupMessage)))
+    : AuthenticationChallengeBase(protectionSpaceForClientCertificatePassword(soupURIToURL(soup_message_get_uri(soupMessage)), tlsPassword)
         , Credential() // proposedCredentials
         , g_tls_password_get_flags(tlsPassword) & G_TLS_PASSWORD_RETRY ? 1 : 0 // previousFailureCount
         , soupMessage // failureResponse


### PR DESCRIPTION
#### 7d61be00ed87662a5412523f7fa001fc36434bf8
<pre>
[SOUP] WebSocketTask: add client authentication support

<a href="https://bugs.webkit.org/show_bug.cgi?id=247608">https://bugs.webkit.org/show_bug.cgi?id=247608</a>

Reviewed by Carlos Garcia Campos.

Since version WebKitGTK version 2.2, developers can register a
authenticate callback to the WebView. This gives a WebKitAuthenticationRequest
which gives a chance to provide certificates with webkit_authentication_request_authenticate.
While developing, it turned out that the websocket implementation does not handle
client certificates. The implemention in this commit is partial based on NetworkDataTaskSoup.

Canonical link: <a href="https://commits.webkit.org/256780@main">https://commits.webkit.org/256780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c10230a73d5634b1b6950f0781347d3f37f78266

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106070 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166412 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5984 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34536 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88916 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102786 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4460 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83144 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31430 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74335 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40269 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19676 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21076 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43625 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2263 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40349 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->