### PR TITLE
Unreviewed. Remove unnecessary uses of WTFMoves in return statements at RenderBlock.cpp

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3496,15 +3496,15 @@ String RenderBlock::updateSecurityDiscCharacters(const RenderStyle& style, Strin
 {
 #if !PLATFORM(COCOA)
     UNUSED_PARAM(style);
-    return WTFMove(string);
+    return string;
 #else
     if (style.textSecurity() == TextSecurity::None)
-        return WTFMove(string);
+        return string;
     // This PUA character in the system font is used to render password field dots on Cocoa platforms.
     constexpr UChar textSecurityDiscPUACodePoint = 0xF79A;
     auto& font = style.fontCascade().primaryFont();
     if (!(font.platformData().isSystemFont() && font.glyphForCharacter(textSecurityDiscPUACodePoint)))
-        return WTFMove(string);
+        return string;
 
     // See RenderText::setRenderedText()
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=247730

* Source/WebCore/rendering/RenderBlock.cpp: (WebCore::RenderBlock::updateSecurityDiscCharacters):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38cdf4eeda35b1b5f494b703ca61e9516e431e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96068 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5317 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29111 "Build is in progress. Recent messages:configuring build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105619 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165946 "Build is in progress. Recent messages:Pull request contains relevant changes; Deleted stale build files; Cleaned up git repository; Running checkout-source") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100046 "Build is in progress. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Running show-identifier") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5433 "Build is in progress. Recent messages:validate-change running; Cleaned up git repository; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34078 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88446 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101436 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101728 "Build is in progress. Recent messages:Running configure-build; Cleaned up git repository; Running fetch-branch-references") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/5433 "Build is in progress. Recent messages:validate-change running; Cleaned up git repository; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82673 "Build is in progress. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/88446 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/5433 "Build is in progress. Recent messages:validate-change running; Cleaned up git repository; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/29111 "Build is in progress. Recent messages:configuring build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/88446 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39809 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/29111 "Build is in progress. Recent messages:configuring build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37485 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; killing old processes; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/29111 "Build is in progress. Recent messages:configuring build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42081 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/82673 "Build is in progress. Recent messages:Pull request contains relevant changes; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43971 "Build is in progress. Recent messages:Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/29111 "Build is in progress. Recent messages:configuring build; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
<!--EWS-Status-Bubble-End-->