### PR TITLE
Unreviewed. Remove unnecessary uses of WTFMoves in return statements at RenderBlock.cpp

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3496,15 +3496,15 @@ String RenderBlock::updateSecurityDiscCharacters(const RenderStyle& style, Strin
 {
 #if !PLATFORM(COCOA)
     UNUSED_PARAM(style);
-    return WTFMove(string);
+    return string;
 #else
     if (style.textSecurity() == TextSecurity::None)
-        return WTFMove(string);
+        return string;
     // This PUA character in the system font is used to render password field dots on Cocoa platforms.
     constexpr UChar textSecurityDiscPUACodePoint = 0xF79A;
     auto& font = style.fontCascade().primaryFont();
     if (!(font.platformData().isSystemFont() && font.glyphForCharacter(textSecurityDiscPUACodePoint)))
-        return WTFMove(string);
+        return string;
 
     // See RenderText::setRenderedText()
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=247730

* Source/WebCore/rendering/RenderBlock.cpp: (WebCore::RenderBlock::updateSecurityDiscCharacters):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38cdf4eeda35b1b5f494b703ca61e9516e431e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5317 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29111 "Hash c38cdf4e for PR 6347 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105619 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165946 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5433 "Built successfully") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34078 "Hash c38cdf4e for PR 6347 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101436 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101728 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82673 "Hash c38cdf4e for PR 6347 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31046 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/29111 "Hash c38cdf4e for PR 6347 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73879 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39809 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/29111 "Hash c38cdf4e for PR 6347 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37485 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/29111 "Hash c38cdf4e for PR 6347 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42081 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/82673 "Hash c38cdf4e for PR 6347 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/43971 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/29111 "Hash c38cdf4e for PR 6347 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->