### PR TITLE
Introduce MultiCacheQueryOptions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any-expected.txt
@@ -9,7 +9,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker-expected.txt
@@ -9,7 +9,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker-expected.txt
@@ -9,7 +9,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker-expected.txt
@@ -9,7 +9,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https-expected.txt
@@ -10,7 +10,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https-expected.txt
@@ -9,7 +9,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/worker/cache-match.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/worker/cache-match.https-expected.txt
@@ -9,7 +9,7 @@ PASS Cache.match with ignoreSearch option (request with no search parameters)
 PASS Cache.match with ignoreSearch option (request with search parameter)
 PASS Cache.match supports ignoreMethod
 PASS Cache.match supports ignoreVary
-FAIL Cache.match does not support cacheName option assert_false: Cache.match does not support cacheName option which was removed in CacheQueryOptions. expected false got true
+PASS Cache.match does not support cacheName option
 PASS Cache.match with URL containing fragment
 PASS Cache.match with string fragment "http" as query
 PASS Cache.match with responses containing "Vary" header

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -262,6 +262,7 @@ set(WebCore_NON_SVG_IDL_FILES
 
     Modules/cache/CacheQueryOptions.idl
     Modules/cache/DOMCache.idl
+    Modules/cache/MultiCacheQueryOptions.idl
     Modules/cache/DOMCacheStorage.idl
     Modules/cache/WindowOrWorkerGlobalScope+Caches.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -232,6 +232,7 @@ $(PROJECT_DIR)/Modules/beacon/Navigator+Beacon.idl
 $(PROJECT_DIR)/Modules/cache/CacheQueryOptions.idl
 $(PROJECT_DIR)/Modules/cache/DOMCache.idl
 $(PROJECT_DIR)/Modules/cache/DOMCacheStorage.idl
+$(PROJECT_DIR)/Modules/cache/MultiCacheQueryOptions.idl
 $(PROJECT_DIR)/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl
 $(PROJECT_DIR)/Modules/compression/CompressionStream.idl
 $(PROJECT_DIR)/Modules/compression/CompressionStream.js

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1723,6 +1723,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMouseEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMouseEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMouseEventInit.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMouseEventInit.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMultiCacheQueryOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMultiCacheQueryOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMutationCallback.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMutationCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMutationEvent.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -254,6 +254,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/cache/CacheQueryOptions.idl \
     $(WebCore)/Modules/cache/DOMCache.idl \
     $(WebCore)/Modules/cache/DOMCacheStorage.idl \
+    $(WebCore)/Modules/cache/MultiCacheQueryOptions.idl \
     $(WebCore)/Modules/cache/WindowOrWorkerGlobalScope+Caches.idl \
     $(WebCore)/Modules/compression/CompressionStream.idl \
     $(WebCore)/Modules/compression/CompressionStreamEncoder.idl \

--- a/Source/WebCore/Modules/cache/CacheQueryOptions.idl
+++ b/Source/WebCore/Modules/cache/CacheQueryOptions.idl
@@ -27,5 +27,4 @@ dictionary CacheQueryOptions {
     boolean ignoreSearch = false;
     boolean ignoreMethod = false;
     boolean ignoreVary = false;
-    DOMString cacheName;
 };

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -31,6 +31,7 @@
 #include "EventLoop.h"
 #include "JSDOMCache.h"
 #include "JSFetchResponse.h"
+#include "MultiCacheQueryOptions.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 
@@ -106,7 +107,7 @@ void DOMCacheStorage::doSequentialMatch(DOMCache::RequestInfo&& info, CacheQuery
     });
 }
 
-void DOMCacheStorage::match(DOMCache::RequestInfo&& info, CacheQueryOptions&& options, Ref<DeferredPromise>&& promise)
+void DOMCacheStorage::match(DOMCache::RequestInfo&& info, MultiCacheQueryOptions&& options, Ref<DeferredPromise>&& promise)
 {
     retrieveCaches([this, info = WTFMove(info), options = WTFMove(options), promise = WTFMove(promise)](std::optional<Exception>&& exception) mutable {
         if (exception) {

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.h
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+struct MultiCacheQueryOptions;
+
 class DOMCacheStorage : public RefCounted<DOMCacheStorage>, public ActiveDOMObject {
 public:
     static Ref<DOMCacheStorage> create(ScriptExecutionContext&, Ref<CacheStorageConnection>&&);
@@ -39,7 +41,7 @@ public:
 
     using KeysPromise = DOMPromiseDeferred<IDLSequence<IDLDOMString>>;
 
-    void match(DOMCache::RequestInfo&&, CacheQueryOptions&&, Ref<DeferredPromise>&&);
+    void match(DOMCache::RequestInfo&&, MultiCacheQueryOptions&&, Ref<DeferredPromise>&&);
     void has(const String&, DOMPromiseDeferred<IDLBoolean>&&);
     void open(const String&, DOMPromiseDeferred<IDLInterface<DOMCache>>&&);
     void remove(const String&, DOMPromiseDeferred<IDLBoolean>&&);

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.idl
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.idl
@@ -32,7 +32,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     EnabledByDeprecatedGlobalSetting=CacheAPIEnabled,
     InterfaceName=CacheStorage,
 ] interface DOMCacheStorage {
-    [NewObject] Promise<any> match(RequestInfo request, optional CacheQueryOptions options);
+    [NewObject] Promise<any> match(RequestInfo request, optional MultiCacheQueryOptions options);
     [NewObject] Promise<boolean> has(DOMString cacheName);
     [NewObject] Promise<DOMCache> open(DOMString cacheName);
     [NewObject, ImplementedAs=remove] Promise<boolean> delete(DOMString cacheName);

--- a/Source/WebCore/Modules/cache/MultiCacheQueryOptions.h
+++ b/Source/WebCore/Modules/cache/MultiCacheQueryOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,14 +25,13 @@
 
 #pragma once
 
+#include "CacheQueryOptions.h"
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-struct CacheQueryOptions {
-    bool ignoreSearch { false };
-    bool ignoreMethod { false };
-    bool ignoreVary { false };
+struct MultiCacheQueryOptions : CacheQueryOptions {
+    String cacheName;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/MultiCacheQueryOptions.idl
+++ b/Source/WebCore/Modules/cache/MultiCacheQueryOptions.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,16 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include <wtf/text/WTFString.h>
-
-namespace WebCore {
-
-struct CacheQueryOptions {
-    bool ignoreSearch { false };
-    bool ignoreMethod { false };
-    bool ignoreVary { false };
+dictionary MultiCacheQueryOptions : CacheQueryOptions{
+    DOMString cacheName;
 };
-
-} // namespace WebCore

--- a/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp
@@ -245,7 +245,7 @@ void WorkerCacheStorageConnection::batchDeleteOperation(DOMCacheIdentifier cache
     uint64_t requestIdentifier = ++m_lastRequestIdentifier;
     m_batchDeleteAndPutPendingRequests.add(requestIdentifier, WTFMove(callback));
 
-    callOnMainThread([workerThread = Ref { m_scope.thread() }, mainThreadConnection = m_mainThreadConnection, requestIdentifier, cacheIdentifier, request = request.isolatedCopy(), options = WTFMove(options).isolatedCopy()]() mutable {
+    callOnMainThread([workerThread = Ref { m_scope.thread() }, mainThreadConnection = m_mainThreadConnection, requestIdentifier, cacheIdentifier, request = request.isolatedCopy(), options]() mutable {
         mainThreadConnection->batchDeleteOperation(cacheIdentifier, request, WTFMove(options), [workerThread = WTFMove(workerThread), requestIdentifier](RecordIdentifiersOrError&& result) mutable {
             workerThread->runLoop().postTaskForMode([requestIdentifier, result = WTFMove(result)] (auto& scope) mutable {
                 downcast<WorkerGlobalScope>(scope).cacheStorageConnection().deleteRecordsCompleted(requestIdentifier, WTFMove(result));

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3639,6 +3639,7 @@ JSMessageEvent.cpp
 JSMessagePort.cpp
 JSMouseEvent.cpp
 JSMouseEventInit.cpp
+JSMultiCacheQueryOptions.cpp
 JSMutationCallback.cpp
 JSMutationEvent.cpp
 JSMutationObserver.cpp

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
@@ -316,7 +316,7 @@ void Cache::retrieveRecords(const RetrieveRecordsOptions& options, RecordsCallba
     if (!records)
         return;
 
-    CacheQueryOptions queryOptions { options.ignoreSearch, options.ignoreMethod, options.ignoreVary, { } };
+    CacheQueryOptions queryOptions { options.ignoreSearch, options.ignoreMethod, options.ignoreVary };
     for (auto& record : *records) {
         if (DOMCacheEngine::queryCacheMatch(options.request, record.url, record.hasVaryStar, record.varyHeaders, queryOptions))
             retrieveRecord(record, taskCounter.copyRef());

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -59,7 +59,6 @@ struct WebCore::CacheQueryOptions {
     bool ignoreSearch;
     bool ignoreMethod;
     bool ignoreVary;
-    String cacheName;
 }
 
 struct WebCore::CharacterRange {


### PR DESCRIPTION
#### 2214092f8c00d55b0acfc09fdd228fa313c42d69
<pre>
Introduce MultiCacheQueryOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247610">https://bugs.webkit.org/show_bug.cgi?id=247610</a>
rdar://problem/102086459

Reviewed by Chris Dumez.

Update WebIDL according spec by introducing MultiCacheQueryOptions which is a CacheQueryOptions with a cacheName option.
Remove cacheName from CacheQueryOptions.
Update related code.

Covered by updated tests.

* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-match.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-match.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/window/cache-match.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/worker/cache-match.https-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/cache/CacheQueryOptions.h:
(WebCore::CacheQueryOptions::isolatedCopy const): Deleted.
(WebCore::CacheQueryOptions::isolatedCopy): Deleted.
* Source/WebCore/Modules/cache/CacheQueryOptions.idl:
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::match):
* Source/WebCore/Modules/cache/DOMCacheStorage.h:
* Source/WebCore/Modules/cache/DOMCacheStorage.idl:
* Source/WebCore/Modules/cache/MultiCacheQueryOptions.h: Added.
* Source/WebCore/Modules/cache/MultiCacheQueryOptions.idl: Added.
* Source/WebCore/Modules/cache/WorkerCacheStorageConnection.cpp:
(WebCore::WorkerCacheStorageConnection::batchDeleteOperation):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp:
(WebKit::CacheStorage::Cache::retrieveRecords):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/256538@main">https://commits.webkit.org/256538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62eb1e92119f105de4bc68dda68f3f6689e550fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105613 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165940 "Found 1 new test failure: fast/images/pagewide-play-pause-offscreen-animations.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5426 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34072 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101430 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101722 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82667 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31044 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39803 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20641 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4526 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39904 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->