### PR TITLE
Make sure nested worker get controlled if matching a service worker registration

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -364,7 +364,6 @@ imported/w3c/web-platform-tests/service-workers/service-worker/worker-in-sandbox
 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event-worker-timing-frame.tentative.https.html [ Skip ]
 imported/w3c/web-platform-tests/service-workers/service-worker/claim-worker-fetch.https.html [ Skip ]
 imported/w3c/web-platform-tests/service-workers/service-worker/client-navigate.https.html [ Skip ]
-imported/w3c/web-platform-tests/service-workers/service-worker/nested-blob-url-workers.https.html [ Skip ]
 imported/w3c/web-platform-tests/service-workers/service-worker/update-bytecheck-cors-import.https.html [ Skip ]
 
 # This test is a flaky timeout.

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/nested-blob-url-workers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/nested-blob-url-workers.https-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Nested blob URL workers should be intercepted by a service worker.
+PASS Nested worker created from a blob URL worker should be intercepted by a service worker.
+PASS Nested blob URL worker created from a worker should be intercepted by a service worker.
+

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -41,17 +41,22 @@
 #include "TextResourceDecoder.h"
 #include "WorkerFetchResult.h"
 #include "WorkerGlobalScope.h"
+#include "WorkerSWClientConnection.h"
 #include "WorkerScriptLoaderClient.h"
 #include "WorkerThreadableLoader.h"
 #include <wtf/Ref.h>
 
 namespace WebCore {
 
-static HashMap<ScriptExecutionContextIdentifier, WorkerScriptLoader*>& scriptExecutionContextIdentifierToWorkerScriptLoaderMap()
+#if ENABLE(SERVICE_WORKER)
+static Lock workerScriptLoaderControlledCallbackMapLock;
+static void accessWorkerScriptLoaderMap(CompletionHandler<void(HashMap<ScriptExecutionContextIdentifier, Ref<WorkerScriptLoader::ServiceWorkerDataManager>>&)>&& callback)
 {
-    static MainThreadNeverDestroyed<HashMap<ScriptExecutionContextIdentifier, WorkerScriptLoader*>> map;
-    return map.get();
+    Locker locker { workerScriptLoaderControlledCallbackMapLock };
+    static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, Ref<WorkerScriptLoader::ServiceWorkerDataManager>>> map;
+    callback(map.get());
 }
+#endif
 
 WorkerScriptLoader::WorkerScriptLoader()
     : m_script(ScriptBuffer::empty())
@@ -60,14 +65,9 @@ WorkerScriptLoader::WorkerScriptLoader()
 
 WorkerScriptLoader::~WorkerScriptLoader()
 {
-    if (m_didAddToWorkerScriptLoaderMap)
-        scriptExecutionContextIdentifierToWorkerScriptLoaderMap().remove(m_clientIdentifier);
-
 #if ENABLE(SERVICE_WORKER)
-    if (m_activeServiceWorkerData) {
-        if (auto* serviceWorkerConnection = ServiceWorkerProvider::singleton().existingServiceWorkerConnection())
-            serviceWorkerConnection->unregisterServiceWorkerClient(m_clientIdentifier);
-    }
+    if (m_didAddToWorkerScriptLoaderMap)
+        accessWorkerScriptLoaderMap([clientIdentifier = m_clientIdentifier](auto& map) { map.remove(clientIdentifier); });
 #endif
 }
 
@@ -158,15 +158,20 @@ void WorkerScriptLoader::loadAsynchronously(ScriptExecutionContext& scriptExecut
     // A service worker job can be executed from a worker context or a document context.
     options.serviceWorkersMode = serviceWorkerMode;
 #if ENABLE(SERVICE_WORKER)
-    if ((m_destination == FetchOptions::Destination::Worker || m_destination == FetchOptions::Destination::Sharedworker) && is<Document>(scriptExecutionContext) && downcast<Document>(scriptExecutionContext).settings().serviceWorkersEnabled()) {
+    if (scriptExecutionContext.settingsValues().serviceWorkersEnabled && clientIdentifier) {
+        ASSERT(m_destination == FetchOptions::Destination::Worker || m_destination == FetchOptions::Destination::Sharedworker);
         m_topOriginForServiceWorkerRegistration = SecurityOriginData { scriptExecutionContext.topOrigin().data() };
-        ASSERT(clientIdentifier);
         options.clientIdentifier = clientIdentifier;
-        // In case of blob URLs, we reuse the document controlling service worker.
+        m_serviceWorkerDataManager = ServiceWorkerDataManager::create(clientIdentifier);
+        m_context = scriptExecutionContext;
+
+        // In case of blob URLs, we reuse the context controlling service worker.
         if (request->url().protocolIsBlob() && scriptExecutionContext.activeServiceWorker())
             setControllingServiceWorker(ServiceWorkerData { scriptExecutionContext.activeServiceWorker()->data() });
         else {
-            scriptExecutionContextIdentifierToWorkerScriptLoaderMap().add(m_clientIdentifier, this);
+            accessWorkerScriptLoaderMap([this](auto& map) mutable {
+                map.add(m_clientIdentifier, *m_serviceWorkerDataManager);
+            });
             m_didAddToWorkerScriptLoaderMap = true;
         }
     } else if (auto* activeServiceWorker = scriptExecutionContext.activeServiceWorker())
@@ -253,9 +258,10 @@ void WorkerScriptLoader::didReceiveResponse(ResourceLoaderIdentifier identifier,
     m_referrerPolicy = response.httpHeaderField(HTTPHeaderName::ReferrerPolicy);
 
 #if ENABLE(SERVICE_WORKER)
-    if (m_topOriginForServiceWorkerRegistration && response.source() == ResourceResponse::Source::MemoryCache) {
+    if (m_topOriginForServiceWorkerRegistration && response.source() == ResourceResponse::Source::MemoryCache && m_context) {
         m_isMatchingServiceWorkerRegistration = true;
-        ServiceWorkerProvider::singleton().serviceWorkerConnection().matchRegistration(WTFMove(*m_topOriginForServiceWorkerRegistration), response.url(), [this, protectedThis = Ref { *this }, response, identifier](auto&& registrationData) mutable {
+        auto& swConnection = is<WorkerGlobalScope>(m_context) ? static_cast<SWClientConnection&>(downcast<WorkerGlobalScope>(*m_context).swClientConnection()) : ServiceWorkerProvider::singleton().serviceWorkerConnection();
+        swConnection.matchRegistration(WTFMove(*m_topOriginForServiceWorkerRegistration), response.url(), [this, protectedThis = Ref { *this }, response, identifier](auto&& registrationData) mutable {
             m_isMatchingServiceWorkerRegistration = false;
             if (registrationData && registrationData->activeWorker)
                 setControllingServiceWorker(WTFMove(*registrationData->activeWorker));
@@ -356,20 +362,49 @@ WorkerFetchResult WorkerScriptLoader::fetchResult() const
     return { script(), responseURL(), certificateInfo(), contentSecurityPolicy(), crossOriginEmbedderPolicy(), referrerPolicy(), { } };
 }
 
-WorkerScriptLoader* WorkerScriptLoader::fromScriptExecutionContextIdentifier(ScriptExecutionContextIdentifier identifier)
-{
-    return scriptExecutionContextIdentifierToWorkerScriptLoaderMap().get(identifier);
-}
-
 #if ENABLE(SERVICE_WORKER)
-bool WorkerScriptLoader::setControllingServiceWorker(ServiceWorkerData&& activeServiceWorkerData)
+std::optional<ServiceWorkerData> WorkerScriptLoader::takeServiceWorkerData()
 {
-    if (!m_client)
-        return false;
-
-    m_activeServiceWorkerData = WTFMove(activeServiceWorkerData);
-    return true;
+    if (!m_serviceWorkerDataManager)
+        return { };
+    return m_serviceWorkerDataManager->takeData();
 }
+
+RefPtr<WorkerScriptLoader::ServiceWorkerDataManager> WorkerScriptLoader::serviceWorkerDataManagerFromIdentifier(ScriptExecutionContextIdentifier identifier)
+{
+    RefPtr<ServiceWorkerDataManager> result;
+    accessWorkerScriptLoaderMap([identifier, &result](auto& map) {
+        result = map.get(identifier);
+    });
+    return result;
+}
+
+void WorkerScriptLoader::setControllingServiceWorker(ServiceWorkerData&& activeServiceWorkerData)
+{
+    m_serviceWorkerDataManager->setData(WTFMove(activeServiceWorkerData));
+}
+
+WorkerScriptLoader::ServiceWorkerDataManager::~ServiceWorkerDataManager()
+{
+    if (!m_activeServiceWorkerData)
+        return;
+    if (auto* serviceWorkerConnection = ServiceWorkerProvider::singleton().existingServiceWorkerConnection())
+        serviceWorkerConnection->unregisterServiceWorkerClient(m_clientIdentifier);
+}
+
+void WorkerScriptLoader::ServiceWorkerDataManager::setData(ServiceWorkerData&& data)
+{
+    Locker lock(m_activeServiceWorkerDataLock);
+    m_activeServiceWorkerData = WTFMove(data).isolatedCopy();
+}
+
+std::optional<ServiceWorkerData> WorkerScriptLoader::ServiceWorkerDataManager::takeData()
+{
+    Locker lock(m_activeServiceWorkerDataLock);
+    std::optional<ServiceWorkerData> data = std::exchange(data, m_activeServiceWorkerData);
+    return data;
+}
+
 #endif
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -189,9 +189,12 @@ void WebSWClientConnection::setServiceWorkerClientIsControlled(ScriptExecutionCo
         return;
     }
 
-    if (auto* loader = WorkerScriptLoader::fromScriptExecutionContextIdentifier(identifier)) {
-        completionHandler(data.activeWorker ? loader->setControllingServiceWorker(WTFMove(*data.activeWorker)) : false);
-        return;
+    if (auto manager = WorkerScriptLoader::serviceWorkerDataManagerFromIdentifier(identifier)) {
+        if (data.activeWorker) {
+            manager->setData(WTFMove(*data.activeWorker));
+            completionHandler(true);
+            return;
+        }
     }
 
     completionHandler(false);


### PR DESCRIPTION
#### 056c2a9cad9c31deb641fcb7ca0d8e1291d92e8c
<pre>
Make sure nested worker get controlled if matching a service worker registration
<a href="https://bugs.webkit.org/show_bug.cgi?id=247619">https://bugs.webkit.org/show_bug.cgi?id=247619</a>
rdar://problem/102090425

Reviewed by Chris Dumez.

Allow to register WorkerScriptLoader living of the main thread (nested workers do create them).
Instead of registering a WorkerScriptLoader*, we now register a callback which is called when we need to set a worker as controlled.
Covered by unskipped test.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/nested-blob-url-workers.https-expected.txt: Added.
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::workerScriptLoaderControlledCallbackMap):
(WebCore::accessWorkerScriptLoaderMap):
(WebCore::WorkerScriptLoader::~WorkerScriptLoader):
(WebCore::WorkerScriptLoader::loadAsynchronously):
(WebCore::WorkerScriptLoader::getWorkerClientControlledCallback):
(): Deleted.
(WebCore::WorkerScriptLoader::fromScriptExecutionContextIdentifier): Deleted.
* Source/WebCore/workers/WorkerScriptLoader.h:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::setServiceWorkerClientIsControlled):

Canonical link: <a href="https://commits.webkit.org/256637@main">https://commits.webkit.org/256637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42e98acf6b0acf73c37aed6be1d829e688aabc46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96071 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105622 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165950 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5436 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34080 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101439 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4015 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82676 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31047 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39812 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37487 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20645 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4606 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43250 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39908 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->