### PR TITLE
[git-webkit] Handle double reverts

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='5.7.7',
+    version='5.7.8',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(5, 7, 7)
+version = Version(5, 7, 8)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
@@ -35,13 +35,22 @@ CHERRY_PICK_RE = [
     re.compile(r'\S* ?[Cc]herry[- ][Pp]ick {}'.format(COMPOUND_COMMIT_REF)),
     re.compile(r'\S* ?[Cc]herry[- ][Pp]icked {}'.format(COMPOUND_COMMIT_REF)),
 ]
-REVERT_RE = [
-    re.compile(r'Reverts? {}'.format(COMPOUND_COMMIT_REF)),
-    re.compile(r'Reverts? \[{}\]'.format(COMPOUND_COMMIT_REF)),
-    re.compile(r'Reverts? \({}\)'.format(COMPOUND_COMMIT_REF)),
-    re.compile(r'Reverts? "{}"'.format(COMPOUND_COMMIT_REF)),
-    re.compile(r'Reverts? "?[Cc]herry[- ][Pp]ick {}'.format(COMPOUND_COMMIT_REF)),
+REVERT_BASES = [
+    r'Reverts? {}',
+    r'Reverts? \[{}\]',
+    r'Reverts? \({}\)',
+    r'Reverts? "{}"',
+    r'Reverts? "?[Cc]herry[- ][Pp]ick {}',
 ]
+REVERT_RE = [
+    re.compile(base.format(COMPOUND_COMMIT_REF)) for base in REVERT_BASES
+]
+DOUBLE_REVERT = [
+    re.compile(r'Reverts? \"{}\.'.format(base.format(COMPOUND_COMMIT_REF))) for base in REVERT_BASES
+] + [
+    re.compile(r'Reverts? \"{}'.format(base.format(COMPOUND_COMMIT_REF))) for base in REVERT_BASES
+]
+
 FOLLOW_UP_FIXES_RE = [
     re.compile(r'Fix following {}'.format(COMPOUND_COMMIT_REF)),
     re.compile(r'Follow-? ?up fix to {}'.format(COMPOUND_COMMIT_REF)),
@@ -92,7 +101,7 @@ class Relationship(object):
         lines = commit.message.splitlines()
 
         for type, regexes in {
-            cls.ORIGINAL: CHERRY_PICK_RE,
+            cls.ORIGINAL: CHERRY_PICK_RE + DOUBLE_REVERT,
             cls.REVERTS: REVERT_RE,
             cls.FOLLOW_UP: FOLLOW_UP_FIXES_RE,
         }.items():

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -106,6 +106,20 @@ class TestRelationship(TestCase):
             ))
         )
 
+    def test_double_revert(self):
+        self.assertEqual(
+            ('original', ['1230@main', '0123456789ab']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Reverts "Revert 1230@main (0123456789ab)"',
+            ))
+        )
+        self.assertEqual(
+            ('original', ['1230@main']), Relationship.parse(Commit(
+                hash='deadbeef1234', revision=1234, identifier='1234@main',
+                message='Revert "Revert 1230@main, it broke the build"',
+            ))
+        )
+
 
 class TestCommitsStory(TestCase):
     def test_cherry_pick(self):


### PR DESCRIPTION
#### 2a567414111405eaefe157503250907ea7942cd8
<pre>
[git-webkit] Handle double reverts
<a href="https://bugs.webkit.org/show_bug.cgi?id=247621">https://bugs.webkit.org/show_bug.cgi?id=247621</a>
rdar://102092026

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py:
(Relationship.parse): Add regexes to search for double reverts.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestRelationship.test_double_revert):

Canonical link: <a href="https://commits.webkit.org/256455@main">https://commits.webkit.org/256455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a8b29ee6b95e1d1927f0a126e47fec3b924cc6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5074 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/28866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/105399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5164 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/101229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/101483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/88206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99408 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/28866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39565 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/28866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/20/builds/94790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/37254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/28866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/41316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2150 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/65/builds/43362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/28866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->