### PR TITLE
Test addition (247071@main): [ macOS wk1 Debug ] Two imported/w3c/web-platform-tests/xhr/ tests are a flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -561,9 +561,6 @@ http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-inse
 # WK1 networking is blocked by JS
 imported/w3c/web-platform-tests/xhr/xhr-timeout-longtask.any.html
 
-webkit.org/b/244715 [ Debug ] imported/w3c/web-platform-tests/xhr/request-content-length.any.worker.html [ Pass Failure ]
-webkit.org/b/244715 [ Debug ] imported/w3c/web-platform-tests/xhr/request-content-length.any.html [ Pass Failure ]
-
 webkit.org/b/187230 editing/mac/pasteboard/can-copy-url-without-title.html [ Skip ]
 
 ### END OF (1) Failures with bug reports

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -254,6 +254,7 @@ private:
     RefPtr<UserGestureToken> m_userGestureToken;
     TaskCancellationGroup m_pendingAbortEvent;
     std::atomic<bool> m_hasRelevantEventListener;
+    bool m_wasDidSendDataCalledForTotalBytes { false };
 };
 
 inline auto XMLHttpRequest::responseType() const -> ResponseType


### PR DESCRIPTION
#### 7cfb84288e855e7c3bf1f79692523a06f450ab0b
<pre>
Test addition (247071@main): [ macOS wk1 Debug ] Two imported/w3c/web-platform-tests/xhr/ tests are a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=244715">https://bugs.webkit.org/show_bug.cgi?id=244715</a>
rdar://99492054

Reviewed by Geoffrey Garen.

The issue is that CFNetwork doesn&apos;t reliably calls didSendData() before calling
didFinishLoad(). As a result, it is possible for a XMLHttpRequest upload to be
marked as DONE without getting any progress events on XMLHttpRequest.upload.

This was causing the test to fail flakily since it verified that at least
one `progress` event get fired at `XMLHttpRequest.upload` before the XHR is
marked as DONE.

To address the issue, we now explicitly call didSendData(bodySize) inside
didFinishLoading() if didSendData() wasn&apos;t called yet.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::didFinishLoading):
(WebCore::XMLHttpRequest::didSendData):
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/256512@main">https://commits.webkit.org/256512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfc1322b0033aac626935076f4a9a23c1779fd26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105533 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165854 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/99951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5329 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33983 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101356 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82578 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30972 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73805 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39714 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4503 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39817 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->