### PR TITLE
Allow WebGPU to compile non-WGSL source

### DIFF
--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
@@ -27,7 +27,8 @@ async function helloTriangle() {
     const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {}}] });
     const pipelineLayoutDesc = { bindGroupLayouts: [uniformBindGroupLayout] };
     const layout = device.createPipelineLayout(pipelineLayoutDesc);
-
+/*
+    FIXME: Use WGSL once compiler is brought up
     const wgslSource = `
                      @vertex fn main(@builtin(vertex_index) VertexIndex: u32) -> @builtin(position) vec4<f32>
                      {
@@ -44,6 +45,35 @@ async function helloTriangle() {
                          return vec4<f32>(1.0, 0.0, 0.0, 1.0);
                      }
     `;
+ */
+    const wgslSource = `
+                #include <metal_stdlib>
+                using namespace metal;
+                struct Vertex {
+                   float4 position [[position]];
+                   float4 color;
+                };
+
+                vertex Vertex vsmain(unsigned VertexIndex [[vertex_id]])
+                {
+                   float2 pos[3] = {
+                       float2( 0.0,  0.5),
+                       float2(-0.5, -0.5),
+                       float2( 0.5, -0.5),
+                   };
+
+                   Vertex vout;
+                   vout.position = float4(pos[VertexIndex], 0.0, 1.0);
+                   vout.color = float4(pos[VertexIndex] + float2(0.5, 0.5), 0.0, 1.0);
+                   return vout;
+                }
+
+                fragment float4 fsmain(Vertex in [[stage_in]])
+                {
+                    return in.color;
+                }
+    `;
+
     const shaderModule = device.createShaderModule({ code: wgslSource, isWHLSL: false, hints: [ {layout: layout }, ] });
     
     /* GPUPipelineStageDescriptors */


### PR DESCRIPTION
#### a45ca421da82023549024f32383049bac3296f94
<pre>
Allow WebGPU to compile non-WGSL source
<a href="https://bugs.webkit.org/show_bug.cgi?id=247657">https://bugs.webkit.org/show_bug.cgi?id=247657</a>
&lt;radar://102116179&gt;

Reviewed by NOBODY (OOPS!).

To facilitate testing, use the string passed to createShaderModule for
compiling the MTLLibrary if the WGSL compiler gives a zero length string.

* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):
(WebGPU::Device::createShaderModule):

* Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js:
(async helloTriangle):
</pre>