### PR TITLE
[content-visibility] Fix dynamic-change-paint-fully-obscuring-child-001.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4836,7 +4836,6 @@ imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visib
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-with-top-layer-hide-after-addition.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/dynamic-change-paint-fully-obscuring-child-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/counter-scoping-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-contain/quote-scoping-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1728,6 +1728,9 @@ bool RenderBox::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, u
     if (!maxDepthToTest)
         return false;
 
+    if (shouldSkipContent())
+        return false;
+
     for (auto& childBox : childrenOfType<RenderBox>(*this)) {
         if (!isCandidateForOpaquenessTest(childBox))
             continue;


### PR DESCRIPTION
#### 64dda353ea50256f1bcd19bb1908b37dec0fb8c5
<pre>
[content-visibility] Fix dynamic-change-paint-fully-obscuring-child-001.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=247617">https://bugs.webkit.org/show_bug.cgi?id=247617</a>

Reviewed by Simon Fraser.

A child can&apos;t obscure a parent element that should skip its contents
due to hidden content-visibility, so adjust foregroundIsKnownToBeOpaqueInRect
to that.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::foregroundIsKnownToBeOpaqueInRect const):

Canonical link: <a href="https://commits.webkit.org/257549@main">https://commits.webkit.org/257549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1f85819f8945ecefcae69145cb1c9a7c23a978b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107909 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168179 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85081 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104566 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104148 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6225 "Found 30 new test failures: editing/deleting/merge-paragraph-with-style-from-rule-live-range.html, fast/canvas/image-pattern-rotate.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/text/text-edge-property-parsing.html, http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html, http/wpt/service-workers/form-data-upload.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/animation-delay.html, imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/baseline-shift.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33217 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88043 "Found 1 new API test failure: TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21209 "Found 1 new test failure: fast/text/text-edge-no-half-leading-with-line-height-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76158 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1631 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22738 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1553 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45173 "Found 11 new test failures: css3/supports-dom-api.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-property-parsing.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html, imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html, ipc/pasteboard-write-custom-data.html, media/video-inaccurate-duration-ended.html, model-element/model-element-width-height-visual.html ... (failure)") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5185 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6476 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42171 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->