### PR TITLE
Interaction regions for file and range inputs are incorrect

### DIFF
--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -1,0 +1,23 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (region
+            (rect (1,2) width=84 height=18)
+)
+        (borderRadius 9.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/input-type-file-region.html
+++ b/LayoutTests/interaction-region/input-type-file-region.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+</style>
+<body>
+<input type="file">
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -1,0 +1,23 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (region
+            (rect (58,2) width=17 height=16)
+)
+        (borderRadius 8.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/input-type-range-region.html
+++ b/LayoutTests/interaction-region/input-type-range-region.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+</style>
+<body>
+<input type="range">
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2542,10 +2542,7 @@ bool Node::willRespondToMouseClickEventsWithEditability(Editability editability)
     return hasEventListeners(eventNames.mouseupEvent)
         || hasEventListeners(eventNames.mousedownEvent)
         || hasEventListeners(eventNames.clickEvent)
-#if !PLATFORM(IOS_FAMILY)
-        || hasEventListeners(eventNames.DOMActivateEvent)
-#endif
-    ;
+        || hasEventListeners(eventNames.DOMActivateEvent);
 }
 
 bool Node::willRespondToMouseWheelEvents() const

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -118,9 +118,15 @@ void RenderFileUploadControl::paintObject(PaintInfo& paintInfo, const LayoutPoin
     if (style().visibility() != Visibility::Visible)
         return;
     
-    if (paintInfo.context().paintingDisabled())
-        return;
+    if (!paintInfo.context().paintingDisabled())
+        paintControl(paintInfo, paintOffset);
 
+    // Paint the children.
+    RenderBlockFlow::paintObject(paintInfo, paintOffset);
+}
+
+void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+{
     // Push a clip.
     GraphicsContextStateSaver stateSaver(paintInfo.context(), false);
     if (paintInfo.phase == PaintPhase::Foreground || paintInfo.phase == PaintPhase::ChildBlockBackgrounds) {
@@ -191,9 +197,6 @@ void RenderFileUploadControl::paintObject(PaintInfo& paintInfo, const LayoutPoin
 #endif
         }
     }
-
-    // Paint the children.
-    RenderBlockFlow::paintObject(paintInfo, paintOffset);
 }
 
 void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -52,6 +52,7 @@ private:
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
     void computePreferredLogicalWidths() override;
     void paintObject(PaintInfo&, const LayoutPoint&) override;
+    void paintControl(PaintInfo&, const LayoutPoint&);
 
     int maxFilenameWidth() const;
     


### PR DESCRIPTION
#### 91f56dce7de3dc8cdecbc8c8fe355c8e6a9ca347
<pre>
Interaction regions for file and range inputs are incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=247645">https://bugs.webkit.org/show_bug.cgi?id=247645</a>

Reviewed by Aditya Keerthi.

* LayoutTests/interaction-region/input-type-file-region-expected.txt: Added.
* LayoutTests/interaction-region/input-type-file-region.html: Added.
* LayoutTests/interaction-region/input-type-range-region-expected.txt: Added.
* LayoutTests/interaction-region/input-type-range-region.html: Added.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::willRespondToMouseClickEventsWithEditability const):
Responding to &quot;DOMActivate&quot; should count as responding to mouse-click,
like on macOS, because it is. I propagated this unnecessary behavior difference
forward in an earlier patch (251077@main), now it&apos;s time to unify the two platforms.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowElement):
(WebCore::shouldAllowNonPointerCursorForElement):
(WebCore::interactionRegionForRenderedRegion):
Disallow &lt;input type=&quot;file&quot;&gt; and &lt;input type=&quot;range&quot;&gt; from themselves generating
interaction regions; they defer to their inner button and thumb as the primary
interactible parts, respectively.

Ensure that the range thumb does generate a interaction region, even though
it uses the default cursor style, not a hand cursor.

* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::paintObject):
(WebCore::RenderFileUploadControl::paintControl):
* Source/WebCore/rendering/RenderFileUploadControl.h:
RenderFileUploadControl previously did not generate *any* event regions of any
kind, because it aggressively cuts off painting if painting is disabled
(as it is for an event region painting pass). Call the parent class&apos;s implementation
of paintObject() even when painting is disabled, so it can emit event regions.

Canonical link: <a href="https://commits.webkit.org/256467@main">https://commits.webkit.org/256467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e677e526548aa3b42ea8f9f3950c97ecf4af8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105436 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5219 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/33884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88249 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/101267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101537 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39616 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/37298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4468 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/63/builds/41461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39721 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->