### PR TITLE
[iPadOS] Wikipedia pages are excessively zoomed in when viewed in an external display

### DIFF
--- a/LayoutTests/fast/viewport/ios/adjust-fixed-width-and-initial-scale-to-avoid-excessive-zooming-expected.txt
+++ b/LayoutTests/fast/viewport/ios/adjust-fixed-width-and-initial-scale-to-avoid-excessive-zooming-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that when the `IgnoreMetaViewport` policy is enabled, a meta viewport that specifies an explicit width (with a large initial scale) doesn't cause us to zoom in excessively.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS visualViewport.scale < 2 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/viewport/ios/adjust-fixed-width-and-initial-scale-to-avoid-excessive-zooming.html
+++ b/LayoutTests/fast/viewport/ios/adjust-fixed-width-and-initial-scale-to-avoid-excessive-zooming.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ShouldIgnoreMetaViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=200, initial-scale=2">
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+#bar {
+    width: 200px;
+    height: 44px;
+    background: linear-gradient(to right, red 0%, green 50%, blue 100%);
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+description("This test verifies that when the `IgnoreMetaViewport` policy is enabled, a meta viewport that specifies an explicit width (with a large initial scale) doesn't cause us to zoom in excessively.");
+
+async function runTest() {
+    await UIHelper.renderingUpdate();
+    shouldBeTrue("visualViewport.scale < 2");
+    finishJSTest();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <div id="bar"></div>
+</body>
+</html>

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -129,6 +129,7 @@ public:
     double layoutSizeScaleFactor() const { return m_layoutSizeScaleFactor; }
 
     void setPrefersHorizontalScrollingBelowDesktopViewportWidths(bool value) { m_prefersHorizontalScrollingBelowDesktopViewportWidths = value; }
+    void setCanIgnoreViewportArgumentsToAvoidExcessiveZoom(bool value) { m_canIgnoreViewportArgumentsToAvoidExcessiveZoom = value; }
 
     WEBCORE_EXPORT IntSize layoutSize() const;
     WEBCORE_EXPORT int layoutWidth() const;
@@ -212,6 +213,7 @@ private:
     bool m_forceAlwaysUserScalable;
     bool m_isKnownToLayOutWiderThanViewport { false };
     bool m_prefersHorizontalScrollingBelowDesktopViewportWidths { false };
+    bool m_canIgnoreViewportArgumentsToAvoidExcessiveZoom { false };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ViewportConfiguration::Parameters&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6838,6 +6838,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     
     bool viewportChanged = false;
 
+    m_viewportConfiguration.setCanIgnoreViewportArgumentsToAvoidExcessiveZoom(shouldIgnoreMetaViewport());
     m_viewportConfiguration.setPrefersHorizontalScrollingBelowDesktopViewportWidths(shouldEnableViewportBehaviorsForResizableWindows());
 
     LOG_WITH_STREAM(VisibleRects, stream << "WebPage " << m_identifier.toUInt64() << " didCommitLoad setting content size to " << coreFrame->view()->contentsSize());
@@ -7069,6 +7070,10 @@ void WebPage::updateWebsitePolicies(WebsitePoliciesData&& websitePolicies)
     
 #if ENABLE(VIDEO)
     m_page->updateMediaElementRateChangeRestrictions();
+#endif
+
+#if ENABLE(META_VIEWPORT)
+    m_viewportConfiguration.setCanIgnoreViewportArgumentsToAvoidExcessiveZoom(shouldIgnoreMetaViewport());
 #endif
 }
 


### PR DESCRIPTION
#### 36ed6c6840cc6882c1b4cb1dd5cc1c283757a597
<pre>
[iPadOS] Wikipedia pages are excessively zoomed in when viewed in an external display
<a href="https://bugs.webkit.org/show_bug.cgi?id=247636">https://bugs.webkit.org/show_bug.cgi?id=247636</a>
rdar://99448942

Reviewed by Tim Horton.

When loading Wikipedia articles in an external display connected to iPad, the page dynamically sets
the meta viewport content string to `width=1000, initial-scale=3.6` (where the initial scale depends
on how wide the display is — in this example, 3600px wide). This leads to the contents of the
article being excessively zoomed, and difficult to read.

To mitigate this, we add a viewport sizing heuristic to cap the maximum initial scale of the page to
a much more reasonable value (somewhat arbitrarily chosen to be 1.2) in the case where both the
initial scale and viewport width are explicitly set. To keep this fixed-width viewport consistent
with the new initial scale, we also adjust the explicitly-specified viewport width as needed.

In the above example, this would turn the `width=1000, initial-scale=3.6` viewport specified by
Wikipedia into a `width=3000, initial-scale=1.2` viewport on an external display.

Test: fast/viewport/ios/adjust-fixed-width-and-initial-scale-to-avoid-excessive-zooming.html

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::viewportArgumentValueIsValid):
(WebCore::adjustViewportArgumentsToAvoidExcessiveZooming):
(WebCore::ViewportConfiguration::setViewportArguments):

Adjust viewport arguments after setting them, if needed.

(WebCore::ViewportConfiguration::description const):
* Source/WebCore/page/ViewportConfiguration.h:

Add the new policy bit.

(WebCore::ViewportConfiguration::setCanIgnoreViewportArgumentsToAvoidExcessiveZoom):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::updateWebsitePolicies):

Set the above policy bit in the case where we&apos;re loading desktop-class content.

Canonical link: <a href="https://commits.webkit.org/256476@main">https://commits.webkit.org/256476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6afce7608837bbbd8cd00eb67b2ea1d4338a1e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105424 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165741 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5206 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33872 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101254 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3833 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82468 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30869 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39603 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20467 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4475 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41360 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39719 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->