### PR TITLE
Make SharedMemory::createHandle, ShareableBitmap::createHandle, ShareableResource::createHandle return std::optional

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
@@ -58,11 +58,11 @@ RefPtr<ImageBuffer> ImageBufferShareableAllocator::createImageBuffer(const Float
     if (!bitmap)
         return nullptr;
 
-    ShareableBitmapHandle handle;
-    if (!bitmap->createHandle(handle))
+    auto handle = bitmap->createHandle();
+    if (!handle)
         return nullptr;
 
-    transferMemoryOwnership(WTFMove(handle.handle()));
+    transferMemoryOwnership(WTFMove(handle->handle()));
     return imageBuffer;
 }
 
@@ -72,11 +72,11 @@ RefPtr<PixelBuffer> ImageBufferShareableAllocator::createPixelBuffer(const Pixel
     if (!pixelBuffer)
         return nullptr;
 
-    SharedMemory::Handle handle;
-    if (!pixelBuffer->data().createHandle(handle, SharedMemory::Protection::ReadOnly))
+    auto handle = pixelBuffer->data().createHandle(SharedMemory::Protection::ReadOnly);
+    if (!handle)
         return nullptr;
 
-    transferMemoryOwnership(WTFMove(handle));
+    transferMemoryOwnership(WTFMove(*handle));
     return pixelBuffer;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -267,7 +267,8 @@ void RemoteRenderingBackend::getShareableBitmapForImageBufferWithQualifiedIdenti
         if (!context)
             return;
         context->drawImageBuffer(*imageBuffer, FloatRect { { }, resultSize }, FloatRect { { }, logicalSize }, { CompositeOperator::Copy });
-        bitmap->createHandle(handle);
+        if (auto bitmapHandle = bitmap->createHandle())
+            handle = WTFMove(*bitmapHandle);
     }();
     completionHandler(WTFMove(handle));
 }
@@ -294,7 +295,8 @@ void RemoteRenderingBackend::getFilteredImageForImageBuffer(RenderingResourceIde
         if (!context)
             return;
         context->drawImage(*image, FloatPoint());
-        bitmap->createHandle(handle);
+        if (auto bitmapHandle = bitmap->createHandle())
+            handle = WTFMove(*bitmapHandle);
     }();
     completionHandler(WTFMove(handle));
 }

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -230,8 +230,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpateInfo&& update)
     if (m_usesOffscreenRendering) {
         auto bitmap = ShareableBitmap::create(windowSize, { });
         glReadPixels(0, 0, windowSize.width(), windowSize.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap->data());
-        ShareableBitmapHandle handle;
-        if (bitmap->createHandle(handle)) {
+        if (auto handle = bitmap->createHandle()) {
             result.emplace();
             result->viewSize = windowSize;
             result->deviceScaleFactor = 1;
@@ -239,7 +238,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpateInfo&& update)
             WebCore::IntRect viewport = { { }, windowSize };
             result->updateRectBounds = viewport;
             result->updateRects.append(viewport);
-            result->bitmapHandle = WTFMove(handle);
+            result->bitmapHandle = WTFMove(*handle);
         }
     } else
         m_context->swapBuffers();

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp
@@ -151,7 +151,8 @@ void RemoteImageDecoderAVFProxy::createFrameImageAtIndex(ImageDecoderIdentifier 
     FloatSize imageSize { float(width), float(height) };
     FloatRect imageRect { { }, imageSize };
     context->drawNativeImage(*nativeImage, imageSize, imageRect, imageRect, { CompositeOperator::Copy });
-    bitmap->createHandle(imageHandle);
+    if (auto handle = bitmap->createHandle())
+        imageHandle = WTFMove(*handle);
 }
 
 void RemoteImageDecoderAVFProxy::clearFrameBufferCache(ImageDecoderIdentifier identifier, size_t index)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -217,9 +217,10 @@ ShareableBitmapHandle RemoteMediaPlayerManagerProxy::bitmapImageForCurrentTime(W
 
     context->drawNativeImage(*image, imageSize, FloatRect { { }, imageSize }, FloatRect { { }, imageSize });
 
-    ShareableBitmapHandle bitmapHandle;
-    bitmap->createHandle(bitmapHandle);
-    return bitmapHandle;
+    auto bitmapHandle = bitmap->createHandle();
+    if (!bitmapHandle)
+        return { };
+    return WTFMove(*bitmapHandle);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -93,22 +93,20 @@ void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifi
 
 void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
 {
-    SharedMemory::Handle handle;
-
-    auto invokeCallbackAtScopeExit = makeScopeExit([&] {
-        completionHandler(WTFMove(handle));
-    });
-
     auto* resource = m_remoteMediaResources.get(identifier);
     if (!resource)
-        return;
+        return completionHandler(std::nullopt);
 
     auto sharedMemory = buffer.sharedCopy();
     if (!sharedMemory)
-        return;
-    sharedMemory->createHandle(handle, SharedMemory::Protection::ReadOnly);
+        return completionHandler(std::nullopt);
+
+    auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
+    if (!handle)
+        return completionHandler(std::nullopt);
 
     resource->dataReceived(sharedMemory->createSharedBuffer(buffer.size()));
+    completionHandler(WTFMove(handle));
 }
 
 void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -196,18 +196,13 @@ void RemoteSourceBufferProxy::sourceBufferPrivateBufferedDirtyChanged(bool flag)
 
 void RemoteSourceBufferProxy::append(IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
 {
-    SharedMemory::Handle handle;
-
-    auto invokeCallbackAtScopeExit = makeScopeExit([&] {
-        completionHandler(WTFMove(handle));
-    });
-
     auto sharedMemory = buffer.sharedCopy();
     if (!sharedMemory)
-        return;
+        return completionHandler(std::nullopt);
+
     m_sourceBufferPrivate->append(sharedMemory->createSharedBuffer(buffer.size()));
 
-    sharedMemory->createHandle(handle, SharedMemory::Protection::ReadOnly);
+    completionHandler(sharedMemory->createHandle(SharedMemory::Protection::ReadOnly));
 }
 
 void RemoteSourceBufferProxy::abort()

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -83,10 +83,10 @@ void WebSWOriginStore::unregisterSWServerConnection(WebSWServerConnection& conne
 
 void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
 {
-    SharedMemory::Handle handle;
-    if (!m_store.createSharedMemoryHandle(handle))
+    auto handle = m_store.createSharedMemoryHandle();
+    if (!handle)
         return;
-    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(handle));
+    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(*handle));
 }
 
 void WebSWOriginStore::didInvalidateSharedMemory()

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -495,7 +495,8 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
                     completionHandler(mappedBody);
                 return;
             }
-            mappedBody.shareableResource->createHandle(mappedBody.shareableResourceHandle);
+            if (auto handle = mappedBody.shareableResource->createHandle())
+                mappedBody.shareableResourceHandle = WTFMove(*handle);
         }
 #endif
         if (completionHandler)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -188,7 +188,8 @@ void Entry::initializeShareableResourceHandleFromStorageRecord() const
     auto shareableResource = ShareableResource::create(sharedMemory.releaseNonNull(), 0, m_sourceStorageRecord.body.size());
     if (!shareableResource)
         return;
-    shareableResource->createHandle(m_shareableResourceHandle);
+    if (auto handle = shareableResource->createHandle())
+        m_shareableResourceHandle = WTFMove(*handle);
 }
 #endif
 

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -51,9 +51,10 @@ void SharedBufferReference::encode(Encoder& encoder) const
     SharedMemory::Handle handle;
     {
         auto sharedMemoryBuffer = m_memory ? m_memory : SharedMemory::copyBuffer(*m_buffer);
-        sharedMemoryBuffer->createHandle(handle, SharedMemory::Protection::ReadOnly);
+        if (auto memoryHandle = sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly))
+            handle = WTFMove(*memoryHandle);
     }
-    encoder << WTFMove(handle);
+    encoder << handle;
 #endif
 }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -68,10 +68,10 @@ StreamConnectionBuffer& StreamConnectionBuffer::operator=(StreamConnectionBuffer
 
 void StreamConnectionBuffer::encode(Encoder& encoder) const
 {
-    WebKit::SharedMemory::Handle handle;
-    if (!m_sharedMemory->createHandle(handle, WebKit::SharedMemory::Protection::ReadWrite))
+    auto handle = m_sharedMemory->createHandle(WebKit::SharedMemory::Protection::ReadWrite);
+    if (!handle)
         CRASH();
-    encoder << handle;
+    encoder << *handle;
 }
 
 std::optional<StreamConnectionBuffer> StreamConnectionBuffer::decode(Decoder& decoder)

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -409,15 +409,15 @@ bool Connection::sendOutgoingMessage(UniqueRef<Encoder>&& encoder)
         if (!oolMessageBody)
             return false;
 
-        WebKit::SharedMemory::Handle handle;
-        if (!oolMessageBody->createHandle(handle, WebKit::SharedMemory::Protection::ReadOnly))
+        auto handle = oolMessageBody->createHandle(WebKit::SharedMemory::Protection::ReadOnly);
+        if (!handle)
             return false;
 
         outputMessage.messageInfo().setBodyOutOfLine();
 
         memcpy(oolMessageBody->data(), outputMessage.body(), outputMessage.bodySize());
 
-        outputMessage.appendAttachment(handle.releaseHandle());
+        outputMessage.appendAttachment(handle->releaseHandle());
     }
 
     return sendOutputMessage(outputMessage);

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -112,7 +112,7 @@ public:
 
     ~SharedMemory();
 
-    bool createHandle(Handle&, Protection);
+    std::optional<Handle> createHandle(Protection);
 
     size_t size() const { return m_size; }
     void* data() const

--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -245,19 +245,20 @@ SharedMemory::~SharedMemory()
     }
 }
     
-bool SharedMemory::createHandle(Handle& handle, Protection protection)
+auto SharedMemory::createHandle(Protection protection) -> std::optional<Handle>
 {
+    Handle handle;
     ASSERT(!handle.m_handle);
     ASSERT(!handle.m_size);
 
     auto sendRight = createSendRight(protection);
     if (!sendRight)
-        return false;
+        return std::nullopt;
 
     handle.m_handle = WTFMove(sendRight);
     handle.m_size = m_size;
 
-    return true;
+    return WTFMove(handle);
 }
 
 WTF::MachSendRight SharedMemory::createSendRight(Protection protection) const

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -202,8 +202,9 @@ SharedMemory::~SharedMemory()
     munmap(m_data, m_size);
 }
 
-bool SharedMemory::createHandle(Handle& handle, Protection)
+auto SharedMemory::createHandle(Protection) -> std::optional<Handle>
 {
+    Handle handle;
     ASSERT_ARG(handle, handle.isNull());
     ASSERT(m_fileDescriptor);
 
@@ -213,11 +214,11 @@ bool SharedMemory::createHandle(Handle& handle, Protection)
     UnixFileDescriptor duplicate { m_fileDescriptor.value(), UnixFileDescriptor::Duplicate };
     if (!duplicate) {
         ASSERT_NOT_REACHED();
-        return false;
+        return std::nullopt;
     }
     handle.m_handle = WTFMove(duplicate);
     handle.m_size = m_size;
-    return true;
+    return { WTFMove(handle) };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/win/SharedMemoryWin.cpp
+++ b/Source/WebKit/Platform/win/SharedMemoryWin.cpp
@@ -141,8 +141,9 @@ SharedMemory::~SharedMemory()
     ::UnmapViewOfFile(m_data);
 }
 
-bool SharedMemory::createHandle(Handle& handle, Protection protection)
+auto SharedMemory::createHandle(Protection protection) -> std::optional<Handle>
 {
+    Handle handle;
     ASSERT_ARG(handle, !handle.m_handle);
     ASSERT_ARG(handle, !handle.m_size);
 
@@ -150,11 +151,11 @@ bool SharedMemory::createHandle(Handle& handle, Protection protection)
 
     HANDLE duplicatedHandle;
     if (!::DuplicateHandle(processHandle, m_handle.get(), processHandle, &duplicatedHandle, accessRights(protection), FALSE, 0))
-        return false;
+        return std::nullopt;
 
     handle.m_handle = Win32Handle { duplicatedHandle };
     handle.m_size = m_size;
-    return true;
+    return WTFMove(handle);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -80,14 +80,14 @@ ProducerSharedCARingBuffer::Pair ProducerSharedCARingBuffer::allocate(const WebC
     if (!sharedMemory)
         return { nullptr, { } };
 
-    ConsumerSharedCARingBuffer::Handle handle;
-    if (!sharedMemory->createHandle(handle, SharedMemory::Protection::ReadOnly))
+    auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
+    if (!handle)
         return { nullptr, { } };
 
     new (NotNull, sharedMemory->data()) TimeBoundsBuffer;
     std::unique_ptr<ProducerSharedCARingBuffer> result { new ProducerSharedCARingBuffer { bytesPerFrame, frameCount, numChannelStreams, sharedMemory.releaseNonNull() } };
     result->initialize();
-    return { WTFMove(result), WTFMove(handle) };
+    return { WTFMove(result), WTFMove(*handle) };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -100,8 +100,10 @@ void ContextMenuContextData::encode(IPC::Encoder& encoder) const
 
 #if ENABLE(SERVICE_CONTROLS)
     ShareableBitmapHandle handle;
-    if (m_controlledImage)
-        m_controlledImage->createHandle(handle, SharedMemory::Protection::ReadOnly);
+    if (m_controlledImage) {
+        if (auto imageHandle = m_controlledImage->createHandle(SharedMemory::Protection::ReadOnly))
+            handle = WTFMove(*imageHandle);
+    }
     encoder << handle;
     encoder << m_controlledSelectionData;
     encoder << m_selectedTelephoneNumbers;

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -78,15 +78,13 @@ void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, Comp
         auto sharedMemory = WebKit::SharedMemory::allocate(byteCount);
         if (!sharedMemory)
             return { };
-        SharedMemory::Handle handle;
-        if (!sharedMemory->createHandle(handle, SharedMemory::Protection::ReadOnly))
-            return { };
-        if (handle.isNull())
+        auto handle = sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
+        if (!handle)
             return { };
         uint8_t* data = static_cast<uint8_t*>(sharedMemory->data());
         for (size_t i = 0; i < sharedMemory->size(); ++i)
             data[i] = i;
-        return handle;
+        return *handle;
     }();
     completionHandler(WTFMove(result));
 }

--- a/Source/WebKit/Shared/PlatformPopupMenuData.cpp
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.cpp
@@ -44,14 +44,8 @@ void PlatformPopupMenuData::encode(IPC::Encoder& encoder) const
     encoder << m_clientInsetRight;
     encoder << m_popupWidth;
     encoder << m_itemHeight;
-
-    ShareableBitmapHandle notSelectedBackingStoreHandle;
-    m_notSelectedBackingStore->createHandle(notSelectedBackingStoreHandle);
-    encoder << notSelectedBackingStoreHandle;
-
-    ShareableBitmapHandle selectedBackingStoreHandle;
-    m_selectedBackingStore->createHandle(selectedBackingStoreHandle);
-    encoder << selectedBackingStoreHandle;
+    encoder << m_notSelectedBackingStore->createHandle();
+    encoder << m_selectedBackingStore->createHandle();
 #else
     UNUSED_PARAM(encoder);
 #endif
@@ -82,15 +76,17 @@ bool PlatformPopupMenuData::decode(IPC::Decoder& decoder, PlatformPopupMenuData&
     if (!decoder.decode(data.m_itemHeight))
         return false;
 
-    ShareableBitmapHandle notSelectedBackingStoreHandle;
-    if (!decoder.decode(notSelectedBackingStoreHandle))
+    std::optional<std::optional<ShareableBitmapHandle>> notSelectedBackingStoreHandle;
+    decoder >> notSelectedBackingStoreHandle;
+    if (!notSelectedBackingStoreHandle || !*notSelectedBackingStoreHandle)
         return false;
-    data.m_notSelectedBackingStore = ShareableBitmap::create(notSelectedBackingStoreHandle);
+    data.m_notSelectedBackingStore = ShareableBitmap::create(**notSelectedBackingStoreHandle);
 
-    ShareableBitmapHandle selectedBackingStoreHandle;
-    if (!decoder.decode(selectedBackingStoreHandle))
+    std::optional<std::optional<ShareableBitmapHandle>> selectedBackingStoreHandle;
+    decoder >> selectedBackingStoreHandle;
+    if (!selectedBackingStoreHandle || !*selectedBackingStoreHandle)
         return false;
-    data.m_selectedBackingStore = ShareableBitmap::create(selectedBackingStoreHandle);
+    data.m_selectedBackingStore = ShareableBitmap::create(**selectedBackingStoreHandle);
 #else
     UNUSED_PARAM(decoder);
     UNUSED_PARAM(data);

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -92,8 +92,7 @@ public:
     // Create a shareable bitmap from a ReadOnly handle.
     static std::optional<Ref<ShareableBitmap>> createReadOnly(const std::optional<ShareableBitmapHandle>&);
 
-    // Create a handle.
-    bool createHandle(ShareableBitmapHandle&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const;
+    std::optional<ShareableBitmapHandle> createHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const;
     
     // Create a ReadOnly handle.
     std::optional<ShareableBitmapHandle> createReadOnlyHandle() const;

--- a/Source/WebKit/Shared/ShareableResource.cpp
+++ b/Source/WebKit/Shared/ShareableResource.cpp
@@ -113,14 +113,17 @@ ShareableResource::ShareableResource(Ref<SharedMemory>&& sharedMemory, unsigned 
 
 ShareableResource::~ShareableResource() = default;
 
-bool ShareableResource::createHandle(Handle& handle)
+auto ShareableResource::createHandle() -> std::optional<Handle>
 {
-    if (!m_sharedMemory->createHandle(handle.m_handle, SharedMemory::Protection::ReadOnly))
-        return false;
+    auto memoryHandle = m_sharedMemory->createHandle(SharedMemory::Protection::ReadOnly);
+    if (!memoryHandle)
+        return std::nullopt;
 
+    Handle handle;
+    handle.m_handle = WTFMove(*memoryHandle);
     handle.m_offset = m_offset;
     handle.m_size = m_size;
-    return true;
+    return { WTFMove(handle) };
 }
 
 const uint8_t* ShareableResource::data() const

--- a/Source/WebKit/Shared/ShareableResource.h
+++ b/Source/WebKit/Shared/ShareableResource.h
@@ -70,8 +70,7 @@ public:
     // Create a shareable resource from a handle.
     static RefPtr<ShareableResource> map(const Handle&);
 
-    // Create a handle.
-    bool createHandle(Handle&);
+    std::optional<Handle> createHandle();
 
     ~ShareableResource();
 

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -70,9 +70,9 @@ SharedStringHashStore::SharedStringHashStore(Client& client)
 {
 }
 
-bool SharedStringHashStore::createSharedMemoryHandle(SharedMemory::Handle& handle)
+std::optional<SharedMemory::Handle> SharedStringHashStore::createSharedMemoryHandle()
 {
-    return m_table.sharedMemory()->createHandle(handle, SharedMemory::Protection::ReadOnly);
+    return m_table.sharedMemory()->createHandle(SharedMemory::Protection::ReadOnly);
 }
 
 void SharedStringHashStore::scheduleAddition(SharedStringHash sharedStringHash)

--- a/Source/WebKit/Shared/SharedStringHashStore.h
+++ b/Source/WebKit/Shared/SharedStringHashStore.h
@@ -44,7 +44,7 @@ public:
 
     SharedStringHashStore(Client&);
 
-    bool createSharedMemoryHandle(SharedMemory::Handle&);
+    std::optional<SharedMemory::Handle> createSharedMemoryHandle();
 
     void scheduleAddition(WebCore::SharedStringHash);
     void scheduleRemoval(WebCore::SharedStringHash);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1909,7 +1909,8 @@ void ArgumentCoder<WebCore::FragmentedSharedBuffer>::encode(Encoder& encoder, co
     SharedMemory::Handle handle;
     {
         auto sharedMemoryBuffer = SharedMemory::copyBuffer(buffer);
-        sharedMemoryBuffer->createHandle(handle, SharedMemory::Protection::ReadOnly);
+        if (auto memoryHandle = sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly))
+            handle = WTFMove(*memoryHandle);
     }
     encoder << WTFMove(handle);
 #endif
@@ -1978,8 +1979,9 @@ static ShareableResource::Handle tryConvertToShareableResourceHandle(const Scrip
         return ShareableResource::Handle { };
 
     ShareableResource::Handle shareableResourceHandle;
-    shareableResource->createHandle(shareableResourceHandle);
-    return shareableResourceHandle;
+    if (auto handle = shareableResource->createHandle())
+        return WTFMove(*handle);
+    return ShareableResource::Handle { };
 }
 
 static std::optional<WebCore::ScriptBuffer> decodeScriptBufferAsShareableResourceHandle(Decoder& decoder)

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -136,14 +136,18 @@ void WebHitTestResultData::encode(IPC::Encoder& encoder) const
     encoder << dictionaryPopupInfo;
 
     WebKit::SharedMemory::Handle imageHandle;
-    if (imageSharedMemory && imageSharedMemory->data())
-        imageSharedMemory->createHandle(imageHandle, WebKit::SharedMemory::Protection::ReadOnly);
+    if (imageSharedMemory && imageSharedMemory->data()) {
+        if (auto handle = imageSharedMemory->createHandle(WebKit::SharedMemory::Protection::ReadOnly))
+            imageHandle = WTFMove(*handle);
+    }
 
     encoder << imageHandle;
 
     ShareableBitmapHandle imageBitmapHandle;
-    if (imageBitmap)
-        imageBitmap->createHandle(imageBitmapHandle, SharedMemory::Protection::ReadOnly);
+    if (imageBitmap) {
+        if (auto handle = imageBitmap->createHandle(SharedMemory::Protection::ReadOnly))
+            imageBitmapHandle = WTFMove(*handle);
+    }
     encoder << imageBitmapHandle;
     encoder << sourceImageMIMEType;
 

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -43,20 +43,17 @@ static void encodeImage(Encoder& encoder, Image& image)
 {
     RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(IntSize(image.size()), { });
     bitmap->createGraphicsContext()->drawImage(image, IntPoint());
-
-    ShareableBitmapHandle handle;
-    bitmap->createHandle(handle);
-
-    encoder << handle;
+    encoder << bitmap->createHandle();
 }
 
 static WARN_UNUSED_RETURN bool decodeImage(Decoder& decoder, RefPtr<Image>& image)
 {
-    ShareableBitmapHandle handle;
-    if (!decoder.decode(handle))
+    std::optional<std::optional<ShareableBitmapHandle>> handle;
+    decoder >> handle;
+    if (!handle || !*handle)
         return false;
 
-    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(handle);
+    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(**handle);
     if (!bitmap)
         return false;
     image = bitmap->createImage();

--- a/Source/WebKit/UIProcess/VisitedLinkStore.cpp
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.cpp
@@ -114,10 +114,10 @@ void VisitedLinkStore::sendStoreHandleToProcess(WebProcessProxy& process)
 {
     ASSERT(process.processPool().processes().containsIf([&](auto& item) { return item.ptr() == &process; }));
 
-    SharedMemory::Handle handle;
-    if (!m_linkHashStore.createSharedMemoryHandle(handle))
+    auto handle = m_linkHashStore.createSharedMemoryHandle();
+    if (!handle)
         return;
-    process.send(Messages::VisitedLinkTableController::SetVisitedLinkTable(WTFMove(handle)), identifier());
+    process.send(Messages::VisitedLinkTableController::SetVisitedLinkTable(WTFMove(*handle)), identifier());
 }
 
 void VisitedLinkStore::didInvalidateSharedMemory()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10591,7 +10591,8 @@ void WebPageProxy::requestAttachmentIcon(const String& identifier, const String&
 
 #if PLATFORM(COCOA)
         if (auto icon = iconForAttachment(fileName, contentType, title, size))
-            icon->createHandle(handle);
+            if (auto iconHandle = icon->createHandle())
+                handle = WTFMove(*iconHandle);
 #endif
 
         send(Messages::WebPage::UpdateAttachmentIcon(identifier, handle, size));
@@ -10643,8 +10644,10 @@ void WebPageProxy::updateAttachmentThumbnail(const String& identifier, const Ref
         return;
     
     ShareableBitmapHandle handle;
-    if (bitmap)
-        bitmap->createHandle(handle);
+    if (bitmap) {
+        if (auto bitmapHandle = bitmap->createHandle())
+            handle = WTFMove(*bitmapHandle);
+    }
 
     send(Messages::WebPage::UpdateAttachmentThumbnail(identifier, handle));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -126,9 +126,9 @@ ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const Param
 
 ImageBufferBackendHandle ImageBufferShareableBitmapBackend::createBackendHandle(SharedMemory::Protection protection) const
 {
-    ShareableBitmapHandle handle;
-    m_bitmap->createHandle(handle, protection);
-    return ImageBufferBackendHandle(WTFMove(handle));
+    if (auto handle = m_bitmap->createHandle(protection))
+        return ImageBufferBackendHandle(WTFMove(*handle));
+    return { };
 }
 
 IntSize ImageBufferShareableBitmapBackend::backendSize() const

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -188,14 +188,12 @@ std::optional<SharedMemory::Handle> RemoteRenderingBackendProxy::updateSharedMem
     auto memory = SharedMemory::allocate(dataSize);
     if (!memory)
         return std::nullopt;
-    SharedMemory::Handle handle;
-    if (!memory->createHandle(handle, SharedMemory::Protection::ReadWrite))
-        return std::nullopt;
-    if (handle.isNull())
+    auto handle = memory->createHandle(SharedMemory::Protection::ReadWrite);
+    if (!handle)
         return std::nullopt;
 
     m_getPixelBufferSharedMemory = WTFMove(memory);
-    handle.takeOwnershipOfMemory(MemoryLedger::Graphics);
+    handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
     m_destroyGetPixelBufferSharedMemoryTimer.startOneShot(5_s);
     return handle;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -102,12 +102,11 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
     if (!bitmap)
         return;
 
-    ShareableBitmapHandle handle;
-    bitmap->createHandle(handle);
-    if (handle.isNull())
+    auto handle = bitmap->createHandle();
+    if (!handle)
         return;
 
-    handle.takeOwnershipOfMemory(MemoryLedger::Graphics);
+    handle->takeOwnershipOfMemory(MemoryLedger::Graphics);
     m_nativeImages.add(image.renderingResourceIdentifier(), image);
 
     // Set itself as an observer to NativeImage, so releaseNativeImage()
@@ -115,7 +114,7 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
     image.addObserver(*this);
 
     // Tell the GPU process to cache this resource.
-    m_remoteRenderingBackendProxy.cacheNativeImage(handle, image.renderingResourceIdentifier());
+    m_remoteRenderingBackendProxy.cacheNativeImage(*handle, image.renderingResourceIdentifier());
 }
 
 void RemoteResourceCacheProxy::recordFontUse(Font& font)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -75,9 +75,11 @@ bool SharedVideoFrameWriter::allocateStorage(size_t size, const Function<void(co
     if (!m_storage)
         return false;
 
-    SharedMemory::Handle handle;
-    m_storage->createHandle(handle, SharedMemory::Protection::ReadOnly);
-    newMemoryCallback(WTFMove(handle));
+    auto handle = m_storage->createHandle(SharedMemory::Protection::ReadOnly);
+    if (!handle)
+        return false;
+
+    newMemoryCallback(WTFMove(*handle));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp
@@ -68,9 +68,14 @@ void WebDragClient::startDrag(DragItem item, DataTransfer& dataTransfer, Frame&)
     RefPtr<ShareableBitmap> bitmap = convertCairoSurfaceToShareableBitmap(dragImage.get().get());
     ShareableBitmapHandle handle;
 
-    // If we have a bitmap, but cannot create a handle to it, we fail early.
-    if (bitmap && !bitmap->createHandle(handle))
-        return;
+    if (bitmap) {
+        if (auto imageHandle = bitmap->createHandle())
+            handle = WTFMove(*imageHandle);
+        else {
+            // If we have a bitmap, but cannot create a handle to it, we fail early.
+            return;
+        }
+    }
 
     m_page->willStartDrag();
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -833,7 +833,9 @@ void DrawingAreaCoordinatedGraphics::display(UpdateInfo& updateInfo)
     if (!bitmap)
         return;
 
-    if (!bitmap->createHandle(updateInfo.bitmapHandle))
+    if (auto handle = bitmap->createHandle())
+        updateInfo.bitmapHandle = WTFMove(*handle);
+    else
         return;
 
     auto rects = m_dirtyRegion.rects();

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1204,9 +1204,9 @@ JSValueRef JSIPCSemaphore::waitFor(JSContextRef context, JSObjectRef, JSObjectRe
 
 SharedMemory::Handle JSSharedMemory::createHandle(SharedMemory::Protection protection)
 {
-    SharedMemory::Handle handle;
-    m_sharedMemory->createHandle(handle, protection);
-    return handle;
+    if (auto handle = m_sharedMemory->createHandle(protection))
+        return *handle;
+    return { };
 }
 
 JSObjectRef JSSharedMemory::createJSWrapper(JSContextRef context)


### PR DESCRIPTION
#### c048bf2dcf1dfe6ac3defff3096a355e683ca102
<pre>
Make SharedMemory::createHandle, ShareableBitmap::createHandle, ShareableResource::createHandle return std::optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=247713">https://bugs.webkit.org/show_bug.cgi?id=247713</a>
rdar://102107414

Reviewed by Jean-Yves Avenard.

* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp:
(WebKit::ImageBufferShareableAllocator::createImageBuffer const):
(WebKit::ImageBufferShareableAllocator::createPixelBuffer const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::getShareableBitmapForImageBufferWithQualifiedIdentifier):
(WebKit::RemoteRenderingBackend::getFilteredImageForImageBuffer):
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.cpp:
(WebKit::RemoteImageDecoderAVFProxy::createFrameImageAtIndex):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::bitmapImageForCurrentTime):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::dataReceived):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::append):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::sendStoreHandle):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::store):
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::initializeShareableResourceHandleFromStorageRecord const):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::encode const):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::encode const):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemory::createHandle):
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemory::createHandle):
* Source/WebKit/Platform/win/SharedMemoryWin.cpp:
(WebKit::SharedMemory::createHandle):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ProducerSharedCARingBuffer::allocate):
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::encode const):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncMessageReturningSharedMemory1):
* Source/WebKit/Shared/ShareableBitmap.cpp:
(WebKit::ShareableBitmap::createHandle const):
(WebKit::ShareableBitmap::createReadOnlyHandle const):
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/Shared/ShareableResource.cpp:
(WebKit::ShareableResource::createHandle):
* Source/WebKit/Shared/ShareableResource.h:
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::SharedStringHashStore::createSharedMemoryHandle):
* Source/WebKit/Shared/SharedStringHashStore.h:
* Source/WebKit/Shared/WebCompiledContentRuleListData.cpp:
(WebKit::WebCompiledContentRuleListData::encode const):
(WebKit::WebCompiledContentRuleListData::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::FragmentedSharedBuffer&gt;::encode):
(IPC::tryConvertToShareableResourceHandle):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::encode const):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::updateIconForDirectory):
(WebKit::WebPageProxy::restoreAppHighlightsAndScrollToIndex):
* Source/WebKit/UIProcess/VisitedLinkStore.cpp:
(WebKit::VisitedLinkStore::sendStoreHandleToProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::updateAttachmentThumbnail):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::createBackendHandle const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::updateSharedMemoryForGetPixelBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::allocateStorage):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::startDrag):
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSSharedMemory::createHandle):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawPagesForPrinting):
(WebKit::WebPage::requestTextRecognition):
(WebKit::WebPage::requestImageBitmap):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::performActionOnElement):

Canonical link: <a href="https://commits.webkit.org/256595@main">https://commits.webkit.org/256595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e397bdf5b8c669d54357737e8061062edd30824

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105763 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5595 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34234 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88602 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101877 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82822 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31174 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74001 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39957 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37631 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20786 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/54 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2189 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/54 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40053 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->