### PR TITLE
Unreviewed. Remove unnecessary uses of WTFMoves in return statements at RenderBlock.cpp

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3496,15 +3496,15 @@ String RenderBlock::updateSecurityDiscCharacters(const RenderStyle& style, Strin
 {
 #if !PLATFORM(COCOA)
     UNUSED_PARAM(style);
-    return WTFMove(string);
+    return string;
 #else
     if (style.textSecurity() == TextSecurity::None)
-        return WTFMove(string);
+        return string;
     // This PUA character in the system font is used to render password field dots on Cocoa platforms.
     constexpr UChar textSecurityDiscPUACodePoint = 0xF79A;
     auto& font = style.fontCascade().primaryFont();
     if (!(font.platformData().isSystemFont() && font.glyphForCharacter(textSecurityDiscPUACodePoint)))
-        return WTFMove(string);
+        return string;
 
     // See RenderText::setRenderedText()
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=247730

* Source/WebCore/rendering/RenderBlock.cpp: (WebCore::RenderBlock::updateSecurityDiscCharacters):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38cdf4eeda35b1b5f494b703ca61e9516e431e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96066 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5315 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29109 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105617 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165944 "Failed to checkout and rebase branch from PR 6345") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100044 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5431 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34076 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88444 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101434 "Failed to checkout and rebase branch from PR 6345") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101726 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/5431 "Failed to checkout and rebase branch from PR 6345") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82671 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/88444 "Failed to checkout and rebase branch from PR 6345") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/5431 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/29109 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/88444 "Failed to checkout and rebase branch from PR 6345") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39807 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/29109 "Failed to checkout and rebase branch from PR 6345") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37483 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/29109 "Failed to checkout and rebase branch from PR 6345") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42079 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/82671 "Failed to checkout and rebase branch from PR 6345") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43969 "Failed to checkout and rebase branch from PR 6345") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/29109 "Failed to checkout and rebase branch from PR 6345") | | 
<!--EWS-Status-Bubble-End-->