### PR TITLE
Error() ICs should not cache special properties.

### DIFF
--- a/JSTests/stress/delete-cache-error.js
+++ b/JSTests/stress/delete-cache-error.js
@@ -1,0 +1,19 @@
+delete Error.stackTraceLimit
+
+// sourceURL is not materialized
+function cacheColumn(o) {
+    delete o.sourceURL
+}
+noInline(cacheColumn)
+
+for (let i = 0; i < 200; ++i) {
+    let e = Error()
+    cacheColumn(e)
+    if (e.sourceURL !== undefined)
+        throw "Test failed on iteration " + i + " " + e.sourceURL
+    
+    if (i == 197) {
+        // now it is
+        Error.stackTraceLimit = 10
+    }
+}

--- a/JSTests/stress/get-own-property-slot-cache-error.js
+++ b/JSTests/stress/get-own-property-slot-cache-error.js
@@ -1,0 +1,6 @@
+delete Error.stackTraceLimit
+// GetOwnPropertySlot does not materializeErrorInfoIfNeeded because stackString is null.
+Object.hasOwn(Error(), "column")
+Error.stackTraceLimit = 10
+// Now it does
+Object.hasOwn(Error(), "column")

--- a/JSTests/stress/get-property-cache-error.js
+++ b/JSTests/stress/get-property-cache-error.js
@@ -1,0 +1,20 @@
+// GetOwnPropertySlot does not materializeErrorInfoIfNeeded because stackString is null.
+delete Error.stackTraceLimit
+expected = undefined
+
+function cacheColumn(o) {
+    return o.column
+}
+noInline(cacheColumn)
+
+for (let i = 0; i < 1000; ++i) {
+    let val = cacheColumn(Error())
+    if (val !== expected)
+        throw "Test failed on iteration " + i + ": " + val
+    
+    if (i == 900) {
+        // now it does
+        Error.stackTraceLimit = 10
+        expected = 32   
+    }
+}

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -303,7 +303,9 @@ bool ErrorInstance::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, P
 {
     VM& vm = globalObject->vm();
     ErrorInstance* thisObject = jsCast<ErrorInstance*>(cell);
-    thisObject->materializeErrorInfoIfNeeded(vm, propertyName);
+    bool materializedProperties = thisObject->materializeErrorInfoIfNeeded(vm, propertyName);
+    if (materializedProperties)
+        slot.disableCaching();
     return Base::deleteProperty(thisObject, globalObject, propertyName, slot);
 }
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -30,7 +30,8 @@ namespace JSC {
 class ErrorInstance : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnSpecialPropertyNames | OverridesPut;
+
+    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnSpecialPropertyNames | OverridesPut | GetOwnPropertySlotIsImpureForPropertyAbsence;
     static constexpr bool needsDestruction = true;
 
     static void destroy(JSCell* cell)


### PR DESCRIPTION
#### 28686e63de0d3d7270a49b0d6b656467bc4fbf68
<pre>
Error() ICs should not cache special properties.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247699">https://bugs.webkit.org/show_bug.cgi?id=247699</a>

Reviewed by Yusuke Suzuki.

HasOwnProperty/DeleteProperty are not always cacheable for special Error()
properties like column. These special properties are materialized on-demand
in materializeErrorInfoIfNeeded, but this function&apos;s behaviour can be changed
by Error.stackTraceLimit without causing a structure transition or firing watchpoints.

That is, we cannot cache property misses, and we cannot assume HasOwnProperty is deterministic
for a given structure if we are using one of these properties.

* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::deleteProperty):
* Source/JavaScriptCore/runtime/ErrorInstance.h:

Canonical link: <a href="https://commits.webkit.org/256519@main">https://commits.webkit.org/256519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/355baeedfa1e8d1152bd3483aff77efe563fc1e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/95998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105553 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165877 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5355 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34008 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101375 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101659 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82602 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/30990 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73823 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39740 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82372 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20577 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28234 "Found 2 new JSC stress test failures: stress/bigdecimal-identifiers-fail-on-oom.js.no-cjit-collect-continuously, stress/bigdecimal-identifiers-fail-on-oom.js.no-cjit-validate-phases (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42014 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85051 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39838 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19201 "Passed tests") | 
<!--EWS-Status-Bubble-End-->