### PR TITLE
Mismatched whitespace widths cause a wrong width of inline box

### DIFF
--- a/LayoutTests/fast/inline/inline-width-containing-collapsed-whitespace-and-image-in-float-expected.txt
+++ b/LayoutTests/fast/inline/inline-width-containing-collapsed-whitespace-and-image-in-float-expected.txt
@@ -1,0 +1,10 @@
+Test if width of inline box including a image and whitespaces is same with the included image width.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelector('li').getBoundingClientRect().width is 32
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/inline/inline-width-containing-collapsed-whitespace-and-image-in-float.html
+++ b/LayoutTests/fast/inline/inline-width-containing-collapsed-whitespace-and-image-in-float.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+body { font-family: sans-serif, Arial; }
+li { float: left; list-style: none; }
+</style>
+<ul>
+  <li>
+    <a href="#">
+      <img src="./resources/checker.png">
+    </a>
+  </li>
+</ul>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Test if width of inline box including a image and whitespaces is same with the included image width.");
+window.onload = function() {
+  shouldBeEqualToNumber("document.querySelector('li').getBoundingClientRect().width", 32);
+}
+</script>

--- a/LayoutTests/fast/text/simple-line-layout-fallback-space-glyph-expected.html
+++ b/LayoutTests/fast/text/simple-line-layout-fallback-space-glyph-expected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ InlineFormattingContextIntegrationEnabled=false ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <title>This tests simple line layout when space glyph needs a fallback font.</title>

--- a/LayoutTests/platform/ios/fast/ruby/base-shorter-than-text-expected.txt
+++ b/LayoutTests/platform/ios/fast/ruby/base-shorter-than-text-expected.txt
@@ -20,8 +20,8 @@ layer at (0,0) size 800x600
               RenderText {#text} at (0,6) size 192x25
                 text run at (0,6) width 192: "\x{304D}\x{3069}\x{3046}\x{305F}\x{3044}\x{304D}\x{3069}\x{3046}"
             RenderRubyBase (anonymous) at (0,0) size 192x73
-              RenderText {#text} at (7,12) size 178x49
-                text run at (7,12) width 178: "\x{6A5F}\x{52D5}\x{968A}"
+              RenderText {#text} at (8,12) size 176x49
+                text run at (8,12) width 176: "\x{6A5F}\x{52D5}\x{968A}"
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {DIV} at (0,204) size 220x292
         RenderBlock {P} at (16,0) size 86x292
@@ -41,6 +41,6 @@ layer at (0,0) size 800x600
                 RenderText {#text} at (6,0) size 25x192
                   text run at (6,0) width 192: "\x{304D}\x{3069}\x{3046}\x{305F}\x{3044}\x{304D}\x{3069}\x{3046}"
               RenderRubyBase (anonymous) at (0,0) size 73x192
-                RenderText {#text} at (12,7) size 49x178
-                  text run at (12,7) width 177: "\x{6A5F}\x{52D5}\x{968A}"
+                RenderText {#text} at (12,8) size 49x176
+                  text run at (12,8) width 176: "\x{6A5F}\x{52D5}\x{968A}"
           RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4096,7 +4096,7 @@ static inline void stripTrailingSpace(float& inlineMax, float& inlineMin, Render
         const UChar space = ' ';
         const FontCascade& font = renderText.style().fontCascade(); // FIXME: This ignores first-line.
         float spaceWidth = font.width(RenderBlock::constructTextRun(&space, 1, renderText.style()));
-        inlineMax -= spaceWidth + font.wordSpacing();
+        inlineMax -= LayoutUnit::fromFloatCeil(spaceWidth + font.wordSpacing());
         if (inlineMin > inlineMax)
             inlineMin = inlineMax;
     }


### PR DESCRIPTION
<pre>
Mismatched whitespace widths cause a wrong width of inline box
<a href="https://bugs.webkit.org/show_bug.cgi?id=247722">https://bugs.webkit.org/show_bug.cgi?id=247722</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=195307">https://src.chromium.org/viewvc/blink?view=revision&revision=195307</a>

When we strip out trailing spaces in stripTrailingSpace(), we just subtract
a raw space width without ceiling. This causes inline box including only image and
whitespaces is wider than expected for some fonts.
To fix this, we can simply subtract the trailing whitespace width after applying
ceiling for consistence.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::stripTrailingSpace): Apply "ceiling" to "inlineMax"
* LayoutTests/fast/inline/inline-width-containing-collapsed-whitespace-and-image-in-float.html: Added Test Case
* LayoutTests/fast/inline/inline-width-containing-collapsed-whitespace-and-image-in-float-expected.txt: Added Test Case Expectations
* LayoutTests/fast/text/simple-line-layout-fallback-glyph-expected.html: Updated Test Expectations
* LayoutTests/platform/ios/fast/ruby/base-shorter-than-expected.txt: Ditto
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cedf37079962ae0553d1588f0c9e5d92d9784227

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105839 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166182 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5679 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102569 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4204 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82892 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31231 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74065 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40029 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20843 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/126 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43429 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40111 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->