### PR TITLE
onorientationchange and orientation attributes must be present unconditionally even on platforms without orientation change

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compat/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/idlharness.window-expected.txt
@@ -22,10 +22,10 @@ PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
-FAIL HTMLBodyElement interface: attribute onorientationchange assert_true: The prototype object must have a property "onorientationchange" expected true got false
-FAIL HTMLBodyElement interface: document.body must inherit property "onorientationchange" with the proper type assert_inherits: property "onorientationchange" not found in prototype chain
-FAIL Window interface: attribute orientation assert_own_property: The global object must have a property "orientation" expected property "orientation" missing
-FAIL Window interface: attribute onorientationchange assert_own_property: The global object must have a property "onorientationchange" expected property "onorientationchange" missing
-FAIL Window interface: window must inherit property "orientation" with the proper type assert_own_property: expected property "orientation" missing
-FAIL Window interface: window must inherit property "onorientationchange" with the proper type assert_own_property: expected property "onorientationchange" missing
+PASS HTMLBodyElement interface: attribute onorientationchange
+PASS HTMLBodyElement interface: document.body must inherit property "onorientationchange" with the proper type
+PASS Window interface: attribute orientation
+PASS Window interface: attribute onorientationchange
+PASS Window interface: window must inherit property "orientation" with the proper type
+PASS Window interface: window must inherit property "onorientationchange" with the proper type
 

--- a/Source/WebCore/html/HTMLBodyElement+Compat.idl
+++ b/Source/WebCore/html/HTMLBodyElement+Compat.idl
@@ -25,6 +25,5 @@
 
 // https://compat.spec.whatwg.org/#windoworientation-interface
 partial interface HTMLBodyElement {
-    // FIXME: This should enabled unconditionally for compatibility.
-    [Conditional=ORIENTATION_EVENTS, WindowEventHandler] attribute EventHandler onorientationchange;
+    [WindowEventHandler] attribute EventHandler onorientationchange;
 };

--- a/Source/WebCore/page/DOMWindow+Compat.idl
+++ b/Source/WebCore/page/DOMWindow+Compat.idl
@@ -24,10 +24,7 @@
  */
 
 // https://compat.spec.whatwg.org/#windoworientation-interface
-[
-    // FIXME: These should enabled unconditionally for compatibility.
-    Conditional=ORIENTATION_EVENTS
-] partial interface DOMWindow {
+partial interface DOMWindow {
     readonly attribute short orientation;
     [WindowEventHandler] attribute EventHandler onorientationchange;
 };

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -645,18 +645,17 @@ ExceptionOr<RefPtr<Element>> DOMWindow::matchingElementInFlatTree(Node& scope, c
     return RefPtr<Element> { nullptr };
 }
 
-#if ENABLE(ORIENTATION_EVENTS)
-
 int DOMWindow::orientation() const
 {
+#if !ENABLE(ORIENTATION_EVENTS)
+    return 0;
+#else
     auto* frame = this->frame();
     if (!frame)
         return 0;
-
     return frame->orientation();
-}
-
 #endif
+}
 
 Screen& DOMWindow::screen()
 {

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -347,12 +347,10 @@ public:
     ExceptionOr<Ref<NodeList>> collectMatchingElementsInFlatTree(Node&, const String& selectors);
     ExceptionOr<RefPtr<Element>> matchingElementInFlatTree(Node&, const String& selectors);
 
-#if ENABLE(ORIENTATION_EVENTS)
     // This is the interface orientation in degrees. Some examples are:
     //  0 is straight up; -90 is when the device is rotated 90 clockwise;
     //  90 is when rotated counter clockwise.
     int orientation() const;
-#endif
 
     Performance& performance() const;
     WEBCORE_EXPORT ReducedResolutionSeconds nowTimestamp() const;


### PR DESCRIPTION
#### 052d5b6a2ca083a096c425d601b79b95c98d6ac8
<pre>
onorientationchange and orientation attributes must be present unconditionally even on platforms without orientation change
<a href="https://bugs.webkit.org/show_bug.cgi?id=247646">https://bugs.webkit.org/show_bug.cgi?id=247646</a>
rdar://problem/102110117

Reviewed by Chris Dumez.

* LayoutTests/imported/w3c/web-platform-tests/compat/idlharness.window-expected.txt:
Expect more PASS.

* Source/WebCore/html/HTMLBodyElement+Compat.idl: Remove the ORIENTATION_EVENTS conditional.
* Source/WebCore/page/DOMWindow+Compat.idl: Ditto.

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::orientation const): Compile unconditionally, return 0 for
!ENABLE(ORIENTATION_EVENTS).

* Source/WebCore/page/DOMWindow.h: Remote conditional around orientation function.

Canonical link: <a href="https://commits.webkit.org/256469@main">https://commits.webkit.org/256469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed44c464536df3b41799979cae134a7bf3b9f1e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105423 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5204 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33871 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101255 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101520 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82467 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30870 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73703 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39601 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37285 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20459 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4470 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39711 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->