### PR TITLE
-webkit-radial-gradient parsing accidentally treats a number of mandatory commas as optional

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-gradient-comma-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compat/webkit-gradient-comma-expected.txt
@@ -1,4 +1,4 @@
 
 PASS -webkit-radial-gradient accepts comma before color stops.
-FAIL -webkit-radial-gradient rejects missing comma before color stops. assert_false: expected false got true
+PASS -webkit-radial-gradient rejects missing comma before color stops.
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -3671,29 +3671,27 @@ static RefPtr<CSSValue> consumePrefixedRadialGradient(CSSParserTokenRange& range
         extentKeyword = consumeIdentUsingMapping(range, extentMap);
         if (!shapeKeyword)
             shapeKeyword = consumeIdentUsingMapping(range, shapeMap);
+        if (shapeKeyword || extentKeyword) {
+            if (!consumeCommaIncludingWhitespace(range))
+                return nullptr;
+        }
     }
 
     CSSPrefixedRadialGradientValue::GradientBox gradientBox = std::monostate { };
 
     if (shapeKeyword && extentKeyword) {
-        consumeCommaIncludingWhitespace(range);
-
         gradientBox = CSSPrefixedRadialGradientValue::ShapeAndExtent { *shapeKeyword, *extentKeyword };
     } else if (shapeKeyword) {
-        consumeCommaIncludingWhitespace(range);
-
         gradientBox = *shapeKeyword;
     } else if (extentKeyword) {
-        consumeCommaIncludingWhitespace(range);
-
         gradientBox = *extentKeyword;
     } else {
         if (auto length1 = consumeLengthOrPercent(range, context.mode, ValueRange::NonNegative)) {
             auto length2 = consumeLengthOrPercent(range, context.mode, ValueRange::NonNegative);
             if (!length2)
                 return nullptr;
-            consumeCommaIncludingWhitespace(range);
-
+            if (!consumeCommaIncludingWhitespace(range))
+                return nullptr;
             gradientBox = CSSPrefixedRadialGradientValue::MeasuredSize { { length1.releaseNonNull(), length2.releaseNonNull() } };
         }
     }
@@ -3703,14 +3701,8 @@ static RefPtr<CSSValue> consumePrefixedRadialGradient(CSSParserTokenRange& range
         return nullptr;
 
     auto colorInterpolationMethod = CSSGradientColorInterpolationMethod::legacyMethod(gradientAlphaPremultiplication(context));
-    return CSSPrefixedRadialGradientValue::create({
-            WTFMove(gradientBox),
-            WTFMove(position)
-        },
-        repeating,
-        colorInterpolationMethod,
-        WTFMove(*stops)
-    );
+    return CSSPrefixedRadialGradientValue::create({ WTFMove(gradientBox), WTFMove(position) },
+        repeating, colorInterpolationMethod, WTFMove(*stops));
 }
 
 static CSSGradientColorInterpolationMethod computeGradientColorInterpolationMethod(const CSSParserContext& context, std::optional<ColorInterpolationMethod> parsedColorInterpolationMethod, const CSSGradientColorStopList& stops)


### PR DESCRIPTION
#### a62f77706c4f564444d9f5a36a1e0a295d050692
<pre>
-webkit-radial-gradient parsing accidentally treats a number of mandatory commas as optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=247649">https://bugs.webkit.org/show_bug.cgi?id=247649</a>
rdar://problem/102111231

Reviewed by Sam Weinig.

* LayoutTests/imported/w3c/web-platform-tests/compat/webkit-gradient-comma-expected.txt:
Expect PASS.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumePrefixedRadialGradient): Rearranged the comma parsing
so it matches the grammar, and fail if the commas are missing.

Canonical link: <a href="https://commits.webkit.org/256468@main">https://commits.webkit.org/256468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bcb92c2a7ee1852d06a193f3295bbb95ca3e2a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105426 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/165743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5208 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33874 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88239 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/101257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101524 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82470 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39605 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41458 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39712 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->