### PR TITLE
Create a temporary grid for computing intrinsic sizes.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1544,6 +1544,7 @@ webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-4.html [ ImageOnlyFailure ]
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-5.html [ ImageOnlyFailure ]
 webkit.org/b/216145 imported/w3c/web-platform-tests/css/css-grid/alignment/grid-item-no-aspect-ratio-stretch-6.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-repeat-max-width-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/234879 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-intrinsic-maximums.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-contribution-003.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3201,8 +3201,6 @@ webkit.org/b/212218 webrtc/datachannel/gather-candidates-networkprocess-crash.ht
 webkit.org/b/212226 imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-008.html [ ImageOnlyFailure ]
 webkit.org/b/212227 imported/w3c/web-platform-tests/css/css-grid/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-repeat-max-width-001.html [ ImageOnlyFailure ]
-
 fast/text/text-styles/-apple-system [ Pass ]
 
 webkit.org/b/214155 imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/blob.https.html [ Pass Timeout Failure ]

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -216,7 +216,7 @@ LayoutUnit GridTrackSizingAlgorithm::computeTrackBasedSize() const
     for (auto& track : allTracks)
         size += track.baseSize();
 
-    size += m_renderGrid->guttersSize(m_grid, m_direction, 0, allTracks.size(), availableSpace());
+    size += m_renderGrid->guttersSize(m_direction, 0, allTracks.size(), availableSpace());
 
     return size;
 }
@@ -471,7 +471,7 @@ void GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems(const Gri
         if (filteredTracks.isEmpty())
             continue;
 
-        spanningTracksSize += m_renderGrid->guttersSize(m_grid, m_direction, itemSpan.startLine(), itemSpan.integerSpan(), availableSpace());
+        spanningTracksSize += m_renderGrid->guttersSize(m_direction, itemSpan.startLine(), itemSpan.integerSpan(), availableSpace());
 
         LayoutUnit extraSpace = itemSizeForTrackSizeComputationPhase(phase, gridItemWithSpan.gridItem()) - spanningTracksSize;
         extraSpace = std::max<LayoutUnit>(extraSpace, 0);
@@ -615,7 +615,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForC
             gridAreaSize += valueForLength(maxTrackSize.length(), availableSize.value_or(0_lu));
     }
 
-    gridAreaSize += m_renderGrid->guttersSize(m_grid, direction, span.startLine(), span.integerSpan(), availableSize);
+    gridAreaSize += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSize);
 
     GridTrackSizingDirection childInlineDirection = GridLayoutFunctions::flowAwareDirectionForChild(*m_renderGrid, child, ForColumns);
     if (gridAreaIsIndefinite)
@@ -630,11 +630,11 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForChild(cons
     // To determine the column track's size based on an orthogonal grid item we need it's logical
     // height, which may depend on the row track's size. It's possible that the row tracks sizing
     // logic has not been performed yet, so we will need to do an estimation.
-    if (direction == ForRows && (m_sizingState == ColumnSizingFirstIteration || m_sizingState == ColumnSizingExtraIterationForSizeContainment || m_sizingState == ColumnSizingSecondIteration)) {
+    if (direction == ForRows && (m_sizingState == ColumnSizingFirstIteration || m_sizingState == ColumnSizingSecondIteration)) {
         ASSERT(GridLayoutFunctions::isOrthogonalChild(*m_renderGrid, child));
         // FIXME (jfernandez) Content Alignment should account for this heuristic.
         // https://github.com/w3c/csswg-drafts/issues/2697
-        if (m_sizingState == ColumnSizingFirstIteration || m_sizingState == ColumnSizingExtraIterationForSizeContainment)
+        if (m_sizingState == ColumnSizingFirstIteration)
             return estimatedGridAreaBreadthForChild(child, ForRows);
         addContentAlignmentOffset = true;
     }
@@ -648,7 +648,7 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForChild(cons
     if (addContentAlignmentOffset)
         gridAreaBreadth += (span.integerSpan() - 1) * m_renderGrid->gridItemOffset(direction);
 
-    gridAreaBreadth += m_renderGrid->guttersSize(m_grid, direction, span.startLine(), span.integerSpan(), availableSpace(direction));
+    gridAreaBreadth += m_renderGrid->guttersSize(direction, span.startLine(), span.integerSpan(), availableSpace(direction));
 
     return gridAreaBreadth;
 }
@@ -1105,7 +1105,7 @@ void IndefiniteSizeStrategy::accumulateFlexFraction(double& flexFraction, GridIt
         GridSpan span = m_algorithm.renderGrid()->gridSpanForChild(*gridItem, outermostDirection);
 
         // Removing gutters from the max-content contribution of the item, so they are not taken into account in FindFrUnitSize().
-        LayoutUnit leftOverSpace = maxContentForChild(*gridItem) - renderGrid()->guttersSize(m_algorithm.grid(), outermostDirection, span.startLine(), span.integerSpan(), availableSpace());
+        LayoutUnit leftOverSpace = maxContentForChild(*gridItem) - renderGrid()->guttersSize(outermostDirection, span.startLine(), span.integerSpan(), availableSpace());
         flexFraction = std::max(flexFraction, findFrUnitSize(span, leftOverSpace));
     }
 }
@@ -1155,7 +1155,7 @@ bool IndefiniteSizeStrategy::recomputeUsedFlexFractionIfNeeded(double& flexFract
 
     LayoutUnit freeSpace = checkMaxSize ? maxSize.value() : -1_lu;
     const Grid& grid = m_algorithm.grid();
-    freeSpace = std::max(freeSpace, minSize.value_or(0_lu)) - renderGrid->guttersSize(grid, ForRows, 0, grid.numTracks(ForRows), availableSpace());
+    freeSpace = std::max(freeSpace, minSize.value_or(0_lu)) - renderGrid->guttersSize(ForRows, 0, grid.numTracks(ForRows), availableSpace());
 
     size_t numberOfTracks = m_algorithm.tracks(ForRows).size();
     flexFraction = findFrUnitSize(GridSpan::translatedDefiniteGridSpan(0, numberOfTracks), freeSpace);
@@ -1450,9 +1450,6 @@ void GridTrackSizingAlgorithm::advanceNextState()
 {
     switch (m_sizingState) {
     case ColumnSizingFirstIteration:
-        m_sizingState = m_strategy->isComputingSizeContainment() || m_strategy->isComputingInlineSizeContainment() ? ColumnSizingExtraIterationForSizeContainment : RowSizingFirstIteration;
-        return;
-    case ColumnSizingExtraIterationForSizeContainment:
         m_sizingState = RowSizingFirstIteration;
         return;
     case RowSizingFirstIteration:
@@ -1476,7 +1473,6 @@ bool GridTrackSizingAlgorithm::isValidTransition() const
 {
     switch (m_sizingState) {
     case ColumnSizingFirstIteration:
-    case ColumnSizingExtraIterationForSizeContainment:
     case ColumnSizingSecondIteration:
         return m_direction == ForColumns;
     case RowSizingFirstIteration:
@@ -1511,7 +1507,7 @@ void GridTrackSizingAlgorithm::setup(GridTrackSizingDirection direction, unsigne
     m_autoSizedTracksForStretchIndex.shrink(0);
 
     if (availableSpace) {
-        LayoutUnit guttersSize = m_renderGrid->guttersSize(m_grid, direction, 0, m_grid.numTracks(direction), this->availableSpace(direction));
+        LayoutUnit guttersSize = m_renderGrid->guttersSize(direction, 0, m_grid.numTracks(direction), this->availableSpace(direction));
         setFreeSpace(direction, *availableSpace - guttersSize);
     } else
         setFreeSpace(direction, std::nullopt);

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -242,7 +242,6 @@ private:
 
     enum SizingState {
         ColumnSizingFirstIteration,
-        ColumnSizingExtraIterationForSizeContainment,
         RowSizingFirstIteration,
         RowSizingExtraIterationForSizeContainment,
         ColumnSizingSecondIteration,


### PR DESCRIPTION
#### 7b600312f1e13c3d54289a9280d12c91ca123641
<pre>
Create a temporary grid for computing intrinsic sizes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247653">https://bugs.webkit.org/show_bug.cgi?id=247653</a>
&lt;rdar://101965460&gt;

Reviewed by Alan Baradlay.

Reverts r249006.

r249006 switched this code from using a temporary Grid during computeIntrinsicLogicalWidths to instead mutate the layout Grid if a layout was pending. If no layout was
pending, it used cached values from the previous layout.

This was to solve an issue with subgrid, where the sizing algorithm could recurse into nested subgrids, which in turn could recurse back into the original grid. The temporary
stack-based Grid wouldn&apos;t be available through this deeply nested callstack and the code defaulted back to the layout grid. Switching Grids mid-sizing caused incorrect sizes to
be computed.

This unforuntately still doesn&apos;t work, since we&apos;re not expecting computeInstrinsicLogicalWidths to have potential side-effects, even if layout was pending.

This change reverts r249006 and instead adds m_currentGrid so that the stack-based temporary Grid is available, without needing to pass it as a parameter. The real layout
Grid is put inside a private wrapper, so that callers can&apos;t accidentally use it, and must always use the &apos;current&apos; grid.

No test unfortunately, but this was causing issues on humble bundle with grids nested inside flexbox, where we trigger repeated layouts (and they weren&apos;t idempotent due to
this bug).

* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::computeTrackBasedSize const):
(WebCore::GridTrackSizingAlgorithm::increaseSizesToAccommodateSpanningItems):
(WebCore::GridTrackSizingAlgorithm::estimatedGridAreaBreadthForChild const):
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForChild const):
(WebCore::IndefiniteSizeStrategy::accumulateFlexFraction const):
(WebCore::IndefiniteSizeStrategy::recomputeUsedFlexFractionIfNeeded const):
(WebCore::GridTrackSizingAlgorithm::setup):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::RenderGrid):
(WebCore::RenderGrid::computeTrackSizesForDefiniteSize):
(WebCore::RenderGrid::canPerformSimplifiedLayout const):
(WebCore::RenderGrid::layoutBlock):
(WebCore::RenderGrid::guttersSize const):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::computeTrackSizesForIndefiniteSize const):
(WebCore::RenderGrid::computeEmptyTracksForAutoRepeat const):
(WebCore::RenderGrid::placeItems):
(WebCore::RenderGrid::placeItemsOnGrid):
(WebCore::RenderGrid::populateExplicitGridAndOrderIterator):
(WebCore::RenderGrid::createEmptyGridAreaAtSpecifiedPositionsOutsideGrid const):
(WebCore::RenderGrid::placeSpecifiedMajorAxisItemsOnGrid):
(WebCore::RenderGrid::placeAutoMajorAxisItemsOnGrid):
(WebCore::RenderGrid::placeAutoMajorAxisItemOnGrid):
(WebCore::RenderGrid::dirtyGrid):
(WebCore::RenderGrid::trackSizesForComputedStyle const):
(WebCore::RenderGrid::layoutGridItems):
(WebCore::RenderGrid::gridAreaBreadthForChildIncludingAlignmentOffsets const):
(WebCore::RenderGrid::populateGridPositionsForDirection):
(WebCore::RenderGrid::firstLineBaseline const):
(WebCore::RenderGrid::lastLineBaseline const):
(WebCore::RenderGrid::getBaselineChild const):
(WebCore::RenderGrid::currentGrid const):
(WebCore::RenderGrid::currentGrid):
(WebCore::RenderGrid::gridAreaBreadthForOutOfFlowChild):
(WebCore::RenderGrid::gridAreaPositionForInFlowChild const):
(WebCore::RenderGrid::nonCollapsedTracks const):
(WebCore::RenderGrid::numTracks const):
(WebCore::RenderGrid::paintChildren):
(WebCore::RenderGrid::computeGridPositionsForOutOfFlowChild const):
(WebCore::RenderGrid::gridSpanForOutOfFlowChild const):
(WebCore::RenderGrid::GridWrapper::GridWrapper):
(WebCore::RenderGrid::GridWrapper::resetCurrentGrid const):
(WebCore::RenderGrid::placeItemsOnGrid const): Deleted.
(WebCore::RenderGrid::populateExplicitGridAndOrderIterator const): Deleted.
(WebCore::RenderGrid::placeSpecifiedMajorAxisItemsOnGrid const): Deleted.
(WebCore::RenderGrid::placeAutoMajorAxisItemsOnGrid const): Deleted.
(WebCore::RenderGrid::placeAutoMajorAxisItemOnGrid const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/256624@main">https://commits.webkit.org/256624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0468d8172fc05581143c38116a0517810dbdd136

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105922 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5800 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34379 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102648 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102050 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82979 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31299 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74181 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40109 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37783 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20928 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4597 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/2812 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40197 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->