### PR TITLE
run-minibrowser should understand the --ios-device command line args

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2992,6 +2992,11 @@ sub installedMobileSafariBundle()
     return File::Spec->catfile(iosSimulatorApplicationsPath(), "MobileSafari.app");
 }
 
+sub installedMobileMiniBrowserBundle()
+{
+    return File::Spec->catfile(iosSimulatorApplicationsPath(), "MobileMiniBrowser.app");
+}
+
 sub mobileSafariBundle()
 {
     determineConfigurationProductDir();
@@ -3002,6 +3007,17 @@ sub mobileSafariBundle()
     }
     return installedMobileSafariBundle();
 }
+
+sub mobileMiniBrowserBundle()
+{
+    determineConfigurationProductDir();
+
+    if (isIOSWebKit() && -d "$configurationProductDir/MobileMiniBrowser.app") {
+        return "$configurationProductDir/MobileMiniBrowser.app";
+    }
+    return installedMobileMiniBrowserBundle();
+}
+
 
 sub plistPathFromBundle($)
 {
@@ -3129,8 +3145,8 @@ sub findOrCreateSimulatorForIOSDevice($)
         $simulatorName = "iPad Pro " . $simulatorNameSuffix;
         $simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.iPad-Pro--9-7-inch-";
     } else {
-        $simulatorName = "iPhone SE " . $simulatorNameSuffix;
-        $simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-SE";
+        $simulatorName = "iPhone 12 " . $simulatorNameSuffix;
+        $simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-12";
     }
 
     my $simulatedDevice = iosSimulatorDeviceByName($simulatorName);
@@ -3357,6 +3373,9 @@ sub runMiniBrowser
     if (isAppleWinWebKit() || isFTW()) {
         my $webKitLauncherPath = File::Spec->catfile(executableProductDir(), "MiniBrowser.exe");
         return system { $webKitLauncherPath } $webKitLauncherPath, @ARGV;
+    }
+    if (isIOSWebKit()) {
+        return runIOSWebKitApp(mobileMiniBrowserBundle());
     }
     return 1;
 }


### PR DESCRIPTION
#### ebc75110236d0b9948c8f018ccbab4c15aee925b
<pre>
run-minibrowser should understand the --ios-device command line args
<a href="https://bugs.webkit.org/show_bug.cgi?id=247629">https://bugs.webkit.org/show_bug.cgi?id=247629</a>
rdar://102103002

Reviewed by Brent Fulgham.

This adds support to the old-run-minibrowser Perl script to launch MobileMiniBrowser
in an iOS simulator.

As of at least Xcode 14.1 we don&apos;t have the iPhone SE simulator (we support
some later generation of iPhone SE). This patch also bumps the default iPhone simulator to
iPhone 12 which aligns with run-webkit-tests --ios-simulator.

* Tools/Scripts/webkitdirs.pm:
(installedMobileMiniBrowserBundle):
(mobileMiniBrowserBundle):
(findOrCreateSimulatorForIOSDevice):
(runIOSWebKitAppInSimulator):
(runMiniBrowser):

Canonical link: <a href="https://commits.webkit.org/256495@main">https://commits.webkit.org/256495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b89cce3d3166bcbe3a0924be8f28d612690f7c06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105528 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5324 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33978 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101352 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82573 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/86990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39709 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82339 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37388 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20551 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28229 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41946 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85017 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39811 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19195 "Passed tests") | 
<!--EWS-Status-Bubble-End-->