### PR TITLE
(DO NOT MERGE) Remove idlharness.window test failure expectation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speech-api/idlharness.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/speech-api/idlharness.window.js
@@ -11,9 +11,11 @@ function getVoices() {
   return new Promise(resolve => {
     const voices = speechSynthesis.getVoices();
     if (voices.length) {
+        console.log('resolved sync');
         resolve(voices);
     } else {
         // wait for voiceschanged event
+        console.log('waiting for voiceschanged event');
         speechSynthesis.addEventListener('voiceschanged', () => {
           resolve(speechSynthesis.getVoices());
         }, { once: true });

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2303,9 +2303,6 @@ http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-wit
 http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction.html [ Skip ]
 
 
-# rdar://97228542 ([ iOS16 ] imported/w3c/web-platform-tests/speech-api/idlharness.window.html is a constant text failure)
-imported/w3c/web-platform-tests/speech-api/idlharness.window.html [ Failure ]
-
 # rdar://97297483 ([ iOS16 ] fast/events/ios/rotation/zz-no-rotation.html is a constant timeout =)
 fast/events/ios/rotation/zz-no-rotation.html [ Timeout ]
 

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -102,6 +102,7 @@ const Vector<Ref<SpeechSynthesisVoice>>& SpeechSynthesis::getVoices()
     if (!m_voiceList.isEmpty())
         return m_voiceList;
 
+    WTFLogAlways("m_voiceList is empty");
     // If the voiceList is empty, that's the cue to get the voices from the platform again.
     auto& voiceList = m_speechSynthesisClient ? m_speechSynthesisClient->voiceList() : ensurePlatformSpeechSynthesizer().voiceList();
     m_voiceList = voiceList.map([](auto& voice) {
@@ -281,6 +282,7 @@ void SpeechSynthesis::boundaryEventOccurred(bool wordBoundary, unsigned charInde
 
 void SpeechSynthesis::voicesChanged()
 {
+    WTFLogAlways("SpeechSynthesis::voicesChanged");
     voicesDidChange();
 }
 

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.cpp
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.cpp
@@ -34,8 +34,10 @@ const Vector<RefPtr<PlatformSpeechSynthesisVoice>>& PlatformSpeechSynthesizer::v
 {
     if (!m_voiceListIsInitialized) {
         ASSERT(m_voiceList.isEmpty());
+        WTFLogAlways("const_cast<PlatformSpeechSynthesizer*>(this)->initializeVoiceList();");
         const_cast<PlatformSpeechSynthesizer*>(this)->initializeVoiceList();
         const_cast<PlatformSpeechSynthesizer*>(this)->m_voiceListIsInitialized = true;
+        WTFLogAlways("initialized");
     }
     return m_voiceList;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11081,6 +11081,7 @@ void WebPageProxy::speechSynthesisVoiceList(CompletionHandler<void(Vector<WebSpe
     auto result = speechSynthesisData().synthesizer->voiceList().map([](auto& voice) {
         return WebSpeechSynthesisVoice { voice->voiceURI(), voice->name(), voice->lang(), voice->localService(), voice->isDefault() };
     });
+    WTFLogAlways("WebPageProxy::speechSynthesisVoiceList result.size() %lu", result.size());
     completionHandler(WTFMove(result));
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -39,7 +39,9 @@ const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisC
     // FIXME: this message should not be sent synchronously. Instead, the UI process should
     // get the list of voices and pass it on to the WebContent processes, see
     // https://bugs.webkit.org/show_bug.cgi?id=195723
+    WTFLogAlways("Sending sync message to UIProcess Messages::WebPageProxy::SpeechSynthesisVoiceList");
     auto sendResult = m_page.sendSync(Messages::WebPageProxy::SpeechSynthesisVoiceList());
+    WTFLogAlways("received response");
     auto [voiceList] = sendResult.takeReplyOr(Vector<WebSpeechSynthesisVoice> { });
 
     m_voices = voiceList.map([](auto& voice) -> RefPtr<WebCore::PlatformSpeechSynthesisVoice> {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -1750,17 +1750,21 @@ void testSuspendServiceWorkerProcessBasedOnClientProcesses(UseSeparateServiceWor
     [webView2 loadRequest:server.request()];
 
     auto webViewToUpdate = useSeparateServiceWorkerProcess == UseSeparateServiceWorkerProcess::Yes ? webView : webView2;
-    [webViewToUpdate _setThrottleStateForTesting: 1];
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerForegroundActivityForTesting]; }));
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting]; }));
 
-    [webViewToUpdate _setThrottleStateForTesting: 2];
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [webViewToUpdate _hasServiceWorkerForegroundActivityForTesting]; }));
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
+        [webViewToUpdate _setThrottleStateForTesting:1];
+        return ![webViewToUpdate _hasServiceWorkerForegroundActivityForTesting] && [webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting];
+    }));
 
-    [webViewToUpdate _setThrottleStateForTesting: 0];
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerForegroundActivityForTesting]; }));
-    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting]; }));
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
+        [webViewToUpdate _setThrottleStateForTesting:2];
+        return [webViewToUpdate _hasServiceWorkerForegroundActivityForTesting] && ![webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting];
+    }));
+
+    EXPECT_TRUE(waitUntilEvaluatesToTrue([&] {
+        [webViewToUpdate _setThrottleStateForTesting:0];
+        return ![webViewToUpdate _hasServiceWorkerForegroundActivityForTesting] && ![webViewToUpdate _hasServiceWorkerBackgroundActivityForTesting];
+    }));
 
     [webView _close];
     webView = nullptr;


### PR DESCRIPTION
#### 1b35b61148bf1ca58416a5cf0068a8c201a40422
<pre>
Remove idlharness.window test failure expectation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247650">https://bugs.webkit.org/show_bug.cgi?id=247650</a>
rdar://97228542

Reviewed by NOBODY (OOPS!).

The test seems to be passing for me locally.

* LayoutTests/platform/ios-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b35b61148bf1ca58416a5cf0068a8c201a40422

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106138 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166471 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6064 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34606 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102849 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102288 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4528 "Found 1 new test failure: imported/w3c/web-platform-tests/speech-api/idlharness.window.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83215 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31493 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74406 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40337 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19736 "Found 1 new test failure: imported/w3c/web-platform-tests/speech-api/idlharness.window.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38000 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21140 "Found 1 new test failure: imported/w3c/web-platform-tests/speech-api/idlharness.window.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4269 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43682 "Found 1 new test failure: imported/w3c/web-platform-tests/speech-api/idlharness.window.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40416 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->