### PR TITLE
RemoteAudioDestinationManager::AudioSamplesStorageChanged sends redundant stream description

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -69,7 +69,7 @@ private:
     void startAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
     void stopAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
 #if PLATFORM(COCOA)
-    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&, uint64_t numberOfFrames);
 #endif
 
     HashMap<RemoteAudioDestinationIdentifier, UniqueRef<RemoteAudioDestination>> m_audioDestinations;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -31,7 +31,7 @@ messages -> RemoteAudioDestinationManager NotRefCounted {
     StartAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
     StopAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
 #if PLATFORM(COCOA)
-    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, uint64_t numberOfFrames)
 #endif
 }
 

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -38,11 +38,9 @@ SharedCARingBufferBase::SharedCARingBufferBase(size_t bytesPerFrame, size_t fram
 {
 }
 
-std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(const WebCore::CAAudioStreamDescription& format, size_t frameCount, ConsumerSharedCARingBuffer::Handle&& handle)
+std::unique_ptr<ConsumerSharedCARingBuffer> ConsumerSharedCARingBuffer::map(uint32_t bytesPerFrame, uint32_t numChannelStreams, size_t frameCount, ConsumerSharedCARingBuffer::Handle&& handle)
 {
     frameCount = WTF::roundUpToPowerOfTwo(frameCount);
-    auto bytesPerFrame = format.bytesPerFrame();
-    auto numChannelStreams = format.numberOfChannelStreams();
 
     // Validate the parameters as they may be coming from an untrusted process.
     auto expectedStorageSize = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams) + sizeof(TimeBoundsBuffer);

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -47,7 +47,13 @@ protected:
 class ConsumerSharedCARingBuffer final : public SharedCARingBufferBase {
 public:
     using Handle = SharedMemory::Handle;
-    static std::unique_ptr<ConsumerSharedCARingBuffer> map(const WebCore::CAAudioStreamDescription& format, size_t frameCount, Handle&&);
+    // FIXME: Remove this deprecated constructor.
+    static std::unique_ptr<ConsumerSharedCARingBuffer> map(const WebCore::CAAudioStreamDescription& format, size_t frameCount, Handle&& handle)
+    {
+        return map(format.bytesPerFrame(), format.numberOfChannelStreams(), frameCount, WTFMove(handle));
+    }
+    static std::unique_ptr<ConsumerSharedCARingBuffer> map(uint32_t bytesPerFrame, uint32_t numChannelStreams, size_t frameCount, Handle&&);
+
 protected:
     using SharedCARingBufferBase::SharedCARingBufferBase;
 };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -117,7 +117,7 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
         getAudioStreamBasicDescription(streamFormat);
         auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(streamFormat, m_numberOfFrames);
         m_ringBuffer = WTFMove(ringBuffer);
-        m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle), streamFormat, m_numberOfFrames }, 0);
+        m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle), m_numberOfFrames }, 0);
         m_audioBufferList = makeUnique<WebCore::WebAudioBufferList>(streamFormat);
         m_audioBufferList->setSampleCount(WebCore::AudioUtilities::renderQuantumSize);
 #endif


### PR DESCRIPTION
#### ce051f767fb9df5e38db1141446915a2b60cdaf3
<pre>
RemoteAudioDestinationManager::AudioSamplesStorageChanged sends redundant stream description
<a href="https://bugs.webkit.org/show_bug.cgi?id=247733">https://bugs.webkit.org/show_bug.cgi?id=247733</a>
rdar://problem/102193653

Reviewed by Youenn Fablet.

The stream must be exactly as RemoteAudioDestination audio output unit adaptor needs,
the sender cannot configure anything related to it.

Remove the parameter.

In later patches, the ring buffer can be obtained via the constructor and as such
the added member variable m_numChannelStreams can be removed.

* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::audioSamplesStorageChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in:
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ConsumerSharedCARingBuffer::map):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::connection):

Canonical link: <a href="https://commits.webkit.org/256687@main">https://commits.webkit.org/256687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a086b2c2fff88f15c0389e91027dc0a9cea751c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106077 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5992 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34544 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102793 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102226 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83152 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31434 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88191 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40277 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37941 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4208 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40356 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->