### PR TITLE
Segfault in JSC::IdentifierArena::makeBigIntDecimalIdentifier

### DIFF
--- a/JSTests/stress/bigdecimal-identifiers-fail-on-oom.js
+++ b/JSTests/stress/bigdecimal-identifiers-fail-on-oom.js
@@ -1,0 +1,20 @@
+function foo() {
+    let m = new WebAssembly.Memory({initial: 1000});
+    try {
+        foo();
+    } catch {}
+    for (let i = 0; i < 1000; i++) {
+        new Uint8Array(i);
+    }
+}
+
+try {
+    foo();
+} catch {}
+
+try {
+    eval('class C{0x1n');
+} catch (e) {
+    if (!(e instanceof SyntaxError))
+        throw e;
+}

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -1316,7 +1316,8 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                     wasString = true;
                     break;
                 case BIGINT:
-                    propertyName = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    propertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                    failIfFalse(propertyName, "Cannot parse big int property name");
                     break;
                 case OPENBRACKET:
                     next();
@@ -3054,8 +3055,8 @@ parseMethod:
             next();
             break;
         case BIGINT:
-            ident = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
-            ASSERT(ident);
+            ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+            failIfFalse(ident, "Cannot parse big int property name");
             next();
             break;
         case ESCAPED_KEYWORD:
@@ -3316,8 +3317,8 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
                 next();
                 break;
             case BIGINT:
-                ident = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
-                ASSERT(ident);
+                ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+                failIfFalse(ident, "Cannot parse big int property name");
                 next();
                 break;
             case DOUBLE:
@@ -4613,7 +4614,8 @@ namedProperty:
         return context.createProperty(const_cast<VM&>(m_vm), m_parserArena, propertyName, node, PropertyNode::Constant, SuperBinding::NotNeeded, ClassElementTag::No);
     }
     case BIGINT: {
-        const Identifier* ident = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        const Identifier* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        failIfFalse(ident, "Cannot parse big int property name");
         next();
 
         if (match(OPENPAREN)) {
@@ -4705,7 +4707,8 @@ template <class TreeBuilder> TreeProperty Parser<LexerType>::parseGetterSetter(T
         numericPropertyName = m_token.m_data.doubleValue;
         next();
     } else if (match(BIGINT)) {
-        stringPropertyName = &m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        stringPropertyName = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
+        failIfFalse(stringPropertyName, "Cannot parse big int property name");
         next();
     } else if (match(OPENBRACKET)) {
         next();

--- a/Source/JavaScriptCore/parser/ParserArena.cpp
+++ b/Source/JavaScriptCore/parser/ParserArena.cpp
@@ -79,15 +79,21 @@ void ParserArena::allocateFreeablePool()
     ASSERT(freeablePool() == pool);
 }
 
-const Identifier& IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Identifier& identifier, uint8_t radix)
+const Identifier* IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Identifier& identifier, uint8_t radix)
 {
     if (radix == 10)
-        return identifier;
+        return &identifier;
 
     DeferTermination deferScope(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
     JSValue bigInt = JSBigInt::parseInt(nullptr, vm, identifier.string(), radix, JSBigInt::ErrorParseMode::ThrowExceptions, JSBigInt::ParseIntSign::Unsigned);
     scope.assertNoException();
+
+    if (bigInt.isEmpty()) {
+        // Handle out-of-memory or other failures by returning null, since
+        // we don't have a global object to throw exceptions to in this scope.
+        return nullptr;
+    }
 
     // FIXME: We are allocating a JSBigInt just to be able to use
     // JSBigInt::tryGetString when radix is not 10.
@@ -106,7 +112,7 @@ const Identifier& IdentifierArena::makeBigIntDecimalIdentifier(VM& vm, const Ide
         heapBigInt = bigInt.asHeapBigInt();
 
     m_identifiers.append(Identifier::fromString(vm, JSBigInt::tryGetString(vm, heapBigInt, 10)));
-    return m_identifiers.last();
+    return &m_identifiers.last();
 }
 
 const Identifier& IdentifierArena::makePrivateIdentifier(VM& vm, ASCIILiteral prefix, unsigned identifier)

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -50,7 +50,7 @@ namespace JSC {
         ALWAYS_INLINE const Identifier& makeIdentifierLCharFromUChar(VM&, const UChar* characters, size_t length);
         ALWAYS_INLINE const Identifier& makeIdentifier(VM&, SymbolImpl*);
 
-        const Identifier& makeBigIntDecimalIdentifier(VM&, const Identifier&, uint8_t radix);
+        const Identifier* makeBigIntDecimalIdentifier(VM&, const Identifier&, uint8_t radix);
         const Identifier& makeNumericIdentifier(VM&, double number);
         const Identifier& makePrivateIdentifier(VM&, ASCIILiteral, unsigned);
 


### PR DESCRIPTION
#### 32b9728139794e15d690f5a3b43dbd9f8162e6ee
<pre>
Segfault in JSC::IdentifierArena::makeBigIntDecimalIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=247644">https://bugs.webkit.org/show_bug.cgi?id=247644</a>
rdar://98566429

Reviewed by Mark Lam and Yusuke Suzuki.

We currently get a segfault because the parser for bigdecimal identifiers allocates a JSBigInt, which
might cause us to run out of memory. The parser doesn&apos;t throw arbitrary exceptions elsewhere, so instead
of throwing out-of-memory as an exception, it just produces an empty JSBigInt and crashes when using it.
This patch addresses the issue by making the result of makeBigIntDecimalIdentifier nullable, checking for
it in the parser, and failing with a SyntaxError if the identifier could not be created.

* JSTests/stress/bigdecimal-identifiers-fail-on-oom.js: Added.
(foo):
* Source/JavaScriptCore/parser/Lexer.cpp:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseClassFieldInitializerSourceElements):
(JSC::Parser&lt;LexerType&gt;::parseProperty):
(JSC::Parser&lt;LexerType&gt;::parseGetterSetter):
* Source/JavaScriptCore/parser/ParserArena.cpp:
(JSC::IdentifierArena::makeBigIntDecimalIdentifier):
* Source/JavaScriptCore/parser/ParserArena.h:

Canonical link: <a href="https://commits.webkit.org/256501@main">https://commits.webkit.org/256501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acf8bbfd5e857488956f8d46117d87a734ed4451

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105448 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165768 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5235 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33904 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101279 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3854 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82495 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30886 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73719 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86919 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39629 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82260 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37310 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20481 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28217 "Found 5 new JSC stress test failures: stress/bigdecimal-identifiers-fail-on-oom.js.bytecode-cache, stress/bigdecimal-identifiers-fail-on-oom.js.default, stress/bigdecimal-identifiers-fail-on-oom.js.mini-mode, stress/bigdecimal-identifiers-fail-on-oom.js.no-cjit-collect-continuously, stress/bigdecimal-identifiers-fail-on-oom.js.no-cjit-validate-phases (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43108 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84938 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2165 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39735 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19184 "Passed tests") | 
<!--EWS-Status-Bubble-End-->