### PR TITLE
Animated AVIF image animates only one loop on down level macOS and non Apple ports

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2275,12 +2275,9 @@ fast/images/animated-webp.html [ Skip ]
 # These tests don't have to be platform-specific, but they are only implemented on Mac now.
 fast/images/eps-as-image.html [ Skip ]
 
-# AVIF images are only supported on GTK and on macOS and iOS post Ventura.
-fast/images/avif-image-decoding.html [ Pass Failure ]
-fast/images/avif-as-image.html [ Pass ImageOnlyFailure ]
-fast/images/avif-heif-container-as-image.html [ Pass ImageOnlyFailure ]
-fast/images/animated-avif.html [ Pass ImageOnlyFailure ]
-http/tests/images/avif-partial-load-crash.html [ Pass Failure ]
+# libavif does not render resources/green-400x400.avif correctly.
+# See https://github.com/AOMediaCodec/av1-avif/issues/195
+fast/images/avif-heif-container-as-image.html [ ImageOnlyFailure ]
 
 # Only applicable on platforms with JPEG XL support
 fast/images/jpegxl-image-decoding.html [ Skip ]

--- a/LayoutTests/fast/images/animated-avif-expected.html
+++ b/LayoutTests/fast/images/animated-avif-expected.html
@@ -1,12 +1,26 @@
 <!DOCTYPE html>
 <html>
-<head>
 <title>AVIF animation reftest: when animation ends, compare its last frame against the reference static avif image.</title>
 <style>
-img { margin: 1px; }
+    canvas {
+        width: 63px;
+        height: 63px;
+    }
 </style>
-</head>
-<body style="margin: 1px">
-<img src=resources/avifs00-ref.avif><img src=resources/avifs01-ref.avif><img src=resources/avifs02-ref.avif>
+<script src="resources/animated-image-loop-count.js"></script>
+<body>
+    <canvas id="canvas-0"></canvas>
+    <canvas id="canvas-1"></canvas>
+    <canvas id="canvas-2"></canvas>
+    <script>
+        (function() {
+            var images = [
+                { src: "resources/avifs00-ref.avif", canvasIds: [ "canvas-0" ], frameCount: 1 },
+                { src: "resources/avifs01-ref.avif", canvasIds: [ "canvas-1" ], frameCount: 1 },
+                { src: "resources/avifs02-ref.avif", canvasIds: [ "canvas-2" ], frameCount: 1 }
+            ];
+            runTest(images);
+        })();
+    </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/animated-avif.html
+++ b/LayoutTests/fast/images/animated-avif.html
@@ -1,26 +1,27 @@
 <!DOCTYPE html>
 <html>
-<head>
 <title>AVIF animation reftest: when animation ends, compare its last frame against the reference static avif image.</title>
-<script>
-    if (window.testRunner)
-        testRunner.dumpAsText(true);
-
-    window.onload = function() {
-        if (window.testRunner)
-            testRunner.waitUntilDone();
-
-        window.setTimeout(function() {
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }, 300);
-    }
-</script>
+<meta name="fuzzy" content="maxDifference=1-9; totalPixels=258-484" />
 <style>
-img { margin: 1px; }
+    canvas {
+        width: 63px;
+        height: 63px;
+    }
 </style>
-</head>
-<body style="margin: 1px">
-<img src=resources/avifs00.avifs><img src=resources/avifs01.avifs><img src=resources/avifs02.avifs>
+<script src="resources/animated-image-loop-count.js"></script>
+<body>
+    <canvas id="canvas-0"></canvas>
+    <canvas id="canvas-1"></canvas>
+    <canvas id="canvas-2"></canvas>
+    <script>
+        (function() {
+            var images = [
+                { src: "resources/avifs00.avifs", canvasIds: [ "canvas-0" ], frameCount: 10 },
+                { src: "resources/avifs01.avifs", canvasIds: [ "canvas-1" ], frameCount: 10 },
+                { src: "resources/avifs02.avifs", canvasIds: [ "canvas-2" ], frameCount: 13 }
+            ];
+            runTest(images);
+        })();
+    </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/animated-gif-loop-count.html
+++ b/LayoutTests/fast/images/animated-gif-loop-count.html
@@ -38,9 +38,42 @@
     <script>
         (function() {
             var images = [
-                { src: "resources/animated-red-green-blue-repeat-1.gif", canvasId: '1', frameCount: 4 },
-                { src: "resources/animated-red-green-blue-repeat-2.gif", canvasId: 'a', frameCount: 7 },
-                { src: "resources/animated-red-green-blue-repeat-infinite.gif", canvasId: 'A', frameCount: 7 }
+                { 
+                    src: "resources/animated-red-green-blue-repeat-1.gif", 
+                    canvasIds: [ 
+                        "canvas-1", 
+                        "canvas-2", 
+                        "canvas-3", 
+                        "canvas-4" 
+                    ], 
+                    frameCount: 4 
+                },
+                { 
+                    src: "resources/animated-red-green-blue-repeat-2.gif", 
+                    canvasIds: [
+                        "canvas-a",
+                        "canvas-b",
+                        "canvas-c",
+                        "canvas-d",
+                        "canvas-e",
+                        "canvas-f",
+                        "canvas-g"
+                    ],
+                    frameCount: 7 
+                },
+                { 
+                    src: "resources/animated-red-green-blue-repeat-infinite.gif", 
+                    canvasIds: [ 
+                        "canvas-A",
+                        "canvas-B",
+                        "canvas-C",
+                        "canvas-D",
+                        "canvas-E",
+                        "canvas-F",
+                        "canvas-G"
+                    ], 
+                    frameCount: 7
+                }
             ];
             runTest(images);
         })();

--- a/LayoutTests/fast/images/animated-jpegxl-loop-count.html
+++ b/LayoutTests/fast/images/animated-jpegxl-loop-count.html
@@ -38,9 +38,42 @@
     <script>
         (function() {
             var images = [
-                { src: "resources/animated-red-green-blue-repeat-1.jxl", canvasId: '1', frameCount: 4 },
-                { src: "resources/animated-red-green-blue-repeat-2.jxl", canvasId: 'a', frameCount: 7 },
-                { src: "resources/animated-red-green-blue-repeat-infinite.jxl", canvasId: 'A', frameCount: 7 }
+                { 
+                    src: "resources/animated-red-green-blue-repeat-1.jxl", 
+                    canvasIds: [ 
+                        "canvas-1", 
+                        "canvas-2", 
+                        "canvas-3", 
+                        "canvas-4" 
+                    ], 
+                    frameCount: 4 
+                },
+                { 
+                    src: "resources/animated-red-green-blue-repeat-2.jxl", 
+                    canvasIds: [
+                        "canvas-a",
+                        "canvas-b",
+                        "canvas-c",
+                        "canvas-d",
+                        "canvas-e",
+                        "canvas-f",
+                        "canvas-g"
+                    ],
+                    frameCount: 7
+                },
+                { 
+                    src: "resources/animated-red-green-blue-repeat-infinite.jxl", 
+                    canvasIds: [ 
+                        "canvas-A",
+                        "canvas-B",
+                        "canvas-C",
+                        "canvas-D",
+                        "canvas-E",
+                        "canvas-F",
+                        "canvas-G"
+                    ], 
+                    frameCount: 7
+                }
             ];
             runTest(images);
         })();

--- a/LayoutTests/fast/images/animated-png-loop-count.html
+++ b/LayoutTests/fast/images/animated-png-loop-count.html
@@ -38,9 +38,42 @@
     <script>
         (function() {
             var images = [
-                { src: "resources/animated-red-green-blue-repeat-1.png", canvasId: '1', frameCount: 4 },
-                { src: "resources/animated-red-green-blue-repeat-2.png", canvasId: 'a', frameCount: 7 },
-                { src: "resources/animated-red-green-blue-repeat-infinite.png", canvasId: 'A', frameCount: 7 }
+                { 
+                    src: "resources/animated-red-green-blue-repeat-1.png", 
+                    canvasIds: [ 
+                        "canvas-1", 
+                        "canvas-2", 
+                        "canvas-3", 
+                        "canvas-4" 
+                    ], 
+                    frameCount: 4
+                },
+                { 
+                    src: "resources/animated-red-green-blue-repeat-2.png", 
+                    canvasIds: [
+                        "canvas-a",
+                        "canvas-b",
+                        "canvas-c",
+                        "canvas-d",
+                        "canvas-e",
+                        "canvas-f",
+                        "canvas-g"
+                    ],
+                    frameCount: 7
+                },
+                { 
+                    src: "resources/animated-red-green-blue-repeat-infinite.png", 
+                    canvasIds: [ 
+                        "canvas-A",
+                        "canvas-B",
+                        "canvas-C",
+                        "canvas-D",
+                        "canvas-E",
+                        "canvas-F",
+                        "canvas-G"
+                    ], 
+                    frameCount: 7 
+                }
             ];
             runTest(images);
         })();

--- a/LayoutTests/fast/images/resources/animated-image-loop-count.js
+++ b/LayoutTests/fast/images/resources/animated-image-loop-count.js
@@ -1,29 +1,30 @@
 function drawFrame(image, canvasId) {
     return new Promise((resolve) => {
-        let canvas = document.getElementById("canvas-" + canvasId);
+        let canvas = document.getElementById(canvasId);
         let context = canvas.getContext("2d");
         context.drawImage(image, 0, 0, canvas.width, canvas.height);
         setTimeout(() => {
-            resolve(String.fromCharCode(canvasId.charCodeAt() + 1));
+            resolve();
         }, 30);
     });
 }
 
-function drawImage(image, canvasId, frameCount) {
-    let promise = drawFrame(image, canvasId);
+function drawImage(image, canvasIds, frameCount) {
+    let promise = drawFrame(image, canvasIds[0]);
     for (let frame = 1; frame < frameCount; ++frame) {
-        promise = promise.then((canvasId) => {
-            return drawFrame(image, canvasId);
+        promise = promise.then(() => {
+            var index = Math.min(frame, canvasIds.length - 1);
+            return drawFrame(image, canvasIds[index]);
         });
     }
     return promise;
 }
 
-function loadImage(src, canvasId, frameCount) {
+function loadImage(src, canvasIds, frameCount) {
     return new Promise((resolve) => {
         let image = new Image;
         image.onload = (() => {
-            drawImage(image, canvasId, frameCount).then(resolve);
+            drawImage(image, canvasIds, frameCount).then(resolve);
         });
         image.src = src;
     });
@@ -41,7 +42,7 @@ function runTest(images) {
     var promises = [];
 
     for (let image of images)
-        promises.push(loadImage(image.src, image.canvasId, image.frameCount));
+        promises.push(loadImage(image.src, image.canvasIds, image.frameCount));
             
     Promise.all(promises).then(() => {
         if (window.testRunner)

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -91,12 +91,6 @@ crypto/workers/subtle/rsa-pss-import-key-verify.html [ Pass ]
 http/wpt/crypto/rsa-pss-crash.any.html [ Pass ]
 http/wpt/crypto/rsa-pss-crash.any.worker.html [ Pass ]
 
-# AVIF tests
-fast/images/avif-image-decoding.html [ Pass ]
-fast/images/avif-as-image.html [ Pass ]
-fast/images/animated-avif.html [ Pass ]
-http/tests/images/avif-partial-load-crash.html [ Pass ]
-
 fast/text/emoji-gender-3.html [ Pass ]
 fast/text/emoji-gender-4.html [ Pass ]
 fast/text/emoji-gender-5.html [ Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3755,8 +3755,10 @@ webkit.org/b/244740 http/wpt/cross-origin-opener-policy/non-secure-to-secure-con
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html [ Pass Timeout Failure ]
 [ Debug ] imported/w3c/web-platform-tests/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3.html [ Pass Timeout Failure ]
 
-fast/images/animated-avif.html [ Pass ]
-http/tests/images/avif-partial-load-crash.html [ Pass ]
+# AVIF tests
+webkit.org/b/247831 fast/images/avif-image-decoding.html [ Failure ]
+webkit.org/b/247831 fast/images/avif-as-image.html [ ImageOnlyFailure ]
+webkit.org/b/247831 fast/images/animated-avif.html [ Timeout ]
 
 # Screen Orientation API doesn't support nested frames yet
 imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -104,10 +104,9 @@ fast/images/animated-heics-draw.html [ Pass ]
 fast/images/animated-heics-verify.html [ Pass ]
 fast/images/heic-as-background-image.html [ Pass ]
 
+# AVIF tests
 [ Ventura+ ] fast/images/avif-heif-container-as-image.html [ Pass ]
-http/tests/images/avif-partial-load-crash.html [ Pass ]
-fast/images/avif-image-decoding.html [ Pass ]
-[ Monterey BigSur ] fast/images/avif-as-image.html [ Pass ]
+[ arm64 ] fast/images/animated-avif.html [ Skip ]
 
 # <rdar://problem/5647952> fast/events/mouseout-on-window.html needs mac DRT to issue mouse out events
 fast/events/mouseout-on-window.html [ Failure ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -772,7 +772,7 @@ http/tests/scroll-to-text-fragment/ [ Skip ]
 # Pre-HMTL5 parser quirks only apply to the mac port for now.
 fast/parser/pre-html5-parser-quirks.html [ Skip ]
 
-# Requires APNG and WebP support.
+# Requires APNG, AVIF and WebP support.
 fast/canvas/canvas-toDataURL-webp.html [ Skip ]
 fast/images/webp-image-decoding.html [ Skip ]
 fast/images/webp-color-profile-lossless.html [ Skip ]
@@ -782,6 +782,11 @@ http/tests/images/webp-partial-load.html [ Skip ]
 http/tests/images/webp-progressive-load.html [ Skip ]
 fast/images/animated-webp-expected.html [ Skip ]
 fast/images/animated-png-loop-count.html [ Skip ]
+fast/images/avif-image-decoding.html [ Skip ]
+fast/images/avif-as-image.html [ Skip ]
+fast/images/avif-heif-container-as-image.html [ Skip ]
+fast/images/animated-avif.html [ Skip ]
+http/tests/images/avif-partial-load-crash.html [ Skip ]
 
 # TODO The following tests requires the DRT's dumpUserGestureInFrameLoadCallbacks
 # method. But that method is not implemented in win port since win port can't

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -594,7 +594,7 @@ String ImageDecoderCG::decodeUTI(const SharedBuffer& data) const
 String ImageDecoderCG::decodeUTI(CGImageSourceRef imageSource, const SharedBuffer& data)
 {
     auto uti = String(CGImageSourceGetType(imageSource));
-    if (uti != "public.heif"_s && uti != "public.heic"_s)
+    if (uti != "public.heif"_s && uti != "public.heic"_s && uti != "public.heics"_s)
         return uti;
 
     if (data.size() < sizeof(unsigned)) {

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.cpp
@@ -113,10 +113,7 @@ void AVIFImageDecoder::tryDecodeSize(bool allDataReceived)
 
     m_frameCount = m_reader->imageCount();
 
-    // FIXME: The avif sequence image can repeat for non-integer times (e.g., 2.5 times)
-    // but ScalableImageDecoder accepts an integer only for the repetition count.
-    // https://github.com/AOMediaCodec/av1-avif/issues/73
-    m_repetitionCount = static_cast<RepetitionCount>(std::round(m_reader->repetitionCount()));
+    m_repetitionCount = m_frameCount > 1 ? RepetitionCountInfinite : RepetitionCountNone;
 }
 
 void AVIFImageDecoder::decode(size_t frameIndex, bool allDataReceived)

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp
@@ -114,22 +114,6 @@ size_t AVIFImageReader::imageCount() const
     return m_avifDecoder->imageCount;
 }
 
-double AVIFImageReader::repetitionCount() const
-{
-    double trackDuration = m_avifDecoder->duration;
-    if (!trackDuration)
-        return 0.0;
-
-    double accumulatedFrameDuration = 0.0;
-    for (int i = 0; i < m_avifDecoder->imageCount; ++i) {
-        avifImageTiming timing;
-        if (avifDecoderNthImageTiming(m_avifDecoder.get(), i, &timing) != AVIF_RESULT_OK)
-            return 0.0;
-        accumulatedFrameDuration += timing.duration;
-    }
-    return accumulatedFrameDuration / trackDuration;
-}
-
 }
 
 #endif // USE(AVIF)

--- a/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.h
+++ b/Source/WebCore/platform/image-decoders/avif/AVIFImageReader.h
@@ -42,7 +42,6 @@ public:
     bool parseHeader(const SharedBuffer&, bool allDataReceived);
     void decodeFrame(size_t index, ScalableImageDecoderFrame&, const SharedBuffer&);
     size_t imageCount() const;
-    double repetitionCount() const;
 
 private:
     RefPtr<WebCore::AVIFImageDecoder> m_decoder;


### PR DESCRIPTION
#### 70ff964ee191a2698da52a707fa83c1e4a8a6092
<pre>
Animated AVIF image animates only one loop on down level macOS and non Apple ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=247704">https://bugs.webkit.org/show_bug.cgi?id=247704</a>
rdar://102164553

Reviewed by Simon Fraser.

Delete the handcrafted implementation for AVIF repetitionCount() since libavif
does not provide loopCount for animated AVIF.

Make ImageDecoderCG::decodeUTI() look for the AVIF brands if CGImageSourceGetType()
returns &quot;public.heics&quot; for the image. This is what CG used to return for AVIF on
plafornss pre macOSVentura.

Refactor animated-image-loop-count.js such that an array for the canvases ids are
passed instead of passing the prefix of the first canvas only. This can be used
to draw the last frame of an animated image only.

* LayoutTests/TestExpectations:
* LayoutTests/fast/images/animated-avif-expected.html:
* LayoutTests/fast/images/animated-avif.html:
* LayoutTests/fast/images/animated-gif-loop-count.html:
* LayoutTests/fast/images/animated-jpegxl-loop-count.html:
* LayoutTests/fast/images/animated-png-loop-count.html:
* LayoutTests/fast/images/resources/animated-image-loop-count.js:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::decodeUTI):
* Source/WebCore/platform/image-decoders/avif/AVIFImageDecoder.cpp:
(WebCore::AVIFImageDecoder::tryDecodeSize):
* Source/WebCore/platform/image-decoders/avif/AVIFImageReader.cpp:
(WebCore::AVIFImageReader::repetitionCount const): Deleted.
* Source/WebCore/platform/image-decoders/avif/AVIFImageReader.h:

Canonical link: <a href="https://commits.webkit.org/256665@main">https://commits.webkit.org/256665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b247369d6cbf7c50dec6cc1b9e2215d9a03929b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105883 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166227 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5743 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34340 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102613 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4264 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82938 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31269 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74130 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40072 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19512 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4623 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43465 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40156 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->