### PR TITLE
Test addition (243907@main): [ iOS ][ macOS ] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url-workers.window.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/workers/resources/dedicated-worker-lifecycle.js
+++ b/LayoutTests/fast/workers/resources/dedicated-worker-lifecycle.js
@@ -30,7 +30,7 @@ function orphanAllWorkers(callback)
 {
     var i;
     for (i = 0; i < numberOfWorkers; i++) {
-        workers[i].onmessage = 0;
+        workers[i].terminate();
         workers[i] = 0;
     }
     workers = [ ];

--- a/LayoutTests/inspector/worker/worker-create-and-terminate-expected.txt
+++ b/LayoutTests/inspector/worker/worker-create-and-terminate-expected.txt
@@ -22,7 +22,3 @@ Worker - inspector/worker/resources/worker-3.js
 PASS: Worker.workerTerminated
 Worker - inspector/worker/resources/worker-1.js
 
--- Running test case: Worker.workerTerminated.GC
-PASS: Worker.workerTerminated
-No Workers
-

--- a/LayoutTests/inspector/worker/worker-create-and-terminate.html
+++ b/LayoutTests/inspector/worker/worker-create-and-terminate.html
@@ -19,10 +19,6 @@ function terminateWorker3FromWorker() {
     worker3.postMessage("close");
 }
 
-function terminateWorker1ViaCollection() {
-    worker1 = null;
-}
-
 function test()
 {
     let workers = [];
@@ -178,25 +174,6 @@ function test()
 
             await Promise.all([
                 checkInternalProperties(`worker1`, {name: "Worker 1", terminated: false}),
-                checkInternalProperties(`worker2`, {name: "Worker 2", terminated: true}),
-            ]);
-        }
-    });
-
-    suite.addTestCase({
-        name: "Worker.workerTerminated.GC",
-        description: "Should receive a Worker.workerTerminated event when terminating a Worker via Garbage Collection.",
-        async test() {
-            let workerTerminatedPromise = waitForWorkerTerminatedEvent();
-            await ProtocolTest.evaluateInPage("terminateWorker1ViaCollection()");
-            await InspectorProtocol.awaitCommand({method: "Runtime.releaseObjectGroup", params: {objectGroup: "test"}});
-            await InspectorProtocol.awaitCommand({method: "Heap.gc", params: {}});
-            await workerTerminatedPromise;
-
-            ProtocolTest.pass("Worker.workerTerminated");
-            dumpWorkers();
-
-            await Promise.all([
                 checkInternalProperties(`worker2`, {name: "Worker 2", terminated: true}),
             ]);
         }

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3746,8 +3746,6 @@ webkit.org/b/244358 imported/w3c/web-platform-tests/html/cross-origin-opener-pol
 
 webkit.org/b/244501 [ Debug ] webgl/2.0.y/conformance2/state/gl-object-get-calls.html [ Pass Timeout ]
 
-webkit.org/b/244549 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url-workers.window.html [ Pass Failure ]
-
 webkit.org/b/244619 editing/selection/ios/tap-to-set-selection-in-editable-web-view.html [ Pass Timeout ]
 
 webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-context-navigation.https.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2346,8 +2346,6 @@ webkit.org/b/244012 imported/w3c/web-platform-tests/css/css-transforms/transform
 
 webkit.org/b/244014 [ Debug ] imported/w3c/web-platform-tests/html/semantics/document-metadata/the-style-element/style-load-after-mutate.html  [ Pass Failure ]
 
-webkit.org/b/244549 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url-workers.window.html [ Pass Failure ]
-
 # These tests are flaky due to "Blocked access to external URL" messages because we don't support WPT domains.
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html [ DumpJSConsoleLogInStdErr Failure Pass ]
 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ DumpJSConsoleLogInStdErr Failure Pass ]

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -105,13 +105,6 @@ ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& s
     return { };
 }
 
-ExceptionOr<void> DedicatedWorkerGlobalScope::importScripts(const FixedVector<String>& urls)
-{
-    auto result = Base::importScripts(urls);
-    thread().workerObjectProxy().reportPendingActivity(hasPendingActivity());
-    return result;
-}
-
 DedicatedWorkerThread& DedicatedWorkerGlobalScope::thread()
 {
     return static_cast<DedicatedWorkerThread&>(Base::thread());

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -96,7 +96,6 @@ private:
 
     Type type() const final { return Type::DedicatedWorker; }
 
-    ExceptionOr<void> importScripts(const FixedVector<String>& urls) final;
     EventTargetInterface eventTargetInterface() const final;
 
     void prepareForDestruction() final;

--- a/Source/WebCore/workers/DedicatedWorkerThread.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerThread.cpp
@@ -58,11 +58,4 @@ Ref<WorkerGlobalScope> DedicatedWorkerThread::createWorkerGlobalScope(const Work
     return scope;
 }
 
-void DedicatedWorkerThread::runEventLoop()
-{
-    // Notify the parent object of our current active state before calling the superclass to run the event loop.
-    m_workerObjectProxy.reportPendingActivity(globalScope()->hasPendingActivity());
-    WorkerThread::runEventLoop();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/workers/DedicatedWorkerThread.h
+++ b/Source/WebCore/workers/DedicatedWorkerThread.h
@@ -52,7 +52,6 @@ public:
 
 protected:
     Ref<WorkerGlobalScope> createWorkerGlobalScope(const WorkerParameters&, Ref<SecurityOrigin>&&, Ref<SecurityOrigin>&& topOrigin) override;
-    void runEventLoop() override;
 
 private:
     DedicatedWorkerThread(const WorkerParameters&, const ScriptBuffer& sourceCode, WorkerLoaderProxy&, WorkerDebuggerProxy&, WorkerObjectProxy&, WorkerThreadStartMode, const SecurityOrigin& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, JSC::RuntimeFlags);

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -183,7 +183,7 @@ void Worker::resume()
 
 bool Worker::virtualHasPendingActivity() const
 {
-    return m_contextProxy.hasPendingActivity() || m_scriptLoader;
+    return m_scriptLoader || (m_didStartWorkerGlobalScope && !m_contextProxy.askedToTerminate());
 }
 
 void Worker::didReceiveResponse(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
@@ -218,6 +218,7 @@ void Worker::notifyFinished()
     if (auto policy = parseReferrerPolicy(m_scriptLoader->referrerPolicy(), ReferrerPolicySource::HTTPHeader))
         referrerPolicy = *policy;
 
+    m_didStartWorkerGlobalScope = true;
     WorkerInitializationData initializationData {
 #if ENABLE(SERVICE_WORKER)
         m_scriptLoader->takeServiceWorkerData(),

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -112,6 +112,7 @@ private:
     JSC::RuntimeFlags m_runtimeFlags;
     Deque<RefPtr<Event>> m_pendingEvents;
     bool m_wasTerminated { false };
+    bool m_didStartWorkerGlobalScope { false };
     const ScriptExecutionContextIdentifier m_clientIdentifier;
 };
 

--- a/Source/WebCore/workers/WorkerGlobalScopeProxy.h
+++ b/Source/WebCore/workers/WorkerGlobalScopeProxy.h
@@ -56,7 +56,7 @@ public:
     virtual void terminateWorkerGlobalScope() = 0;
     virtual void postMessageToWorkerGlobalScope(MessageWithMessagePorts&&) = 0;
     virtual void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&) = 0;
-    virtual bool hasPendingActivity() const = 0;
+    virtual bool askedToTerminate() const = 0;
     virtual void workerObjectDestroyed() = 0;
     virtual void notifyNetworkStateChange(bool isOnline) = 0;
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -51,7 +51,6 @@ private:
     void terminateWorkerGlobalScope() final;
     void postMessageToWorkerGlobalScope(MessageWithMessagePorts&&) final;
     void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&) final;
-    bool hasPendingActivity() const final;
     void workerObjectDestroyed() final;
     void notifyNetworkStateChange(bool isOnline) final;
     void suspendForBackForwardCache() final;
@@ -62,8 +61,6 @@ private:
     void postMessageToWorkerObject(MessageWithMessagePorts&&) final;
     void postTaskToWorkerObject(Function<void(Worker&)>&&) final;
     void postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL) final;
-    void confirmMessageFromWorkerObject(bool hasPendingActivity) final;
-    void reportPendingActivity(bool hasPendingActivity) final;
     void workerGlobalScopeClosed() final;
     void workerGlobalScopeDestroyed() final;
 
@@ -84,11 +81,9 @@ private:
 
     void workerThreadCreated(DedicatedWorkerThread&);
 
-    // Only use this method on the worker object thread.
-    bool askedToTerminate() const { return m_askedToTerminate; }
+    bool askedToTerminate() const final { return m_askedToTerminate; }
 
     void workerGlobalScopeDestroyedInternal();
-    void reportPendingActivityInternal(bool confirmingMessage, bool hasPendingActivity);
     Worker* workerObject() const { return m_workerObject; }
 
     RefPtr<ScriptExecutionContext> m_scriptExecutionContext;
@@ -98,9 +93,6 @@ private:
     Worker* m_workerObject;
     bool m_mayBeDestroyed { false };
     RefPtr<DedicatedWorkerThread> m_workerThread;
-
-    unsigned m_unconfirmedMessageCount { 0 }; // Unconfirmed messages from worker object to worker thread.
-    bool m_workerThreadHadPendingActivity { false }; // The latest confirmation from worker thread reported that it was still active.
 
     bool m_askedToSuspend { false };
     bool m_askedToTerminate { false };

--- a/Source/WebCore/workers/WorkerObjectProxy.h
+++ b/Source/WebCore/workers/WorkerObjectProxy.h
@@ -44,10 +44,7 @@ class Worker;
 class WorkerObjectProxy : public WorkerReportingProxy {
 public:
     virtual void postMessageToWorkerObject(MessageWithMessagePorts&&) = 0;
-    virtual void postTaskToWorkerObject(Function<void(Worker&)>&&) { };
-
-    virtual void confirmMessageFromWorkerObject(bool hasPendingActivity) = 0;
-    virtual void reportPendingActivity(bool hasPendingActivity) = 0;
+    virtual void postTaskToWorkerObject(Function<void(Worker&)>&&) { }
 
     // No need to notify the parent page context when dedicated workers are closing.
     void workerGlobalScopeClosed() override { }

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -71,8 +71,6 @@ private:
     void postExceptionToWorkerObject(const String&, int, int, const String&) final { };
     void workerGlobalScopeDestroyed() final { };
     void postMessageToWorkerObject(MessageWithMessagePorts&&) final { };
-    void confirmMessageFromWorkerObject(bool) final { };
-    void reportPendingActivity(bool) final { };
 };
 
 // FIXME: Use a valid WorkerReportingProxy
@@ -145,7 +143,6 @@ static void fireMessageEvent(ServiceWorkerGlobalScope& scope, MessageWithMessage
     auto ports = MessagePort::entanglePorts(scope, WTFMove(message.transferredPorts));
     auto messageEvent = ExtendableMessageEvent::create(WTFMove(ports), WTFMove(message.message), SecurityOriginData::fromURL(sourceURL).toString(), { }, source);
     scope.dispatchEvent(messageEvent);
-    scope.thread().workerObjectProxy().confirmMessageFromWorkerObject(scope.hasPendingActivity());
     scope.updateExtendedEventsSet(messageEvent.ptr());
 }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -67,8 +67,6 @@ private:
     void postMessageToWorkerObject(MessageWithMessagePorts&&) final { }
     void workerGlobalScopeDestroyed() final { }
     void workerGlobalScopeClosed() final;
-    void confirmMessageFromWorkerObject(bool) final { }
-    void reportPendingActivity(bool) final { }
 
     // WorkerLoaderProxy.
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;


### PR DESCRIPTION
#### 6a2efe71cf30402d9fd66706ccbf59d27363cdca
<pre>
Test addition (243907@main): [ iOS ][ macOS ] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/blob-url-workers.window.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244549">https://bugs.webkit.org/show_bug.cgi?id=244549</a>
rdar://99341974

Reviewed by Geoffrey Garen.

The test was flaky because the Worker object was getting garbage collected too
aggressively and message event listeners on the Worker object wouldn&apos;t get
called as a result.

Basically, the worker can fire events as long as:
1. Its script is being loaded
2. Its script is running since the script can post messages at any point

This patch updates Worker::virtualHasPendingActivity() accordingly to address
the issue.

Our new behavior seems more inline with the specification [1] and Blink.

[1] <a href="https://html.spec.whatwg.org/#the-worker&apos">https://html.spec.whatwg.org/#the-worker&apos</a>;s-lifetime

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::virtualHasPendingActivity const):
(WebCore::Worker::notifyFinished):
* Source/WebCore/workers/Worker.h:

Canonical link: <a href="https://commits.webkit.org/256496@main">https://commits.webkit.org/256496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2439ef0893b09604b578ba3ad4d0232aeaac66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105508 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165831 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5302 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33960 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101336 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101610 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82556 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30948 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39689 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41866 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39795 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->