### PR TITLE
[LBSE] Allow to query supplementalTransform() without creation

### DIFF
--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -147,7 +147,7 @@ void SVGAnimateMotionElement::startAnimation()
     RefPtr targetElement = this->targetElement();
     if (!targetElement)
         return;
-    if (AffineTransform* transform = targetElement->supplementalTransform())
+    if (auto* transform = targetElement->ensureSupplementalTransform())
         transform->makeIdentity();
 }
 
@@ -155,7 +155,7 @@ void SVGAnimateMotionElement::stopAnimation(SVGElement* targetElement)
 {
     if (!targetElement)
         return;
-    if (AffineTransform* transform = targetElement->supplementalTransform())
+    if (auto* transform = targetElement->ensureSupplementalTransform())
         transform->makeIdentity();
     applyResultsToTarget();
 }
@@ -212,7 +212,7 @@ void SVGAnimateMotionElement::calculateAnimatedValue(float percentage, unsigned 
     if (!targetElement)
         return;
 
-    AffineTransform* transform = targetElement->supplementalTransform();
+    auto* transform = targetElement->ensureSupplementalTransform();
     if (!transform)
         return;
 
@@ -258,13 +258,13 @@ void SVGAnimateMotionElement::applyResultsToTarget()
 
     updateTargetElement(*targetElement);
 
-    AffineTransform* targetSupplementalTransform = targetElement->supplementalTransform();
+    auto* targetSupplementalTransform = targetElement->ensureSupplementalTransform();
     if (!targetSupplementalTransform)
         return;
 
     // ...except in case where we have additional instances in <use> trees.
     for (auto& instance : copyToVectorOf<Ref<SVGElement>>(targetElement->instances())) {
-        AffineTransform* transform = instance->supplementalTransform();
+        auto* transform = instance->ensureSupplementalTransform();
         if (!transform || *transform == *targetSupplementalTransform)
             continue;
         *transform = *targetSupplementalTransform;

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -87,7 +87,8 @@ public:
     void loadEventTimerFired();
     virtual Timer* loadEventTimer();
 
-    virtual AffineTransform* supplementalTransform() { return nullptr; }
+    virtual AffineTransform* ensureSupplementalTransform() { return nullptr; }
+    virtual AffineTransform* supplementalTransform() const { return nullptr; }
 
     inline void setAnimatedSVGAttributesAreDirty();
     inline void setPresentationalHintStyleIsDirty();

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -122,7 +122,7 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
     return matrix;
 }
 
-AffineTransform* SVGGraphicsElement::supplementalTransform()
+AffineTransform* SVGGraphicsElement::ensureSupplementalTransform()
 {
     if (!m_supplementalTransform)
         m_supplementalTransform = makeUnique<AffineTransform>();
@@ -209,7 +209,7 @@ void SVGGraphicsElement::didAttachRenderers()
 
 Path SVGGraphicsElement::toClipPath()
 {
-    // FIXME: [LBSE] Stop mutating the path here.
+    // FIXME: [LBSE] Stop mutating the path here and stop calling animatedLocalTransform().
     Path path = pathFromGraphicsElement(this);
     // FIXME: How do we know the element has done a layout?
     path.transform(animatedLocalTransform());

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -48,7 +48,8 @@ public:
 
     AffineTransform localCoordinateSpaceTransform(SVGLocatable::CTMScope mode) const override { return SVGTransformable::localCoordinateSpaceTransform(mode); }
     AffineTransform animatedLocalTransform() const override;
-    AffineTransform* supplementalTransform() override;
+    AffineTransform* ensureSupplementalTransform() override;
+    AffineTransform* supplementalTransform() const override { return m_supplementalTransform.get(); }
 
     virtual bool hasTransformRelatedAttributes() const { return !transform().concatenate().isIdentity() || m_supplementalTransform; }
 


### PR DESCRIPTION
#### e633ef2c414eb2708df4f5b58b19ca72b20dfa0b
<pre>
[LBSE] Allow to query supplementalTransform() without creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247670">https://bugs.webkit.org/show_bug.cgi?id=247670</a>

Reviewed by Rob Buis.

There is no way to check for the presence of SMIL supplementalTransform() instances,
since calling that method implicitly creates it. Split it up into another
ensureSupplementalTransform() method, that forces creation and another supplementalTransform()
method that simply returns the object, if present.

Covered by existing tests.

* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::startAnimation):
(WebCore::SVGAnimateMotionElement::stopAnimation):
(WebCore::SVGAnimateMotionElement::calculateAnimatedValue):
(WebCore::SVGAnimateMotionElement::applyResultsToTarget):
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::ensureSupplementalTransform):
(WebCore::SVGElement::supplementalTransform const):
(WebCore::SVGElement::supplementalTransform): Deleted.
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::ensureSupplementalTransform):
(WebCore::SVGGraphicsElement::svgAttributeChanged):
(WebCore::SVGGraphicsElement::toClipPath):
(WebCore::SVGGraphicsElement::supplementalTransform): Deleted.
* Source/WebCore/svg/SVGGraphicsElement.h:

Canonical link: <a href="https://commits.webkit.org/256786@main">https://commits.webkit.org/256786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/270c8a69a15bf4d4695801bc0eec666af7ceb37c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106357 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166638 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6313 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34826 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103057 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102504 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83444 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31687 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88430 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/131 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21333 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4712 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4912 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40632 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->