### PR TITLE
REGRESSION (r278062): Multiple backgrounds with "background-blend-mode: difference" breaks

### DIFF
--- a/LayoutTests/fast/backgrounds/background-blend-mode-difference-expected.html
+++ b/LayoutTests/fast/backgrounds/background-blend-mode-difference-expected.html
@@ -1,0 +1,16 @@
+<style>
+    .checkboard {
+        background-image:
+            linear-gradient(45deg, black 25%, transparent 25%, transparent 75%, black 75%, black),
+            linear-gradient(45deg, black 25%, transparent 25%, transparent 75%, black 75%, black);
+        background-position: 0 0, 50px 50px;
+        background-size: 25% 25%;
+        outline: 2px solid red;
+        height: 400px;
+        width: 400px;
+
+    }
+</style>
+<body>
+    <div class="checkboard"></div>
+</body>

--- a/LayoutTests/fast/backgrounds/background-blend-mode-difference.html
+++ b/LayoutTests/fast/backgrounds/background-blend-mode-difference.html
@@ -1,0 +1,16 @@
+<meta name="fuzzy" content="maxDifference=2; totalPixels=86920-102000" />
+<style>
+    .checkboard {
+        background-blend-mode: difference;
+        background-image:
+            linear-gradient(to bottom, white 50%, black 50%),
+            linear-gradient(to right, black 50%, white 50%);
+        background-size: 25% 25%;
+        outline: 2px solid red;
+        height: 400px;
+        width: 400px;
+    }
+</style>
+<body>
+    <div class="checkboard"></div>
+</body>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -598,6 +598,9 @@ fast/gradients/conic-two-hints.html [ Skip ]
 fast/canvas/canvas-conic-gradient-angle.html [ Skip ]
 fast/canvas/canvas-conic-gradient-center.html [ Skip ]
 
+# Diagonal gradients
+fast/backgrounds/background-blend-mode-difference.html [ Skip ]
+
 # TODO Investigate why these mouse scroll tests are failing.
 fast/events/scroll-in-scaled-page-with-overflow-hidden.html [ Failure ]
 fast/events/wheel/continuous-platform-wheelevent-in-scrolling-div.html [ Failure ]

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -398,7 +398,7 @@ void GraphicsContextCG::drawPattern(NativeImage& nativeImage, const FloatRect& d
     CGContextStateSaver stateSaver(context);
     CGContextClipToRect(context, destRect);
 
-    setCompositeOperation(options.compositeOperator(), options.blendMode());
+    setCGBlendMode(context, options.compositeOperator(), options.blendMode());
 
     CGContextTranslateCTM(context, destRect.x(), destRect.y() + destRect.height());
     CGContextScaleCTM(context, 1, -1);


### PR DESCRIPTION
#### 9ffcb90d8fa7d8d637ddf00a67adda0338468feb
<pre>
REGRESSION (r278062): Multiple backgrounds with &quot;background-blend-mode: difference&quot; breaks
<a href="https://bugs.webkit.org/show_bug.cgi?id=246590">https://bugs.webkit.org/show_bug.cgi?id=246590</a>
rdar://101257606

Reviewed by Tim Horton.

r278062 replaced the call to GraphicsContextCG::setPlatformCompositeOperation()
by GraphicsContext::setCompositeOperation() in GraphicsContextCG::drawPattern().
setCompositeOperation() is platform independent and should not be called from
GraphicsContextCG methods. Call GraphicsContextCG::setCGBlendMode() instead.

* LayoutTests/fast/backgrounds/background-blend-mode-difference-expected.html: Added.
* LayoutTests/fast/backgrounds/background-blend-mode-difference.html: Added.
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawPattern):

Canonical link: <a href="https://commits.webkit.org/256578@main">https://commits.webkit.org/256578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/486a2f2ec579635ab26b56c7a77c32f862f51aed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105640 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165969 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5458 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34100 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88468 "Updated gtk dependencies (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101458 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4040 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82695 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/88468 "Updated gtk dependencies (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87790 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/88468 "Updated gtk dependencies (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39830 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19318 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37505 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20662 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4553 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43266 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2185 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39927 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->