### PR TITLE
Messages passing shared CARingBuffer handle pass also the frame count

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -93,7 +93,7 @@ public:
     }
 
 #if PLATFORM(COCOA)
-    void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle, uint64_t numberOfFrames)
+    void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle)
     {
         if (m_isPlaying) {
             stop();
@@ -101,7 +101,7 @@ public:
             if (m_isPlaying)
                 return;
         }
-        m_ringBuffer = ConsumerSharedCARingBuffer::map(sizeof(Float32), m_numOutputChannels, numberOfFrames, WTFMove(handle));
+        m_ringBuffer = ConsumerSharedCARingBuffer::map(sizeof(Float32), m_numOutputChannels, WTFMove(handle));
         if (!m_ringBuffer)
             return;
         start();
@@ -221,10 +221,10 @@ void RemoteAudioDestinationManager::stopAudioDestination(RemoteAudioDestinationI
 }
 
 #if PLATFORM(COCOA)
-void RemoteAudioDestinationManager::audioSamplesStorageChanged(RemoteAudioDestinationIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, uint64_t numberOfFrames)
+void RemoteAudioDestinationManager::audioSamplesStorageChanged(RemoteAudioDestinationIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle)
 {
     if (auto* item = m_audioDestinations.get(identifier))
-        item->audioSamplesStorageChanged(WTFMove(handle), numberOfFrames);
+        item->audioSamplesStorageChanged(WTFMove(handle));
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -69,7 +69,7 @@ private:
     void startAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
     void stopAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
 #if PLATFORM(COCOA)
-    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&);
 #endif
 
     HashMap<RemoteAudioDestinationIdentifier, UniqueRef<RemoteAudioDestination>> m_audioDestinations;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -31,7 +31,7 @@ messages -> RemoteAudioDestinationManager NotRefCounted {
     StartAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
     StopAudioDestination(WebKit::RemoteAudioDestinationIdentifier identifier) -> (bool isPlaying)
 #if PLATFORM(COCOA)
-    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle)
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -58,7 +58,7 @@ RemoteAudioSourceProviderProxy::~RemoteAudioSourceProviderProxy() = default;
 std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configureAudioStorage(const WebCore::CAAudioStreamDescription& format, size_t frameCount)
 {
     auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, frameCount);
-    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format, frameCount }, 0);
+    m_connection->send(Messages::RemoteAudioSourceProviderManager::AudioStorageChanged { m_identifier, WTFMove(handle), format }, 0);
     // Use a redundant variable to avoid move in return position and to obtain copy elision. Clang or libc++ does not allow returning covariant of Ts from std::unique_ptr<T>s in this position.
     std::unique_ptr<WebCore::CARingBuffer> caRingBuffer = WTFMove(ringBuffer);  // NOLINT: see above.
     return caRingBuffer;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -56,7 +56,7 @@ public:
     Unit(AudioMediaStreamTrackRendererInternalUnitIdentifier, Ref<IPC::Connection>&&, bool shouldRegisterAsSpeakerSamplesProducer, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&&);
     ~Unit();
 
-    void start(ConsumerSharedCARingBuffer::Handle&&, uint64_t numberOfFrames, IPC::Semaphore&&);
+    void start(ConsumerSharedCARingBuffer::Handle&&, IPC::Semaphore&&);
     void stop();
     void setAudioOutputDevice(const String&);
     OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&);
@@ -118,10 +118,10 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMed
         m_gpuConnectionToWebProcess.gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
 }
 
-void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, uint64_t numberOfFrames, IPC::Semaphore&& semaphore)
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, IPC::Semaphore&& semaphore)
 {
     if (auto* unit = m_units.get(identifier))
-        unit->start(WTFMove(handle), numberOfFrames, WTFMove(semaphore));
+        unit->start(WTFMove(handle), WTFMove(semaphore));
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
@@ -205,11 +205,11 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::setShouldRegi
         WebCore::CoreAudioCaptureSourceFactory::singleton().registerSpeakerSamplesProducer(*this);
 }
 
-void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(ConsumerSharedCARingBuffer::Handle&& handle, uint64_t numberOfFrames, IPC::Semaphore&& semaphore)
+void RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start(ConsumerSharedCARingBuffer::Handle&& handle, IPC::Semaphore&& semaphore)
 {
     if (m_isPlaying)
         stop();
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(*m_description, numberOfFrames, WTFMove(handle));
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(*m_description, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_readOffset = 0;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -64,7 +64,7 @@ private:
     // Messages
     void createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback);
     void deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
-    void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, ConsumerSharedCARingBuffer::Handle&&, uint64_t numberOfFrames, IPC::Semaphore&&);
+    void startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier, ConsumerSharedCARingBuffer::Handle&&, IPC::Semaphore&&);
     void stopUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
     void setAudioOutputDevice(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&);
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in
@@ -27,7 +27,7 @@ messages -> RemoteAudioMediaStreamTrackRendererInternalUnitManager NotRefCounted
     CreateUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier) -> (std::optional<WebCore::CAAudioStreamDescription> description, size_t frameChunkSize)
     DeleteUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
-    StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, uint64_t numberOfFrames, IPC::Semaphore renderSemaphore)
+    StartUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, IPC::Semaphore renderSemaphore)
     StopUnit(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 
     SetAudioOutputDevice(WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, String deviceId)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -64,11 +64,11 @@ RemoteMediaRecorder::~RemoteMediaRecorder()
 {
 }
 
-void RemoteMediaRecorder::audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void RemoteMediaRecorder::audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
 {
     MESSAGE_CHECK(m_recordAudio);
     m_audioBufferList = nullptr;
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_description = description;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -67,7 +67,7 @@ private:
     RemoteMediaRecorder(GPUConnectionToWebProcess&, MediaRecorderIdentifier, Ref<WebCore::MediaRecorderPrivateWriter>&&, bool recordAudio);
 
     // IPC::MessageReceiver
-    void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
     void audioSamplesAvailable(MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(SharedVideoFrame&&);
     void fetchData(CompletionHandler<void(IPC::DataReference&&, double)>&&);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in
@@ -24,7 +24,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS) && ENABLE(MEDIA_STREAM)
 
 messages -> RemoteMediaRecorder NotRefCounted {
-    AudioSamplesStorageChanged(WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioSamplesStorageChanged(WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description)
     AudioSamplesAvailable(MediaTime time, uint64_t numberOfFrames)
     VideoFrameAvailable(struct WebKit::SharedVideoFrame frame)
     FetchData() -> (IPC::DataReference buffer, double timeCode)

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -72,10 +72,10 @@ void SpeechRecognitionRemoteRealtimeMediaSource::stopProducingData()
 
 #if PLATFORM(COCOA)
 
-void SpeechRecognitionRemoteRealtimeMediaSource::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void SpeechRecognitionRemoteRealtimeMediaSource::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
 {
     m_buffer = nullptr;
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_description = description;

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h
@@ -53,7 +53,7 @@ public:
     WebCore::RealtimeMediaSourceIdentifier identifier() const { return m_identifier; }
 
 #if PLATFORM(COCOA)
-    void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
 #endif
 
     void remoteAudioSamplesAvailable(MediaTime, uint64_t numberOfFrames);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp
@@ -108,10 +108,10 @@ uint64_t SpeechRecognitionRemoteRealtimeMediaSourceManager::messageSenderDestina
 
 #if PLATFORM(COCOA)
 
-void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
 {
     if (auto source = m_sources.get(identifier))
-        source->setStorage(WTFMove(handle), description, numberOfFrames);
+        source->setStorage(WTFMove(handle), description);
 }
 
 #endif

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -60,7 +60,7 @@ private:
     void remoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier);
     void remoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier);
 #if PLATFORM(COCOA)
-    void setStorage(WebCore::RealtimeMediaSourceIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void setStorage(WebCore::RealtimeMediaSourceIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
 #endif
 
     // IPC::MessageReceiver.

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in
@@ -28,7 +28,7 @@ messages -> SpeechRecognitionRemoteRealtimeMediaSourceManager NotRefCounted {
     RemoteCaptureFailed(WebCore::RealtimeMediaSourceIdentifier identifier)
     RemoteSourceStopped(WebCore::RealtimeMediaSourceIdentifier identifier)
 #if PLATFORM(COCOA)
-    SetStorage(WebCore::RealtimeMediaSourceIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    SetStorage(WebCore::RealtimeMediaSourceIdentifier identifier, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description)
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -117,7 +117,7 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
         getAudioStreamBasicDescription(streamFormat);
         auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(streamFormat, m_numberOfFrames);
         m_ringBuffer = WTFMove(ringBuffer);
-        m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle), m_numberOfFrames }, 0);
+        m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle) }, 0);
         m_audioBufferList = makeUnique<WebCore::WebAudioBufferList>(streamFormat);
         m_audioBufferList->setSampleCount(WebCore::AudioUtilities::renderQuantumSize);
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -90,7 +90,7 @@ void RemoteAudioSourceProviderManager::removeProvider(MediaPlayerIdentifier iden
     });
 }
 
-void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
 {
     ASSERT(!WTF::isMainRunLoop());
 
@@ -99,7 +99,7 @@ void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier
         RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for storageChanged", identifier.toUInt64());
         return;
     }
-    iterator->value->setStorage(WTFMove(handle), description, numberOfFrames);
+    iterator->value->setStorage(WTFMove(handle), description);
 }
 
 void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifier identifier, uint64_t startFrame, uint64_t numberOfFrames)
@@ -119,15 +119,15 @@ RemoteAudioSourceProviderManager::RemoteAudio::RemoteAudio(Ref<RemoteAudioSource
 {
 }
 
-void RemoteAudioSourceProviderManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames)
+void RemoteAudioSourceProviderManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)
 {
     m_buffer = nullptr;
     handle.takeOwnershipOfMemory(MemoryLedger::Media);
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_description = description;
-    m_buffer = makeUnique<WebAudioBufferList>(description, numberOfFrames);
+    m_buffer = makeUnique<WebAudioBufferList>(description);
 }
 
 void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -55,7 +55,7 @@ private:
     RemoteAudioSourceProviderManager();
 
     // Messages
-    void audioStorageChanged(WebCore::MediaPlayerIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+    void audioStorageChanged(WebCore::MediaPlayerIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
     void audioSamplesAvailable(WebCore::MediaPlayerIdentifier, uint64_t startFrame, uint64_t numberOfFrames);
 
     void setConnection(IPC::Connection*);
@@ -65,7 +65,7 @@ private:
     public:
         explicit RemoteAudio(Ref<RemoteAudioSourceProvider>&&);
 
-        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames);
+        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
         void audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames);
 
     private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
@@ -26,7 +26,7 @@
 #if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
 
 messages -> RemoteAudioSourceProviderManager NotRefCounted {
-    AudioStorageChanged(WebCore::MediaPlayerIdentifier id, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames)
+    AudioStorageChanged(WebCore::MediaPlayerIdentifier id, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description)
     AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames)
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -185,7 +185,7 @@ void AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start()
     m_numberOfFrames = m_description->sampleRate() * 2;
     auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(*m_description, m_numberOfFrames);
     m_ringBuffer = WTFMove(ringBuffer);
-    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { m_identifier, WTFMove(handle), m_numberOfFrames, *m_semaphore }, 0);
+    WebProcess::singleton().ensureGPUProcessConnection().connection().send(Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::StartUnit { m_identifier, WTFMove(handle), *m_semaphore }, 0);
 
     m_buffer = makeUnique<WebCore::WebAudioBufferList>(*m_description, m_numberOfFrames);
     m_buffer->setSampleCount(m_frameChunkSize);

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -125,7 +125,7 @@ void MediaRecorderPrivate::audioSamplesAvailable(const MediaTime& time, const Pl
         auto& format = m_description->streamDescription();
         auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, m_numberOfFrames);
         m_ringBuffer = WTFMove(ringBuffer);
-        m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format, m_numberOfFrames }, m_identifier);
+        m_connection->send(Messages::RemoteMediaRecorder::AudioSamplesStorageChanged { WTFMove(handle), format }, m_identifier);
         m_silenceAudioBuffer = nullptr;
     }
 

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -104,7 +104,7 @@ private:
             auto& format = m_description->streamDescription();
             auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(format, numberOfFrames);
             m_ringBuffer = WTFMove(ringBuffer);
-            m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::SetStorage(m_identifier, WTFMove(handle), format, numberOfFrames), 0);
+            m_connection->send(Messages::SpeechRecognitionRemoteRealtimeMediaSourceManager::SetStorage(m_identifier, WTFMove(handle), format), 0);
         }
 
         ASSERT(is<WebAudioBufferList>(audioData));

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -128,7 +128,7 @@ void RemoteCaptureSampleManager::setVideoFrameObjectHeapProxy(RemoteVideoFrameOb
     m_videoFrameObjectHeapProxy = proxy;
 }
 
-void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
+void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
 {
     ASSERT(!WTF::isMainRunLoop());
 
@@ -137,7 +137,7 @@ void RemoteCaptureSampleManager::audioStorageChanged(WebCore::RealtimeMediaSourc
         RELEASE_LOG_ERROR(WebRTC, "Unable to find source %llu for storageChanged", identifier.toUInt64());
         return;
     }
-    iterator->value->setStorage(WTFMove(handle), description, numberOfFrames, WTFMove(semaphore), mediaTime, frameChunkSize);
+    iterator->value->setStorage(WTFMove(handle), description, WTFMove(semaphore), mediaTime, frameChunkSize);
 }
 
 void RemoteCaptureSampleManager::videoFrameAvailable(RealtimeMediaSourceIdentifier identifier, RemoteVideoFrameProxy::Properties&& properties, VideoFrameTimeMetadata metadata)
@@ -214,11 +214,11 @@ void RemoteCaptureSampleManager::RemoteAudio::startThread()
     m_thread = Thread::create("RemoteCaptureSampleManager::RemoteAudio thread", WTFMove(threadLoop), ThreadType::Audio, Thread::QOS::UserInteractive);
 }
 
-void RemoteCaptureSampleManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, uint64_t numberOfFrames, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
+void RemoteCaptureSampleManager::RemoteAudio::setStorage(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description, IPC::Semaphore&& semaphore, const MediaTime& mediaTime, size_t frameChunkSize)
 {
     stopThread();
     m_buffer = nullptr;
-    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, numberOfFrames, WTFMove(handle));
+    m_ringBuffer = ConsumerSharedCARingBuffer::map(description, WTFMove(handle));
     if (!m_ringBuffer)
         return;
     m_semaphore = WTFMove(semaphore);

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -69,7 +69,7 @@ public:
 
 private:
     // Messages
-    void audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameSampleSize);
+    void audioStorageChanged(WebCore::RealtimeMediaSourceIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, IPC::Semaphore&&, const MediaTime&, size_t frameSampleSize);
     void audioSamplesAvailable(WebCore::RealtimeMediaSourceIdentifier, MediaTime, uint64_t numberOfFrames);
     void videoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier, RemoteVideoFrameProxy::Properties&&, WebCore::VideoFrameTimeMetadata);
     // FIXME: Will be removed once RemoteVideoFrameProxy providers are the only ones sending data.
@@ -83,7 +83,7 @@ private:
         explicit RemoteAudio(Ref<RemoteRealtimeAudioSource>&&);
         ~RemoteAudio();
 
-        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, uint64_t numberOfFrames, IPC::Semaphore&&, const MediaTime&, size_t frameChunkSize);
+        void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&, IPC::Semaphore&&, const MediaTime&, size_t frameChunkSize);
 
     private:
         void stopThread();

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 messages -> RemoteCaptureSampleManager NotRefCounted {
-    AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, uint64_t numberOfFrames, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
+    AudioStorageChanged(WebCore::RealtimeMediaSourceIdentifier id, WebKit::ConsumerSharedCARingBuffer::Handle storageHandle, WebCore::CAAudioStreamDescription description, IPC::Semaphore captureSemaphore, MediaTime mediaTime, size_t frameChunkSize);
     VideoFrameAvailable(WebCore::RealtimeMediaSourceIdentifier id, WebKit::RemoteVideoFrameProxy::Properties sample, struct WebCore::VideoFrameTimeMetadata metadata)
     VideoFrameAvailableCV(WebCore::RealtimeMediaSourceIdentifier id, RetainPtr<CVPixelBufferRef> pixelBuffer, WebCore::VideoFrame::Rotation rotation, bool mirrored, MediaTime presentationTime, struct WebCore::VideoFrameTimeMetadata metadata)
 


### PR DESCRIPTION
#### a1fc3fc6f00982ef076b89da069c1536d6bd4f19
<pre>
Messages passing shared CARingBuffer handle pass also the frame count
<a href="https://bugs.webkit.org/show_bug.cgi?id=247729">https://bugs.webkit.org/show_bug.cgi?id=247729</a>
rdar://problem/102190399

Reviewed by Youenn Fablet.

The number of frames is inherent property of the buffer, and should be part of the buffer handle.
Move the count to the handle.

This makes the message arguments less crowded and enables the buffer handle to be moved to
the actual creation functions in the future.

* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::audioSamplesStorageChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::configureAudioStorage):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::start):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.messages.in:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::audioSamplesStorageChanged):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.messages.in:
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ConsumerSharedCARingBuffer::map):
(WebKit::ProducerSharedCARingBuffer::allocate):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
(WebKit::ConsumerSharedCARingBuffer::Handle::encode const):
(WebKit::ConsumerSharedCARingBuffer::Handle::decode):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::source):
(WebKit::UserMediaCaptureManagerProxy::SourceProxy::numberOfFrames): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSource::setStorage):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRemoteRealtimeMediaSourceManager::setStorage):
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::connection):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::audioStorageChanged):
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::setStorage):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::start):
* Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp:
(WebKit::MediaRecorderPrivate::audioSamplesAvailable):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::audioStorageChanged):
(WebKit::RemoteCaptureSampleManager::RemoteAudio::setStorage):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/256693@main">https://commits.webkit.org/256693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0992f4bd4e289301fdf8ae10492af03c7020e85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106096 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6016 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34564 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102809 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4484 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83172 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31457 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74360 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40296 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21102 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4640 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4227 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1041 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40378 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->