### PR TITLE
CARingBuffer has two implementations for almost the same thing

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp
@@ -35,9 +35,6 @@
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 
-const uint32_t kGeneralRingTimeBoundsQueueSize = 32;
-const uint32_t kGeneralRingTimeBoundsQueueMask = kGeneralRingTimeBoundsQueueSize - 1;
-
 namespace WebCore {
 
 CARingBuffer::CARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams)
@@ -69,7 +66,6 @@ void CARingBuffer::initialize()
         pointer = channelData;
         channelData += m_capacityBytes;
     }
-    flush();
 }
 
 static void ZeroRange(Vector<Byte*>& pointers, size_t offset, size_t nbytes)
@@ -146,6 +142,21 @@ inline void ZeroABL(AudioBufferList* list, size_t destOffset, size_t nbytes)
     }
 }
 
+void CARingBuffer::setTimeBounds(TimeBounds bufferBounds)
+{
+    m_storeBounds = bufferBounds;
+
+    auto& bounds = timeBoundsBuffer();
+    unsigned index = (bounds.index.load(std::memory_order_acquire) + 1) % boundsBufferSize;
+    bounds.buffer[index] = bufferBounds;
+    bounds.index.store(index, std::memory_order_release);
+}
+
+CARingBuffer::TimeBounds CARingBuffer::getStoreTimeBounds()
+{
+    return m_storeBounds;
+}
+
 CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t framesToWrite, uint64_t startFrame)
 {
     if (!framesToWrite)
@@ -156,28 +167,27 @@ CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t fram
 
     uint64_t endFrame = startFrame + framesToWrite;
 
-    if (startFrame < currentEndFrame()) {
+    if (startFrame < m_storeBounds.startFrame) {
         // Throw everything out when going backwards.
-        setCurrentFrameBounds(startFrame, startFrame);
-    } else if (endFrame - currentStartFrame() <= m_frameCount) {
+        setTimeBounds({ startFrame, startFrame });
+    } else if (endFrame - m_storeBounds.startFrame <= m_frameCount) {
         // The buffer has not yet wrapped and will not need to.
         // No-op.
     } else {
         // Advance the start time past the region we are about to overwrite
         // starting one buffer of time behind where we're writing.
         uint64_t newStartFrame = endFrame - m_frameCount;
-        uint64_t newEndFrame = std::max(newStartFrame, currentEndFrame());
-        setCurrentFrameBounds(newStartFrame, newEndFrame);
+        uint64_t newEndFrame = std::max(newStartFrame, m_storeBounds.endFrame);
+        setTimeBounds({ newStartFrame, newEndFrame });
     }
 
     // Write the new frames.
     size_t offset0;
     size_t offset1;
-    uint64_t curEnd = currentEndFrame();
 
-    if (startFrame > curEnd) {
+    if (startFrame > m_storeBounds.endFrame) {
         // We are skipping some samples, so zero the range we are skipping.
-        offset0 = frameOffset(curEnd);
+        offset0 = frameOffset(m_storeBounds.endFrame);
         offset1 = frameOffset(startFrame);
         if (offset0 < offset1)
             ZeroRange(m_pointers, offset0, offset1 - offset0);
@@ -199,66 +209,64 @@ CARingBuffer::Error CARingBuffer::store(const AudioBufferList* list, size_t fram
     }
 
     // Now update the end time.
-    setCurrentFrameBounds(currentStartFrame(), endFrame);
+    setTimeBounds({ m_storeBounds.startFrame, endFrame });
 
     return Ok;
 }
 
-void CARingBuffer::getCurrentFrameBounds(uint64_t& startFrame, uint64_t& endFrame)
+CARingBuffer::TimeBounds CARingBuffer::getFetchTimeBounds()
 {
-    updateFrameBounds();
-    getCurrentFrameBoundsWithoutUpdate(startFrame, endFrame);
-}
-
-void CARingBuffer::clipTimeBounds(uint64_t& startRead, uint64_t& endRead)
-{
-    uint64_t startTime;
-    uint64_t endTime;
-
-    getCurrentFrameBoundsWithoutUpdate(startTime, endTime);
-
-    if (startRead > endTime || endRead < startTime) {
-        endRead = startRead;
-        return;
+    auto& bounds = timeBoundsBuffer();
+    unsigned index = bounds.index.load(std::memory_order_acquire);
+    if (UNLIKELY(index >= boundsBufferSize)) {
+        ASSERT_NOT_REACHED();
+        return { };
     }
 
-    startRead = std::max(startRead, startTime);
-    endRead = std::min(endRead, endTime);
-    endRead = std::max(endRead, startRead);
+    auto fetchBounds = bounds.buffer[index];
+    if (fetchBounds.endFrame - fetchBounds.startFrame > m_frameCount) {
+        ASSERT_NOT_REACHED();
+        return { };
+    }
+    return fetchBounds;
 }
 
-bool CARingBuffer::fetchIfHasEnoughData(AudioBufferList* list, size_t frameCount, uint64_t startFrame, FetchMode mode)
+static CARingBuffer::TimeBounds clamp(CARingBuffer::TimeBounds value, CARingBuffer::TimeBounds limit)
 {
-    // When the RingBuffer is backed by shared memory, getCurrentFrameBounds() makes sure we pull frame bounds from shared memory before fetching.
-    uint64_t start, end;
-    getCurrentFrameBounds(start, end);
-    if (startFrame < start || startFrame + frameCount > end)
-        return false;
+    return {
+        std::clamp(value.startFrame, limit.startFrame, limit.endFrame),
+        std::clamp(value.endFrame, limit.startFrame, limit.endFrame)
+    };
+}
 
-    fetchInternal(list, frameCount, startFrame, mode);
+bool CARingBuffer::fetchIfHasEnoughData(AudioBufferList* list, size_t frameCount, uint64_t startRead, FetchMode mode)
+{
+    auto bufferBounds = getFetchTimeBounds();
+    if (startRead < bufferBounds.startFrame || startRead + frameCount > bufferBounds.endFrame)
+        return false;
+    fetchInternal(list, frameCount, startRead, mode, bufferBounds);
     return true;
 }
 
 void CARingBuffer::fetch(AudioBufferList* list, size_t frameCount, uint64_t startRead, FetchMode mode)
 {
-    // When the RingBuffer is backed by shared memory, make sure we pull frame bounds from shared memory before fetching.
-    updateFrameBounds();
-    fetchInternal(list, frameCount, startRead, mode);
+    fetchInternal(list, frameCount, startRead, mode, getFetchTimeBounds());
 }
 
-void CARingBuffer::fetchInternal(AudioBufferList* list, size_t nFrames, uint64_t startRead, FetchMode mode)
+void CARingBuffer::fetchInternal(AudioBufferList* list, size_t nFrames, uint64_t startRead, FetchMode mode, TimeBounds bufferBounds)
 {
     if (!nFrames)
         return;
-    
-    startRead = std::max<uint64_t>(0, startRead);
-    
+
     uint64_t endRead = startRead + nFrames;
     
     uint64_t startRead0 = startRead;
     uint64_t endRead0 = endRead;
-    
-    clipTimeBounds(startRead, endRead);
+    {
+        auto fetchBounds = clamp({ startRead, endRead }, bufferBounds);
+        startRead = fetchBounds.startFrame;
+        endRead = fetchBounds.endFrame;
+    }
 
     if (startRead == endRead) {
         ZeroABL(list, 0, nFrames * m_bytesPerFrame);
@@ -325,56 +333,10 @@ std::unique_ptr<InProcessCARingBuffer> InProcessCARingBuffer::allocate(const Web
 InProcessCARingBuffer::InProcessCARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams, Vector<uint8_t>&& buffer)
     : CARingBuffer(bytesPerFrame, frameCount, numChannelStreams)
     , m_buffer(WTFMove(buffer))
-    , m_timeBoundsQueue(kGeneralRingTimeBoundsQueueSize)
 {
 }
 
 InProcessCARingBuffer::~InProcessCARingBuffer() = default;
-
-void InProcessCARingBuffer::flush()
-{
-    Locker locker { m_currentFrameBoundsLock };
-    for (auto& timeBounds : m_timeBoundsQueue) {
-        timeBounds.m_startFrame = 0;
-        timeBounds.m_endFrame = 0;
-        timeBounds.m_updateCounter = 0;
-    }
-    m_timeBoundsQueuePtr = 0;
-}
-
-void InProcessCARingBuffer::setCurrentFrameBounds(uint64_t startTime, uint64_t endTime)
-{
-    Locker locker { m_currentFrameBoundsLock };
-    uint32_t nextPtr = m_timeBoundsQueuePtr.load() + 1;
-    uint32_t index = nextPtr & kGeneralRingTimeBoundsQueueMask;
-
-    m_timeBoundsQueue[index].m_startFrame = startTime;
-    m_timeBoundsQueue[index].m_endFrame = endTime;
-    m_timeBoundsQueue[index].m_updateCounter = nextPtr;
-    m_timeBoundsQueuePtr++;
-}
-
-SUPPRESS_TSAN void InProcessCARingBuffer::getCurrentFrameBoundsWithoutUpdate(uint64_t& startFrame, uint64_t& endFrame)
-{
-    uint32_t curPtr = m_timeBoundsQueuePtr.load();
-    uint32_t index = curPtr & kGeneralRingTimeBoundsQueueMask;
-    auto& bounds = m_timeBoundsQueue[index];
-
-    startFrame = bounds.m_startFrame;
-    endFrame = bounds.m_endFrame;
-}
-
-SUPPRESS_TSAN uint64_t InProcessCARingBuffer::currentStartFrame() const
-{
-    uint32_t index = m_timeBoundsQueuePtr.load() & kGeneralRingTimeBoundsQueueMask;
-    return m_timeBoundsQueue[index].m_startFrame;
-}
-
-SUPPRESS_TSAN uint64_t InProcessCARingBuffer::currentEndFrame() const
-{
-    uint32_t index = m_timeBoundsQueuePtr.load() & kGeneralRingTimeBoundsQueueMask;
-    return m_timeBoundsQueue[index].m_endFrame;
-}
 
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -107,13 +107,12 @@ void AudioSourceProviderAVFObjC::provideInput(AudioBus* bus, size_t framesToProc
         return;
     }
 
-    uint64_t startFrame = 0;
-    uint64_t endFrame = 0;
+
     uint64_t seekTo = std::exchange(m_seekTo, NoSeek);
     if (seekTo != NoSeek)
         m_readCount = seekTo;
 
-    m_ringBuffer->getCurrentFrameBounds(startFrame, endFrame);
+    auto [startFrame, endFrame] = m_ringBuffer->getFetchTimeBounds();
 
     if (!m_readCount || m_readCount == seekTo) {
         // We have not started rendering yet. If there aren't enough frames in the buffer, then output
@@ -378,9 +377,7 @@ void AudioSourceProviderAVFObjC::process(MTAudioProcessingTapRef tap, CMItemCoun
         m_writeAheadCount = m_tapDescription->mSampleRate * earlyBy.toDouble();
     }
 
-    uint64_t startFrame = 0;
-    uint64_t endFrame = 0;
-    m_ringBuffer->getCurrentFrameBounds(startFrame, endFrame);
+    auto [startFrame, endFrame] = m_ringBuffer->getStoreTimeBounds();
 
     // Check to see if the underlying media has seeked, which would require us to "flush"
     // our outstanding buffers.


### PR DESCRIPTION
#### a72b93ec11fdf094188844a9e2218bd227c4c156
<pre>
CARingBuffer has two implementations for almost the same thing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247721">https://bugs.webkit.org/show_bug.cgi?id=247721</a>

Reviewed by Eric Carlson.

The CARingBuffer implementations duplicate the underlying
parallel operation logic.

Move the WebKit side implementation to CARingBuffer and delete
the WebCore side implementation. WebKit side is a bit more
correct.

This way the WebKit code is tested by the CARingBufferTests.

Change the implementation slightly to account that there are
&quot;fetch bounds&quot; and &quot;store bounds&quot;:
 getStoreTimeBounds()
 getFetchTimeBounds()

The fetch time bounds are shared across potentially untrusted
processes, and as such should not be used unless needed.
Answering the question &quot;What time range did I store previously?&quot;
is a question involving local information, since there is just
one producer. This means that it can be fulfilled with the
local store time bounds and should not be loaded from the
shared memory.

Removes CARingBuffer::flush() since that is just used to
initialize the shared time bounds storage. This logic is
in the constructors of the types now.

Removes CARingBuffer::size(), it is an unused function.

* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pullSamples):
(WebCore::AudioSampleDataSource::pullAvailableSamplesAsChunks):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::initialize):
(WebCore::CARingBuffer::setTimeBounds):
(WebCore::CARingBuffer::getStoreTimeBounds):
(WebCore::CARingBuffer::store):
(WebCore::CARingBuffer::getFetchTimeBounds):
(WebCore::clamp):
(WebCore::CARingBuffer::fetchIfHasEnoughData):
(WebCore::CARingBuffer::fetch):
(WebCore::CARingBuffer::fetchInternal):
(WebCore::InProcessCARingBuffer::InProcessCARingBuffer):
(WebCore::CARingBuffer::getCurrentFrameBounds): Deleted.
(WebCore::CARingBuffer::clipTimeBounds): Deleted.
(WebCore::InProcessCARingBuffer::flush): Deleted.
(WebCore::InProcessCARingBuffer::setCurrentFrameBounds): Deleted.
(WebCore::InProcessCARingBuffer::getCurrentFrameBoundsWithoutUpdate): Deleted.
(WebCore::InProcessCARingBuffer::currentStartFrame const): Deleted.
(WebCore::InProcessCARingBuffer::currentEndFrame const): Deleted.
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
(WebCore::CARingBuffer::updateFrameBounds): Deleted.
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::provideInput):
(WebCore::AudioSourceProviderAVFObjC::process):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollingNodeForViewportConstrainedRole):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ConsumerSharedCARingBuffer::map):
(WebKit::ProducerSharedCARingBuffer::allocate):
(WebKit::SharedCARingBufferBase::data): Deleted.
(WebKit::SharedCARingBufferBase::sharedFrameBounds const): Deleted.
(WebKit::SharedCARingBufferBase::getCurrentFrameBoundsWithoutUpdate): Deleted.
(WebKit::SharedCARingBufferBase::flush): Deleted.
(WebKit::SharedCARingBufferBase::updateFrameBounds): Deleted.
(WebKit::SharedCARingBufferBase::size const): Deleted.
(WebKit::ProducerSharedCARingBuffer::setCurrentFrameBounds): Deleted.
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp:
(TestWebKitAPI::makeBounds):
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/256563@main">https://commits.webkit.org/256563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ba78fe653ba6ce8def565158a28b0176f347d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105600 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165924 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5411 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34058 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101417 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/3991 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82653 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31028 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73863 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39790 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19283 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37466 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20623 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4545 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43231 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39886 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->