### PR TITLE
REGRESSION (252960@main, WPT resync): [ macOS Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2344,8 +2344,6 @@ webkit.org/b/246356 imported/w3c/web-platform-tests/html/semantics/embedded-cont
 # The following test only fail on Mac EWS bots.
 webkit.org/b/244012 imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-below-001.xht [ Pass ImageOnlyFailure ]
 
-webkit.org/b/244014 [ Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html  [ Pass Failure ]
-
 # These tests are flaky due to "Blocked access to external URL" messages because we don't support WPT domains.
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html [ DumpJSConsoleLogInStdErr Failure Pass ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ DumpJSConsoleLogInStdErr Failure Pass ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3282,9 +3282,7 @@ void Document::implicitClose()
         // For now, only do this when there is a Frame, otherwise this could cause JS reentrancy
         // below SVG font parsing, for example. <https://webkit.org/b/136269>
         if (auto* currentPage = page()) {
-            ImageLoader::dispatchPendingBeforeLoadEvents(currentPage);
             ImageLoader::dispatchPendingLoadEvents(currentPage);
-            ImageLoader::dispatchPendingErrorEvents(currentPage);
             HTMLLinkElement::dispatchPendingLoadEvents(currentPage);
             HTMLStyleElement::dispatchPendingLoadEvents(currentPage);
         }

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -76,7 +76,7 @@ public:
     WEBCORE_EXPORT void setAs(const AtomString&);
     WEBCORE_EXPORT String as() const;
 
-    void dispatchPendingEvent(LinkEventSender*);
+    void dispatchPendingEvent(LinkEventSender*, const AtomString& eventType);
     static void dispatchPendingLoadEvents(Page*);
 
     WEBCORE_EXPORT DOMTokenList& relList();

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -47,7 +47,7 @@ using namespace HTMLNames;
 
 static StyleEventSender& styleLoadEventSender()
 {
-    static NeverDestroyed<StyleEventSender> sharedLoadEventSender(eventNames().loadEvent);
+    static NeverDestroyed<StyleEventSender> sharedLoadEventSender;
     return sharedLoadEventSender;
 }
 
@@ -128,19 +128,16 @@ void HTMLStyleElement::dispatchPendingLoadEvents(Page* page)
     styleLoadEventSender().dispatchPendingEvents(page);
 }
 
-void HTMLStyleElement::dispatchPendingEvent(StyleEventSender* eventSender)
+void HTMLStyleElement::dispatchPendingEvent(StyleEventSender* eventSender, const AtomString& eventType)
 {
     ASSERT_UNUSED(eventSender, eventSender == &styleLoadEventSender());
-    if (m_loadedSheet)
-        dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
-    else
-        dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    dispatchEvent(Event::create(eventType, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 void HTMLStyleElement::notifyLoadedSheetAndAllCriticalSubresources(bool errorOccurred)
 {
     m_loadedSheet = !errorOccurred;
-    styleLoadEventSender().dispatchEventSoon(*this);
+    styleLoadEventSender().dispatchEventSoon(*this, m_loadedSheet ? eventNames().loadEvent : eventNames().errorEvent);
 }
 
 void HTMLStyleElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT bool disabled() const;
     WEBCORE_EXPORT void setDisabled(bool);
 
-    void dispatchPendingEvent(StyleEventSender*);
+    void dispatchPendingEvent(StyleEventSender*, const AtomString& eventType);
     static void dispatchPendingLoadEvents(Page*);
 
     void finishParsingChildren() final;

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -99,22 +99,9 @@ static TextStream& operator<<(TextStream& ts, ImageLoading loading)
 }
 #endif // !LOG_DISABLED
 
-// FIXME: beforeload event no longer exists. Delete this code.
-static ImageEventSender& beforeLoadEventSender()
-{
-    static NeverDestroyed<ImageEventSender> sender(eventNames().beforeloadEvent);
-    return sender;
-}
-
 static ImageEventSender& loadEventSender()
 {
-    static NeverDestroyed<ImageEventSender> sender(eventNames().loadEvent);
-    return sender;
-}
-
-static ImageEventSender& errorEventSender()
-{
-    static NeverDestroyed<ImageEventSender> sender(eventNames().errorEvent);
+    static NeverDestroyed<ImageEventSender> sender;
     return sender;
 }
 
@@ -142,17 +129,9 @@ ImageLoader::~ImageLoader()
     if (m_image)
         m_image->removeClient(*this);
 
-    ASSERT(m_hasPendingBeforeLoadEvent || !beforeLoadEventSender().hasPendingEvents(*this));
-    if (m_hasPendingBeforeLoadEvent)
-        beforeLoadEventSender().cancelEvent(*this);
-
-    ASSERT(m_hasPendingLoadEvent || !loadEventSender().hasPendingEvents(*this));
-    if (m_hasPendingLoadEvent)
+    ASSERT(m_hasPendingLoadEvent || m_hasPendingErrorEvent || !loadEventSender().hasPendingEvents(*this));
+    if (m_hasPendingLoadEvent || m_hasPendingErrorEvent)
         loadEventSender().cancelEvent(*this);
-
-    ASSERT(m_hasPendingErrorEvent || !errorEventSender().hasPendingEvents(*this));
-    if (m_hasPendingErrorEvent)
-        errorEventSender().cancelEvent(*this);
 }
 
 void ImageLoader::clearImage()
@@ -172,17 +151,10 @@ void ImageLoader::clearImageWithoutConsideringPendingLoadEvent()
     CachedImage* oldImage = m_image.get();
     if (oldImage) {
         m_image = nullptr;
-        if (m_hasPendingBeforeLoadEvent) {
-            beforeLoadEventSender().cancelEvent(*this);
-            m_hasPendingBeforeLoadEvent = false;
-        }
-        if (m_hasPendingLoadEvent) {
+        m_hasPendingBeforeLoadEvent = false;
+        if (m_hasPendingLoadEvent || m_hasPendingErrorEvent) {
             loadEventSender().cancelEvent(*this);
-            m_hasPendingLoadEvent = false;
-        }
-        if (m_hasPendingErrorEvent) {
-            errorEventSender().cancelEvent(*this);
-            m_hasPendingErrorEvent = false;
+            m_hasPendingLoadEvent = m_hasPendingErrorEvent = false;
         }
         m_imageComplete = true;
         if (oldImage)
@@ -270,14 +242,14 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         if (!newImage && !pageIsBeingDismissed(document)) {
             m_failedLoadURL = attr;
             m_hasPendingErrorEvent = true;
-            errorEventSender().dispatchEventSoon(*this);
+            loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
         } else
             clearFailedLoadURL();
     } else if (!attr.isNull()) {
         // Fire an error event if the url is empty.
         m_failedLoadURL = attr;
         m_hasPendingErrorEvent = true;
-        errorEventSender().dispatchEventSoon(*this);
+        loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
     }
 
     didUpdateCachedImage(relevantMutation, WTFMove(newImage));
@@ -293,12 +265,9 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
     if (newImage != oldImage || relevantMutation == RelevantMutation::Yes) {
         LOG_WITH_STREAM(LazyLoading, stream << " switching from old image " << oldImage << " to image " << newImage.get() << " " << (newImage ? newImage->url() : URL()));
 
-        if (m_hasPendingBeforeLoadEvent) {
-            beforeLoadEventSender().cancelEvent(*this);
-            m_hasPendingBeforeLoadEvent = false;
-        }
+        m_hasPendingBeforeLoadEvent = false;
         if (m_hasPendingLoadEvent) {
-            loadEventSender().cancelEvent(*this);
+            loadEventSender().cancelEvent(*this, eventNames().loadEvent);
             m_hasPendingLoadEvent = false;
         }
 
@@ -307,7 +276,7 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
         // this load and we should not cancel the event.
         // FIXME: If both previous load and this one got blocked with an error, we can receive one error event instead of two.
         if (m_hasPendingErrorEvent && newImage) {
-            errorEventSender().cancelEvent(*this);
+            loadEventSender().cancelEvent(*this, eventNames().errorEvent);
             m_hasPendingErrorEvent = false;
         }
 
@@ -326,8 +295,7 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
                 LazyLoadImageObserver::observe(element());
 
             // If newImage is cached, addClient() will result in the load event
-            // being queued to fire. Ensure this happens after beforeload is
-            // dispatched.
+            // being queued to fire.
             newImage->addClient(*this);
         } else
             resetLazyImageLoading(element().document());
@@ -380,7 +348,7 @@ inline void ImageLoader::rejectDecodePromises(ASCIILiteral message)
 
 void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
-    LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " notifyFinished - hasPendingBeforeLoadEvent " << hasPendingBeforeLoadEvent() << " hasPendingLoadEvent " << m_hasPendingLoadEvent);
+    LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " notifyFinished - hasPendingLoadEvent " << m_hasPendingLoadEvent);
 
     ASSERT(m_failedLoadURL.isEmpty());
     ASSERT_UNUSED(resource, &resource == m_image.get());
@@ -406,7 +374,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         clearImageWithoutConsideringPendingLoadEvent();
 
         m_hasPendingErrorEvent = true;
-        errorEventSender().dispatchEventSoon(*this);
+        loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
 
         auto message = makeString("Cannot load image ", imageURL.string(), " due to access control checks.");
         element().document().addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
@@ -434,7 +402,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
 
     if (hasPendingDecodePromises())
         decode();
-    loadEventSender().dispatchEventSoon(*this);
+    loadEventSender().dispatchEventSoon(*this, eventNames().loadEvent);
 }
 
 RenderImageResource* ImageLoader::renderImageResource()
@@ -556,12 +524,9 @@ void ImageLoader::timerFired()
     m_protectedElement = nullptr;
 }
 
-void ImageLoader::dispatchPendingEvent(ImageEventSender* eventSender)
+void ImageLoader::dispatchPendingEvent(ImageEventSender* eventSender, const AtomString& eventType)
 {
-    ASSERT(eventSender == &beforeLoadEventSender() || eventSender == &loadEventSender() || eventSender == &errorEventSender());
-    const AtomString& eventType = eventSender->eventType();
-    if (eventType == eventNames().beforeloadEvent)
-        dispatchPendingBeforeLoadEvent();
+    ASSERT_UNUSED(eventSender, eventSender == &loadEventSender());
     if (eventType == eventNames().loadEvent)
         dispatchPendingLoadEvent();
     if (eventType == eventNames().errorEvent)
@@ -602,7 +567,7 @@ void ImageLoader::dispatchPendingErrorEvent()
     if (!m_hasPendingErrorEvent)
         return;
     m_hasPendingErrorEvent = false;
-    errorEventSender().cancelEvent(*this);
+    loadEventSender().cancelEvent(*this, eventNames().errorEvent);
     if (element().document().hasLivingRenderTree())
         element().dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
@@ -611,19 +576,9 @@ void ImageLoader::dispatchPendingErrorEvent()
     updatedHasPendingEvent();
 }
 
-void ImageLoader::dispatchPendingBeforeLoadEvents(Page* page)
-{
-    beforeLoadEventSender().dispatchPendingEvents(page);
-}
-
 void ImageLoader::dispatchPendingLoadEvents(Page* page)
 {
     loadEventSender().dispatchPendingEvents(page);
-}
-
-void ImageLoader::dispatchPendingErrorEvents(Page* page)
-{
-    errorEventSender().dispatchPendingEvents(page);
 }
 
 void ImageLoader::elementDidMoveToNewDocument(Document& oldDocument)

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -64,7 +64,7 @@ public:
     bool imageComplete() const { return m_imageComplete; }
 
     CachedImage* image() const { return m_image.get(); }
-    void clearImage(); // Cancels pending beforeload and load events, and doesn't dispatch new ones.
+    void clearImage(); // Cancels pending load events, and doesn't dispatch new ones.
     
     size_t pendingDecodePromisesCountForTesting() const { return m_decodingPromises.size(); }
     void decode(Ref<DeferredPromise>&&);
@@ -75,11 +75,9 @@ public:
     bool hasPendingBeforeLoadEvent() const { return m_hasPendingBeforeLoadEvent; }
     bool hasPendingActivity() const { return m_hasPendingLoadEvent || m_hasPendingErrorEvent; }
 
-    void dispatchPendingEvent(ImageEventSender*);
+    void dispatchPendingEvent(ImageEventSender*, const AtomString& eventType);
 
-    static void dispatchPendingBeforeLoadEvents(Page*);
     static void dispatchPendingLoadEvents(Page*);
-    static void dispatchPendingErrorEvents(Page*);
 
     void loadDeferredImage();
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -105,7 +105,7 @@ public:
     void connectConditions();
     bool hasConditionsConnected() const { return m_conditionsConnected; }
     
-    void dispatchPendingEvent(SMILEventSender*);
+    void dispatchPendingEvent(SMILEventSender*, const AtomString& eventType);
 
 protected:
     void addBeginTime(SMILTime eventTime, SMILTime endTime, SMILTimeWithOrigin::Origin = SMILTimeWithOrigin::ParserOrigin);

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -125,9 +125,6 @@ void XMLDocumentParser::append(RefPtr<StringImpl>&& inputSource)
     }
 
     doWrite(source);
-
-    // After parsing, dispatch image beforeload events.
-    ImageLoader::dispatchPendingBeforeLoadEvents(nullptr);
 }
 
 void XMLDocumentParser::handleError(XMLErrors::ErrorType type, const char* m, TextPosition position)


### PR DESCRIPTION
#### a5047de4052aba74f36f2ae51ef33d733aa3b020
<pre>
REGRESSION (252960@main, WPT resync): [ macOS Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244014">https://bugs.webkit.org/show_bug.cgi?id=244014</a>
rdar://98757197

Reviewed by Ryosuke Niwa.

The test in question starts out with an empty &lt;style&gt; and then adds an @import
to it. However, the URL of the @import points to a missing resource. As a
result, we first schedule the dispatch of a load event, then an error event.
The test makes sure that a load event is fired and times out if none gets fired.

The issue was that HTMLStyleElement was using the same EventSender for the load
and error events. However, EventSender was storing senders in its queue, not
events. The state about whether to send a load or an error event was stored on
the HTMLStyleElement instance instead.

This meant that we could schedule a load event and then an error event right
after one another. The request to send an error event would override the state
on the HTMLStyleElement and we would end up sending 2 error events, instead of
a load event followed by an error event.

To address the issue, I updated EventSender to store the event type in its
queue, in addition to the sender. We would have used two separate EventSenders
like HTMLLinkElement was doing. However, I worry that ordering between load
and error events may be incorrect if we use separate queues.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
* Source/WebCore/dom/EventSender.h:
(WebCore::EventSender::hasPendingEvents const):
(WebCore::Counter&gt;::EventSender):
(WebCore::Counter&gt;::dispatchEventSoon):
(WebCore::Counter&gt;::cancelEvent):
(WebCore::Counter&gt;::dispatchPendingEvents):
(WebCore::EventSender::eventType const): Deleted.
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::didAttachRenderers):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::linkLoadEventSender):
(WebCore::HTMLLinkElement::~HTMLLinkElement):
(WebCore::HTMLLinkElement::linkLoaded):
(WebCore::HTMLLinkElement::linkLoadingErrored):
(WebCore::HTMLLinkElement::dispatchPendingEvent):
(WebCore::HTMLLinkElement::notifyLoadedSheetAndAllCriticalSubresources):
(WebCore::linkErrorEventSender): Deleted.
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::styleLoadEventSender):
(WebCore::HTMLStyleElement::dispatchPendingEvent):
(WebCore::HTMLStyleElement::notifyLoadedSheetAndAllCriticalSubresources):
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::attach):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::loadEventSender):
(WebCore::ImageLoader::ImageLoader):
(WebCore::ImageLoader::~ImageLoader):
(WebCore::ImageLoader::clearImageWithoutConsideringPendingLoadEvent):
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::notifyFinished):
(WebCore::ImageLoader::dispatchPendingEvent):
(WebCore::ImageLoader::dispatchPendingErrorEvent):
(WebCore::beforeLoadEventSender): Deleted.
(WebCore::errorEventSender): Deleted.
(WebCore::ImageLoader::dispatchPendingBeforeLoadEvent): Deleted.
(WebCore::ImageLoader::dispatchPendingBeforeLoadEvents): Deleted.
(WebCore::ImageLoader::dispatchPendingErrorEvents): Deleted.
* Source/WebCore/loader/ImageLoader.h:
(WebCore::ImageLoader::hasPendingBeforeLoadEvent const): Deleted.
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::smilEventSender):
(WebCore::SVGSMILElement::~SVGSMILElement):
(WebCore::SVGSMILElement::progress):
(WebCore::SVGSMILElement::dispatchPendingEvent):
(WebCore::smilBeginEventSender): Deleted.
(WebCore::smilEndEventSender): Deleted.
* Source/WebCore/svg/animation/SVGSMILElement.h:
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::append):

Canonical link: <a href="https://commits.webkit.org/256535@main">https://commits.webkit.org/256535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b72b279654880764d0d875584bd1bac61e42decc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105631 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5446 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34089 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101448 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101739 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82685 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87779 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39820 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37495 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4522 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42091 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39914 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->