### PR TITLE
font-variant-alternates list support and case-insensitivity

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3750,9 +3750,7 @@ webkit.org/b/182042 imported/w3c/web-platform-tests/css/css-fonts/font-default-0
 webkit.org/b/182042 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-03.html [ ImageOnlyFailure ]
 webkit.org/b/86071 imported/w3c/web-platform-tests/css/css-fonts/font-kerning-05.html [ ImageOnlyFailure ]
 
-# font-variant-alternates
-# (failing because of font-family case matching, and multiple properties unimplemented)
-webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/alternates-order.html [ ImageOnlyFailure ]
+# font-variant-alternates: swash doesn't work
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-13.html [ ImageOnlyFailure ]
 webkit.org/b/246121 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-14.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1948,6 +1948,7 @@ webkit.org/b/245900 [ Debug ] fast/inline/inline-box-adjust-position-crash2.html
 webkit.org/b/246766 imported/w3c/web-platform-tests/reporting/generateTestReport-honors-endpoint.http.sub.html [ Failure ]
 
 # font-variant-alternates https://bugs.webkit.org/show_bug.cgi?id=246952
+webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/alternates-order.html [ ImageOnlyFailure ]
 webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-03.html [ ImageOnlyFailure ]
 webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-04.html [ ImageOnlyFailure ]
 webkit.org/b/246952 imported/w3c/web-platform-tests/css/css-fonts/font-variant-alternates-05.html [ ImageOnlyFailure ]

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -78,6 +78,18 @@ UChar32 String::characterStartingAt(unsigned i) const
     return m_impl->characterStartingAt(i);
 }
 
+String makeStringByJoining(Span<const String> strings, const String& separator)
+{
+    StringBuilder builder;
+    for (const auto& string : strings) {
+        if (builder.isEmpty())
+            builder.append(string);
+        else
+            builder.append(separator, string);
+    }
+    return builder.toString();
+}
+
 String makeStringByRemoving(const String& string, unsigned position, unsigned lengthToRemove)
 {
     if (!lengthToRemove)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -474,6 +474,8 @@ ALWAYS_INLINE String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& s
 
 WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN makeStringByRemoving(const String&, unsigned position, unsigned lengthToRemove);
 
+WTF_EXPORT_PRIVATE String makeStringByJoining(Span<const String> strings, const String& separator);
+
 inline std::optional<UCharDirection> String::defaultWritingDirection() const
 {
     if (m_impl)
@@ -599,6 +601,7 @@ using WTF::String;
 using WTF::charactersToDouble;
 using WTF::charactersToFloat;
 using WTF::emptyString;
+using WTF::makeStringByJoining;
 using WTF::makeStringByRemoving;
 using WTF::makeStringByReplacingAll;
 using WTF::nullString;

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -251,11 +251,13 @@ void CSSFontSelector::addFontFeatureValuesRule(const StyleRuleFontFeatureValues&
     Ref<FontFeatureValues> fontFeatureValues = fontFeatureValuesRule.value();
 
     for (const auto& fontFamily : fontFeatureValuesRule.fontFamilies()) {
-        auto exist = m_featureValues.get(fontFamily);
+        // https://www.w3.org/TR/css-fonts-3/#font-family-casing
+        auto lowercased = fontFamily.string().convertToLowercaseWithoutLocale();
+        auto exist = m_featureValues.get(lowercased);
         if (exist)
             exist->updateOrInsert(fontFeatureValues.get());
         else
-            m_featureValues.set(fontFamily, fontFeatureValues);
+            m_featureValues.set(lowercased, fontFeatureValues);
     }
 
     ++m_version;
@@ -352,7 +354,9 @@ const FontPaletteValues& CSSFontSelector::lookupFontPaletteValues(const AtomStri
 
 RefPtr<FontFeatureValues> CSSFontSelector::lookupFontFeatureValues(const AtomString& familyName)
 {
-    auto iterator = m_featureValues.find(familyName);
+    // https://www.w3.org/TR/css-fonts-3/#font-family-casing
+    auto lowercased = familyName.string().convertToLowercaseWithoutLocale();
+    auto iterator = m_featureValues.find(lowercased);
     if (iterator == m_featureValues.end())
         return nullptr;
 

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -138,7 +138,7 @@ private:
         }
     };
     HashMap<std::pair<AtomString, AtomString>, FontPaletteValues, PaletteMapHash> m_paletteMap;
-    HashMap<AtomString, Ref<FontFeatureValues>> m_featureValues;
+    HashMap<String, Ref<FontFeatureValues>> m_featureValues;
 
     HashSet<RefPtr<CSSFontFace>> m_cssConnectionsPossiblyToRemove;
     HashSet<RefPtr<StyleRuleFontFace>> m_cssConnectionsEncounteredDuringBuild;

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -194,10 +194,8 @@ struct FontVariantAlternatesValues {
     }
 
     std::optional<String> stylistic;
-    // FIXME: supports a list of strings for styleset and characterVariant.
-    // https://bugs.webkit.org/show_bug.cgi?id=246811
-    std::optional<String> styleset;
-    std::optional<String> characterVariant;
+    Vector<String> styleset;
+    Vector<String> characterVariant;
     std::optional<String> swash;
     std::optional<String> ornaments;
     std::optional<String> annotation;

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -447,4 +447,19 @@ TEST(WTF, StringSplitWithConsecutiveSeparators)
         EXPECT_STREQ(expected[i].utf8().data(), actual[i].utf8().data()) << "Vectors differ at index " << i;
 }
 
+TEST(WTF, StringMakeStringByJoining)
+{
+    Vector<String> test1 = { "hello"_s, "foo"_s, "bar"_s };
+    auto test1_result = makeStringByJoining(test1, " "_s);
+    ASSERT_EQ(test1_result, "hello foo bar"_s);
+
+    std::array<String, 1> test2 = { "hello"_s };
+    auto test2_result = makeStringByJoining(test2, "sdf"_s);
+    ASSERT_EQ(test2_result, "hello"_s);
+    
+    std::vector<String> test3 = { "foo"_s, "bar"_s };
+    auto test3_result = makeStringByJoining(test3, ", "_s);
+    ASSERT_EQ(test3_result, "foo, bar"_s);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### fd6f66d0417561831691ccd5ea165b4062f7f4f4
<pre>
font-variant-alternates list support and case-insensitivity
<a href="https://bugs.webkit.org/show_bug.cgi?id=246811">https://bugs.webkit.org/show_bug.cgi?id=246811</a>
rdar://101638181

<a href="https://www.w3.org/TR/css-fonts-4/#font-variant-alternates-prop">https://www.w3.org/TR/css-fonts-4/#font-variant-alternates-prop</a>

CSS &quot;character-variant&quot; and &quot;styleset&quot; support a list of
feature names in CSS. Before this patch, only a single feature name was supported.

This patch also contains a change to make font family name matching
case insensitive for &quot;@font-feature-values&quot; at-rule.

Reviewed by Darin Adler.

* LayoutTests/TestExpectations:

The alternates-order.html layout test contains 9 specific tests related to font variant.
This patch fixes the remaining 2 out of 9 which were failing:
  - one because of the case-sensitivity in font name matching.
  - another because of the missing support for list value.

* LayoutTests/platform/gtk/TestExpectations:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::makeStringByJoining):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontFeatureValuesRule):
(WebCore::CSSFontSelector::lookupFontFeatureValues):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeFontVariantAlternates):
* Source/WebCore/platform/text/TextFlags.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::computeFeatureSettingsFromVariants):
* Source/WebCore/platform/text/TextFlags.h:
* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/256702@main">https://commits.webkit.org/256702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f8527593d1ee9ef9164c4ec08cdc6792184a3a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105985 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166335 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5875 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34443 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102710 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4381 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83045 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31368 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74267 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87427 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40172 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19605 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82823 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37845 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20996 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28299 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4639 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43558 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85501 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2226 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40266 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19271 "Passed tests") | 
<!--EWS-Status-Bubble-End-->