### PR TITLE
ASSERTION FAILED: !visualMetricsValues.isEmpty() in WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath

### DIFF
--- a/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash-expected.txt
+++ b/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash-expected.txt
@@ -1,0 +1,5 @@
+PASS if no crash.
+
+
+
+

--- a/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash.html
+++ b/LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>PASS if no crash.</p>
+<svg>
+  <text style='white-space: normal'> </text>
+  <text style='white-space: nowrap'> </text>
+  <text style='white-space: pre'> </text>
+  <text style='white-space: pre-wrap'> </text>
+  <text style='white-space: pre-line'> </text>
+</svg>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -419,6 +419,8 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
     // This text node has nothing but white space. We may still need a renderer in some cases.
     if (parentRenderer.isTable() || parentRenderer.isTableRow() || parentRenderer.isTableSection() || parentRenderer.isRenderTableCol() || parentRenderer.isFrameSet() || parentRenderer.isRenderGrid() || (parentRenderer.isFlexibleBox() && !parentRenderer.isRenderButton()))
         return false;
+    if (parentRenderer.style().whiteSpace() == WhiteSpace::PreWrap && parentRenderer.isSVGRoot())
+        return false;
     if (parentRenderer.style().preserveNewline()) // pre/pre-wrap/pre-line always make renderers.
         return true;
 


### PR DESCRIPTION
<pre>
ASSERTION FAILED: !visualMetricsValues.isEmpty() in WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=136941">https://bugs.webkit.org/show_bug.cgi?id=136941</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/cfed17d1b14f9cff420321fca6eac89bca504492">https://chromium.googlesource.com/chromium/blink/+/cfed17d1b14f9cff420321fca6eac89bca504492</a>

SVGTextMetricsBuilder only knows how to handle 'white-space: pre' with
regards to whitespace preservation, meaning it will collapse the spaces
in the node, and hence not generate any SVGTextMetrics for it.
Filter this case out to avoid even creating the text layout object in
the first place.

* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(RenderTreeUpdater::textRendererIsNeeded): Added "SVG" text cases with "PreWrap" whitespace handling
* LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash.html: Added Test Case
* LayoutTests/svg/text/white-space-pre-wrap-whitespace-only-crash-expected.txt: Added Test Case Expectations
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bef0988d65e8b4a67040072600c72c7a48f0d8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106878 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167142 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6930 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35408 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103555 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5203 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83990 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32207 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75132 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/638 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20344 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21808 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5424 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44290 "Found 3 new test failures: fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html, svg/text/white-space-pre-wrap-whitespace-only-crash.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41153 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->