### PR TITLE
[GTK4] Disable threaded rendering by default

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -37,11 +37,7 @@ namespace Nicosia {
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
 #if (ENABLE(DEVELOPER_MODE) && PLATFORM(WPE)) || USE(GTK4)
-#if USE(GTK4)
-    unsigned numThreads = 4;
-#else
     unsigned numThreads = 0;
-#endif
     if (const char* numThreadsEnv = getenv("WEBKIT_NICOSIA_PAINTING_THREADS")) {
         if (sscanf(numThreadsEnv, "%u", &numThreads) == 1) {
             if (numThreads > 8) {


### PR DESCRIPTION
#### b97318e0d7f98c24ea6db78c3e36e7e80a880707
<pre>
[GTK4] Disable threaded rendering by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=247719">https://bugs.webkit.org/show_bug.cgi?id=247719</a>

Reviewed by Miguel Gomez.

Cairo is not thread safe and threaded rendering is causing some crashes
when building with GTK4.

* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp:
(Nicosia::PaintingEngine::create):

Canonical link: <a href="https://commits.webkit.org/256526@main">https://commits.webkit.org/256526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56ceba2ef84ba4d34b695f6a3d8a08d74d2b77e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105596 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165919 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5407 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34053 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88423 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101413 "Hash 56ceba2e for PR 6337 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101705 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/3989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82649 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31022 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73857 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39786 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37462 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4515 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42058 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39885 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->