### PR TITLE
Stop assuming shorthand is serializable when longhand has a pending-substitution value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cssText-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cssText-expected.txt
@@ -7,6 +7,6 @@ FAIL target5 assert_equals: expected "background: var(--prop)  !important;" but 
 FAIL target6 assert_equals: expected "background: green;" but got "background-color: green;"
 PASS target7
 PASS target8
-FAIL target9 assert_equals: expected "margin-right: ; margin-bottom: ; margin-left: ; margin-top: 10px;" but got "margin: var(--prop);"
+PASS target9
 PASS target10
 

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1787,12 +1787,10 @@ StringBuilder StyleProperties::asTextInternal() const
         CSSPropertyID propertyID = property.id();
         ASSERT(isLonghand(propertyID) || propertyID == CSSPropertyCustom);
         Vector<CSSPropertyID> shorthands;
-        String value;
 
         if (is<CSSPendingSubstitutionValue>(property.value())) {
             auto& substitutionValue = downcast<CSSPendingSubstitutionValue>(*property.value());
             shorthands.append(substitutionValue.shorthandPropertyId());
-            value = substitutionValue.shorthandValue().cssText();
         } else {
             switch (propertyID) {
             case CSSPropertyBackgroundPositionX:
@@ -1809,6 +1807,7 @@ StringBuilder StyleProperties::asTextInternal() const
             }
         }
 
+        String value;
         bool alreadyUsedShorthand = false;
         for (auto& shorthandPropertyID : shorthands) {
             ASSERT(isShorthandCSSProperty(shorthandPropertyID));
@@ -1819,10 +1818,11 @@ StringBuilder StyleProperties::asTextInternal() const
                 alreadyUsedShorthand = true;
                 break;
             }
-            if (!shorthandPropertyAppeared[shorthandPropertyIndex] && value.isNull())
-                value = getPropertyValue(shorthandPropertyID);
+            if (shorthandPropertyAppeared[shorthandPropertyIndex])
+                continue;
             shorthandPropertyAppeared.set(shorthandPropertyIndex);
 
+            value = getPropertyValue(shorthandPropertyID);
             if (!value.isNull()) {
                 propertyID = shorthandPropertyID;
                 shorthandPropertyUsed.set(shorthandPropertyIndex);


### PR DESCRIPTION
#### b7eeaa128fab066bdfeeaf9ee72ee7a43270861c
<pre>
Stop assuming shorthand is serializable when longhand has a pending-substitution value
<a href="https://bugs.webkit.org/show_bug.cgi?id=247734">https://bugs.webkit.org/show_bug.cgi?id=247734</a>

Reviewed by Darin Adler.

When a shorthand is set to a value containing var(), all longhands are
set to a pending-substitution value that refers to the shorthand and its
original value.

When StyleProperties::asTextInternal() encountered a longhand set to a
pending-substitution value, it used to assume that the original value of
the shorthand was still a valid serialization.

However, that&apos;s not true, e.g.

   element.style.margin = &quot;var(--m)&quot;;
   element.style.marginTop = &quot;1px&quot;;

then margin-left is set to a pending-substitution still referring to
&quot;var(--m)&quot;, but due to the later change in margin-top, margin is no
longer serializable.

So this patch uses getPropertyValue() to attempt to serialize the
shorthand, as was already been done for non-pending-substitution values.

Test: imported/w3c/web-platform-tests/css/css-variables/variable-cssText.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/variable-cssText-expected.txt:
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::asTextInternal const):

Canonical link: <a href="https://commits.webkit.org/256564@main">https://commits.webkit.org/256564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13965de7b4e887120580ceb30996df9880b37327

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105651 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165982 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5469 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34112 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101469 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82706 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31074 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73909 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39841 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37516 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20680 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43286 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/44002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39942 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->