### PR TITLE
[ macOS wk2 ] imported/w3c/web-platform-tests/permissions/permissions-cg.https.html is a flaky failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/permissions/permissions-cg.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions/permissions-cg.https.html
@@ -7,20 +7,44 @@
 <script src="/resources/testdriver-vendor.js"></script>
 
 <script>
+async function garbageCollect() {
+  if (typeof TestUtils !== 'undefined' && TestUtils.gc) {
+    await TestUtils.gc();
+  } else if (self.gc) {
+    await self.gc();
+  } else if (self.GCController) {
+    // Present in some WebKit development environments
+    await GCController.collect();
+  } else {
+    var gcRec = function (n) {
+      if (n < 1)
+        return {};
+      var temp = {i: "ab" + i + (i / 100000)};
+      temp += "foo";
+      gcRec(n-1);
+    };
+    for (var i = 0; i < 1000; i++)
+      gcRec(10);
+  }
+}
+
 promise_test(async () => {
   const { state: initialState } = await navigator.permissions.query({
     name: "geolocation",
   });
 
   const pass = new Promise(async (resolve) => {
-    const status = await navigator.permissions.query({
+    let status = await navigator.permissions.query({
       name: "geolocation",
     });
     status.addEventListener("change", resolve, { once: true });
-  });
 
-  // Will cause change event to be dispatched.
-  await test_driver.set_permission({ name: "geolocation" }, "granted");
+    status = null;
+    garbageCollect();
+
+    // Will cause change event to be dispatched.
+    test_driver.set_permission({ name: "geolocation" }, "granted");
+  });
 
   // Wait for the change event to be dispatched.
   await pass;

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1765,8 +1765,6 @@ imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html [ Fa
 
 webkit.org/b/245727 [ Monterey ] imported/w3c/web-platform-tests/notifications/idlharness.https.any.sharedworker.html [ Failure ]
 
-webkit.org/b/245802 imported/w3c/web-platform-tests/permissions/permissions-cg.https.html [ Pass Failure ]
-
 # webkit.org/b/246773 Constant crashes on wk2 debug
 [ Debug ] http/tests/security/showModalDialog-sync-cross-origin-page-load.html [ Skip ]
 [ Debug ] http/tests/security/showModalDialog-sync-cross-origin-page-load2.html [ Skip ]


### PR DESCRIPTION
#### 72b68e3da33f8d73d5aa7385426b1215d202778f
<pre>
[ macOS wk2 ] imported/w3c/web-platform-tests/permissions/permissions-cg.https.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=245802">https://bugs.webkit.org/show_bug.cgi?id=245802</a>
rdar://100530413

Reviewed by Geoffrey Garen.

Make sure the PermissionStatus object gets constructed and its `change` event
listener gets registered *BEFORE* we update the permission state. Previously,
the order wasn&apos;t guaranteed and this would lead to flakiness because the `change`
would get fired before the event listener got added.

Also trigger garbage collection explicitly to make it more likely to trigger
GC bugs, given that this is what the test intends to cover.

* LayoutTests/imported/w3c/web-platform-tests/permissions/permissions-cg.https.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/256550@main">https://commits.webkit.org/256550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0a6f6874dc009a81665710ac90f15e93f6f0b72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105653 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165984 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5471 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34114 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101471 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101763 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82709 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31084 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87804 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39843 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37518 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20679 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/44004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39941 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->