### PR TITLE
[Curl] Discard response headers when an error occurs

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -466,16 +466,16 @@ void CurlRequest::didCompleteTransfer(CURLcode result)
         return;
     }
 
-    if (needToInvokeDidReceiveResponse()) {
-        // Processing of didReceiveResponse() has not been completed. (For example, HEAD method)
-        // When completeDidReceiveResponse() is called, didCompleteTransfer() will be called again.
-
-        m_finishedResultCode = result;
-        invokeDidReceiveResponse(m_response, Action::FinishTransfer);
-        return;
-    }
-
     if (result == CURLE_OK) {
+        if (needToInvokeDidReceiveResponse()) {
+            // Processing of didReceiveResponse() has not been completed. (For example, HEAD method)
+            // When completeDidReceiveResponse() is called, didCompleteTransfer() will be called again.
+
+            m_finishedResultCode = result;
+            invokeDidReceiveResponse(m_response, Action::FinishTransfer);
+            return;
+        }
+
         if (m_multipartHandle)
             m_multipartHandle->didComplete();
 


### PR DESCRIPTION
#### c9f5e13a69fa0a4098f85b6bf73ababb5e56aa07
<pre>
[Curl] Discard response headers when an error occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=247716">https://bugs.webkit.org/show_bug.cgi?id=247716</a>

Reviewed by Fujii Hironori.

If a cURL error occurs before the response body is received,
the previously received response headers are not notified to WebCore
to avoid malfunction.

* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::didReceiveHeader):
(WebCore::CurlRequest::didCompleteTransfer):
(WebCore::CurlRequest::shouldAbortConnectRequest): Deleted.
* Source/WebCore/platform/network/curl/CurlRequest.h:

Canonical link: <a href="https://commits.webkit.org/256639@main">https://commits.webkit.org/256639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5078b40b826d0c2d00ca36736155f105245a9be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105945 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166293 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5827 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34402 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102671 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102073 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83004 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31320 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88071 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40132 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4607 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/3186 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40220 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->