### PR TITLE
Prevent hidden documents from locking the screen orientation

### DIFF
--- a/LayoutTests/fast/screen-orientation/hidden-document-check-expected.txt
+++ b/LayoutTests/fast/screen-orientation/hidden-document-check-expected.txt
@@ -1,0 +1,12 @@
+This test checks that trying to lock or unlock a hidden document results in a SecurityError.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.hidden is true
+PASS SecurityError rejected promise  with SecurityError: Only visible documents can lock the screen orientation.
+PASS screen.orientation.unlock() threw exception SecurityError: Only visible documents can unlock the screen orientation.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt
@@ -1,0 +1,3 @@
+
+PASS test locking the orientation when document is hidden
+

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long" />
+<title>Prevent hidden documents from locking orientation</title>
+<link rel="help" href="https://github.com/w3c/screen-orientation/pull/232" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+  import { getOppositeOrientation } from "./resources/orientation-utils.js";
+  let rect;
+
+  promise_setup(async (t) => {
+    rect = await test_driver.minimize_window();
+    assert_true(document.hidden, "document must be hidden");
+  });
+
+  promise_test(async (t) => {
+    await promise_rejects_dom(
+      t,
+      "SecurityError",
+      screen.orientation.lock("landscape"),
+      "Locking orientation must reject when the document is hidden"
+    );
+
+    assert_throws_dom(
+      "SecurityError",
+      () => {
+        screen.orientation.unlock();
+      },
+      "Unlocking orientation must throw when the document is hidden"
+    );
+
+    await test_driver.set_window_rect(rect);
+    assert_false(document.hidden, "document must not be hidden");
+    // not longer throws
+    screen.orientation.unlock();
+  }, "test locking the orientation when document is hidden");
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -367,6 +367,7 @@ webkit.org/b/165799 svg/animations/animations-paused-page-non-visible.html [ Ski
 webkit.org/b/165799 svg/animations/animations-paused-in-background-page-iframe.html [ Skip ]
 webkit.org/b/165799 svg/animations/animations-paused-in-background-page.html [ Skip ]
 webkit.org/b/165799 webaudio/silent-audio-interrupted-in-background.html [ Skip ]
+webkit.org/b/165799 imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
 
 # AutoFill button is not supported
 fast/forms/auto-fill-button/mouse-down-input-mouse-release-auto-fill-button.html

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -110,6 +110,12 @@ void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
         promise->reject(Exception { SecurityError, "Only first party documents can lock the screen orientation"_s });
         return;
     }
+
+    if (document->page() && !document->page()->isVisible()) {
+        promise->reject(Exception { SecurityError, "Only visible documents can lock the screen orientation"_s });
+        return;
+    }
+
     if (document->settings().fullscreenRequirementForScreenOrientationLockingEnabled()) {
 #if ENABLE(FULLSCREEN_API)
         if (!document->fullscreenManager().isFullscreen()) {
@@ -156,6 +162,9 @@ ExceptionOr<void> ScreenOrientation::unlock()
 
     if (!document->isSameOriginAsTopDocument())
         return { };
+
+    if (document->page() && !document->page()->isVisible())
+        return Exception { SecurityError, "Only visible documents can unlock the screen orientation"_s };
 
     if (auto* manager = this->manager())
         manager->unlock();


### PR DESCRIPTION
#### a68ef76884df02cb25c760874bfc38df99c09783
<pre>
Prevent hidden documents from locking the screen orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247248">https://bugs.webkit.org/show_bug.cgi?id=247248</a>
rdar://102019707

Reviewed by Youenn Fablet.

* LayoutTests/fast/screen-orientation/hidden-document-check-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
(window.test_driver_internal.action_sequence):
(async if):
(window.test_driver_internal.minimize_window):
(window.test_driver_internal.set_window_rect):
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):

Canonical link: <a href="https://commits.webkit.org/257019@main">https://commits.webkit.org/257019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7728e53740054c201264599410236e60ba99348

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107073 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167338 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7174 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35584 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103738 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5369 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84205 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32375 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89039 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75299 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/825 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4832 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44440 "Found 1 new test failure: fast/images/animated-heics-draw.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2065 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41357 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->