### PR TITLE
Shared memory IPC sometimes fails under Rosetta

### DIFF
--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -64,15 +64,6 @@ static int toVMMemoryLedger(MemoryLedger memoryLedger)
 }
 #endif
 
-static inline std::optional<size_t> safeRoundPage(size_t size)
-{
-    size_t roundedSize;
-    if (__builtin_add_overflow(size, static_cast<size_t>(PAGE_MASK), &roundedSize))
-        return std::nullopt;
-    roundedSize &= ~static_cast<size_t>(PAGE_MASK);
-    return roundedSize;
-}
-
 void SharedMemory::Handle::takeOwnershipOfMemory(MemoryLedger memoryLedger) const
 {
 #if HAVE(MACH_MEMORY_ENTRY)
@@ -124,10 +115,6 @@ bool SharedMemory::Handle::decode(IPC::Decoder& decoder, Handle& handle)
     if (!decoder.decode(bufferSize))
         return false;
 
-    auto roundedSize = safeRoundPage(bufferSize);
-    if (UNLIKELY(!roundedSize))
-        return false;
-
     auto sendRight = decoder.decode<MachSendRight>();
     if (UNLIKELY(!decoder.isValid()))
         return false;
@@ -151,15 +138,9 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
     ASSERT(size);
 
-    auto roundedSize = safeRoundPage(size);
-    if (!roundedSize) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::allocate: Failed to allocate shared memory (%zu bytes) due to overflow", nullptr, size);
-        return nullptr;
-    }
-
     mach_vm_address_t address = 0;
     // Using VM_FLAGS_PURGABLE so that we can later transfer ownership of the memory via mach_memory_entry_ownership().
-    kern_return_t kr = mach_vm_allocate(mach_task_self(), &address, *roundedSize, VM_FLAGS_ANYWHERE | VM_FLAGS_PURGABLE);
+    kern_return_t kr = mach_vm_allocate(mach_task_self(), &address, size, VM_FLAGS_ANYWHERE | VM_FLAGS_PURGABLE);
     if (kr != KERN_SUCCESS) {
         RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::allocate: Failed to allocate mach_vm_allocate shared memory (%zu bytes). %" PUBLIC_LOG_STRING " (%x)", nullptr, size, mach_error_string(kr), kr);
         return nullptr;
@@ -187,27 +168,21 @@ static inline vm_prot_t machProtection(SharedMemory::Protection protection)
 
 static WTF::MachSendRight makeMemoryEntry(size_t size, vm_offset_t offset, SharedMemory::Protection protection, mach_port_t parentEntry)
 {
-    auto roundedSize = safeRoundPage(size);
-    if (!roundedSize) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::makeMemoryEntry: Failed to create a mach port for shared memory (%zu bytes) due to overflow", nullptr, size);
-        return { };
-    }
-
-    memory_object_size_t memoryObjectSize = *roundedSize;
+    memory_object_size_t memoryObjectSize = size;
     mach_port_t port = MACH_PORT_NULL;
 
 #if HAVE(MEMORY_ATTRIBUTION_VM_SHARE_SUPPORT)
-    kern_return_t kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK | MAP_MEM_VM_SHARE, &port, parentEntry);
+    kern_return_t kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK | MAP_MEM_VM_SHARE | MAP_MEM_USE_DATA_ADDR, &port, parentEntry);
     if (kr != KERN_SUCCESS) {
         RELEASE_LOG_ERROR(VirtualMemory, "SharedMemory::makeMemoryEntry: Failed to create a mach port for shared memory. Error: %" PUBLIC_LOG_STRING " (%x)", mach_error_string(kr), kr);
         return { };
     }
 #else
     // First try without MAP_MEM_VM_SHARE because it prevents memory ownership transfer. We only pass the MAP_MEM_VM_SHARE flag as a fallback.
-    kern_return_t kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK, &port, parentEntry);
+    kern_return_t kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK | MAP_MEM_USE_DATA_ADDR, &port, parentEntry);
     if (kr != KERN_SUCCESS) {
         RELEASE_LOG(VirtualMemory, "SharedMemory::makeMemoryEntry: Failed to create a mach port for shared memory, will try again with MAP_MEM_VM_SHARE flag. Error: %" PUBLIC_LOG_STRING " (%x)", mach_error_string(kr), kr);
-        kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK | MAP_MEM_VM_SHARE, &port, parentEntry);
+        kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, offset, machProtection(protection) | VM_PROT_IS_MASK | MAP_MEM_VM_SHARE | MAP_MEM_USE_DATA_ADDR, &port, parentEntry);
         if (kr != KERN_SUCCESS) {
             RELEASE_LOG_ERROR(VirtualMemory, "SharedMemory::makeMemoryEntry: Failed to create a mach port for shared memory with MAP_MEM_VM_SHARE flag. Error: %" PUBLIC_LOG_STRING " (%x)", mach_error_string(kr), kr);
             return { };
@@ -241,15 +216,11 @@ RefPtr<SharedMemory> SharedMemory::map(const Handle& handle, Protection protecti
 {
     if (handle.isNull())
         return nullptr;
-    auto roundedSize = safeRoundPage(handle.m_size);
-    if (UNLIKELY(!roundedSize)) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::map: Failed to map %zu bytes due to overflow", nullptr, handle.m_size);
-        return nullptr;
-    }
 
     vm_prot_t vmProtection = machProtection(protection);
     mach_vm_address_t mappedAddress = 0;
-    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, *roundedSize, 0, VM_FLAGS_ANYWHERE, handle.m_handle.sendRight(), 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
+
+    kern_return_t kr = mach_vm_map(mach_task_self(), &mappedAddress, handle.m_size, 0, VM_FLAGS_ANYWHERE | VM_FLAGS_RETURN_DATA_ADDR, handle.m_handle.sendRight(), 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
     if (kr != KERN_SUCCESS) {
         RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::map: Failed to map shared memory. %" PUBLIC_LOG_STRING " (%x)", nullptr, mach_error_string(kr), kr);
         return nullptr;
@@ -266,13 +237,7 @@ RefPtr<SharedMemory> SharedMemory::map(const Handle& handle, Protection protecti
 SharedMemory::~SharedMemory()
 {
     if (m_data) {
-        auto roundedSize = safeRoundPage(m_size);
-        if (!roundedSize) {
-            RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::~SharedMemory: Failed to deallocate memory (%zu bytes) due to overflow", this, m_size);
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-
-        kern_return_t kr = mach_vm_deallocate(mach_task_self(), toVMAddress(m_data), *roundedSize);
+        kern_return_t kr = mach_vm_deallocate(mach_task_self(), toVMAddress(m_data), m_size);
         if (kr != KERN_SUCCESS) {
             RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::~SharedMemory: Failed to deallocate shared memory. %" PUBLIC_LOG_STRING " (%x)", this, mach_error_string(kr), kr);
             ASSERT_NOT_REACHED();
@@ -284,12 +249,6 @@ bool SharedMemory::createHandle(Handle& handle, Protection protection)
 {
     ASSERT(!handle.m_handle);
     ASSERT(!handle.m_size);
-
-    auto roundedSize = safeRoundPage(m_size);
-    if (!roundedSize) {
-        RELEASE_LOG_ERROR(VirtualMemory, "%p - SharedMemory::createHandle: Failed to create handle (%zu bytes) due to overflow", this, m_size);
-        return false;
-    }
 
     auto sendRight = createSendRight(protection);
     if (!sendRight)


### PR DESCRIPTION
#### eece793cfe01232ecbbf6a69457b83fcbfac896a
<pre>
Shared memory IPC sometimes fails under Rosetta
<a href="https://bugs.webkit.org/show_bug.cgi?id=247691">https://bugs.webkit.org/show_bug.cgi?id=247691</a>
rdar://99827403

Reviewed by Geoffrey Garen.

Sending a SharedMemory object over IPC sometimes fails when the sending process runs under Rosetta
and the receiving process is ARM64. This is due to the Rosetta process using a 4KB page size and the
receiving process using a 16KB page size. On the sending side, SharedMemory calls `safeRoundPage` on
the actual size to round the allocation up to a 4KB boundary. On the receiving side, SharedMemory
calls `safeRoundPage` again on the actual size, but now rounds up to a 16KB boundary. This means the
receiving side might try to ask the kernel to map a larger memory region that was created on the
sending side. This causes `mach_vm_map` to fail with an invalid argument error.

One easy way to trigger this issue is to implement a URL scheme handler in a Rosetta UIProcess that
returns some small payload. This will result in a buffer being sent to an ARM WebContent process.

To fix this, the kernel team recommended that we:

1. Stop rounding the page size in user space. The syscalls we use here (e.g. mach_vm_allocate) are
already documented to handle page rounding for you.

2. Defensively handle the case where we might try to share a non-page-aligned region. (This actually
doesn&apos;t apply in our case since `SharedMemory::allocate` is always returning a page-aligned region
but it&apos;s good to do in case someone adds that capability in the future.) We do this by using
`MAP_MEM_USE_DATA_ADDR` with `mach_make_memory_entry_64` and `VM_FLAGS_RETURN_DATA_ADDR` with
`mach_vm_map`.

This patch implements those recommendations.

To test this, I ran `URLSchemeHandler.Basic` under Rosetta. Before this patch, WebContent crashed
with the assert `Received invalid message: &apos;WebPage_URLSchemeTaskDidReceiveData&apos;`. After this patch,
the test no longer crashes.

* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemory::Handle::decode):
(WebKit::SharedMemory::allocate):
(WebKit::makeMemoryEntry):
(WebKit::SharedMemory::map):
(WebKit::SharedMemory::~SharedMemory):
(WebKit::SharedMemory::createHandle):
(WebKit::safeRoundPage): Deleted.

Canonical link: <a href="https://commits.webkit.org/256505@main">https://commits.webkit.org/256505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a31a43ed178160aca1a9383efd3fabcdf8eac55

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29038 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/105552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5354 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34007 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88375 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/101374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101658 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82601 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/30985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39739 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37416 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4498 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42013 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39836 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->