### PR TITLE
Add Options::allowDoubleShape() for testing.

### DIFF
--- a/JSTests/microbenchmarks/bit-test-constant.js
+++ b/JSTests/microbenchmarks/bit-test-constant.js
@@ -1,4 +1,7 @@
 //@ skip if not $jitTests
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let glob = 0
 
 function doTest(number) {

--- a/JSTests/microbenchmarks/memcpy-typed-loop-large.js
+++ b/JSTests/microbenchmarks/memcpy-typed-loop-large.js
@@ -1,4 +1,7 @@
 //@ skip if not $jitTests
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 function doTest(arr1, arr2) {
     if (arr1.length != arr2.length)
         return []

--- a/JSTests/stress/arith-abs-on-various-types.js
+++ b/JSTests/stress/arith-abs-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js
+++ b/JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 // Checked int_min < value < 0
 function opaqueCheckedBetweenIntMinAndZeroExclusive(arg) {
     if (arg < 0) {

--- a/JSTests/stress/arith-acos-on-various-types.js
+++ b/JSTests/stress/arith-acos-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let acosOfHalf = Math.acos(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-acosh-on-various-types.js
+++ b/JSTests/stress/arith-acosh-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let acoshOfFour = Math.acosh(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-asin-on-various-types.js
+++ b/JSTests/stress/arith-asin-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let asinOfHalf = Math.asin(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-asinh-on-various-types.js
+++ b/JSTests/stress/arith-asinh-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let asinhOfFour = Math.asinh(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-atan-on-various-types.js
+++ b/JSTests/stress/arith-atan-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let atanOfFour = Math.atan(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-atanh-on-various-types.js
+++ b/JSTests/stress/arith-atanh-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let atanhOfHalf = Math.atanh(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-cbrt-on-various-types.js
+++ b/JSTests/stress/arith-cbrt-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let cbrtOfHalf = Math.cbrt(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-ceil-on-various-types.js
+++ b/JSTests/stress/arith-ceil-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/arith-clz32-on-various-types.js
+++ b/JSTests/stress/arith-clz32-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "32"],

--- a/JSTests/stress/arith-cos-on-various-types.js
+++ b/JSTests/stress/arith-cos-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let cosOfFour = Math.cos(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-cosh-on-various-types.js
+++ b/JSTests/stress/arith-cosh-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let coshOfFour = Math.cosh(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-expm1-on-various-types.js
+++ b/JSTests/stress/arith-expm1-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let expm1OfHalf = Math.expm1(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-floor-on-various-types.js
+++ b/JSTests/stress/arith-floor-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/arith-fround-on-various-types.js
+++ b/JSTests/stress/arith-fround-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let froundOfPi = Math.fround(Math.PI);
 let froundOfE = Math.fround(Math.E);
 

--- a/JSTests/stress/arith-log10-on-various-types.js
+++ b/JSTests/stress/arith-log10-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let log10OfHalf = Math.log10(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-log2-on-various-types.js
+++ b/JSTests/stress/arith-log2-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let log2OfHalf = Math.log2(0.5);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-negate-on-various-types.js
+++ b/JSTests/stress/arith-negate-on-various-types.js
@@ -2,6 +2,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/arith-round-on-various-types.js
+++ b/JSTests/stress/arith-round-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/arith-sin-on-various-types.js
+++ b/JSTests/stress/arith-sin-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let sinOfFour = Math.sin(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-sinh-on-various-types.js
+++ b/JSTests/stress/arith-sinh-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let sinhOfFour = Math.sinh(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-sqrt-on-various-types.js
+++ b/JSTests/stress/arith-sqrt-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/arith-tan-on-various-types.js
+++ b/JSTests/stress/arith-tan-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let tanOfFour = Math.tan(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-tanh-on-various-types.js
+++ b/JSTests/stress/arith-tanh-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let tanhOfFour = Math.tanh(4);
 
 let validInputTestCases = [

--- a/JSTests/stress/arith-trunc-on-various-types.js
+++ b/JSTests/stress/arith-trunc-on-various-types.js
@@ -3,6 +3,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 let validInputTestCases = [
     // input as string, expected result as string.
     ["undefined", "NaN"],

--- a/JSTests/stress/array-slice-cow.js
+++ b/JSTests/stress/array-slice-cow.js
@@ -3,6 +3,8 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
+var allowDoubleShape = $vm.allowDoubleShape();
+
 function testInt32()
 {
     var array = [0, 1, 2, 3];
@@ -17,8 +19,13 @@ function testDouble()
 {
     var array = [0.1, 1.1, 2.1, 3.1];
     var slice = array.slice(1);
-    shouldBe($vm.indexingMode(array), "CopyOnWriteArrayWithDouble");
-    shouldBe($vm.indexingMode(slice), "ArrayWithDouble");
+    if (allowDoubleShape) {
+        shouldBe($vm.indexingMode(array), "CopyOnWriteArrayWithDouble");
+        shouldBe($vm.indexingMode(slice), "ArrayWithDouble");
+    } else {
+        shouldBe($vm.indexingMode(array), "CopyOnWriteArrayWithContiguous");
+        shouldBe($vm.indexingMode(slice), "ArrayWithContiguous");
+    }
     return slice;
 }
 noInline(testDouble);

--- a/JSTests/stress/arrayprofile-should-not-convert-get-by-val-cow.js
+++ b/JSTests/stress/arrayprofile-should-not-convert-get-by-val-cow.js
@@ -3,6 +3,8 @@ function assertEq(a, b) {
         throw new Error("values not the same: " + a + " and " + b);
 }
 
+var allowDoubleShape = $vm.allowDoubleShape();
+
 function withArrayArgInt32(i, array) {
     let result = array[i];
     assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithInt32");
@@ -19,14 +21,20 @@ noInline(withArrayLiteralInt32);
 
 function withArrayArgDouble(i, array) {
     let result = array[i];
-    assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithDouble");
+    if (allowDoubleShape)
+        assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithDouble");
+    else
+        assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithContiguous");
 }
 noInline(withArrayArgDouble);
 
 function withArrayLiteralDouble(i) {
     let array = [0,1.3145,2];
     let result = array[i];
-    assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithDouble");
+    if (allowDoubleShape)
+        assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithDouble");
+    else
+        assertEq($vm.indexingMode(array), "CopyOnWriteArrayWithContiguous");        
 }
 noInline(withArrayLiteralDouble);
 

--- a/JSTests/stress/bit-op-with-object-returning-int32.js
+++ b/JSTests/stress/bit-op-with-object-returning-int32.js
@@ -1,4 +1,7 @@
 //@ skip if not $jitTests
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 function assert(a, e) {
     if (a !== e)
         throw new Error("Expected: " + e + " but got: " + a);

--- a/JSTests/stress/bitwise-not-fixup-rules.js
+++ b/JSTests/stress/bitwise-not-fixup-rules.js
@@ -1,4 +1,6 @@
 //@ skip unless $jitTests
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
 
 function assert(a, e) {
     if (a !== e)

--- a/JSTests/stress/compare-strict-eq-on-various-types.js
+++ b/JSTests/stress/compare-strict-eq-on-various-types.js
@@ -2,6 +2,9 @@
 //@ defaultNoEagerRun
 "use strict";
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 function opaqueKitString() {
     return "Kit";
 }

--- a/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js
+++ b/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js
@@ -4,6 +4,9 @@ function shouldBe(actual, expected) {
         throw new Error('bad value: ' + actual);
 }
 
+if (!$vm.useJIT())
+    $vm.exit();
+
 var putter = function(o) {
     o._unsupported = not_string;
 }

--- a/JSTests/stress/int8-repeat-in-then-out-of-bounds.js
+++ b/JSTests/stress/int8-repeat-in-then-out-of-bounds.js
@@ -1,5 +1,8 @@
 //@ if $jitTests then defaultNoEagerRun(*NO_CJIT_OPTIONS) else skip end
 
+if (typeof $vm != "undefined" && !$vm.useJIT())
+    $vm.exit();
+
 function foo(a, inBounds) {
     a[0] = 1;
     if (!inBounds) {

--- a/JSTests/stress/regress-189028.js
+++ b/JSTests/stress/regress-189028.js
@@ -6,14 +6,20 @@ function assert(x, y) {
     }
 }
 
+var allowDoubleShape = $vm.allowDoubleShape();
+
+var arrayWithDoubleOrContiguousStr = allowDoubleShape ? "ArrayWithDouble" : "ArrayWithContiguous";
+var nonArrayWithDoubleOrContiguousStr = allowDoubleShape ? "NonArrayWithDouble" : "NonArrayWithContiguous";
+var copyOnWriteArrayWithDoubleOrContiguousStr = allowDoubleShape ? "CopyOnWriteArrayWithDouble" : "CopyOnWriteArrayWithContiguous";
+
 (function() {
     let arr = [1.1, 2.2];
     let arr2 = [1.1, 2.2];
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
-    assert($vm.indexingMode(arr2), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr2), copyOnWriteArrayWithDoubleOrContiguousStr);
 
     let o = $vm.createGlobalObject();
 
@@ -26,7 +32,7 @@ function assert(x, y) {
     arr2.__proto__ = proto;
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "ArrayWithSlowPutArrayStorage");
 })();
@@ -38,9 +44,9 @@ gc();
     let arr2 = [1.1, 2.2];
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
-    assert($vm.indexingMode(arr2), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr2), copyOnWriteArrayWithDoubleOrContiguousStr);
 
     let o = $vm.createGlobalObject();
 
@@ -51,9 +57,9 @@ gc();
     arr2.__proto__ = proto;
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
-    assert($vm.indexingMode(arr2), "ArrayWithDouble");
+    assert($vm.indexingMode(arr2), arrayWithDoubleOrContiguousStr);
 
     $vm.haveABadTime(o);
 
@@ -61,7 +67,7 @@ gc();
     assert($vm.isHavingABadTime(proto), true);
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "ArrayWithSlowPutArrayStorage");
 })();
@@ -73,7 +79,7 @@ gc();
     let arr2 = {};
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "NonArray");
 
@@ -88,14 +94,14 @@ gc();
     arr2.__proto__ = proto;
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "NonArray");
 
     arr2[0] = 1.1;
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "NonArrayWithSlowPutArrayStorage");
 })();
@@ -107,7 +113,7 @@ gc();
     let arr2 = {};
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "NonArray");
 
@@ -120,16 +126,16 @@ gc();
     arr2.__proto__ = proto;
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "NonArray");
 
     arr2[0] = 1.1;
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
-    assert($vm.indexingMode(arr2), "NonArrayWithDouble");
+    assert($vm.indexingMode(arr2), nonArrayWithDoubleOrContiguousStr);
 
     $vm.haveABadTime(o);
 
@@ -137,7 +143,7 @@ gc();
     assert($vm.isHavingABadTime(proto), true);
 
     assert($vm.isHavingABadTime(arr), false);
-    assert($vm.indexingMode(arr), "CopyOnWriteArrayWithDouble");
+    assert($vm.indexingMode(arr), copyOnWriteArrayWithDoubleOrContiguousStr);
     assert($vm.isHavingABadTime(arr2), false);
     assert($vm.indexingMode(arr2), "NonArrayWithSlowPutArrayStorage");
 })();

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -1414,6 +1414,7 @@ void AccessCase::generateWithGuard(
                 expectedShape = Int32Shape;
                 break;
             case IndexedDoubleLoad:
+                ASSERT(Options::allowDoubleShape());
                 expectedShape = DoubleShape;
                 break;
             case IndexedContiguousLoad:
@@ -1512,6 +1513,7 @@ void AccessCase::generateWithGuard(
                 expectedShape = Int32Shape;
                 break;
             case IndexedDoubleStore:
+                ASSERT(Options::allowDoubleShape());
                 expectedShape = DoubleShape;
                 break;
             case IndexedContiguousStore:

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -166,6 +166,7 @@ inline bool shouldUseContiguous(ArrayModes arrayModes)
 
 inline bool shouldUseDouble(ArrayModes arrayModes)
 {
+    ASSERT(Options::allowDoubleShape());
     return arrayModesIncludeIgnoringTypedArrays(arrayModes, DoubleShape);
 }
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -676,6 +676,7 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
                 accessType = AccessCase::IndexedInt32Load;
                 break;
             case DoubleShape:
+                ASSERT(Options::allowDoubleShape());
                 accessType = AccessCase::IndexedDoubleLoad;
                 break;
             case ContiguousShape:
@@ -1115,6 +1116,7 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
                 accessType = AccessCase::IndexedInt32Store;
                 break;
             case DoubleShape:
+                ASSERT(Options::allowDoubleShape());
                 accessType = AccessCase::IndexedDoubleStore;
                 break;
             case ContiguousShape:

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -762,6 +762,7 @@ IndexingType toIndexingShape(Array::Type type)
     case Array::Int32:
         return Int32Shape;
     case Array::Double:
+        ASSERT(Options::allowDoubleShape());
         return DoubleShape;
     case Array::Contiguous:
         return ContiguousShape;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2345,6 +2345,7 @@ JSC_DEFINE_JIT_OPERATION(operationEnsureDouble, char*, (VM* vmPointer, JSCell* c
     if (!cell->isObject())
         return nullptr;
 
+    ASSERT(Options::allowDoubleShape());
     auto* result = reinterpret_cast<char*>(asObject(cell)->tryMakeWritableDouble(vm).data());
     ASSERT((!isCopyOnWrite(asObject(cell)->indexingMode()) && hasDouble(cell->indexingMode())) || !result);
     return result;

--- a/Source/JavaScriptCore/runtime/IndexingType.h
+++ b/Source/JavaScriptCore/runtime/IndexingType.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012, 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -214,7 +214,7 @@ inline IndexingType indexingTypeForValue(JSValue value)
     if (value.isInt32())
         return Int32Shape;
 
-    if (value.isNumber() && value.asNumber() == value.asNumber())
+    if (value.isNumber() && value.asNumber() == value.asNumber() && Options::allowDoubleShape())
         return DoubleShape;
 
     return ContiguousShape;

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -205,6 +205,7 @@ ALWAYS_INLINE void JSArray::pushInline(JSGlobalObject* globalObject, JSValue val
     }
 
     case ArrayWithDouble: {
+        ASSERT(Options::allowDoubleShape());
         if (!value.isNumber()) {
             convertDoubleToContiguous(vm);
             scope.release();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -999,13 +999,21 @@ void JSGlobalObject::init(VM& vm)
     
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(UndecidedShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithUndecided));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(Int32Shape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithInt32));
-    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(DoubleShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithDouble));
-    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(ContiguousShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithContiguous));
+
+    Structure* arrayWithContiguousStructure = JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithContiguous);
+    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(DoubleShape)].set(vm, this,
+        Options::allowDoubleShape() ? JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithDouble) : arrayWithContiguousStructure);
+    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(ContiguousShape)].set(vm, this, arrayWithContiguousStructure);
+
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(ArrayStorageShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithArrayStorage));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(SlowPutArrayStorageShape)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), ArrayWithSlowPutArrayStorage));
     m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(CopyOnWriteArrayWithInt32)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), CopyOnWriteArrayWithInt32));
-    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), CopyOnWriteArrayWithDouble));
-    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous)].set(vm, this, JSArray::createStructure(vm, this, m_arrayPrototype.get(), CopyOnWriteArrayWithContiguous));
+
+    Structure* copyOnWriteArrayWithContiguous = JSArray::createStructure(vm, this, m_arrayPrototype.get(), CopyOnWriteArrayWithContiguous);
+    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble)].set(vm, this,
+        Options::allowDoubleShape() ? JSArray::createStructure(vm, this, m_arrayPrototype.get(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguous);
+    m_originalArrayStructureForIndexingShape[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous)].set(vm, this, copyOnWriteArrayWithContiguous);
+
     for (unsigned i = 0; i < NumberOfArrayIndexingModes; ++i)
         m_arrayStructureForIndexingShapeDuringAllocation[i] = m_originalArrayStructureForIndexingShape[i];
 

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -104,6 +104,7 @@ public:
         }
 
         if (indexingType == DoubleShape) {
+            ASSERT(Options::allowDoubleShape());
             for (unsigned i = 0; i < length; i++) {
                 double d = array->butterfly()->contiguousDouble().at(array, i);
                 JSValue value = std::isnan(d) ? jsUndefined() : JSValue(JSValue::EncodeAsDouble, d);

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1272,6 +1272,7 @@ ContiguousJSValues JSObject::convertUndecidedToInt32(VM& vm)
 
 ContiguousDoubles JSObject::convertUndecidedToDouble(VM& vm)
 {
+    ASSERT(Options::allowDoubleShape());
     ASSERT(hasUndecided(indexingType()));
 
     Butterfly* butterfly = m_butterfly.get();
@@ -1547,6 +1548,7 @@ void JSObject::convertUndecidedForValue(VM& vm, JSValue value)
     }
     
     if (type == DoubleShape) {
+        ASSERT(Options::allowDoubleShape());
         convertUndecidedToDouble(vm);
         return;
     }
@@ -1562,7 +1564,7 @@ void JSObject::createInitialForValueAndSet(VM& vm, unsigned index, JSValue value
         return;
     }
     
-    if (value.isDouble()) {
+    if (value.isDouble() && Options::allowDoubleShape()) {
         double doubleValue = value.asNumber();
         if (doubleValue == doubleValue) {
             createInitialDouble(vm, index + 1).at(this, index) = doubleValue;
@@ -1577,7 +1579,7 @@ void JSObject::convertInt32ForValue(VM& vm, JSValue value)
 {
     ASSERT(!value.isInt32());
     
-    if (value.isDouble() && !std::isnan(value.asDouble())) {
+    if (value.isDouble() && !std::isnan(value.asDouble()) && Options::allowDoubleShape()) {
         convertInt32ToDouble(vm);
         return;
     }
@@ -1678,6 +1680,7 @@ ContiguousJSValues JSObject::tryMakeWritableInt32Slow(VM& vm)
 
 ContiguousDoubles JSObject::tryMakeWritableDoubleSlow(VM& vm)
 {
+    ASSERT(Options::allowDoubleShape());
     ASSERT(inherits(info()));
 
     if (isCopyOnWrite(indexingMode())) {
@@ -2987,6 +2990,7 @@ bool JSObject::putByIndexBeyondVectorLengthWithoutAttributes(JSGlobalObject* glo
         return true;
         
     case DoubleShape: {
+        ASSERT(Options::allowDoubleShape());
         ASSERT(value.isNumber());
         double valueAsDouble = value.asNumber();
         ASSERT(valueAsDouble == valueAsDouble);
@@ -3119,6 +3123,7 @@ bool JSObject::putByIndexBeyondVectorLength(JSGlobalObject* globalObject, unsign
         RELEASE_AND_RETURN(scope, putByIndexBeyondVectorLengthWithoutAttributes<Int32Shape>(globalObject, i, value));
         
     case ALL_DOUBLE_INDEXING_TYPES:
+        ASSERT(Options::allowDoubleShape());
         RELEASE_AND_RETURN(scope, putByIndexBeyondVectorLengthWithoutAttributes<DoubleShape>(globalObject, i, value));
         
     case ALL_CONTIGUOUS_INDEXING_TYPES:
@@ -3284,6 +3289,7 @@ bool JSObject::putDirectIndexSlowOrBeyondVectorLength(JSGlobalObject* globalObje
     }
         
     case ALL_DOUBLE_INDEXING_TYPES: {
+        ASSERT(Options::allowDoubleShape());
         ASSERT(!indexingShouldBeSparse());
         if (attributes)
             return putDirectIndexBeyondVectorLengthWithArrayStorage(globalObject, i, value, attributes, mode, ensureArrayStorageExistsAndEnterDictionaryIndexingMode(vm));
@@ -3437,6 +3443,7 @@ unsigned JSObject::countElements(Butterfly* butterfly)
             break;
             
         case DoubleShape: {
+            ASSERT(Options::allowDoubleShape());
             double value = butterfly->contiguousDouble().at(this, i);
             if (value == value)
                 numValues++;
@@ -3461,6 +3468,7 @@ unsigned JSObject::countElements()
         return countElements<Int32Shape>(butterfly());
         
     case ALL_DOUBLE_INDEXING_TYPES:
+        ASSERT(Options::allowDoubleShape());
         return countElements<DoubleShape>(butterfly());
         
     case ALL_CONTIGUOUS_INDEXING_TYPES:

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -534,6 +534,9 @@ void Options::recomputeDependentOptions()
     Options::forceUnlinkedDFG() = false;
 #endif
 
+    if (!Options::allowDoubleShape())
+        Options::useJIT() = false; // We don't support JIT with !allowDoubleShape. So disable it.
+
     // At initialization time, we may decide that useJIT should be false for any
     // number of reasons (including failing to allocate JIT memory), and therefore,
     // will / should not be able to enable any JIT related services.

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -350,6 +350,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, forceWeakRandomSeed, false, Normal, nullptr) \
     v(Unsigned, forcedWeakRandomSeed, 0, Normal, nullptr) \
     \
+    v(Bool, allowDoubleShape, true, Normal, "debugging option to test disabling use of DoubleShape") \
     v(Bool, useZombieMode, false, Normal, "debugging option to scribble over dead objects with 0xbadbeef0") \
     v(Bool, useImmortalObjects, false, Normal, "debugging option to keep all objects alive forever") \
     v(Bool, sweepSynchronously, false, Normal, "debugging option to sweep all dead objects synchronously at GC end before resuming mutator") \

--- a/Source/JavaScriptCore/runtime/StructureTransitionTable.h
+++ b/Source/JavaScriptCore/runtime/StructureTransitionTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,6 +90,7 @@ inline IndexingType newIndexingType(IndexingType oldType, TransitionKind transit
         ASSERT(!hasIndexedProperties(oldType) || hasUndecided(oldType) || oldType == CopyOnWriteArrayWithInt32);
         return (oldType & ~IndexingShapeAndWritabilityMask) | Int32Shape;
     case TransitionKind::AllocateDouble:
+        ASSERT(Options::allowDoubleShape());
         ASSERT(!hasIndexedProperties(oldType) || hasUndecided(oldType) || hasInt32(oldType) || oldType == CopyOnWriteArrayWithDouble);
         return (oldType & ~IndexingShapeAndWritabilityMask) | DoubleShape;
     case TransitionKind::AllocateContiguous:

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -249,8 +249,10 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     symbolTableStructure.set(*this, SymbolTable::createStructure(*this, nullptr, jsNull()));
 
     immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithInt32) - NumberOfIndexingShapes].set(*this, JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithInt32));
-    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble) - NumberOfIndexingShapes].set(*this, JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble));
-    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].set(*this, JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous));
+    Structure* copyOnWriteArrayWithContiguousStructure = JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous);
+    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble) - NumberOfIndexingShapes].set(*this,
+        Options::allowDoubleShape() ? JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
+    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].set(*this, copyOnWriteArrayWithContiguousStructure);
 
     sourceCodeStructure.set(*this, JSSourceCode::createStructure(*this, nullptr, jsNull()));
     scriptFetcherStructure.set(*this, JSScriptFetcher::createStructure(*this, nullptr, jsNull()));

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2092,6 +2092,7 @@ namespace JSC {
 
 static NO_RETURN_DUE_TO_CRASH JSC_DECLARE_HOST_FUNCTION(functionCrash);
 static JSC_DECLARE_HOST_FUNCTION(functionBreakpoint);
+static JSC_DECLARE_HOST_FUNCTION(functionExit);
 static JSC_DECLARE_HOST_FUNCTION(functionDFGTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionFTLTrue);
 static JSC_DECLARE_HOST_FUNCTION(functionCpuMfence);
@@ -2207,6 +2208,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionDumpJITSizeStatistics);
 static JSC_DECLARE_HOST_FUNCTION(functionResetJITSizeStatistics);
 #endif
 
+static JSC_DECLARE_HOST_FUNCTION(functionAllowDoubleShape);
 static JSC_DECLARE_HOST_FUNCTION(functionEnsureArrayStorage);
 #if PLATFORM(COCOA)
 static JSC_DECLARE_HOST_FUNCTION(functionSetCrashLogMessage);;
@@ -2271,6 +2273,14 @@ JSC_DEFINE_HOST_FUNCTION(functionBreakpoint, (JSGlobalObject* globalObject, Call
         WTFBreakpointTrap();
 
     return encodedJSUndefined();
+}
+
+// Executes exit(EXIT_SUCCESS).
+// Usage: $vm.exit()
+JSC_DEFINE_HOST_FUNCTION(functionExit, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    exit(EXIT_SUCCESS);
 }
 
 // Returns true if the current frame is a DFG frame.
@@ -3912,6 +3922,14 @@ JSC_DEFINE_HOST_FUNCTION(functionResetJITSizeStatistics, (JSGlobalObject* global
 }
 #endif
 
+// Checks if DoubleShape is allowed.
+// Usage: var allowed = $vm.allowDoubleShape()
+JSC_DEFINE_HOST_FUNCTION(functionAllowDoubleShape, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(jsBoolean(Options::allowDoubleShape()));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEnsureArrayStorage, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -3962,6 +3980,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "abort"_s, functionCrash, 0);
     addFunction(vm, "crash"_s, functionCrash, 0);
     addFunction(vm, "breakpoint"_s, functionBreakpoint, 0);
+    addFunction(vm, "exit"_s, functionExit, 0);
 
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "dfgTrue"_s), 0, functionDFGTrue, ImplementationVisibility::Public, DFGTrueIntrinsic, jsDollarVMPropertyAttributes);
     putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "ftlTrue"_s), 0, functionFTLTrue, ImplementationVisibility::Public, FTLTrueIntrinsic, jsDollarVMPropertyAttributes);
@@ -4114,6 +4133,7 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "resetJITSizeStatistics"_s, functionResetJITSizeStatistics, 0);
 #endif
 
+    addFunction(vm, "allowDoubleShape"_s, functionAllowDoubleShape, 0);
     addFunction(vm, "ensureArrayStorage"_s, functionEnsureArrayStorage, 1);
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/bindings/js/JSDOMConvertSequences.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertSequences.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,6 +103,7 @@ struct NumericSequenceConverter {
         }
 
         ASSERT(indexingType == JSC::DoubleShape);
+        ASSERT(JSC::Options::allowDoubleShape());
         for (unsigned i = 0; i < length; i++) {
             double doubleValue = array->butterfly()->contiguousDouble().at(array, i);
             if (std::isnan(doubleValue))

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2013-2022 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1282,6 +1282,18 @@ BASE_MODES = [
         ]
     ],
     [
+        "Lockdown",
+        "lockdown",
+        [
+            "--useJIT=false",
+            "--useGenerationalGC=false",
+            "--useConcurrentGC=false",
+            "--useLLIntICs=false",
+            "--useZombieMode=true",
+            "--allowDoubleShape=false",
+        ]
+    ],
+    [
         "MiniMode",
         "mini-mode",
         [
@@ -1488,6 +1500,7 @@ def defaultRunCfg(cfg, subsetOptions, *optionalTestSpecificOptions)
         runDefaultCfg(cfg, *optionalTestSpecificOptions)
         runBytecodeCacheCfg(cfg, *optionalTestSpecificOptions)
         runMiniModeCfg(cfg, *optionalTestSpecificOptions)
+        runLockdownCfg(cfg, *optionalTestSpecificOptions)
         if $jitTests
             if not subsetOptions.has_key?(:skipNoLLInt)
                 runNoLLIntCfg(cfg, *optionalTestSpecificOptions)


### PR DESCRIPTION
#### c8ec8e9493510f0f1dad79270006439ebda61001
<pre>
Add Options::allowDoubleShape() for testing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247548">https://bugs.webkit.org/show_bug.cgi?id=247548</a>
&lt;rdar://problem/102013094&gt;

Reviewed by Yusuke Suzuki.

1. Added Options::allowDoubleShape() which forces contiguous arrays to be used instead
   of double arrays.  Also added lots of ASSERTs to confirm that Options::allowDoubleShape()
   is true when double shaped arrays are in use.
2. Added $vm.exit() to enable exiting early.  This is needed to allow tests to exit early
   without failing if they require JIT but JIT is disabled.
3. Added $vm.allowDoubleShape() to check the state of Options::allowDoubleShape().  This
   is needed for tests that assert the shape of arrays.
4. Fixed up JSC stress tests to handle the case of running with --allowDoubleShape=false.
5. Fixed up JSC stress tests to handle the case of running without the JIT since
   --allowDoubleShape=false also disables the JIT for now.
6. Added a lockdown configuration for JSC stress tests.

* JSTests/microbenchmarks/bit-test-constant.js:
* JSTests/microbenchmarks/memcpy-typed-loop-large.js:
* JSTests/stress/arith-abs-on-various-types.js:
* JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js:
* JSTests/stress/arith-acos-on-various-types.js:
* JSTests/stress/arith-acosh-on-various-types.js:
* JSTests/stress/arith-asin-on-various-types.js:
* JSTests/stress/arith-asinh-on-various-types.js:
* JSTests/stress/arith-atan-on-various-types.js:
* JSTests/stress/arith-atanh-on-various-types.js:
* JSTests/stress/arith-cbrt-on-various-types.js:
* JSTests/stress/arith-ceil-on-various-types.js:
* JSTests/stress/arith-clz32-on-various-types.js:
* JSTests/stress/arith-cos-on-various-types.js:
* JSTests/stress/arith-cosh-on-various-types.js:
* JSTests/stress/arith-expm1-on-various-types.js:
* JSTests/stress/arith-floor-on-various-types.js:
* JSTests/stress/arith-fround-on-various-types.js:
* JSTests/stress/arith-log10-on-various-types.js:
* JSTests/stress/arith-log2-on-various-types.js:
* JSTests/stress/arith-negate-on-various-types.js:
* JSTests/stress/arith-round-on-various-types.js:
* JSTests/stress/arith-sin-on-various-types.js:
* JSTests/stress/arith-sinh-on-various-types.js:
* JSTests/stress/arith-sqrt-on-various-types.js:
* JSTests/stress/arith-tan-on-various-types.js:
* JSTests/stress/arith-tanh-on-various-types.js:
* JSTests/stress/arith-trunc-on-various-types.js:
* JSTests/stress/array-slice-cow.js:
(testDouble):
* JSTests/stress/arrayprofile-should-not-convert-get-by-val-cow.js:
(withArrayArgDouble):
(withArrayLiteralDouble):
* JSTests/stress/bit-op-with-object-returning-int32.js:
* JSTests/stress/bitwise-not-fixup-rules.js:
* JSTests/stress/compare-strict-eq-on-various-types.js:
* JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js:
* JSTests/stress/int8-repeat-in-then-out-of-bounds.js:
* JSTests/stress/regress-189028.js:
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::generateWithGuard):
* Source/JavaScriptCore/bytecode/ArrayProfile.h:
(JSC::shouldUseDouble):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayGetByVal):
(JSC::tryCacheArrayPutByVal):
* Source/JavaScriptCore/dfg/DFGArrayMode.cpp:
(JSC::DFG::toIndexingShape):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/IndexingType.h:
(JSC::indexingTypeForValue):
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::pushInline):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
(JSC::JSImmutableButterfly::createFromArray):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::convertUndecidedToDouble):
(JSC::JSObject::convertUndecidedForValue):
(JSC::JSObject::createInitialForValueAndSet):
(JSC::JSObject::convertInt32ForValue):
(JSC::JSObject::tryMakeWritableDoubleSlow):
(JSC::JSObject::putByIndexBeyondVectorLengthWithoutAttributes):
(JSC::JSObject::putByIndexBeyondVectorLength):
(JSC::JSObject::putDirectIndexSlowOrBeyondVectorLength):
(JSC::JSObject::countElements):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::recomputeDependentOptions):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/StructureTransitionTable.h:
(JSC::newIndexingType):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
* Source/WebCore/bindings/js/JSDOMConvertSequences.h:
(WebCore::Detail::NumericSequenceConverter::convertArray):
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/256537@main">https://commits.webkit.org/256537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/118d18240f3b9ff20f88bd35e35e306b418acfb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/28948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105465 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5256 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/33915 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101293 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3870 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82512 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30905 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73738 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/86934 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39646 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19163 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82277 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37327 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20496 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28221 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4524 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/41734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43119 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/84955 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39752 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19187 "Passed tests") | 
<!--EWS-Status-Bubble-End-->