### PR TITLE
[LBSE] Enforce presence of a RenderSVGViewportContainer, even if the <svg> has no children

### DIFF
--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-01-t-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-01-t-expected.txt
@@ -2,3 +2,5 @@ layer at (0,0) size 480x360
   RenderView at (0,0) size 480x360
 layer at (0,0) size 480x360
   RenderSVGRoot {svg} at (0,0) size 480x360
+layer at (0,0) size 480x360
+  RenderSVGViewportContainer at (0,0) size 480x360

--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/custom/svg-root-background-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/custom/svg-root-background-expected.txt
@@ -5,3 +5,5 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
 layer at (8,8) size 200x200
   RenderSVGRoot {svg} at (8,8) size 200x200 [bgcolor=#008000]
+layer at (8,8) size 200x200
+  RenderSVGViewportContainer at (0,0) size 200x200

--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/hixie/intrinsic/003-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/hixie/intrinsic/003-expected.txt
@@ -10,6 +10,8 @@ layer at (0,0) size 800x267
               RenderView at (0,0) size 100x200
             layer at (0,0) size 100x200
               RenderSVGRoot {svg} at (0,0) size 100x200
+            layer at (0,0) size 100x200
+              RenderSVGViewportContainer at (0,0) size 100x200
       RenderBlock {P} at (0,216) size 784x19
         RenderText {#text} at (0,0) size 431x18
           text run at (0,0) width 431: "There should be a complete unbroken yin-yang symbol (\x{262F}) above."

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -898,12 +898,22 @@ void RenderTreeBuilder::destroyAndCleanUpAnonymousWrappers(RenderObject& rendere
 
 void RenderTreeBuilder::updateAfterDescendants(RenderElement& renderer)
 {
-    if (is<RenderBlock>(renderer))
-        firstLetterBuilder().updateAfterDescendants(downcast<RenderBlock>(renderer));
-    if (is<RenderListItem>(renderer))
-        listBuilder().updateItemMarker(downcast<RenderListItem>(renderer));
-    if (is<RenderBlockFlow>(renderer))
-        multiColumnBuilder().updateAfterDescendants(downcast<RenderBlockFlow>(renderer));
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(renderer)) {
+        svgBuilder().updateAfterDescendants(*svgRoot);
+        return; // A RenderSVGRoot cannot be a RenderBlock, RenderListItem or RenderBlockFlow: early return.
+    }
+#endif
+
+    // Do not early return here in any case. For example, RenderListItem derives
+    // from RenderBlockFlow and indirectly from RenderBlock thus fulfilling all
+    // update conditions below.
+    if (auto* block = dynamicDowncast<RenderBlock>(renderer))
+        firstLetterBuilder().updateAfterDescendants(*block);
+    if (auto* listItem = dynamicDowncast<RenderListItem>(renderer))
+        listBuilder().updateItemMarker(*listItem);
+    if (auto* blockFlow = dynamicDowncast<RenderBlockFlow>(renderer))
+        multiColumnBuilder().updateAfterDescendants(*blockFlow);
 }
 
 RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderGrid(RenderGrid& parent, RenderObject& child)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp
@@ -82,14 +82,6 @@ void RenderTreeBuilder::SVG::attach(RenderSVGRoot& parent, RenderPtr<RenderObjec
 {
     auto& childToAdd = *child;
     m_builder.attachToRenderElement(findOrCreateParentForChild(parent), WTFMove(child), beforeChild);
-
-    // updateFromStyle() needs access to the SVGSVGElement, which is only posssible
-    // after the newly created RenderSVGViewportContainer was inserted into the render tree.
-    // However updateFromStyle() was already called at this point. Therefore we have to
-    // call it again here.
-    ASSERT(parent.viewportContainer());
-    parent.viewportContainer()->updateFromStyle();
-
     SVGResourcesCache::clientWasAddedToTree(childToAdd);
 }
 #endif
@@ -162,7 +154,11 @@ RenderSVGViewportContainer& RenderTreeBuilder::SVG::findOrCreateParentForChild(R
 {
     if (auto* viewportContainer = parent.viewportContainer())
         return *viewportContainer;
+    return createViewportContainer(parent);
+}
 
+RenderSVGViewportContainer& RenderTreeBuilder::SVG::createViewportContainer(RenderSVGRoot& parent)
+{
     auto viewportContainerStyle = RenderStyle::createAnonymousStyleWithDisplay(parent.style(), RenderStyle::initialDisplay());
     viewportContainerStyle.setUsedZIndex(0); // Enforce a stacking context.
     viewportContainerStyle.setTransformOriginX(Length(0, LengthType::Fixed));
@@ -174,7 +170,25 @@ RenderSVGViewportContainer& RenderTreeBuilder::SVG::findOrCreateParentForChild(R
     auto* viewportContainerRenderer = viewportContainer.get();
     m_builder.attachToRenderElement(parent, WTFMove(viewportContainer), nullptr);
     parent.setViewportContainer(*viewportContainerRenderer);
+
+    // updateFromStyle() needs access to the SVGSVGElement, which is only posssible
+    // after the newly created RenderSVGViewportContainer was inserted into the render tree.
+    // However updateFromStyle() was already called at this point. Therefore we have to
+    // call it again here.
+    viewportContainerRenderer->updateFromStyle();
     return *viewportContainerRenderer;
+}
+
+void RenderTreeBuilder::SVG::updateAfterDescendants(RenderSVGRoot& svgRoot)
+{
+    // Usually the anonymous RenderSVGViewportContainer, wrapping all children of RenderSVGRoot,
+    // is created when the first <svg> child element is inserted into the render tree. We'll
+    // only reach this point with viewportContainer=nullptr, if the <svg> had no children -- we
+    // still need to ensure the creation of the RenderSVGViewportContainer, otherwise computing
+    // e.g. getCTM() would ignore the presence of a 'viewBox' induced transform (and ignore zoom/pan).
+    if (svgRoot.viewportContainer())
+        return;
+    createViewportContainer(svgRoot);
 }
 #endif
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
@@ -43,6 +43,8 @@ public:
     SVG(RenderTreeBuilder&);
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+    void updateAfterDescendants(RenderSVGRoot&);
+
     void attach(RenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderSVGContainer& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 #endif
@@ -65,6 +67,7 @@ public:
 private:
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     RenderSVGViewportContainer& findOrCreateParentForChild(RenderSVGRoot&);
+    RenderSVGViewportContainer& createViewportContainer(RenderSVGRoot&);
 #endif
     RenderTreeBuilder& m_builder;
 };


### PR DESCRIPTION
#### e9c7dfad5a10d4706ea2fa2bdbc50e9d736186dd
<pre>
[LBSE] Enforce presence of a RenderSVGViewportContainer, even if the &lt;svg&gt; has no children
<a href="https://bugs.webkit.org/show_bug.cgi?id=247669">https://bugs.webkit.org/show_bug.cgi?id=247669</a>

Reviewed by Rob Buis.

The anonymous RenderSVGViewportContainer, enclosing all descendants of the outermost
&lt;svg&gt; element, is usually created when the first child is supposed to be added to
the &lt;svg&gt; element. This logic fails, if there is no descendant.

However zooming/panning/viewBox coordinate transformations are applied to the
RenderSVGViewportContainer, not the RenderSVGRoot. For rendering/hit-testing there
is no issue, since no content is rendered/testable. But it does matter for getCTM(),
getScreenCTM() etc. since they just walk the render tree -- the asence of a
RenderSVGViewportContainer will mean that viewBox transformations aren&apos;t included
in the resulting matrices -- fix that.

This patch is a pre-requisite for implementing getCTM() / getScreenCTM() in LBSE.

Covered by existing tests, that need a rebaseline for a few cases that failed to create
a RenderSVGViewportContainer before.

* LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/W3C-SVG-1.1/struct-frag-01-t-expected.txt:
* LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/custom/svg-root-background-expected.txt:
* LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/hixie/intrinsic/003-expected.txt:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp:
(WebCore::RenderTreeBuilder::SVG::attach):
(WebCore::RenderTreeBuilder::SVG::findOrCreateParentForChild):
(WebCore::RenderTreeBuilder::SVG::createViewportContainer):
(WebCore::RenderTreeBuilder::SVG::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h:

Canonical link: <a href="https://commits.webkit.org/256604@main">https://commits.webkit.org/256604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56178433a9d07c0f466b53c3c78ae2b6916e3a58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105683 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166025 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5510 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34150 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101505 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4083 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82743 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31106 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73941 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39878 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20716 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4580 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43319 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/44039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39976 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->