### PR TITLE
Revert [252611@main] Align XHR aborting with the specification and other browser engines

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5428,11 +5428,6 @@ fast/text/install-font-style-recalc.html [ Failure ]
 # These tests have been timing out since their import.
 imported/w3c/web-platform-tests/web-locks/bfcache
 
-# This test is timing out in WebKit as well as Blink/Gecko because it expects an XHR to fail
-# with a network error instead of a abort one when its iframe goes away. The test should be
-# fixed.
-imported/w3c/web-platform-tests/xhr/open-url-multi-window-4.htm [ Skip ]
-
 webkit.org/b/239533 [ Debug ] editing/inserting/insert-list-user-select-none-crash.html [ Skip ]
 
 # Mismatching line wrapping when -webkit-hyphen is auto.

--- a/LayoutTests/http/tests/navigation/page-cache-xhr-expected.txt
+++ b/LayoutTests/http/tests/navigation/page-cache-xhr-expected.txt
@@ -4,7 +4,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 pageshow - not from cache
-PASS Executed the XHR abort handler
+PASS Executed the XHR error handler before entering PageCache
+PASS xhr.status is 0
 pagehide - entering cache
 pageshow - from cache
 PASS Page did enter and was restored from the page cache

--- a/LayoutTests/http/tests/navigation/page-cache-xhr.html
+++ b/LayoutTests/http/tests/navigation/page-cache-xhr.html
@@ -34,11 +34,18 @@ function xhrLoaded()
 }
 
 function xhrAbort() {
-    testPassed("Executed the XHR abort handler");
+    testFailed("Executed the XHR abort handler unexpectedly");
+    finishJSTest();
 }
 
 function xhrError() {
-    testFailed("Executed the XHR error handler unexpectedly");
+    if (restoredFromPageCache) {
+        testFailed("Executed the XHR error handler after restoring from PageCache");
+        return;
+    }
+
+    testPassed("Executed the XHR error handler before entering PageCache");
+    shouldBe("xhr.status", "0");
 }
 
 window.addEventListener('load', function() {

--- a/LayoutTests/http/tests/navigation/resources/page-cache-xhr-in-loading-iframe.html
+++ b/LayoutTests/http/tests/navigation/resources/page-cache-xhr-in-loading-iframe.html
@@ -17,9 +17,6 @@ function doXHR()
     xhr.addEventListener("error", () => {
         doXHR();
     });
-    xhr.addEventListener("abort", () => {
-        doXHR();
-    });
     xhr.addEventListener("progress", () => {
     });
 

--- a/LayoutTests/http/tests/xmlhttprequest/cross-origin-redirect-responseURL-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/cross-origin-redirect-responseURL-expected.txt
@@ -1,7 +1,5 @@
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://localhost:22/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:22/ due to access control checks.
 Test XMLHttpRequest responseURL.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/xmlhttprequest/frame-load-cancelled-abort-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/frame-load-cancelled-abort-expected.txt
@@ -9,6 +9,7 @@ That didFinishedLoading() call should immediately exit and not update the object
 Loading subframe to cancel
 Ready State: 1
 Body of subframe is loaded. XMLHttpRequest should be in progress. Nuking the iframe
+Ready State: 4
 Iframe unloaded
 Iframe removed
 

--- a/LayoutTests/http/tests/xmlhttprequest/frame-unload-abort-crash-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/frame-unload-abort-crash-expected.txt
@@ -4,4 +4,5 @@ Test for bug 25394: crash in DocumentLoader::addResponse due to bad |this| point
 You should see a few messages followed by PASSED once.
 
 Ready State: 1
+Ready State: 4
 PASSED

--- a/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: PASS: Expected 'abort', got 'abort'.
+CONSOLE MESSAGE: PASS: Expected 'error', got 'error'.
 If this text shows up, you've successfully navigated to 'navigation-target.html'.

--- a/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort.html
+++ b/LayoutTests/http/tests/xmlhttprequest/navigation-should-abort.html
@@ -8,10 +8,10 @@
         var req = new XMLHttpRequest();
         req.open("GET", "resources/endlessxml.py");
         req.onerror = function () {
-            console.log("FAIL: Expected 'abort', got 'error'.");
+            console.log("PASS: Expected 'error', got 'error'.");
         };
         req.onabort = function () {
-            console.log("PASS: Expected 'abort', got 'abort'.");
+            console.log("FAIL: Expected 'error', got 'abort'.");
         };
         req.send(null);
 

--- a/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-2-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-2-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://localhost:22/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:22/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-refresh-immediate.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-refresh-immediate.window-expected.txt
@@ -1,8 +1,10 @@
 
-PASS document.open() aborts documents that are queued for navigation through <meta> refresh with timeout 0 (XMLHttpRequest)
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT document.open() aborts documents that are queued for navigation through <meta> refresh with timeout 0 (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are queued for navigation through <meta> refresh with timeout 0 (fetch())
 PASS document.open() aborts documents that are queued for navigation through <meta> refresh with timeout 0 (image loading)
-PASS document.open() aborts documents that are queued for navigation through Refresh header with timeout 0 (XMLHttpRequest)
+TIMEOUT document.open() aborts documents that are queued for navigation through Refresh header with timeout 0 (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are queued for navigation through Refresh header with timeout 0 (fetch())
 PASS document.open() aborts documents that are queued for navigation through Refresh header with timeout 0 (image loading)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-while-navigating.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-while-navigating.window-expected.txt
@@ -1,11 +1,15 @@
 
-PASS document.open() aborts documents that are navigating through Location (XMLHttpRequest)
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT document.open() aborts documents that are navigating through Location (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are navigating through Location (fetch())
 PASS document.open() aborts documents that are navigating through Location (image loading)
-PASS document.open() aborts documents that are navigating through iframe loading (XMLHttpRequest)
+TIMEOUT document.open() aborts documents that are navigating through iframe loading (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are navigating through iframe loading (fetch())
 PASS document.open() aborts documents that are navigating through iframe loading (image loading)
-PASS document.open() aborts documents that are queued for navigation through .click() (XMLHttpRequest)
+TIMEOUT document.open() aborts documents that are queued for navigation through .click() (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are queued for navigation through .click() (fetch())
 PASS document.open() aborts documents that are queued for navigation through .click() (image loading)
+
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_origin
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_origin due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_wildcard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_wildcard-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_wildcard
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=match_wildcard due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_multi-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_multi-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=multi
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=multi due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_null-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_null-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=null
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=null due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=origin
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=origin due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'entry.redirectStart')
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin_uppercase-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin_uppercase-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=uppercase
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=uppercase due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_space-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=space
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=space due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_wildcard-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_wildcard-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=wildcard
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=wildcard due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: Error: assert_greater_than: The iframe should have at least one resource timing entry. expected a number greater than 0 but got 0
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_zero-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_zero-expected.txt
@@ -1,6 +1,4 @@
 Blocked access to external URL http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=zero
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://www.localhost:8800/resource-timing/resources/TAOResponse.py?tao=zero due to access control checks.
 CONSOLE MESSAGE: NetworkError:  A network error occurred.
 CONSOLE MESSAGE: TypeError: undefined is not an object (evaluating 'entry.redirectStart')
 Description

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt
@@ -1,3 +1,3 @@
 
-PASS XMLHttpRequest: abort event should fire when stop() method is used
+FAIL XMLHttpRequest: abort event should fire when stop() method is used assert_equals: expected true but got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt
@@ -1,3 +1,3 @@
 
-PASS open() after window.stop()
+FAIL open() after window.stop() assert_unreached: loadend should not be fired after window.stop() and open() Reached unreachable code
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/request/request-bad-port.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/api/request/request-bad-port.any-expected.txt
@@ -1,243 +1,83 @@
 CONSOLE MESSAGE: Not allowed to use restricted network port 1: http://example.com:1/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:1/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://example.com:7/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:7/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 9: http://example.com:9/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:9/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 11: http://example.com:11/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:11/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 13: http://example.com:13/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:13/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 15: http://example.com:15/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:15/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 17: http://example.com:17/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:17/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 19: http://example.com:19/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:19/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 20: http://example.com:20/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:20/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 21: http://example.com:21/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:21/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 22: http://example.com:22/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:22/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 23: http://example.com:23/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:23/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 25: http://example.com:25/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:25/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 37: http://example.com:37/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:37/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 42: http://example.com:42/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:42/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 43: http://example.com:43/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:43/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 53: http://example.com:53/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:53/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 69: http://example.com:69/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:69/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 77: http://example.com:77/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:77/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 79: http://example.com:79/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:79/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 87: http://example.com:87/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:87/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 95: http://example.com:95/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:95/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 101: http://example.com:101/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:101/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 102: http://example.com:102/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:102/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 103: http://example.com:103/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:103/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 104: http://example.com:104/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:104/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 109: http://example.com:109/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:109/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 110: http://example.com:110/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:110/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 111: http://example.com:111/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:111/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 113: http://example.com:113/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:113/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 115: http://example.com:115/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:115/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 117: http://example.com:117/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:117/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 119: http://example.com:119/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:119/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 123: http://example.com:123/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:123/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 135: http://example.com:135/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:135/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 137: http://example.com:137/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:137/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 139: http://example.com:139/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:139/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 143: http://example.com:143/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:143/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 161: http://example.com:161/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:161/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 179: http://example.com:179/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:179/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 389: http://example.com:389/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:389/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 427: http://example.com:427/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:427/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 465: http://example.com:465/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:465/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 512: http://example.com:512/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:512/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 513: http://example.com:513/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:513/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 514: http://example.com:514/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:514/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 515: http://example.com:515/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:515/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 526: http://example.com:526/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:526/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 530: http://example.com:530/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:530/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 531: http://example.com:531/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:531/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 532: http://example.com:532/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:532/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 540: http://example.com:540/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:540/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 548: http://example.com:548/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:548/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 554: http://example.com:554/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:554/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 556: http://example.com:556/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:556/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 563: http://example.com:563/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:563/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 587: http://example.com:587/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:587/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 601: http://example.com:601/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:601/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 636: http://example.com:636/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:636/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 989: http://example.com:989/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:989/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 990: http://example.com:990/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:990/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 993: http://example.com:993/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:993/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 995: http://example.com:995/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:995/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 1719: http://example.com:1719/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:1719/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 1720: http://example.com:1720/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:1720/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 1723: http://example.com:1723/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:1723/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 2049: http://example.com:2049/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:2049/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 3659: http://example.com:3659/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:3659/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 4045: http://example.com:4045/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:4045/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 5060: http://example.com:5060/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:5060/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 5061: http://example.com:5061/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:5061/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6000: http://example.com:6000/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6000/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6566: http://example.com:6566/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6566/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6665: http://example.com:6665/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6665/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6666: http://example.com:6666/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6666/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6667: http://example.com:6667/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6667/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6668: http://example.com:6668/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6668/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6669: http://example.com:6669/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6669/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 6697: http://example.com:6697/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:6697/ due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 10080: http://example.com:10080/
-CONSOLE MESSAGE: Not allowed to use restricted network port
-CONSOLE MESSAGE: Fetch API cannot load http://example.com:10080/ due to access control checks.
 
 PASS Request on bad port 1 should throw TypeError.
 PASS Request on bad port 7 should throw TypeError.

--- a/LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-while-navigating.window-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/abort-while-navigating.window-expected.txt
@@ -3,14 +3,15 @@ CONSOLE MESSAGE: Fetch API cannot load http://localhost:8800/common/blank.html d
 
 Harness Error (TIMEOUT), message = null
 
-PASS document.open() aborts documents that are navigating through Location (XMLHttpRequest)
+TIMEOUT document.open() aborts documents that are navigating through Location (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are navigating through Location (fetch())
 PASS document.open() aborts documents that are navigating through Location (image loading)
 TIMEOUT document.open() aborts documents that are navigating through iframe loading (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are navigating through iframe loading (fetch())
 PASS document.open() aborts documents that are navigating through iframe loading (image loading)
-PASS document.open() aborts documents that are queued for navigation through .click() (XMLHttpRequest)
+TIMEOUT document.open() aborts documents that are queued for navigation through .click() (XMLHttpRequest) Test timed out
 PASS document.open() aborts documents that are queued for navigation through .click() (fetch())
 PASS document.open() aborts documents that are queued for navigation through .click() (image loading)
+
 
 

--- a/LayoutTests/platform/win/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
+++ b/LayoutTests/platform/win/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/LayoutTests/platform/wincairo-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
+++ b/LayoutTests/platform/wincairo-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt
@@ -1,7 +1,6 @@
 CONSOLE MESSAGE: Origin http://127.0.0.1:8000 is not allowed by Access-Control-Allow-Origin. Status code: 200
 CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:8000/xmlhttprequest/resources/reply.xml due to access control checks.
 CONSOLE MESSAGE: Not allowed to use restricted network port 7: http://localhost:7/
-CONSOLE MESSAGE: XMLHttpRequest cannot load http://localhost:7/ due to access control checks.
 Test that a cross-origin redirect to a server that responds is indistinguishable from one that does not. Should say PASS:
 
 PASS

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3737,7 +3737,7 @@ void FrameLoader::requestFromDelegate(ResourceRequest& request, ResourceLoaderId
     notifier().dispatchWillSendRequest(m_documentLoader.get(), identifier, newRequest, ResourceResponse(), nullptr);
 
     if (newRequest.isNull())
-        error = blockedError(request);
+        error = cancelledError(request);
     else
         error = ResourceError();
 
@@ -4074,7 +4074,7 @@ ResourceError FrameLoader::blockedByContentBlockerError(const ResourceRequest& r
 ResourceError FrameLoader::blockedError(const ResourceRequest& request) const
 {
     ResourceError error = m_client->blockedError(request);
-    error.setType(ResourceError::Type::AccessControl);
+    error.setType(ResourceError::Type::Cancellation);
     return error;
 }
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -113,6 +113,7 @@ XMLHttpRequest::XMLHttpRequest(ScriptExecutionContext& context)
     , m_error(false)
     , m_uploadListenerFlag(false)
     , m_uploadComplete(false)
+    , m_wasAbortedByClient(false)
     , m_responseCacheIsValid(false)
     , m_readyState(static_cast<unsigned>(UNSENT))
     , m_responseType(static_cast<unsigned>(ResponseType::EmptyString))
@@ -375,6 +376,7 @@ ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, boo
     m_method = normalizeHTTPMethod(method);
     m_error = false;
     m_uploadComplete = false;
+    m_wasAbortedByClient = false;
 
     // clear stuff from possible previous load
     clearResponse();
@@ -680,6 +682,7 @@ void XMLHttpRequest::abort()
 {
     Ref<XMLHttpRequest> protectedThis(*this);
 
+    m_wasAbortedByClient = true;
     if (!internalAbort())
         return;
 
@@ -698,7 +701,6 @@ void XMLHttpRequest::abort()
 
 bool XMLHttpRequest::internalAbort()
 {
-    m_pendingAbortEvent.cancel();
     m_error = true;
 
     // FIXME: when we add the support for multi-part XHR, we will have to think be careful with this initialization.
@@ -768,6 +770,7 @@ void XMLHttpRequest::networkError()
     
 void XMLHttpRequest::abortError()
 {
+    ASSERT(m_wasAbortedByClient);
     genericError();
     dispatchErrorEvents(eventNames().abortEvent);
 }
@@ -895,12 +898,10 @@ void XMLHttpRequest::didFail(const ResourceError& error)
     if (m_error)
         return;
 
-    if (error.isCancellation()) {
-        internalAbort();
-        queueCancellableTaskKeepingObjectAlive(*this, TaskSource::Networking, m_pendingAbortEvent, [this] {
-            m_exceptionCode = AbortError;
-            abortError();
-        });
+    // The XHR specification says we should only fire an abort event if the cancelation was requested by the client.
+    if (m_wasAbortedByClient && error.isCancellation()) {
+        m_exceptionCode = AbortError;
+        abortError();
         return;
     }
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -207,6 +207,7 @@ private:
     unsigned m_error : 1;
     unsigned m_uploadListenerFlag : 1;
     unsigned m_uploadComplete : 1;
+    unsigned m_wasAbortedByClient : 1;
     unsigned m_responseCacheIsValid : 1;
     unsigned m_readyState : 3; // State
     unsigned m_responseType : 3; // ResponseType
@@ -252,7 +253,6 @@ private:
 
     std::optional<ExceptionCode> m_exceptionCode;
     RefPtr<UserGestureToken> m_userGestureToken;
-    TaskCancellationGroup m_pendingAbortEvent;
     std::atomic<bool> m_hasRelevantEventListener;
     bool m_wasDidSendDataCalledForTotalBytes { false };
 };


### PR DESCRIPTION
#### b37371177a8cb1150db551c272cbe13384471090
<pre>
Revert [252611@main] Align XHR aborting with the specification and other browser engines
<a href="https://bugs.webkit.org/show_bug.cgi?id=242817">https://bugs.webkit.org/show_bug.cgi?id=242817</a>
rdar://101617443

Unreviewed, revert 252611@main as it broke the Capital One app.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/navigation/page-cache-xhr-expected.txt:
* LayoutTests/http/tests/navigation/page-cache-xhr.html:
* LayoutTests/http/tests/navigation/resources/page-cache-xhr-in-loading-iframe.html:
* LayoutTests/http/tests/xmlhttprequest/cross-origin-redirect-responseURL-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/frame-load-cancelled-abort-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/frame-unload-abort-crash-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/navigation-should-abort-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/navigation-should-abort.html:
* LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-2-expected.txt:
* LayoutTests/http/tests/xmlhttprequest/redirect-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_match_wildcard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_multi-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_null-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_origin_uppercase-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_space-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_wildcard-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/resource_TAO_zero-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt:
* LayoutTests/platform/mac-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt:
* LayoutTests/platform/win/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt:
* LayoutTests/platform/wincairo-wk1/http/tests/xmlhttprequest/redirect-cross-origin-post-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::requestFromDelegate):
(WebCore::FrameLoader::blockedError const):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::XMLHttpRequest):
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::abort):
(WebCore::XMLHttpRequest::internalAbort):
(WebCore::XMLHttpRequest::abortError):
(WebCore::XMLHttpRequest::didFail):
* Source/WebCore/xml/XMLHttpRequest.h:

Canonical link: <a href="https://commits.webkit.org/256586@main">https://commits.webkit.org/256586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0897bbf432c3d3c65b4b4839843204424ad4b1cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5485 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/29289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105777 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100212 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/5609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101901 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/5609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/88614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/5609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/29289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39971 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/29289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37645 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/29289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4564 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/67 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/68 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/29289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->