### PR TITLE
WebSocket requests should include Sec-Fetch-Mode=websocket for FetchMetadata

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-metadata-websocket-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-metadata-websocket-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Websocket Handshake fetch metadata
+PASS WebSocket Handshake: sec-fetch-dest
+PASS WebSocket Handshake: sec-fetch-mode
+PASS WebSocket Handshake: sec-fetch-site
+PASS WebSocket Handshake: sec-fetch-user
+

--- a/LayoutTests/http/wpt/fetch/fetch-metadata-websocket.html
+++ b/LayoutTests/http/wpt/fetch/fetch-metadata-websocket.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+
+<link rel="author" href="mtrzos@google.com" title="Maciek Trzos">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/fetch/metadata/resources/helper.js></script>
+<script src=/common/utils.js></script>
+<body></body>
+<script>
+  let nonce = token();
+
+console.log(window.location.href);
+
+  promise_test(t => {
+    return new Promise((resolve, reject) => {
+      let key = "websocket-" + nonce;
+
+      let ws = new WebSocket("ws://localhost:8800/fetch/metadata/resources/record-header.py?file=" + key);
+      let expected = {"site": "same-origin", "user": "", "mode": "websocket", "dest": "websocket"};
+
+      // This is expected to fail but will still record the headers from the handshake.
+      ws.addEventListener("error", e => {
+        validate_expectations(key, expected, "WebSocket Handshake")
+          .then(_ => resolve())
+          .catch(e => reject(e));
+      });
+    })
+  }, "Websocket Handshake fetch metadata");
+</script>
+

--- a/LayoutTests/platform/mac-bigsur/http/wpt/fetch/fetch-metadata-websocket-expected.txt
+++ b/LayoutTests/platform/mac-bigsur/http/wpt/fetch/fetch-metadata-websocket-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Websocket Handshake fetch metadata
+FAIL WebSocket Handshake: sec-fetch-dest assert_equals: expected "websocket" but got ""
+FAIL WebSocket Handshake: sec-fetch-mode assert_equals: expected "websocket" but got ""
+FAIL WebSocket Handshake: sec-fetch-site assert_equals: expected "same-origin" but got ""
+PASS WebSocket Handshake: sec-fetch-user
+

--- a/LayoutTests/platform/win/http/wpt/fetch/fetch-metadata-websocket-expected.txt
+++ b/LayoutTests/platform/win/http/wpt/fetch/fetch-metadata-websocket-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Websocket Handshake fetch metadata
+FAIL WebSocket Handshake: sec-fetch-dest assert_equals: expected "websocket" but got ""
+FAIL WebSocket Handshake: sec-fetch-mode assert_equals: expected "websocket" but got ""
+FAIL WebSocket Handshake: sec-fetch-site assert_equals: expected "same-origin" but got ""
+PASS WebSocket Handshake: sec-fetch-user
+


### PR DESCRIPTION
#### f05061a1e8307f802de0f4f17059ae8a6dee58d9
<pre>
WebSocket requests should include Sec-Fetch-Mode=websocket for FetchMetadata
<a href="https://bugs.webkit.org/show_bug.cgi?id=237550">https://bugs.webkit.org/show_bug.cgi?id=237550</a>
rdar://problem/90106854

Reviewed by Alex Christensen.

Add Sec Fetch headers to the WebSocket Handshake request.
We specila case this since we do not have a good use of websocket destination and mode enumeration values.
And the URL needs to be translated from ws to http scheme.

Add win and bigsur expectations since they do not support custom HTTP headers.

* LayoutTests/platform/win/http/wpt/fetch/fetch-metadata-websocket-expected.txt:
* LayoutTests/platform/mac-bigsur/http/wpt/fetch:
* LayoutTests/http/wpt/fetch/fetch-metadata-websocket-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-metadata-websocket.html: Added.
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::webSocketConnectRequest):

Canonical link: <a href="https://commits.webkit.org/256527@main">https://commits.webkit.org/256527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c75758121a5afe6486182615dfe937c393ca753b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105604 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165929 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5417 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34063 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101421 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101713 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82657 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31032 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73866 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39794 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4517 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42066 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39893 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->