### PR TITLE
Crash in pas_segregated_page_switch_lock_and_rebias_while_ineligible_impl

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_page.c
@@ -127,7 +127,7 @@ void pas_segregated_page_switch_lock_and_rebias_while_ineligible_impl(
         page_lock = page->lock_ptr;
         PAS_TESTING_ASSERT(page_lock);
 
-        if (*held_lock == page_lock && *held_lock == &cache_node->page_lock) {
+        if (*held_lock == page_lock && cache_node && *held_lock == &cache_node->page_lock) {
             pas_compiler_fence();
             return;
         }


### PR DESCRIPTION
#### 0b3756093c94f5b7a611b2393554a0e49d6fedf7
<pre>
Crash in pas_segregated_page_switch_lock_and_rebias_while_ineligible_impl
<a href="https://bugs.webkit.org/show_bug.cgi?id=245968">https://bugs.webkit.org/show_bug.cgi?id=245968</a>

Reviewed by Mark Lam and Yusuke Suzuki.

There is a pretty frequent crash here that occurs when derefrencing
cache_node-&gt;page_lock when cache_node is nullptr. It&apos;s a little strange
because the crash occurs on line 146, which should be unreachable in
this case because there is a check for nullptr on line 137 that ensures
the rest of the function is skipped in this case. And yet, it&apos;s
happening anyway. Perhaps that check is being optimized out due to the
even earlier dereference of cache_node on line 130? I&apos;m not sure, but
clearly cache_node is expected to be nullptr here, so let&apos;s check for
it earlier before the first dereference, which is good to do no matter
what.

This solution was suggested by Benjamin Otte, but it&apos;s not his fault if
it doesn&apos;t fix the crash! This is only a speculative fix. To know for
sure whether this is the problem, somebody would have to study the
disassembled code more closely.

* Source/bmalloc/libpas/src/libpas/pas_segregated_page.c:
(pas_segregated_page_switch_lock_and_rebias_while_ineligible_impl):

Canonical link: <a href="https://commits.webkit.org/256486@main">https://commits.webkit.org/256486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e14bc92909598d1263d6bdf4c199791755f2d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105427 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165744 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5209 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33875 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101258 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3837 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82471 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30873 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73706 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86898 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39606 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82233 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37289 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20461 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4484 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43089 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84910 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39713 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19177 "Passed tests") | 
<!--EWS-Status-Bubble-End-->