### PR TITLE
Report WebCodecsVideoFrame memoryCost

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -129,6 +129,8 @@ public:
 
     const WebCodecsVideoFrameData& data() const { return m_data; }
 
+    size_t memoryCost() const { return m_data.memoryCost(); }
+
 private:
     WebCodecsVideoFrame();
     explicit WebCodecsVideoFrame(WebCodecsVideoFrameData&&);

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl
@@ -40,6 +40,7 @@ typedef (HTMLImageElement or HTMLCanvasElement or ImageBitmap
     EnabledBySetting=WebCodecsEnabled,
     Exposed=(Window,DedicatedWorker),
     InterfaceName=VideoFrame,
+    ReportExtraMemoryCost,
 ] interface WebCodecsVideoFrame {
     constructor(CanvasImageSource image, optional VideoFrameInit init = {});
     constructor(WebCodecsVideoFrame image, optional VideoFrameInit init = {});

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameData.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameData.h
@@ -33,6 +33,9 @@
 namespace WebCore {
 
 struct WebCodecsVideoFrameData {
+    // We might want to make memory cost take into account the video frame format.
+    size_t memoryCost() const { return 4 * codedWidth * codedHeight; }
+
     RefPtr<VideoFrame> internalFrame;
     std::optional<VideoPixelFormat> format;
     size_t codedWidth { 0 };

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4377,7 +4377,8 @@ size_t SerializedScriptValue::computeMemoryCost() const
         if (chunk)
             cost += chunk->memoryCost();
     }
-    // FIXME: Add memory cost to serialized video frames.
+    for (auto& frame : m_serializedVideoFrames)
+        cost += frame.memoryCost();
 #endif
 
     for (auto& handle : m_blobHandles)


### PR DESCRIPTION
#### 34128a822f3670002871d33dbfa4a01d1c6b95a3
<pre>
Report WebCodecsVideoFrame memoryCost
<a href="https://bugs.webkit.org/show_bug.cgi?id=247720">https://bugs.webkit.org/show_bug.cgi?id=247720</a>
rdar://problem/102182069

Reviewed by Eric Carlson.

Report a rough estimate of WebCodecs Video Frame size.
We compute the size as if it is RGBA as a good enough estimate, though NV12 would be smaller for instance.

* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
(WebCore::WebCodecsVideoFrame::memoryCost const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.idl:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameData.h:
(WebCore::WebCodecsVideoFrameData::memoryCost const):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::SerializedScriptValue::computeMemoryCost const):

Canonical link: <a href="https://commits.webkit.org/256745@main">https://commits.webkit.org/256745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2f397f9b3fb063e1e33047027388145138ea79d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105599 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165923 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5410 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34057 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101416 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101708 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3993 "Found 2 new test failures: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb, imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_avc (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82652 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31027 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73862 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39789 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19285 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37465 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20626 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4685 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42061 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43232 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/interfaces/SharedWorkerGlobalScope/onconnect.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43951 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39889 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->