### PR TITLE
CAAudioStreamDescription should be held like a value type

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
@@ -41,7 +41,7 @@ Ref<AudioSampleBufferList> AudioSampleBufferList::create(const CAAudioStreamDesc
 }
 
 AudioSampleBufferList::AudioSampleBufferList(const CAAudioStreamDescription& format, size_t maximumSampleCount)
-    : m_internalFormat(makeUniqueRef<CAAudioStreamDescription>(format))
+    : m_internalFormat(format)
     , m_sampleCapacity(maximumSampleCount)
     , m_maxBufferSizePerChannel(maximumSampleCount * format.bytesPerFrame() / format.numberOfChannelStreams())
     , m_bufferList(makeUniqueRef<WebAudioBufferList>(m_internalFormat, m_maxBufferSizePerChannel))
@@ -97,7 +97,7 @@ void AudioSampleBufferList::applyGain(AudioBufferList& bufferList, float gain, A
 
 void AudioSampleBufferList::applyGain(float gain)
 {
-    applyGain(m_bufferList.get(), gain, m_internalFormat->format());
+    applyGain(m_bufferList.get(), gain, m_internalFormat.format());
 }
 
 static void mixBuffers(WebAudioBufferList& destinationBuffer, const AudioBufferList& sourceBuffer, AudioStreamDescription::PCMFormat format, size_t frameCount)
@@ -160,7 +160,7 @@ OSStatus AudioSampleBufferList::mixFrom(const AudioSampleBufferList& source, siz
 
     m_sampleCount = frameCount;
 
-    mixBuffers(bufferList(), source.bufferList(), m_internalFormat->format(), frameCount);
+    mixBuffers(bufferList(), source.bufferList(), m_internalFormat.format(), frameCount);
     return 0;
 }
 
@@ -182,7 +182,7 @@ OSStatus AudioSampleBufferList::copyFrom(const AudioSampleBufferList& source, si
     for (uint32_t i = 0; i < m_bufferList->bufferCount(); i++) {
         uint8_t* sourceData = static_cast<uint8_t*>(source.bufferList().buffer(i)->mData);
         uint8_t* destination = static_cast<uint8_t*>(m_bufferList->buffer(i)->mData);
-        memcpy(destination, sourceData, frameCount * m_internalFormat->bytesPerPacket());
+        memcpy(destination, sourceData, frameCount * m_internalFormat.bytesPerPacket());
     }
 
     return 0;
@@ -198,7 +198,7 @@ OSStatus AudioSampleBufferList::copyTo(AudioBufferList& buffer, size_t frameCoun
     for (uint32_t i = 0; i < buffer.mNumberBuffers; i++) {
         uint8_t* sourceData = static_cast<uint8_t*>(m_bufferList->buffer(i)->mData);
         uint8_t* destination = static_cast<uint8_t*>(buffer.mBuffers[i].mData);
-        memcpy(destination, sourceData, frameCount * m_internalFormat->bytesPerPacket());
+        memcpy(destination, sourceData, frameCount * m_internalFormat.bytesPerPacket());
     }
 
     return 0;
@@ -211,7 +211,7 @@ OSStatus AudioSampleBufferList::mixFrom(const AudioBufferList& source, size_t fr
     if (source.mNumberBuffers > m_bufferList->bufferCount())
         return kAudio_ParamError;
 
-    mixBuffers(bufferList(), source, m_internalFormat->format(), frameCount);
+    mixBuffers(bufferList(), source, m_internalFormat.format(), frameCount);
     return 0;
 }
 
@@ -226,7 +226,7 @@ void AudioSampleBufferList::reset()
 
 void AudioSampleBufferList::zero()
 {
-    zeroABL(m_bufferList.get(), m_internalFormat->bytesPerPacket() * m_sampleCapacity);
+    zeroABL(m_bufferList.get(), m_internalFormat.bytesPerPacket() * m_sampleCapacity);
 }
 
 void AudioSampleBufferList::zeroABL(AudioBufferList& buffer, size_t byteCount)

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
@@ -58,7 +58,7 @@ public:
     OSStatus mixFrom(const AudioBufferList&, size_t count = SIZE_MAX);
     OSStatus copyTo(AudioBufferList&, size_t count = SIZE_MAX);
 
-    const AudioStreamBasicDescription& streamDescription() const { return m_internalFormat->streamDescription(); }
+    const AudioStreamBasicDescription& streamDescription() const { return m_internalFormat.streamDescription(); }
     const WebAudioBufferList& bufferList() const { return m_bufferList; }
     WebAudioBufferList& bufferList() { return m_bufferList; }
 
@@ -78,7 +78,7 @@ public:
 protected:
     AudioSampleBufferList(const CAAudioStreamDescription&, size_t);
 
-    UniqueRef<CAAudioStreamDescription> m_internalFormat;
+    CAAudioStreamDescription m_internalFormat;
 
     uint64_t m_timestamp { 0 };
     double m_hostTime { -1 };

--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.cpp
@@ -28,11 +28,6 @@
 
 namespace WebCore {
 
-CAAudioStreamDescription::CAAudioStreamDescription()
-    : m_streamDescription({ })
-{
-}
-
 CAAudioStreamDescription::~CAAudioStreamDescription() = default;
 
 CAAudioStreamDescription::CAAudioStreamDescription(const AudioStreamBasicDescription &desc)

--- a/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
+++ b/Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h
@@ -36,7 +36,6 @@ inline bool operator!=(const AudioStreamBasicDescription& a, const AudioStreamBa
 class WEBCORE_EXPORT CAAudioStreamDescription final : public AudioStreamDescription {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    CAAudioStreamDescription();
     CAAudioStreamDescription(const AudioStreamBasicDescription&);
     CAAudioStreamDescription(double, uint32_t, PCMFormat, bool);
     ~CAAudioStreamDescription();
@@ -70,7 +69,7 @@ public:
     AudioStreamBasicDescription& streamDescription();
 
     template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static WARN_UNUSED_RETURN bool decode(Decoder&, CAAudioStreamDescription&);
+    template<class Decoder> static std::optional<CAAudioStreamDescription> decode(Decoder&);
 
 private:
     AudioStreamBasicDescription m_streamDescription;
@@ -85,9 +84,12 @@ void CAAudioStreamDescription::encode(Encoder& encoder) const
 }
 
 template<class Decoder>
-bool CAAudioStreamDescription::decode(Decoder& decoder, CAAudioStreamDescription& description)
+std::optional<CAAudioStreamDescription> CAAudioStreamDescription::decode(Decoder& decoder)
 {
-    return decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&description.m_streamDescription), sizeof(description.m_streamDescription), 1);
+    AudioStreamBasicDescription asbd { };
+    if (!decoder.decodeFixedLengthData(reinterpret_cast<uint8_t*>(&asbd), sizeof(asbd), 1))
+        return std::nullopt;
+    return CAAudioStreamDescription { asbd };
 }
 
 inline CAAudioStreamDescription toCAAudioStreamDescription(const AudioStreamDescription& description)

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -106,7 +106,7 @@ void MediaRecorderPrivateAVFImpl::audioSamplesAvailable(const MediaTime& mediaTi
     if (shouldMuteAudio()) {
         if (!m_audioBuffer || m_description != toCAAudioStreamDescription(description)) {
             m_description = toCAAudioStreamDescription(description);
-            m_audioBuffer = makeUnique<WebAudioBufferList>(m_description, sampleCount);
+            m_audioBuffer = makeUnique<WebAudioBufferList>(*m_description, sampleCount);
         } else
             m_audioBuffer->setSampleCount(sampleCount);
         m_audioBuffer->zeroFlatBuffer();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -61,7 +61,7 @@ private:
 
     Ref<MediaRecorderPrivateWriter> m_writer;
     RefPtr<VideoFrame> m_blackFrame;
-    CAAudioStreamDescription m_description;
+    std::optional<CAAudioStreamDescription> m_description;
     std::unique_ptr<WebAudioBufferList> m_audioBuffer;
 };
 

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
@@ -51,9 +51,9 @@ void AudioMediaStreamTrackRendererCocoa::start(CompletionHandler<void()>&& callb
 {
     clear();
 
-    AudioMediaStreamTrackRendererUnit::singleton().retrieveFormatDescription([weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto* formatDescription) mutable {
+    AudioMediaStreamTrackRendererUnit::singleton().retrieveFormatDescription([weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto formatDescription) mutable {
         if (weakThis && formatDescription) {
-            weakThis->m_outputDescription = makeUnique<CAAudioStreamDescription>(*formatDescription);
+            weakThis->m_outputDescription = *formatDescription;
             weakThis->m_shouldRecreateDataSource = true;
         }
         callback();
@@ -80,7 +80,7 @@ void AudioMediaStreamTrackRendererCocoa::clear()
     stop();
 
     setRegisteredDataSource(nullptr);
-    m_outputDescription = { };
+    m_outputDescription = std::nullopt;
 }
 
 void AudioMediaStreamTrackRendererCocoa::setVolume(float volume)

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h
@@ -29,18 +29,18 @@
 
 #include "AudioMediaStreamTrackRenderer.h"
 #include "AudioMediaStreamTrackRendererUnit.h"
+#include "CAAudioStreamDescription.h"
 #include "Logging.h"
-#include <wtf/WeakPtr.h>
-
 #include <AudioToolbox/AudioToolbox.h>
 #include <CoreAudio/CoreAudioTypes.h>
+#include <optional>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class AudioSampleDataSource;
 class AudioSampleBufferList;
 class BaseAudioMediaStreamTrackRendererUnit;
-class CAAudioStreamDescription;
 
 class AudioMediaStreamTrackRendererCocoa : public AudioMediaStreamTrackRenderer, public CanMakeWeakPtr<AudioMediaStreamTrackRendererCocoa, WeakPtrFactoryInitialization::Eager> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -62,7 +62,7 @@ private:
 
     BaseAudioMediaStreamTrackRendererUnit& rendererUnit();
 
-    std::unique_ptr<CAAudioStreamDescription> m_outputDescription;
+    std::optional<CAAudioStreamDescription> m_outputDescription;
     RefPtr<AudioSampleDataSource> m_dataSource; // Used in background thread.
     RefPtr<AudioSampleDataSource> m_registeredDataSource; // Used in main thread.
     bool m_shouldRecreateDataSource { false };

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -45,7 +45,7 @@ public:
 
     virtual void start() = 0;
     virtual void stop() = 0;
-    virtual void retrieveFormatDescription(CompletionHandler<void(const CAAudioStreamDescription*)>&&) = 0;
+    virtual void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&) = 0;
     virtual void setAudioOutputDevice(const String&) = 0;
 };
 

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -154,7 +154,7 @@ void AudioMediaStreamTrackRendererUnit::reset()
     });
 }
 
-void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHandler<void(const CAAudioStreamDescription*)>&& callback)
+void AudioMediaStreamTrackRendererUnit::retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&& callback)
 {
     ASSERT(isMainThread());
     m_internalUnit->retrieveFormatDescription(WTFMove(callback));

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -55,7 +55,7 @@ public:
     WEBCORE_EXPORT void render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&);
     void reset();
 
-    void retrieveFormatDescription(CompletionHandler<void(const CAAudioStreamDescription*)>&&);
+    void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&);
 
     // BaseAudioMediaStreamTrackRendererUnit
     void setAudioOutputDevice(const String&) final;

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
@@ -90,10 +90,10 @@ void IncomingAudioMediaStreamTrackRendererUnit::addSource(Ref<AudioSampleDataSou
             return;
 
         m_outputStreamDescription = outputDescription;
-        m_audioBufferList = makeUnique<WebAudioBufferList>(m_outputStreamDescription);
-        m_sampleCount = m_outputStreamDescription.sampleRate() / 100;
+        m_audioBufferList = makeUnique<WebAudioBufferList>(*m_outputStreamDescription);
+        m_sampleCount = m_outputStreamDescription->sampleRate() / 100;
         m_audioBufferList->setSampleCount(m_sampleCount);
-        m_mixedSource = AudioSampleDataSource::create(m_outputStreamDescription.sampleRate() * 0.5, *this, LibWebRTCAudioModule::PollSamplesCount + 1);
+        m_mixedSource = AudioSampleDataSource::create(m_outputStreamDescription->sampleRate() * 0.5, *this, LibWebRTCAudioModule::PollSamplesCount + 1);
         m_mixedSource->setInputFormat(outputDescription);
         m_mixedSource->setOutputFormat(outputDescription);
         m_writeCount = 0;
@@ -166,7 +166,7 @@ void IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk(uint64_t curren
 {
     ASSERT(!isMainThread());
 
-    uint64_t timeStamp = currentAudioSampleCount * m_outputStreamDescription.sampleRate() / LibWebRTCAudioFormat::sampleRate;
+    uint64_t timeStamp = currentAudioSampleCount * m_outputStreamDescription->sampleRate() / LibWebRTCAudioFormat::sampleRate;
 
     // Mix all sources.
     bool hasCopiedData = false;
@@ -175,7 +175,7 @@ void IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk(uint64_t curren
             hasCopiedData = true;
     }
 
-    CMTime startTime = PAL::CMTimeMake(m_writeCount, m_outputStreamDescription.sampleRate());
+    CMTime startTime = PAL::CMTimeMake(m_writeCount, m_outputStreamDescription->sampleRate());
     if (hasCopiedData)
         m_mixedSource->pushSamples(PAL::toMediaTime(startTime), *m_audioBufferList, m_sampleCount);
     m_writeCount += m_sampleCount;

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -89,7 +89,7 @@ private:
     // Background thread variables.
     Vector<Ref<AudioSampleDataSource>> m_renderSources;
     RefPtr<AudioSampleDataSource> m_mixedSource;
-    CAAudioStreamDescription m_outputStreamDescription;
+    std::optional<CAAudioStreamDescription> m_outputStreamDescription;
     std::unique_ptr<WebAudioBufferList> m_audioBufferList;
     size_t m_sampleCount { 0 };
     size_t m_writeCount { 0 };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp
@@ -415,14 +415,14 @@ OSStatus CoreAudioSharedUnit::provideSpeakerData(AudioUnitRenderActionFlags& fla
             });
         }
 
-        AudioSampleBufferList::zeroABL(ioData, static_cast<size_t>(inNumberFrames * m_speakerProcFormat.bytesPerFrame()));
+        AudioSampleBufferList::zeroABL(ioData, static_cast<size_t>(inNumberFrames * m_speakerProcFormat->bytesPerFrame()));
         flags = kAudioUnitRenderAction_OutputIsSilence;
         return noErr;
     }
 
     Locker locker { AdoptLock, m_speakerSamplesProducerLock };
     if (!m_speakerSamplesProducer) {
-        AudioSampleBufferList::zeroABL(ioData, static_cast<size_t>(inNumberFrames * m_speakerProcFormat.bytesPerFrame()));
+        AudioSampleBufferList::zeroABL(ioData, static_cast<size_t>(inNumberFrames * m_speakerProcFormat->bytesPerFrame()));
         flags = kAudioUnitRenderAction_OutputIsSilence;
         return noErr;
     }
@@ -474,7 +474,7 @@ OSStatus CoreAudioSharedUnit::processMicrophoneSamples(AudioUnitRenderActionFlag
     if (volume() != 1.0)
         m_microphoneSampleBuffer->applyGain(volume());
 
-    audioSamplesAvailable(MediaTime(sampleTime, m_microphoneProcFormat.sampleRate()), m_microphoneSampleBuffer->bufferList(), m_microphoneProcFormat, inNumberFrames);
+    audioSamplesAvailable(MediaTime(sampleTime, m_microphoneProcFormat->sampleRate()), m_microphoneSampleBuffer->bufferList(), *m_microphoneProcFormat, inNumberFrames);
     return noErr;
 }
 

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h
@@ -90,7 +90,6 @@ private:
     static size_t preferredIOBufferSize();
 
     CapabilityValueOrRange sampleRateCapacities() const final { return m_sampleRateCapabilities; }
-    const CAAudioStreamDescription& microphoneFormat() const { return m_microphoneProcFormat; }
 
     bool hasAudioUnit() const final { return !!m_ioUnit; }
     void captureDeviceChanged() final;
@@ -128,11 +127,11 @@ private:
     // Only read/modified from the IO thread.
     Vector<Ref<AudioSampleDataSource>> m_activeSources;
 
-    CAAudioStreamDescription m_microphoneProcFormat;
+    std::optional<CAAudioStreamDescription> m_microphoneProcFormat;
     RefPtr<AudioSampleBufferList> m_microphoneSampleBuffer;
     double m_latestMicTimeStamp { 0 };
 
-    CAAudioStreamDescription m_speakerProcFormat;
+    std::optional<CAAudioStreamDescription> m_speakerProcFormat;
 
     double m_DTSConversionRatio { 0 };
 

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
@@ -55,8 +55,8 @@ private:
     void pullAudioData();
 
     Ref<AudioSampleDataSource> m_sampleConverter;
-    CAAudioStreamDescription m_inputStreamDescription;
-    CAAudioStreamDescription m_outputStreamDescription;
+    std::optional<CAAudioStreamDescription> m_inputStreamDescription;
+    std::optional<CAAudioStreamDescription> m_outputStreamDescription;
 
     Vector<uint8_t> m_audioBuffer;
     uint64_t m_readCount { 0 };

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -62,7 +62,7 @@ public:
 
 private:
     // Messages
-    void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, CompletionHandler<void(const WebCore::CAAudioStreamDescription&, size_t)>&& callback);
+    void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback);
     void deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
     void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, ConsumerSharedCARingBuffer::Handle&&, uint64_t numberOfFrames, IPC::Semaphore&&);
     void stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
 
 messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager NotRefCounted {
-    CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier) -> (WebCore::CAAudioStreamDescription description, size_t frameChunkSize)
+    CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier) -> (std::optional<WebCore::CAAudioStreamDescription> description, size_t frameChunkSize)
     DeleteUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
     StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, uint64_t numberOfFrames, IPC::Semaphore renderSemaphore)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -72,19 +72,19 @@ void RemoteMediaRecorder::audioSamplesStorageChanged(ConsumerSharedCARingBuffer:
     if (!m_ringBuffer)
         return;
     m_description = description;
-    m_audioBufferList = makeUnique<WebAudioBufferList>(m_description);
+    m_audioBufferList = makeUnique<WebAudioBufferList>(*m_description);
 }
 
 void RemoteMediaRecorder::audioSamplesAvailable(MediaTime time, uint64_t numberOfFrames)
 {
     MESSAGE_CHECK(m_ringBuffer);
     MESSAGE_CHECK(m_audioBufferList);
-    MESSAGE_CHECK(WebAudioBufferList::isSupportedDescription(m_description, numberOfFrames));
+    MESSAGE_CHECK(m_description && WebAudioBufferList::isSupportedDescription(*m_description, numberOfFrames));
 
     m_audioBufferList->setSampleCount(numberOfFrames);
     m_ringBuffer->fetch(m_audioBufferList->list(), numberOfFrames, time.timeValue());
 
-    m_writer->appendAudioSampleBuffer(*m_audioBufferList, m_description, time, numberOfFrames);
+    m_writer->appendAudioSampleBuffer(*m_audioBufferList, *m_description, time, numberOfFrames);
 }
 
 void RemoteMediaRecorder::videoFrameAvailable(SharedVideoFrame&& sharedVideoFrame)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -81,7 +81,7 @@ private:
     MediaRecorderIdentifier m_identifier;
     Ref<WebCore::MediaRecorderPrivateWriter> m_writer;
 
-    WebCore::CAAudioStreamDescription m_description;
+    std::optional<WebCore::CAAudioStreamDescription> m_description;
     std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_audioBufferList;
     const bool m_recordAudio;

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -90,7 +90,6 @@ public:
     }
 
     RealtimeMediaSource& source() { return m_source; }
-    CAAudioStreamDescription& description() { return m_description; }
     int64_t numberOfFrames() { return m_numberOfFrames; }
 
     void audioUnitWillStart() final
@@ -155,8 +154,8 @@ private:
             m_frameChunkSize = std::max(WebCore::AudioUtilities::renderQuantumSize, AudioSession::sharedSession().preferredBufferSize());
 
             // Allocate a ring buffer large enough to contain 2 seconds of audio.
-            m_numberOfFrames = m_description.sampleRate() * 2;
-            auto& format = m_description.streamDescription();
+            m_numberOfFrames = m_description->sampleRate() * 2;
+            auto& format = m_description->streamDescription();
             auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, m_numberOfFrames);
             m_ringBuffer = WTFMove(ringBuffer);
             m_connection->send(Messages::RemoteCaptureSampleManager::AudioStorageChanged(m_id, WTFMove(handle), format, m_numberOfFrames, *m_captureSemaphore, m_startTime, m_frameChunkSize), 0);
@@ -233,7 +232,7 @@ private:
     ProcessIdentity m_resourceOwner;
     Ref<RealtimeMediaSource> m_source;
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
-    CAAudioStreamDescription m_description { };
+    std::optional<CAAudioStreamDescription> m_description { };
     int64_t m_numberOfFrames { 0 };
     bool m_isStopped { false };
     std::unique_ptr<ImageRotationSessionVT> m_rotationSession;

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -95,7 +95,7 @@ void SpeechRecognitionRemoteRealtimeMediaSource::remoteAudioSamplesAvailable(Med
 
     m_buffer->setSampleCount(numberOfFrames);
     m_ringBuffer->fetch(m_buffer->list(), numberOfFrames, time.timeValue());
-    audioSamplesAvailable(time, *m_buffer, m_description, numberOfFrames);
+    audioSamplesAvailable(time, *m_buffer, *m_description, numberOfFrames);
 #else
     UNUSED_PARAM(time);
     UNUSED_PARAM(numberOfFrames);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -75,7 +75,7 @@ private:
     WebCore::RealtimeMediaSourceSettings m_settings;
 
 #if PLATFORM(COCOA)
-    WebCore::CAAudioStreamDescription m_description;
+    std::optional<WebCore::CAAudioStreamDescription> m_description;
     std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -137,7 +137,7 @@ void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64
         return;
     }
 
-    if (!WebAudioBufferList::isSupportedDescription(m_description, numberOfFrames)) {
+    if (!WebAudioBufferList::isSupportedDescription(*m_description, numberOfFrames)) {
         RELEASE_LOG_ERROR(Media, "Unable to support description with given number of frames for audio provider %llu", m_provider->identifier().toUInt64());
         return;
     }
@@ -146,7 +146,7 @@ void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64
 
     m_ringBuffer->fetch(m_buffer->list(), numberOfFrames, startFrame);
 
-    m_provider->audioSamplesAvailable(*m_buffer, m_description, numberOfFrames);
+    m_provider->audioSamplesAvailable(*m_buffer, *m_description, numberOfFrames);
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -70,7 +70,7 @@ private:
 
     private:
         Ref<RemoteAudioSourceProvider> m_provider;
-        WebCore::CAAudioStreamDescription m_description;
+        std::optional<WebCore::CAAudioStreamDescription> m_description;
         std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
         std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
     };

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -121,8 +121,8 @@ void MediaRecorderPrivate::audioSamplesAvailable(const MediaTime& time, const Pl
         m_description = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
 
         // Allocate a ring buffer large enough to contain 2 seconds of audio.
-        m_numberOfFrames = m_description.sampleRate() * 2;
-        auto& format = m_description.streamDescription();
+        m_numberOfFrames = m_description->sampleRate() * 2;
+        auto& format = m_description->streamDescription();
         auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, m_numberOfFrames);
         m_ringBuffer = WTFMove(ringBuffer);
         m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format, m_numberOfFrames }, m_identifier);
@@ -133,7 +133,7 @@ void MediaRecorderPrivate::audioSamplesAvailable(const MediaTime& time, const Pl
 
     if (shouldMuteAudio()) {
         if (!m_silenceAudioBuffer)
-            m_silenceAudioBuffer = makeUnique<WebAudioBufferList>(m_description, numberOfFrames);
+            m_silenceAudioBuffer = makeUnique<WebAudioBufferList>(*m_description, numberOfFrames);
         else
             m_silenceAudioBuffer->setSampleCount(numberOfFrames);
         m_silenceAudioBuffer->zeroFlatBuffer();

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -74,7 +74,7 @@ private:
     Ref<IPC::Connection> m_connection;
 
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
-    WebCore::CAAudioStreamDescription m_description { };
+    std::optional<WebCore::CAAudioStreamDescription> m_description;
     std::unique_ptr<WebCore::WebAudioBufferList> m_silenceAudioBuffer;
     uint64_t m_numberOfFrames { 0 };
     WebCore::MediaRecorderPrivateOptions m_options;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -100,8 +100,8 @@ private:
         if (m_description != description) {
             ASSERT(description.platformDescription().type == PlatformDescription::CAAudioStreamBasicType);
             m_description = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
-            size_t numberOfFrames = m_description.sampleRate() * 2;
-            auto& format = m_description.streamDescription();
+            size_t numberOfFrames = m_description->sampleRate() * 2;
+            auto& format = m_description->streamDescription();
             auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, numberOfFrames);
             m_ringBuffer = WTFMove(ringBuffer);
             m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::SetStorage(m_identifier, WTFMove(handle), format, numberOfFrames), 0);
@@ -134,7 +134,7 @@ private:
 
 #if PLATFORM(COCOA)
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
-    CAAudioStreamDescription m_description { };
+    std::optional<CAAudioStreamDescription> m_description { };
 #endif
 };
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -204,11 +204,11 @@ void RemoteCaptureSampleManager::RemoteAudio::startThread()
             if (m_shouldStopThread)
                 break;
 
-            auto currentTime = m_startTime + MediaTime { m_readOffset, static_cast<uint32_t>(m_description.sampleRate()) };
+            auto currentTime = m_startTime + MediaTime { m_readOffset, static_cast<uint32_t>(m_description->sampleRate()) };
             m_ringBuffer->fetch(m_buffer->list(), m_frameChunkSize, m_readOffset);
             m_readOffset += m_frameChunkSize;
 
-            m_source->remoteAudioSamplesAvailable(currentTime, *m_buffer, m_description, m_frameChunkSize);
+            m_source->remoteAudioSamplesAvailable(currentTime, *m_buffer, *m_description, m_frameChunkSize);
         } while (!m_shouldStopThread);
     };
     m_thread = Thread::create("RemoteCaptureSampleManager::RemoteAudio thread", WTFMove(threadLoop), ThreadType::Audio, Thread::QOS::UserInteractive);

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -90,7 +90,7 @@ private:
         void startThread();
 
         Ref<RemoteRealtimeAudioSource> m_source;
-        WebCore::CAAudioStreamDescription m_description;
+        std::optional<WebCore::CAAudioStreamDescription> m_description;
         std::unique_ptr<WebCore::WebAudioBufferList> m_buffer;
         std::unique_ptr<ConsumerSharedCARingBuffer> m_ringBuffer;
         int64_t m_readOffset { 0 };

--- a/Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp
@@ -49,16 +49,16 @@ public:
     {
         m_description = CAAudioStreamDescription(sampleRate, numChannels, format, isInterleaved);
         m_capacity = capacity;
-        size_t listSize = offsetof(AudioBufferList, mBuffers) + (sizeof(AudioBuffer) * std::max<uint32_t>(1, m_description.numberOfChannelStreams()));
+        size_t listSize = offsetof(AudioBufferList, mBuffers) + (sizeof(AudioBuffer) * std::max<uint32_t>(1, m_description->numberOfChannelStreams()));
         m_bufferList = std::unique_ptr<AudioBufferList>(static_cast<AudioBufferList*>(::operator new (listSize)));
-        m_ringBuffer = InProcessCARingBuffer::allocate(m_description, capacity);
+        m_ringBuffer = InProcessCARingBuffer::allocate(*m_description, capacity);
     }
 
     void setListDataBuffer(uint8_t* bufferData, size_t sampleCount)
     {
-        size_t bufferCount = m_description.numberOfChannelStreams();
-        size_t channelCount = m_description.numberOfInterleavedChannels();
-        size_t bytesPerChannel = sampleCount * m_description.bytesPerFrame();
+        size_t bufferCount = m_description->numberOfChannelStreams();
+        size_t channelCount = m_description->numberOfInterleavedChannels();
+        size_t bytesPerChannel = sampleCount * m_description->bytesPerFrame();
 
         m_bufferList->mNumberBuffers = bufferCount;
         for (unsigned i = 0; i < bufferCount; ++i) {
@@ -70,7 +70,7 @@ public:
         }
     }
 
-    const CAAudioStreamDescription& description() const { return m_description; }
+    const CAAudioStreamDescription& description() const { return *m_description; }
     AudioBufferList& bufferList() const { return *m_bufferList.get(); }
     CARingBuffer& ringBuffer() const { return *m_ringBuffer.get(); }
     size_t capacity() const { return m_capacity; }
@@ -79,7 +79,7 @@ private:
 
     std::unique_ptr<AudioBufferList> m_bufferList;
     std::unique_ptr<InProcessCARingBuffer> m_ringBuffer;
-    CAAudioStreamDescription m_description = { };
+    std::optional<CAAudioStreamDescription> m_description;
     size_t m_capacity = { 0 };
 };
 


### PR DESCRIPTION
#### 0b3759dd1cde2f99b360f48de7abddeb75c2c032
<pre>
CAAudioStreamDescription should be held like a value type
<a href="https://bugs.webkit.org/show_bug.cgi?id=247663">https://bugs.webkit.org/show_bug.cgi?id=247663</a>
rdar://problem/102128846

Reviewed by Youenn Fablet.

CAAudioStreamDescription was needlessly held in three different ways:
 - as uninitialized dummy value until dynamically initialized:
   CAAudioStreamDescription m_description;
 - as an optional:
   std::optional&lt;CAAudioStreamDescription&gt; m_description;
 - as a reference type:
   std::unique_ptr&lt;CAAudioStreamDescription&gt; m_description;
   UniqueRef&lt;CAAudioStreamDescription&gt; m_description = makeUnique&lt;..&gt;().

The type itself should be a value type. Work towards that
and the future rename of the type to AudioStreamDescription by
following:
 - Make CAAudioStreamDescription non-default constructible. All
   instances are really valid data.
 - Hold std::optional&lt;&gt; in case the instance is initialized
   dynamically

* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp:
(WebCore::AudioSampleBufferList::AudioSampleBufferList):
(WebCore::AudioSampleBufferList::applyGain):
(WebCore::AudioSampleBufferList::mixFrom):
(WebCore::AudioSampleBufferList::copyFrom):
(WebCore::AudioSampleBufferList::copyTo):
(WebCore::AudioSampleBufferList::zero):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h:
(WebCore::AudioSampleBufferList::streamDescription const):
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.cpp:
* Source/WebCore/platform/audio/cocoa/CAAudioStreamDescription.h:
(WebCore::CAAudioStreamDescription::decode):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::audioSamplesAvailable):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp:
(WebCore::AudioMediaStreamTrackRendererCocoa::start):
(WebCore::AudioMediaStreamTrackRendererCocoa::clear):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::retrieveFormatDescription):
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::retrieveFormatDescription):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::addSource):
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::renderAudioChunk):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.cpp:
(WebCore::CoreAudioSharedUnit::provideSpeakerData):
(WebCore::CoreAudioSharedUnit::processMicrophoneSamples):
* Source/WebCore/platform/mediastream/mac/CoreAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp:
(WebCore::RealtimeOutgoingAudioSourceCocoa::isReachingBufferedAudioDataHighLimit):
(WebCore::RealtimeOutgoingAudioSourceCocoa::isReachingBufferedAudioDataLowLimit):
(WebCore::RealtimeOutgoingAudioSourceCocoa::hasBufferedEnoughData):
(WebCore::RealtimeOutgoingAudioSourceCocoa::audioSamplesAvailable):
(WebCore::RealtimeOutgoingAudioSourceCocoa::pullAudioData):
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::createUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::Unit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::render):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::audioSamplesStorageChanged):
(WebKit::RemoteMediaRecorder::audioSamplesAvailable):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::source):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::description): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::remoteAudioSamplesAvailable):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::~Proxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::createRemoteUnit):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::initialize):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::retrieveFormatDescription):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::audioSamplesAvailable):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::RemoteAudio::startThread):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp:
(TestWebKitAPI::CARingBufferTest::setup):
(TestWebKitAPI::CARingBufferTest::setListDataBuffer):
(TestWebKitAPI::CARingBufferTest::description const):

Canonical link: <a href="https://commits.webkit.org/256562@main">https://commits.webkit.org/256562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb436c7ece9e534349f9ed3edccc50e505b20405

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105629 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165957 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5444 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34087 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101446 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4031 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82683 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31054 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39818 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20652 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43259 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39915 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->