### PR TITLE
:lang() selectors should serialize without quotation marks if they were parsed without them

### DIFF
--- a/LayoutTests/fast/css/css-lang-selector-with-string-arguments-text-expected.txt
+++ b/LayoutTests/fast/css/css-lang-selector-with-string-arguments-text-expected.txt
@@ -4,18 +4,18 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS parseThenSerializeRule(':lang("a") { }') is ':lang("a") { }'
-PASS parseThenSerializeRule(':lang("bb", cc) { }') is ':lang("bb", "cc") { }'
-PASS parseThenSerializeRule(':lang("ddd", eee) { }') is ':lang("ddd", "eee") { }'
-PASS parseThenSerializeRule(':lang("ddd", eee, ffff) { }') is ':lang("ddd", "eee", "ffff") { }'
-PASS parseThenSerializeRule(':lang("ddd", eee, "ffff") { }') is ':lang("ddd", "eee", "ffff") { }'
+PASS parseThenSerializeRule(':lang("bb", cc) { }') is ':lang("bb", cc) { }'
+PASS parseThenSerializeRule(':lang("ddd", eee) { }') is ':lang("ddd", eee) { }'
+PASS parseThenSerializeRule(':lang("ddd", eee, ffff) { }') is ':lang("ddd", eee, ffff) { }'
+PASS parseThenSerializeRule(':lang("ddd", eee, "ffff") { }') is ':lang("ddd", eee, "ffff") { }'
 PASS parseThenSerializeRule(':lang("*-1997") { }') is ':lang("*-1997") { }'
 PASS parseThenSerializeRule(':lang("*-1997", "*-1998") { }') is ':lang("*-1997", "*-1998") { }'
 PASS parseThenSerializeRule(':lang("*-1997", "*-1998", "*-1999") { }') is ':lang("*-1997", "*-1998", "*-1999") { }'
 PASS parseThenSerializeRule(':lang("") { }') is ':lang("") { }'
 
-PASS parseThenSerializeRule(':lang(foo, "bar", baz) { }') is ':lang("foo", "bar", "baz") { }'
-PASS parseThenSerializeRule(':lang(foo,      "bar"     , baz) { }') is ':lang("foo", "bar", "baz") { }'
-PASS parseThenSerializeRule(':lang(    foo    ,     "bar"    ,     baz    ) { }') is ':lang("foo", "bar", "baz") { }'
+PASS parseThenSerializeRule(':lang(foo, "bar", baz) { }') is ':lang(foo, "bar", baz) { }'
+PASS parseThenSerializeRule(':lang(foo,      "bar"     , baz) { }') is ':lang(foo, "bar", baz) { }'
+PASS parseThenSerializeRule(':lang(    foo    ,     "bar"    ,     baz    ) { }') is ':lang(foo, "bar", baz) { }'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/css-lang-selector-with-string-arguments-text.html
+++ b/LayoutTests/fast/css/css-lang-selector-with-string-arguments-text.html
@@ -1,6 +1,6 @@
 <html>
 <head id="head">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -32,13 +32,7 @@ function expectedSerializedSelector(selector)
     args = args[1].split(/\s*,\s*/);
     var expected = ':lang(';
     for (var i = 0; i < args.length; ++i) {
-        var arg = args[i];
-        var hasQuotes = arg.indexOf('"') == 0 && arg.lastIndexOf('"') == arg.length - 1;
-        if (!hasQuotes)
-            expected += '"';
         expected += args[i];
-        if (!hasQuotes)
-            expected += '"';
         if (i < args.length - 1)
             expected += ', ';
     }
@@ -63,10 +57,9 @@ testSelectorRoundTrip(':lang("")');
 
 debug('');
 
-shouldBe("parseThenSerializeRule(':lang(foo, \"bar\", baz) { }')", "':lang(\"foo\", \"bar\", \"baz\") { }'");
-shouldBe("parseThenSerializeRule(':lang(foo,      \"bar\"     , baz) { }')", "':lang(\"foo\", \"bar\", \"baz\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    foo    ,     \"bar\"    ,     baz    ) { }')", "':lang(\"foo\", \"bar\", \"baz\") { }'");
+shouldBe("parseThenSerializeRule(':lang(foo, \"bar\", baz) { }')", "':lang(foo, \"bar\", baz) { }'");
+shouldBe("parseThenSerializeRule(':lang(foo,      \"bar\"     , baz) { }')", "':lang(foo, \"bar\", baz) { }'");
+shouldBe("parseThenSerializeRule(':lang(    foo    ,     \"bar\"    ,     baz    ) { }')", "':lang(foo, \"bar\", baz) { }'");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/css/css-selector-text-expected.txt
+++ b/LayoutTests/fast/css/css-selector-text-expected.txt
@@ -3,501 +3,501 @@ This tests parsing and re-serialization of some CSS selectors.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS parseThenSerializeRule('* { }') is '* { }'
-PASS parseThenSerializeRule('a { }') is 'a { }'
-PASS parseThenSerializeRule('#a { }') is '#a { }'
-PASS parseThenSerializeRule('.a { }') is '.a { }'
-PASS parseThenSerializeRule(':active { }') is ':active { }'
-PASS parseThenSerializeRule('[a] { }') is '[a] { }'
-PASS parseThenSerializeRule('[a="b"] { }') is '[a="b"] { }'
-PASS parseThenSerializeRule('[a~="b"] { }') is '[a~="b"] { }'
-PASS parseThenSerializeRule('[a|="b"] { }') is '[a|="b"] { }'
-PASS parseThenSerializeRule('[a^="b"] { }') is '[a^="b"] { }'
-PASS parseThenSerializeRule('[a$="b"] { }') is '[a$="b"] { }'
-PASS parseThenSerializeRule('[a*="b"] { }') is '[a*="b"] { }'
-PASS parseThenSerializeRule('[a="b" i] { }') is '[a="b" i] { }'
-PASS parseThenSerializeRule('[a~="b" i] { }') is '[a~="b" i] { }'
-PASS parseThenSerializeRule('[a|="b" i] { }') is '[a|="b" i] { }'
-PASS parseThenSerializeRule('[a^="b" i] { }') is '[a^="b" i] { }'
-PASS parseThenSerializeRule('[a$="b" i] { }') is '[a$="b" i] { }'
-PASS parseThenSerializeRule('[a*="b" i] { }') is '[a*="b" i] { }'
+PASS parseThenSerializeRule('* { }') is "* { }"
+PASS parseThenSerializeRule('a { }') is "a { }"
+PASS parseThenSerializeRule('#a { }') is "#a { }"
+PASS parseThenSerializeRule('.a { }') is ".a { }"
+PASS parseThenSerializeRule(':active { }') is ":active { }"
+PASS parseThenSerializeRule('[a] { }') is "[a] { }"
+PASS parseThenSerializeRule('[a="b"] { }') is "[a=\"b\"] { }"
+PASS parseThenSerializeRule('[a~="b"] { }') is "[a~=\"b\"] { }"
+PASS parseThenSerializeRule('[a|="b"] { }') is "[a|=\"b\"] { }"
+PASS parseThenSerializeRule('[a^="b"] { }') is "[a^=\"b\"] { }"
+PASS parseThenSerializeRule('[a$="b"] { }') is "[a$=\"b\"] { }"
+PASS parseThenSerializeRule('[a*="b"] { }') is "[a*=\"b\"] { }"
+PASS parseThenSerializeRule('[a="b" i] { }') is "[a=\"b\" i] { }"
+PASS parseThenSerializeRule('[a~="b" i] { }') is "[a~=\"b\" i] { }"
+PASS parseThenSerializeRule('[a|="b" i] { }') is "[a|=\"b\" i] { }"
+PASS parseThenSerializeRule('[a^="b" i] { }') is "[a^=\"b\" i] { }"
+PASS parseThenSerializeRule('[a$="b" i] { }') is "[a$=\"b\" i] { }"
+PASS parseThenSerializeRule('[a*="b" i] { }') is "[a*=\"b\" i] { }"
 
-PASS parseThenSerializeRule('*|a { }') is 'a { }'
-PASS parseThenSerializeRule('*|* { }') is '* { }'
-PASS parseThenSerializeRule('|a { }') is '|a { }'
-PASS parseThenSerializeRule('|* { }') is '|* { }'
-PASS parseThenSerializeRule('[*|a] { }') is '[*|a] { }'
-PASS parseThenSerializeRule('[|a] { }') is '[a] { }'
+PASS parseThenSerializeRule('*|a { }') is "a { }"
+PASS parseThenSerializeRule('*|* { }') is "* { }"
+PASS parseThenSerializeRule('|a { }') is "|a { }"
+PASS parseThenSerializeRule('|* { }') is "|* { }"
+PASS parseThenSerializeRule('[*|a] { }') is "[*|a] { }"
+PASS parseThenSerializeRule('[|a] { }') is "[a] { }"
 
-PASS parseThenSerializeRule('a:active { }') is 'a:active { }'
-PASS parseThenSerializeRule('a b { }') is 'a b { }'
-PASS parseThenSerializeRule('a + b { }') is 'a + b { }'
-PASS parseThenSerializeRule('a ~ b { }') is 'a ~ b { }'
-PASS parseThenSerializeRule('a > b { }') is 'a > b { }'
+PASS parseThenSerializeRule('a:active { }') is "a:active { }"
+PASS parseThenSerializeRule('a b { }') is "a b { }"
+PASS parseThenSerializeRule('a + b { }') is "a + b { }"
+PASS parseThenSerializeRule('a ~ b { }') is "a ~ b { }"
+PASS parseThenSerializeRule('a > b { }') is "a > b { }"
 
-PASS parseThenSerializeRule(':active { }') is ':active { }'
-PASS parseThenSerializeRule(':any-link { }') is ':any-link { }'
-PASS parseThenSerializeRule(':checked { }') is ':checked { }'
-PASS parseThenSerializeRule(':disabled { }') is ':disabled { }'
-PASS parseThenSerializeRule(':empty { }') is ':empty { }'
-PASS parseThenSerializeRule(':enabled { }') is ':enabled { }'
-PASS parseThenSerializeRule(':first-child { }') is ':first-child { }'
-PASS parseThenSerializeRule(':first-of-type { }') is ':first-of-type { }'
-PASS parseThenSerializeRule(':focus { }') is ':focus { }'
-PASS parseThenSerializeRule(':hover { }') is ':hover { }'
-PASS parseThenSerializeRule(':indeterminate { }') is ':indeterminate { }'
-PASS parseThenSerializeRule(':link { }') is ':link { }'
-PASS parseThenSerializeRule(':not(:placeholder-shown) { }') is ':not(:placeholder-shown) { }'
-PASS parseThenSerializeRule(':placeholder-shown { }') is ':placeholder-shown { }'
-PASS parseThenSerializeRule(':root { }') is ':root { }'
-PASS parseThenSerializeRule(':target { }') is ':target { }'
-PASS parseThenSerializeRule(':visited { }') is ':visited { }'
+PASS parseThenSerializeRule(':active { }') is ":active { }"
+PASS parseThenSerializeRule(':any-link { }') is ":any-link { }"
+PASS parseThenSerializeRule(':checked { }') is ":checked { }"
+PASS parseThenSerializeRule(':disabled { }') is ":disabled { }"
+PASS parseThenSerializeRule(':empty { }') is ":empty { }"
+PASS parseThenSerializeRule(':enabled { }') is ":enabled { }"
+PASS parseThenSerializeRule(':first-child { }') is ":first-child { }"
+PASS parseThenSerializeRule(':first-of-type { }') is ":first-of-type { }"
+PASS parseThenSerializeRule(':focus { }') is ":focus { }"
+PASS parseThenSerializeRule(':hover { }') is ":hover { }"
+PASS parseThenSerializeRule(':indeterminate { }') is ":indeterminate { }"
+PASS parseThenSerializeRule(':link { }') is ":link { }"
+PASS parseThenSerializeRule(':not(:placeholder-shown) { }') is ":not(:placeholder-shown) { }"
+PASS parseThenSerializeRule(':placeholder-shown { }') is ":placeholder-shown { }"
+PASS parseThenSerializeRule(':root { }') is ":root { }"
+PASS parseThenSerializeRule(':target { }') is ":target { }"
+PASS parseThenSerializeRule(':visited { }') is ":visited { }"
 
-PASS parseThenSerializeRule(':lang("*-ab") { }') is ':lang("*-ab") { }'
-PASS parseThenSerializeRule(':lang("*-ab-") { }') is ':lang("*-ab-") { }'
-PASS parseThenSerializeRule(':lang("*-DE-1996") { }') is ':lang("*-DE-1996") { }'
+PASS parseThenSerializeRule(':lang("*-ab") { }') is ":lang(\"*-ab\") { }"
+PASS parseThenSerializeRule(':lang("*-ab-") { }') is ":lang(\"*-ab-\") { }"
+PASS parseThenSerializeRule(':lang("*-DE-1996") { }') is ":lang(\"*-DE-1996\") { }"
 
-PASS parseThenSerializeRule(':lang(a) { }') is ':lang("a") { }'
-PASS parseThenSerializeRule(':lang(a, b, c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(fr, de, en, id) { }') is ':lang("fr", "de", "en", "id") { }'
-PASS parseThenSerializeRule(':lang(fr, fr-ca, fr-be) { }') is ':lang("fr", "fr-ca", "fr-be") { }'
-PASS parseThenSerializeRule(':lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996) { }') is ':lang("de-DE", "de-DE-1996", "de-Latn-DE", "de-Latf-DE", "de-Latn-DE-1996") { }'
-PASS parseThenSerializeRule(':lang(de-CH, it-CH, fr-CH, rm-CH) { }') is ':lang("de-CH", "it-CH", "fr-CH", "rm-CH") { }'
-PASS parseThenSerializeRule(':lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996, de-CH, it-CH, fr-CH, rm-CH) { }') is ':lang("de-DE", "de-DE-1996", "de-Latn-DE", "de-Latf-DE", "de-Latn-DE-1996", "de-CH", "it-CH", "fr-CH", "rm-CH") { }'
+PASS parseThenSerializeRule(':lang(a) { }') is ":lang(a) { }"
+PASS parseThenSerializeRule(':lang(a, b, c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(fr, de, en, id) { }') is ":lang(fr, de, en, id) { }"
+PASS parseThenSerializeRule(':lang(fr, fr-ca, fr-be) { }') is ":lang(fr, fr-ca, fr-be) { }"
+PASS parseThenSerializeRule(':lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996) { }') is ":lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996) { }"
+PASS parseThenSerializeRule(':lang(de-CH, it-CH, fr-CH, rm-CH) { }') is ":lang(de-CH, it-CH, fr-CH, rm-CH) { }"
+PASS parseThenSerializeRule(':lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996, de-CH, it-CH, fr-CH, rm-CH) { }') is ":lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996, de-CH, it-CH, fr-CH, rm-CH) { }"
 
-PASS parseThenSerializeRule(':lang(a, a, a) { }') is ':lang("a", "a", "a") { }'
-PASS parseThenSerializeRule(':lang(en, en, en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(en-us, en-us, en-us) { }') is ':lang("en-us", "en-us", "en-us") { }'
-PASS parseThenSerializeRule(':lang(de-DE-1996, de-DE-1996, de-DE-1996) { }') is ':lang("de-DE-1996", "de-DE-1996", "de-DE-1996") { }'
-PASS parseThenSerializeRule(':lang(de-Latn-DE-1996, de-Latn-DE-1996, de-Latn-DE-1996) { }') is ':lang("de-Latn-DE-1996", "de-Latn-DE-1996", "de-Latn-DE-1996") { }'
-PASS parseThenSerializeRule(':lang(java, java, java) { }') is ':lang("java", "java", "java") { }'
+PASS parseThenSerializeRule(':lang(a, a, a) { }') is ":lang(a, a, a) { }"
+PASS parseThenSerializeRule(':lang(en, en, en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(en-us, en-us, en-us) { }') is ":lang(en-us, en-us, en-us) { }"
+PASS parseThenSerializeRule(':lang(de-DE-1996, de-DE-1996, de-DE-1996) { }') is ":lang(de-DE-1996, de-DE-1996, de-DE-1996) { }"
+PASS parseThenSerializeRule(':lang(de-Latn-DE-1996, de-Latn-DE-1996, de-Latn-DE-1996) { }') is ":lang(de-Latn-DE-1996, de-Latn-DE-1996, de-Latn-DE-1996) { }"
+PASS parseThenSerializeRule(':lang(java, java, java) { }') is ":lang(java, java, java) { }"
 
-PASS parseThenSerializeRule(':not(a) { }') is ':not(a) { }'
-PASS parseThenSerializeRule(':-webkit-any(a, b, p) { }') is ':-webkit-any(a, b, p) { }'
+PASS parseThenSerializeRule(':not(a) { }') is ":not(a) { }"
+PASS parseThenSerializeRule(':-webkit-any(a, b, p) { }') is ":-webkit-any(a, b, p) { }"
 
-PASS parseThenSerializeRule('::after { }') is '::after { }'
-PASS parseThenSerializeRule('::before { }') is '::before { }'
-PASS parseThenSerializeRule('::first-letter { }') is '::first-letter { }'
-PASS parseThenSerializeRule('::first-line { }') is '::first-line { }'
-PASS parseThenSerializeRule('::selection { }') is '::selection { }'
+PASS parseThenSerializeRule('::after { }') is "::after { }"
+PASS parseThenSerializeRule('::before { }') is "::before { }"
+PASS parseThenSerializeRule('::first-letter { }') is "::first-letter { }"
+PASS parseThenSerializeRule('::first-line { }') is "::first-line { }"
+PASS parseThenSerializeRule('::selection { }') is "::selection { }"
 
-PASS parseThenSerializeRule(':-webkit-any-link { }') is ':-webkit-any-link { }'
-PASS parseThenSerializeRule(':-webkit-drag { }') is ':-webkit-drag { }'
-PASS parseThenSerializeRule(':autofill { }') is ':autofill { }'
-PASS parseThenSerializeRule(':-webkit-autofill { }') is ':autofill { }'
+PASS parseThenSerializeRule(':-webkit-any-link { }') is ":-webkit-any-link { }"
+PASS parseThenSerializeRule(':-webkit-drag { }') is ":-webkit-drag { }"
+PASS parseThenSerializeRule(':autofill { }') is ":autofill { }"
+PASS parseThenSerializeRule(':-webkit-autofill { }') is ":autofill { }"
 
-PASS parseThenSerializeRule(':nth-child(odd) { }') is ':nth-child(2n+1) { }'
-PASS parseThenSerializeRule(':nth-child(even) { }') is ':nth-child(2n) { }'
-PASS parseThenSerializeRule(':nth-child(n) { }') is ':nth-child(n) { }'
-PASS parseThenSerializeRule(':nth-child(-n) { }') is ':nth-child(-n) { }'
-PASS parseThenSerializeRule(':nth-child(5) { }') is ':nth-child(5) { }'
-PASS parseThenSerializeRule(':nth-child(-5) { }') is ':nth-child(-5) { }'
-PASS parseThenSerializeRule(':nth-child(5n+7) { }') is ':nth-child(5n+7) { }'
-PASS parseThenSerializeRule(':nth-child(-5n+7) { }') is ':nth-child(-5n+7) { }'
-PASS parseThenSerializeRule(':nth-child(5n-7) { }') is ':nth-child(5n-7) { }'
-PASS parseThenSerializeRule(':nth-child(-5n-7) { }') is ':nth-child(-5n-7) { }'
+PASS parseThenSerializeRule(':nth-child(odd) { }') is ":nth-child(2n+1) { }"
+PASS parseThenSerializeRule(':nth-child(even) { }') is ":nth-child(2n) { }"
+PASS parseThenSerializeRule(':nth-child(n) { }') is ":nth-child(n) { }"
+PASS parseThenSerializeRule(':nth-child(-n) { }') is ":nth-child(-n) { }"
+PASS parseThenSerializeRule(':nth-child(5) { }') is ":nth-child(5) { }"
+PASS parseThenSerializeRule(':nth-child(-5) { }') is ":nth-child(-5) { }"
+PASS parseThenSerializeRule(':nth-child(5n+7) { }') is ":nth-child(5n+7) { }"
+PASS parseThenSerializeRule(':nth-child(-5n+7) { }') is ":nth-child(-5n+7) { }"
+PASS parseThenSerializeRule(':nth-child(5n-7) { }') is ":nth-child(5n-7) { }"
+PASS parseThenSerializeRule(':nth-child(-5n-7) { }') is ":nth-child(-5n-7) { }"
 
-PASS parseThenSerializeRule(':nth-child(odd of .foo, :nth-child(odd)) { }') is ':nth-child(2n+1 of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(even of .foo, :nth-child(odd)) { }') is ':nth-child(2n of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(n of .foo, :nth-child(odd)) { }') is ':nth-child(n of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(-n of .foo, :nth-child(odd)) { }') is ':nth-child(-n of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(5 of .foo, :nth-child(odd)) { }') is ':nth-child(5 of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(-5 of .foo, :nth-child(odd)) { }') is ':nth-child(-5 of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(5n+7 of .foo, :nth-child(odd)) { }') is ':nth-child(5n+7 of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(-5n+7 of .foo, :nth-child(odd)) { }') is ':nth-child(-5n+7 of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(5n-7 of .foo, :nth-child(odd)) { }') is ':nth-child(5n-7 of .foo, :nth-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-child(-5n-7 of .foo, :nth-child(odd)) { }') is ':nth-child(-5n-7 of .foo, :nth-child(2n+1)) { }'
+PASS parseThenSerializeRule(':nth-child(odd of .foo, :nth-child(odd)) { }') is ":nth-child(2n+1 of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(even of .foo, :nth-child(odd)) { }') is ":nth-child(2n of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(n of .foo, :nth-child(odd)) { }') is ":nth-child(n of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(-n of .foo, :nth-child(odd)) { }') is ":nth-child(-n of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(5 of .foo, :nth-child(odd)) { }') is ":nth-child(5 of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(-5 of .foo, :nth-child(odd)) { }') is ":nth-child(-5 of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(5n+7 of .foo, :nth-child(odd)) { }') is ":nth-child(5n+7 of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(-5n+7 of .foo, :nth-child(odd)) { }') is ":nth-child(-5n+7 of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(5n-7 of .foo, :nth-child(odd)) { }') is ":nth-child(5n-7 of .foo, :nth-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-child(-5n-7 of .foo, :nth-child(odd)) { }') is ":nth-child(-5n-7 of .foo, :nth-child(2n+1)) { }"
 
-PASS parseThenSerializeRule(':nth-last-child(odd of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(2n+1 of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(even of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(2n of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(n of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(n of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(-n of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(-n of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(5 of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(5 of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(-5 of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(-5 of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(5n+7 of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(5n+7 of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(-5n+7 of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(-5n+7 of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(5n-7 of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(5n-7 of .foo, :nth-last-child(2n+1)) { }'
-PASS parseThenSerializeRule(':nth-last-child(-5n-7 of .foo, :nth-last-child(odd)) { }') is ':nth-last-child(-5n-7 of .foo, :nth-last-child(2n+1)) { }'
+PASS parseThenSerializeRule(':nth-last-child(odd of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(2n+1 of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(even of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(2n of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(n of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(n of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(-n of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(-n of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(5 of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(5 of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(-5 of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(-5 of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(5n+7 of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(5n+7 of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(-5n+7 of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(-5n+7 of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(5n-7 of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(5n-7 of .foo, :nth-last-child(2n+1)) { }"
+PASS parseThenSerializeRule(':nth-last-child(-5n-7 of .foo, :nth-last-child(odd)) { }') is ":nth-last-child(-5n-7 of .foo, :nth-last-child(2n+1)) { }"
 
-PASS parseThenSerializeRule(':is(single) { }') is ':is(single) { }'
-PASS parseThenSerializeRule(':is(a, b, p) { }') is ':is(a, b, p) { }'
-PASS parseThenSerializeRule(':is(#alice, #bob, #chris) { }') is ':is(#alice, #bob, #chris) { }'
-PASS parseThenSerializeRule(':is(.selector, #tama, #hanayo, #midoriko) { }') is ':is(.selector, #tama, #hanayo, #midoriko) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :visited) { }') is ':is(.name, #ok, :visited) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :visited, :link) { }') is ':is(.name, #ok, :visited, :link) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :is(:visited)) { }') is ':is(.name, #ok, :is(:visited)) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :not(:link)) { }') is ':is(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :not(:link)) { }') is ':is(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :-webkit-any(hello)) { }') is ':is(.name, #ok, :-webkit-any(hello)) { }'
-PASS parseThenSerializeRule(':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':is([type="file"]) { }') is ':is([type="file"]) { }'
-PASS parseThenSerializeRule(':is(:hover) { }') is ':is(:hover) { }'
-PASS parseThenSerializeRule('input:is([type="file"], :hover, :focus):enabled { }') is 'input:is([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':is(input[type="file"], a:hover, button:focus) { }') is ':is(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':is(.class1.class2.class3) { }') is ':is(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':is(.class1:hover) { }') is ':is(.class1:hover) { }'
-PASS parseThenSerializeRule(':is(a.class1.class2.class3:hover) { }') is ':is(a.class1.class2.class3:hover) { }'
-PASS parseThenSerializeRule(':where(single) { }') is ':where(single) { }'
-PASS parseThenSerializeRule(':where(a, b, p) { }') is ':where(a, b, p) { }'
-PASS parseThenSerializeRule(':where(#alice, #bob, #chris) { }') is ':where(#alice, #bob, #chris) { }'
-PASS parseThenSerializeRule(':where(.selector, #tama, #hanayo, #midoriko) { }') is ':where(.selector, #tama, #hanayo, #midoriko) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :visited) { }') is ':where(.name, #ok, :visited) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :visited, :link) { }') is ':where(.name, #ok, :visited, :link) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :where(:visited)) { }') is ':where(.name, #ok, :where(:visited)) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :not(:link)) { }') is ':where(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :not(:link)) { }') is ':where(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :where(hello)) { }') is ':where(.name, #ok, :where(hello)) { }'
-PASS parseThenSerializeRule(':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko)) { }') is ':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':where([type="file"]) { }') is ':where([type="file"]) { }'
-PASS parseThenSerializeRule(':where(:hover) { }') is ':where(:hover) { }'
-PASS parseThenSerializeRule('input:where([type="file"], :hover, :focus):enabled { }') is 'input:where([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':where(input[type="file"], a:hover, button:focus) { }') is ':where(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':where(.class1.class2.class3) { }') is ':where(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':where(.class1:hover) { }') is ':where(.class1:hover) { }'
-PASS parseThenSerializeRule(':where(a.class1.class2.class3:hover) { }') is ':where(a.class1.class2.class3:hover) { }'
-PASS parseThenSerializeRule(':matches(:is(single)) { }') is ':matches(:is(single)) { }'
-PASS parseThenSerializeRule(':matches(:is(a, b, p)) { }') is ':matches(:is(a, b, p)) { }'
-PASS parseThenSerializeRule(':matches(:is(#alice, #bob, #chris)) { }') is ':matches(:is(#alice, #bob, #chris)) { }'
-PASS parseThenSerializeRule(':matches(:is(.selector, #tama, #hanayo, #midoriko)) { }') is ':matches(:is(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :visited)) { }') is ':matches(:is(.name, #ok, :visited)) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :visited, :link)) { }') is ':matches(:is(.name, #ok, :visited, :link)) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :is(:visited))) { }') is ':matches(:is(.name, #ok, :is(:visited))) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :not(:link))) { }') is ':matches(:is(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :not(:link))) { }') is ':matches(:is(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :matches(hello))) { }') is ':matches(:is(.name, #ok, :matches(hello))) { }'
-PASS parseThenSerializeRule(':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko))) { }') is ':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko))) { }'
-PASS parseThenSerializeRule(':matches(:is([type="file"])) { }') is ':matches(:is([type="file"])) { }'
-PASS parseThenSerializeRule(':matches(:is(:hover)) { }') is ':matches(:is(:hover)) { }'
-PASS parseThenSerializeRule(':matches(input:is([type="file"], :hover, :focus):enabled) { }') is ':matches(input:is([type="file"], :hover, :focus):enabled) { }'
-PASS parseThenSerializeRule(':matches(:is(input[type="file"], a:hover, button:focus)) { }') is ':matches(:is(input[type="file"], a:hover, button:focus)) { }'
-PASS parseThenSerializeRule(':matches(:is(.class1.class2.class3)) { }') is ':matches(:is(.class1.class2.class3)) { }'
-PASS parseThenSerializeRule(':matches(:is(.class1:hover)) { }') is ':matches(:is(.class1:hover)) { }'
-PASS parseThenSerializeRule(':matches(:is(a.class1.class2.class3:hover)) { }') is ':matches(:is(a.class1.class2.class3:hover)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(single)) { }') is ':-webkit-any(:is(single)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(a, b, p)) { }') is ':-webkit-any(:is(a, b, p)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(#alice, #bob, #chris)) { }') is ':-webkit-any(:is(#alice, #bob, #chris)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko)) { }') is ':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :visited)) { }') is ':-webkit-any(:is(.name, #ok, :visited)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :visited, :link)) { }') is ':-webkit-any(:is(.name, #ok, :visited, :link)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :is(:visited))) { }') is ':-webkit-any(:is(.name, #ok, :is(:visited))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :not(:link))) { }') is ':-webkit-any(:is(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :not(:link))) { }') is ':-webkit-any(:is(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :-webkit-any(hello))) { }') is ':-webkit-any(:is(.name, #ok, :-webkit-any(hello))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }') is ':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is([type="file"])) { }') is ':-webkit-any(:is([type="file"])) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(:hover)) { }') is ':-webkit-any(:is(:hover)) { }'
-PASS parseThenSerializeRule(':-webkit-any(input:is([type="file"], :hover, :focus):enabled) { }') is ':-webkit-any(input:is([type="file"], :hover, :focus):enabled) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(input[type="file"], a:hover, button:focus)) { }') is ':-webkit-any(:is(input[type="file"], a:hover, button:focus)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.class1.class2.class3)) { }') is ':-webkit-any(:is(.class1.class2.class3)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(.class1:hover)) { }') is ':-webkit-any(:is(.class1:hover)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:is(a.class1.class2.class3:hover)) { }') is ':-webkit-any(:is(a.class1.class2.class3:hover)) { }'
+PASS parseThenSerializeRule(':is(single) { }') is ":is(single) { }"
+PASS parseThenSerializeRule(':is(a, b, p) { }') is ":is(a, b, p) { }"
+PASS parseThenSerializeRule(':is(#alice, #bob, #chris) { }') is ":is(#alice, #bob, #chris) { }"
+PASS parseThenSerializeRule(':is(.selector, #tama, #hanayo, #midoriko) { }') is ":is(.selector, #tama, #hanayo, #midoriko) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :visited) { }') is ":is(.name, #ok, :visited) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :visited, :link) { }') is ":is(.name, #ok, :visited, :link) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :is(:visited)) { }') is ":is(.name, #ok, :is(:visited)) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :not(:link)) { }') is ":is(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :not(:link)) { }') is ":is(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :-webkit-any(hello)) { }') is ":is(.name, #ok, :-webkit-any(hello)) { }"
+PASS parseThenSerializeRule(':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ":is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':is([type="file"]) { }') is ":is([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':is(:hover) { }') is ":is(:hover) { }"
+PASS parseThenSerializeRule('input:is([type="file"], :hover, :focus):enabled { }') is "input:is([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':is(input[type="file"], a:hover, button:focus) { }') is ":is(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':is(.class1.class2.class3) { }') is ":is(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':is(.class1:hover) { }') is ":is(.class1:hover) { }"
+PASS parseThenSerializeRule(':is(a.class1.class2.class3:hover) { }') is ":is(a.class1.class2.class3:hover) { }"
+PASS parseThenSerializeRule(':where(single) { }') is ":where(single) { }"
+PASS parseThenSerializeRule(':where(a, b, p) { }') is ":where(a, b, p) { }"
+PASS parseThenSerializeRule(':where(#alice, #bob, #chris) { }') is ":where(#alice, #bob, #chris) { }"
+PASS parseThenSerializeRule(':where(.selector, #tama, #hanayo, #midoriko) { }') is ":where(.selector, #tama, #hanayo, #midoriko) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :visited) { }') is ":where(.name, #ok, :visited) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :visited, :link) { }') is ":where(.name, #ok, :visited, :link) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :where(:visited)) { }') is ":where(.name, #ok, :where(:visited)) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :not(:link)) { }') is ":where(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :not(:link)) { }') is ":where(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :where(hello)) { }') is ":where(.name, #ok, :where(hello)) { }"
+PASS parseThenSerializeRule(':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko)) { }') is ":where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':where([type="file"]) { }') is ":where([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':where(:hover) { }') is ":where(:hover) { }"
+PASS parseThenSerializeRule('input:where([type="file"], :hover, :focus):enabled { }') is "input:where([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':where(input[type="file"], a:hover, button:focus) { }') is ":where(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':where(.class1.class2.class3) { }') is ":where(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':where(.class1:hover) { }') is ":where(.class1:hover) { }"
+PASS parseThenSerializeRule(':where(a.class1.class2.class3:hover) { }') is ":where(a.class1.class2.class3:hover) { }"
+PASS parseThenSerializeRule(':matches(:is(single)) { }') is ":matches(:is(single)) { }"
+PASS parseThenSerializeRule(':matches(:is(a, b, p)) { }') is ":matches(:is(a, b, p)) { }"
+PASS parseThenSerializeRule(':matches(:is(#alice, #bob, #chris)) { }') is ":matches(:is(#alice, #bob, #chris)) { }"
+PASS parseThenSerializeRule(':matches(:is(.selector, #tama, #hanayo, #midoriko)) { }') is ":matches(:is(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :visited)) { }') is ":matches(:is(.name, #ok, :visited)) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :visited, :link)) { }') is ":matches(:is(.name, #ok, :visited, :link)) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :is(:visited))) { }') is ":matches(:is(.name, #ok, :is(:visited))) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :not(:link))) { }') is ":matches(:is(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :not(:link))) { }') is ":matches(:is(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :matches(hello))) { }') is ":matches(:is(.name, #ok, :matches(hello))) { }"
+PASS parseThenSerializeRule(':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko))) { }') is ":matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko))) { }"
+PASS parseThenSerializeRule(':matches(:is([type="file"])) { }') is ":matches(:is([type=\"file\"])) { }"
+PASS parseThenSerializeRule(':matches(:is(:hover)) { }') is ":matches(:is(:hover)) { }"
+PASS parseThenSerializeRule(':matches(input:is([type="file"], :hover, :focus):enabled) { }') is ":matches(input:is([type=\"file\"], :hover, :focus):enabled) { }"
+PASS parseThenSerializeRule(':matches(:is(input[type="file"], a:hover, button:focus)) { }') is ":matches(:is(input[type=\"file\"], a:hover, button:focus)) { }"
+PASS parseThenSerializeRule(':matches(:is(.class1.class2.class3)) { }') is ":matches(:is(.class1.class2.class3)) { }"
+PASS parseThenSerializeRule(':matches(:is(.class1:hover)) { }') is ":matches(:is(.class1:hover)) { }"
+PASS parseThenSerializeRule(':matches(:is(a.class1.class2.class3:hover)) { }') is ":matches(:is(a.class1.class2.class3:hover)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(single)) { }') is ":-webkit-any(:is(single)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(a, b, p)) { }') is ":-webkit-any(:is(a, b, p)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(#alice, #bob, #chris)) { }') is ":-webkit-any(:is(#alice, #bob, #chris)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko)) { }') is ":-webkit-any(:is(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :visited)) { }') is ":-webkit-any(:is(.name, #ok, :visited)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :visited, :link)) { }') is ":-webkit-any(:is(.name, #ok, :visited, :link)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :is(:visited))) { }') is ":-webkit-any(:is(.name, #ok, :is(:visited))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :not(:link))) { }') is ":-webkit-any(:is(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :not(:link))) { }') is ":-webkit-any(:is(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :-webkit-any(hello))) { }') is ":-webkit-any(:is(.name, #ok, :-webkit-any(hello))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }') is ":-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is([type="file"])) { }') is ":-webkit-any(:is([type=\"file\"])) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(:hover)) { }') is ":-webkit-any(:is(:hover)) { }"
+PASS parseThenSerializeRule(':-webkit-any(input:is([type="file"], :hover, :focus):enabled) { }') is ":-webkit-any(input:is([type=\"file\"], :hover, :focus):enabled) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(input[type="file"], a:hover, button:focus)) { }') is ":-webkit-any(:is(input[type=\"file\"], a:hover, button:focus)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.class1.class2.class3)) { }') is ":-webkit-any(:is(.class1.class2.class3)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(.class1:hover)) { }') is ":-webkit-any(:is(.class1:hover)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:is(a.class1.class2.class3:hover)) { }') is ":-webkit-any(:is(a.class1.class2.class3:hover)) { }"
 
-PASS parseThenSerializeRule(':matches(single) { }') is ':matches(single) { }'
-PASS parseThenSerializeRule(':matches(a, b, p) { }') is ':matches(a, b, p) { }'
-PASS parseThenSerializeRule(':matches(#alice, #bob, #chris) { }') is ':matches(#alice, #bob, #chris) { }'
-PASS parseThenSerializeRule(':matches(.selector, #tama, #hanayo, #midoriko) { }') is ':matches(.selector, #tama, #hanayo, #midoriko) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :visited) { }') is ':matches(.name, #ok, :visited) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :visited, :link) { }') is ':matches(.name, #ok, :visited, :link) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :matches(:visited)) { }') is ':matches(.name, #ok, :matches(:visited)) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :not(:link)) { }') is ':matches(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :not(:link)) { }') is ':matches(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :-webkit-any(hello)) { }') is ':matches(.name, #ok, :-webkit-any(hello)) { }'
-PASS parseThenSerializeRule(':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':matches([type="file"]) { }') is ':matches([type="file"]) { }'
-PASS parseThenSerializeRule(':matches(:hover) { }') is ':matches(:hover) { }'
-PASS parseThenSerializeRule('input:matches([type="file"], :hover, :focus):enabled { }') is 'input:matches([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':matches(input[type="file"], a:hover, button:focus) { }') is ':matches(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':matches(.class1.class2.class3) { }') is ':matches(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':matches(.class1:hover) { }') is ':matches(.class1:hover) { }'
-PASS parseThenSerializeRule(':matches(a.class1.class2.class3:hover) { }') is ':matches(a.class1.class2.class3:hover) { }'
-PASS parseThenSerializeRule(':is(:matches(single)) { }') is ':is(:matches(single)) { }'
-PASS parseThenSerializeRule(':is(:matches(a, b, p)) { }') is ':is(:matches(a, b, p)) { }'
-PASS parseThenSerializeRule(':is(:matches(#alice, #bob, #chris)) { }') is ':is(:matches(#alice, #bob, #chris)) { }'
-PASS parseThenSerializeRule(':is(:matches(.selector, #tama, #hanayo, #midoriko)) { }') is ':is(:matches(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :visited)) { }') is ':is(:matches(.name, #ok, :visited)) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :visited, :link)) { }') is ':is(:matches(.name, #ok, :visited, :link)) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :matches(:visited))) { }') is ':is(:matches(.name, #ok, :matches(:visited))) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :not(:link))) { }') is ':is(:matches(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :not(:link))) { }') is ':is(:matches(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :is(hello))) { }') is ':is(:matches(.name, #ok, :is(hello))) { }'
-PASS parseThenSerializeRule(':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko))) { }') is ':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko))) { }'
-PASS parseThenSerializeRule(':is(:matches([type="file"])) { }') is ':is(:matches([type="file"])) { }'
-PASS parseThenSerializeRule(':is(:matches(:hover)) { }') is ':is(:matches(:hover)) { }'
-PASS parseThenSerializeRule(':is(input:matches([type="file"], :hover, :focus):enabled) { }') is ':is(input:matches([type="file"], :hover, :focus):enabled) { }'
-PASS parseThenSerializeRule(':is(:matches(input[type="file"], a:hover, button:focus)) { }') is ':is(:matches(input[type="file"], a:hover, button:focus)) { }'
-PASS parseThenSerializeRule(':is(:matches(.class1.class2.class3)) { }') is ':is(:matches(.class1.class2.class3)) { }'
-PASS parseThenSerializeRule(':is(:matches(.class1:hover)) { }') is ':is(:matches(.class1:hover)) { }'
-PASS parseThenSerializeRule(':is(:matches(a.class1.class2.class3:hover)) { }') is ':is(:matches(a.class1.class2.class3:hover)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(single)) { }') is ':-webkit-any(:matches(single)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(a, b, p)) { }') is ':-webkit-any(:matches(a, b, p)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(#alice, #bob, #chris)) { }') is ':-webkit-any(:matches(#alice, #bob, #chris)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko)) { }') is ':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :visited)) { }') is ':-webkit-any(:matches(.name, #ok, :visited)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :visited, :link)) { }') is ':-webkit-any(:matches(.name, #ok, :visited, :link)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :matches(:visited))) { }') is ':-webkit-any(:matches(.name, #ok, :matches(:visited))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :not(:link))) { }') is ':-webkit-any(:matches(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :not(:link))) { }') is ':-webkit-any(:matches(.name, #ok, :not(:link))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :-webkit-any(hello))) { }') is ':-webkit-any(:matches(.name, #ok, :-webkit-any(hello))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }') is ':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches([type="file"])) { }') is ':-webkit-any(:matches([type="file"])) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(:hover)) { }') is ':-webkit-any(:matches(:hover)) { }'
-PASS parseThenSerializeRule(':-webkit-any(input:matches([type="file"], :hover, :focus):enabled) { }') is ':-webkit-any(input:matches([type="file"], :hover, :focus):enabled) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(input[type="file"], a:hover, button:focus)) { }') is ':-webkit-any(:matches(input[type="file"], a:hover, button:focus)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.class1.class2.class3)) { }') is ':-webkit-any(:matches(.class1.class2.class3)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(.class1:hover)) { }') is ':-webkit-any(:matches(.class1:hover)) { }'
-PASS parseThenSerializeRule(':-webkit-any(:matches(a.class1.class2.class3:hover)) { }') is ':-webkit-any(:matches(a.class1.class2.class3:hover)) { }'
+PASS parseThenSerializeRule(':matches(single) { }') is ":matches(single) { }"
+PASS parseThenSerializeRule(':matches(a, b, p) { }') is ":matches(a, b, p) { }"
+PASS parseThenSerializeRule(':matches(#alice, #bob, #chris) { }') is ":matches(#alice, #bob, #chris) { }"
+PASS parseThenSerializeRule(':matches(.selector, #tama, #hanayo, #midoriko) { }') is ":matches(.selector, #tama, #hanayo, #midoriko) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :visited) { }') is ":matches(.name, #ok, :visited) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :visited, :link) { }') is ":matches(.name, #ok, :visited, :link) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :matches(:visited)) { }') is ":matches(.name, #ok, :matches(:visited)) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :not(:link)) { }') is ":matches(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :not(:link)) { }') is ":matches(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :-webkit-any(hello)) { }') is ":matches(.name, #ok, :-webkit-any(hello)) { }"
+PASS parseThenSerializeRule(':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ":matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':matches([type="file"]) { }') is ":matches([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':matches(:hover) { }') is ":matches(:hover) { }"
+PASS parseThenSerializeRule('input:matches([type="file"], :hover, :focus):enabled { }') is "input:matches([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':matches(input[type="file"], a:hover, button:focus) { }') is ":matches(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':matches(.class1.class2.class3) { }') is ":matches(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':matches(.class1:hover) { }') is ":matches(.class1:hover) { }"
+PASS parseThenSerializeRule(':matches(a.class1.class2.class3:hover) { }') is ":matches(a.class1.class2.class3:hover) { }"
+PASS parseThenSerializeRule(':is(:matches(single)) { }') is ":is(:matches(single)) { }"
+PASS parseThenSerializeRule(':is(:matches(a, b, p)) { }') is ":is(:matches(a, b, p)) { }"
+PASS parseThenSerializeRule(':is(:matches(#alice, #bob, #chris)) { }') is ":is(:matches(#alice, #bob, #chris)) { }"
+PASS parseThenSerializeRule(':is(:matches(.selector, #tama, #hanayo, #midoriko)) { }') is ":is(:matches(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :visited)) { }') is ":is(:matches(.name, #ok, :visited)) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :visited, :link)) { }') is ":is(:matches(.name, #ok, :visited, :link)) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :matches(:visited))) { }') is ":is(:matches(.name, #ok, :matches(:visited))) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :not(:link))) { }') is ":is(:matches(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :not(:link))) { }') is ":is(:matches(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :is(hello))) { }') is ":is(:matches(.name, #ok, :is(hello))) { }"
+PASS parseThenSerializeRule(':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko))) { }') is ":is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko))) { }"
+PASS parseThenSerializeRule(':is(:matches([type="file"])) { }') is ":is(:matches([type=\"file\"])) { }"
+PASS parseThenSerializeRule(':is(:matches(:hover)) { }') is ":is(:matches(:hover)) { }"
+PASS parseThenSerializeRule(':is(input:matches([type="file"], :hover, :focus):enabled) { }') is ":is(input:matches([type=\"file\"], :hover, :focus):enabled) { }"
+PASS parseThenSerializeRule(':is(:matches(input[type="file"], a:hover, button:focus)) { }') is ":is(:matches(input[type=\"file\"], a:hover, button:focus)) { }"
+PASS parseThenSerializeRule(':is(:matches(.class1.class2.class3)) { }') is ":is(:matches(.class1.class2.class3)) { }"
+PASS parseThenSerializeRule(':is(:matches(.class1:hover)) { }') is ":is(:matches(.class1:hover)) { }"
+PASS parseThenSerializeRule(':is(:matches(a.class1.class2.class3:hover)) { }') is ":is(:matches(a.class1.class2.class3:hover)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(single)) { }') is ":-webkit-any(:matches(single)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(a, b, p)) { }') is ":-webkit-any(:matches(a, b, p)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(#alice, #bob, #chris)) { }') is ":-webkit-any(:matches(#alice, #bob, #chris)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko)) { }') is ":-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :visited)) { }') is ":-webkit-any(:matches(.name, #ok, :visited)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :visited, :link)) { }') is ":-webkit-any(:matches(.name, #ok, :visited, :link)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :matches(:visited))) { }') is ":-webkit-any(:matches(.name, #ok, :matches(:visited))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :not(:link))) { }') is ":-webkit-any(:matches(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :not(:link))) { }') is ":-webkit-any(:matches(.name, #ok, :not(:link))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :-webkit-any(hello))) { }') is ":-webkit-any(:matches(.name, #ok, :-webkit-any(hello))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }') is ":-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches([type="file"])) { }') is ":-webkit-any(:matches([type=\"file\"])) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(:hover)) { }') is ":-webkit-any(:matches(:hover)) { }"
+PASS parseThenSerializeRule(':-webkit-any(input:matches([type="file"], :hover, :focus):enabled) { }') is ":-webkit-any(input:matches([type=\"file\"], :hover, :focus):enabled) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(input[type="file"], a:hover, button:focus)) { }') is ":-webkit-any(:matches(input[type=\"file\"], a:hover, button:focus)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.class1.class2.class3)) { }') is ":-webkit-any(:matches(.class1.class2.class3)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(.class1:hover)) { }') is ":-webkit-any(:matches(.class1:hover)) { }"
+PASS parseThenSerializeRule(':-webkit-any(:matches(a.class1.class2.class3:hover)) { }') is ":-webkit-any(:matches(a.class1.class2.class3:hover)) { }"
 
-PASS parseThenSerializeRule(':not(div) { }') is ':not(div) { }'
-PASS parseThenSerializeRule(':not(.div) { }') is ':not(.div) { }'
-PASS parseThenSerializeRule(':not(#div) { }') is ':not(#div) { }'
-PASS parseThenSerializeRule(':not([div]) { }') is ':not([div]) { }'
-PASS parseThenSerializeRule(':not(:empty) { }') is ':not(:empty) { }'
-PASS parseThenSerializeRule(':not(div.div#div[div]:empty) { }') is ':not(div.div#div[div]:empty) { }'
-PASS parseThenSerializeRule(':not(div.div:empty[div]#div) { }') is ':not(div.div:empty[div]#div) { }'
-PASS parseThenSerializeRule(':not(div.div, #div[div], :empty) { }') is ':not(div.div, #div[div], :empty) { }'
-PASS parseThenSerializeRule(':not(div, .div, #div, [div], :empty) { }') is ':not(div, .div, #div, [div], :empty) { }'
-PASS parseThenSerializeRule(':not(:not(div)) { }') is ':not(:not(div)) { }'
-PASS parseThenSerializeRule(':not(:not(div)):not(:not(foo)):not(:not(bar)) { }') is ':not(:not(div)):not(:not(foo)):not(:not(bar)) { }'
-PASS parseThenSerializeRule(':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz)) { }') is ':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz)) { }'
-PASS parseThenSerializeRule(':not(:is(*)) { }') is ':not(:is(*)) { }'
-PASS parseThenSerializeRule(':not(:is(foo, bar)) { }') is ':not(:is(foo, bar)) { }'
-PASS parseThenSerializeRule(':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar])) { }') is ':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar])) { }'
-PASS parseThenSerializeRule(':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar])) { }') is ':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar])) { }'
-PASS parseThenSerializeRule(':not(:matches(*)) { }') is ':not(:matches(*)) { }'
-PASS parseThenSerializeRule(':not(:matches(foo, bar)) { }') is ':not(:matches(foo, bar)) { }'
-PASS parseThenSerializeRule(':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar])) { }') is ':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar])) { }'
-PASS parseThenSerializeRule(':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar])) { }') is ':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar])) { }'
-PASS parseThenSerializeRule(':nth-child(2n of :not(a.b, c#d.e)) { }') is ':nth-child(2n of :not(a.b, c#d.e)) { }'
-PASS parseThenSerializeRule(':not(:nth-child(2n of :not(a.b, c#d.e))) { }') is ':not(:nth-child(2n of :not(a.b, c#d.e))) { }'
-PASS parseThenSerializeRule(':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }') is ':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }'
-PASS parseThenSerializeRule('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }') is 'a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }'
+PASS parseThenSerializeRule(':not(div) { }') is ":not(div) { }"
+PASS parseThenSerializeRule(':not(.div) { }') is ":not(.div) { }"
+PASS parseThenSerializeRule(':not(#div) { }') is ":not(#div) { }"
+PASS parseThenSerializeRule(':not([div]) { }') is ":not([div]) { }"
+PASS parseThenSerializeRule(':not(:empty) { }') is ":not(:empty) { }"
+PASS parseThenSerializeRule(':not(div.div#div[div]:empty) { }') is ":not(div.div#div[div]:empty) { }"
+PASS parseThenSerializeRule(':not(div.div:empty[div]#div) { }') is ":not(div.div:empty[div]#div) { }"
+PASS parseThenSerializeRule(':not(div.div, #div[div], :empty) { }') is ":not(div.div, #div[div], :empty) { }"
+PASS parseThenSerializeRule(':not(div, .div, #div, [div], :empty) { }') is ":not(div, .div, #div, [div], :empty) { }"
+PASS parseThenSerializeRule(':not(:not(div)) { }') is ":not(:not(div)) { }"
+PASS parseThenSerializeRule(':not(:not(div)):not(:not(foo)):not(:not(bar)) { }') is ":not(:not(div)):not(:not(foo)):not(:not(bar)) { }"
+PASS parseThenSerializeRule(':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz)) { }') is ":not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz)) { }"
+PASS parseThenSerializeRule(':not(:is(*)) { }') is ":not(:is(*)) { }"
+PASS parseThenSerializeRule(':not(:is(foo, bar)) { }') is ":not(:is(foo, bar)) { }"
+PASS parseThenSerializeRule(':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar])) { }') is ":not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar])) { }"
+PASS parseThenSerializeRule(':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar])) { }') is ":not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar])) { }"
+PASS parseThenSerializeRule(':not(:matches(*)) { }') is ":not(:matches(*)) { }"
+PASS parseThenSerializeRule(':not(:matches(foo, bar)) { }') is ":not(:matches(foo, bar)) { }"
+PASS parseThenSerializeRule(':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar])) { }') is ":not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar])) { }"
+PASS parseThenSerializeRule(':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar])) { }') is ":not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar])) { }"
+PASS parseThenSerializeRule(':nth-child(2n of :not(a.b, c#d.e)) { }') is ":nth-child(2n of :not(a.b, c#d.e)) { }"
+PASS parseThenSerializeRule(':not(:nth-child(2n of :not(a.b, c#d.e))) { }') is ":not(:nth-child(2n of :not(a.b, c#d.e))) { }"
+PASS parseThenSerializeRule(':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }') is ":not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }"
+PASS parseThenSerializeRule('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }') is "a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) { }"
 
-PASS parseThenSerializeRule('::-webkit-file-upload-button { }') is '::-webkit-file-upload-button { }'
-PASS parseThenSerializeRule('::-webkit-search-cancel-button { }') is '::-webkit-search-cancel-button { }'
-PASS parseThenSerializeRule('::-webkit-search-decoration { }') is '::-webkit-search-decoration { }'
-PASS parseThenSerializeRule('::-webkit-search-results-button { }') is '::-webkit-search-results-button { }'
-PASS parseThenSerializeRule('::-webkit-search-results-decoration { }') is '::-webkit-search-results-decoration { }'
-PASS parseThenSerializeRule('::-webkit-slider-thumb { }') is '::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('::file-selector-button { }') is '::file-selector-button { }'
+PASS parseThenSerializeRule('::-webkit-file-upload-button { }') is "::-webkit-file-upload-button { }"
+PASS parseThenSerializeRule('::-webkit-search-cancel-button { }') is "::-webkit-search-cancel-button { }"
+PASS parseThenSerializeRule('::-webkit-search-decoration { }') is "::-webkit-search-decoration { }"
+PASS parseThenSerializeRule('::-webkit-search-results-button { }') is "::-webkit-search-results-button { }"
+PASS parseThenSerializeRule('::-webkit-search-results-decoration { }') is "::-webkit-search-results-decoration { }"
+PASS parseThenSerializeRule('::-webkit-slider-thumb { }') is "::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('::file-selector-button { }') is "::file-selector-button { }"
 
-PASS parseThenSerializeRule('a::-webkit-slider-thumb { }') is 'a::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('a ::-webkit-slider-thumb { }') is 'a ::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('[a]::-webkit-slider-thumb { }') is '[a]::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('[a] ::-webkit-slider-thumb { }') is '[a] ::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('.a::-webkit-slider-thumb { }') is '.a::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('.a ::-webkit-slider-thumb { }') is '.a ::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('#a::-webkit-slider-thumb { }') is '#a::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('#a ::-webkit-slider-thumb { }') is '#a ::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('* ::-webkit-slider-thumb { }') is '* ::-webkit-slider-thumb { }'
+PASS parseThenSerializeRule('a::-webkit-slider-thumb { }') is "a::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('a ::-webkit-slider-thumb { }') is "a ::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('[a]::-webkit-slider-thumb { }') is "[a]::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('[a] ::-webkit-slider-thumb { }') is "[a] ::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('.a::-webkit-slider-thumb { }') is ".a::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('.a ::-webkit-slider-thumb { }') is ".a ::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('#a::-webkit-slider-thumb { }') is "#a::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('#a ::-webkit-slider-thumb { }') is "#a ::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('* ::-webkit-slider-thumb { }') is "* ::-webkit-slider-thumb { }"
 
-PASS parseThenSerializeRule('a[b]::-webkit-slider-thumb { }') is 'a[b]::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('a.b::-webkit-slider-thumb { }') is 'a.b::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('a#b::-webkit-slider-thumb { }') is 'a#b::-webkit-slider-thumb { }'
-PASS parseThenSerializeRule('a[b].c#d::-webkit-slider-thumb { }') is 'a[b].c#d::-webkit-slider-thumb { }'
+PASS parseThenSerializeRule('a[b]::-webkit-slider-thumb { }') is "a[b]::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('a.b::-webkit-slider-thumb { }') is "a.b::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('a#b::-webkit-slider-thumb { }') is "a#b::-webkit-slider-thumb { }"
+PASS parseThenSerializeRule('a[b].c#d::-webkit-slider-thumb { }') is "a[b].c#d::-webkit-slider-thumb { }"
 
-PASS parseThenSerializeRule('a[b]::placeholder { }') is 'a[b]::placeholder { }'
-PASS parseThenSerializeRule('a.b::placeholder { }') is 'a.b::placeholder { }'
-PASS parseThenSerializeRule('a#b::placeholder { }') is 'a#b::placeholder { }'
-PASS parseThenSerializeRule('a[b].c#d::placeholder { }') is 'a[b].c#d::placeholder { }'
-PASS parseThenSerializeRule('a[b]::-webkit-input-placeholder { }') is 'a[b]::-webkit-input-placeholder { }'
-PASS parseThenSerializeRule('a.b::-webkit-input-placeholder { }') is 'a.b::-webkit-input-placeholder { }'
-PASS parseThenSerializeRule('a#b::-webkit-input-placeholder { }') is 'a#b::-webkit-input-placeholder { }'
-PASS parseThenSerializeRule('a[b].c#d::-webkit-input-placeholder { }') is 'a[b].c#d::-webkit-input-placeholder { }'
+PASS parseThenSerializeRule('a[b]::placeholder { }') is "a[b]::placeholder { }"
+PASS parseThenSerializeRule('a.b::placeholder { }') is "a.b::placeholder { }"
+PASS parseThenSerializeRule('a#b::placeholder { }') is "a#b::placeholder { }"
+PASS parseThenSerializeRule('a[b].c#d::placeholder { }') is "a[b].c#d::placeholder { }"
+PASS parseThenSerializeRule('a[b]::-webkit-input-placeholder { }') is "a[b]::-webkit-input-placeholder { }"
+PASS parseThenSerializeRule('a.b::-webkit-input-placeholder { }') is "a.b::-webkit-input-placeholder { }"
+PASS parseThenSerializeRule('a#b::-webkit-input-placeholder { }') is "a#b::-webkit-input-placeholder { }"
+PASS parseThenSerializeRule('a[b].c#d::-webkit-input-placeholder { }') is "a[b].c#d::-webkit-input-placeholder { }"
 
-PASS parseThenSerializeRule('a[b]:default { }') is 'a[b]:default { }'
-PASS parseThenSerializeRule('a.b:default { }') is 'a.b:default { }'
-PASS parseThenSerializeRule('a#b:default { }') is 'a#b:default { }'
-PASS parseThenSerializeRule('a[b].c#d:default { }') is 'a[b].c#d:default { }'
+PASS parseThenSerializeRule('a[b]:default { }') is "a[b]:default { }"
+PASS parseThenSerializeRule('a.b:default { }') is "a.b:default { }"
+PASS parseThenSerializeRule('a#b:default { }') is "a#b:default { }"
+PASS parseThenSerializeRule('a[b].c#d:default { }') is "a[b].c#d:default { }"
 
-PASS parseThenSerializeRule('a[b]:in-range { }') is 'a[b]:in-range { }'
-PASS parseThenSerializeRule('a.b:in-range { }') is 'a.b:in-range { }'
-PASS parseThenSerializeRule('a#b:in-range { }') is 'a#b:in-range { }'
-PASS parseThenSerializeRule('a[b].c#d:in-range { }') is 'a[b].c#d:in-range { }'
+PASS parseThenSerializeRule('a[b]:in-range { }') is "a[b]:in-range { }"
+PASS parseThenSerializeRule('a.b:in-range { }') is "a.b:in-range { }"
+PASS parseThenSerializeRule('a#b:in-range { }') is "a#b:in-range { }"
+PASS parseThenSerializeRule('a[b].c#d:in-range { }') is "a[b].c#d:in-range { }"
 
-PASS parseThenSerializeRule('a[b]:out-of-range { }') is 'a[b]:out-of-range { }'
-PASS parseThenSerializeRule('a.b:out-of-range { }') is 'a.b:out-of-range { }'
-PASS parseThenSerializeRule('a#b:out-of-range { }') is 'a#b:out-of-range { }'
-PASS parseThenSerializeRule('a[b].c#d:out-of-range { }') is 'a[b].c#d:out-of-range { }'
+PASS parseThenSerializeRule('a[b]:out-of-range { }') is "a[b]:out-of-range { }"
+PASS parseThenSerializeRule('a.b:out-of-range { }') is "a.b:out-of-range { }"
+PASS parseThenSerializeRule('a#b:out-of-range { }') is "a#b:out-of-range { }"
+PASS parseThenSerializeRule('a[b].c#d:out-of-range { }') is "a[b].c#d:out-of-range { }"
 
-PASS parseThenSerializeRule('a[b]:focus-within { }') is 'a[b]:focus-within { }'
-PASS parseThenSerializeRule('a.b:focus-within { }') is 'a.b:focus-within { }'
-PASS parseThenSerializeRule('a#b:focus-within { }') is 'a#b:focus-within { }'
-PASS parseThenSerializeRule('a[b].c#d:focus-within { }') is 'a[b].c#d:focus-within { }'
+PASS parseThenSerializeRule('a[b]:focus-within { }') is "a[b]:focus-within { }"
+PASS parseThenSerializeRule('a.b:focus-within { }') is "a.b:focus-within { }"
+PASS parseThenSerializeRule('a#b:focus-within { }') is "a#b:focus-within { }"
+PASS parseThenSerializeRule('a[b].c#d:focus-within { }') is "a[b].c#d:focus-within { }"
 
-PASS parseThenSerializeRule('input:not([type="file"]):focus { }') is 'input:not([type="file"]):focus { }'
-PASS parseThenSerializeRule(':-webkit-any([type="file"]) { }') is ':-webkit-any([type="file"]) { }'
-PASS parseThenSerializeRule(':-webkit-any(:hover) { }') is ':-webkit-any(:hover) { }'
-PASS parseThenSerializeRule('input:-webkit-any([type="file"], :hover, :focus):enabled { }') is 'input:-webkit-any([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':-webkit-any(input[type="file"], a:hover, button:focus) { }') is ':-webkit-any(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':-webkit-any(.class1.class2.class3) { }') is ':-webkit-any(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':-webkit-any(.class1:hover) { }') is ':-webkit-any(.class1:hover) { }'
-PASS parseThenSerializeRule(':-webkit-any(a.class1.class2.class3:hover) { }') is ':-webkit-any(a.class1.class2.class3:hover) { }'
-PASS parseThenSerializeRule('a:any-link { }') is 'a:any-link { }'
-PASS parseThenSerializeRule('a :any-link { }') is 'a :any-link { }'
-PASS parseThenSerializeRule('div:any-link { }') is 'div:any-link { }'
-PASS parseThenSerializeRule('div :any-link { }') is 'div :any-link { }'
-PASS parseThenSerializeRule(':any-link > div { }') is ':any-link > div { }'
-PASS parseThenSerializeRule(':any-link + div { }') is ':any-link + div { }'
-PASS parseThenSerializeRule(':not(:any-link) { }') is ':not(:any-link) { }'
+PASS parseThenSerializeRule('input:not([type="file"]):focus { }') is "input:not([type=\"file\"]):focus { }"
+PASS parseThenSerializeRule(':-webkit-any([type="file"]) { }') is ":-webkit-any([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':-webkit-any(:hover) { }') is ":-webkit-any(:hover) { }"
+PASS parseThenSerializeRule('input:-webkit-any([type="file"], :hover, :focus):enabled { }') is "input:-webkit-any([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':-webkit-any(input[type="file"], a:hover, button:focus) { }') is ":-webkit-any(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':-webkit-any(.class1.class2.class3) { }') is ":-webkit-any(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':-webkit-any(.class1:hover) { }') is ":-webkit-any(.class1:hover) { }"
+PASS parseThenSerializeRule(':-webkit-any(a.class1.class2.class3:hover) { }') is ":-webkit-any(a.class1.class2.class3:hover) { }"
+PASS parseThenSerializeRule('a:any-link { }') is "a:any-link { }"
+PASS parseThenSerializeRule('a :any-link { }') is "a :any-link { }"
+PASS parseThenSerializeRule('div:any-link { }') is "div:any-link { }"
+PASS parseThenSerializeRule('div :any-link { }') is "div :any-link { }"
+PASS parseThenSerializeRule(':any-link > div { }') is ":any-link > div { }"
+PASS parseThenSerializeRule(':any-link + div { }') is ":any-link + div { }"
+PASS parseThenSerializeRule(':not(:any-link) { }') is ":not(:any-link) { }"
 
-PASS parseThenSerializeRule('*:active { }') is ':active { }'
+PASS parseThenSerializeRule('*:active { }') is ":active { }"
 
-PASS parseThenSerializeRule('input[type=file]:focus { }') is 'input[type="file"]:focus { }'
+PASS parseThenSerializeRule('input[type=file]:focus { }') is "input[type=\"file\"]:focus { }"
 
-PASS parseThenSerializeRule('a+b { }') is 'a + b { }'
-PASS parseThenSerializeRule('a~b { }') is 'a ~ b { }'
-PASS parseThenSerializeRule('a>b { }') is 'a > b { }'
+PASS parseThenSerializeRule('a+b { }') is "a + b { }"
+PASS parseThenSerializeRule('a~b { }') is "a ~ b { }"
+PASS parseThenSerializeRule('a>b { }') is "a > b { }"
 
-PASS parseThenSerializeRule(':after { }') is '::after { }'
-PASS parseThenSerializeRule(':before { }') is '::before { }'
-PASS parseThenSerializeRule(':first-letter { }') is '::first-letter { }'
-PASS parseThenSerializeRule(':first-line { }') is '::first-line { }'
-PASS parseThenSerializeRule(':-webkit-any(    a.class1  ,  	#id,[attr]  ) { }') is ':-webkit-any(a.class1, #id, [attr]) { }'
+PASS parseThenSerializeRule(':after { }') is "::after { }"
+PASS parseThenSerializeRule(':before { }') is "::before { }"
+PASS parseThenSerializeRule(':first-letter { }') is "::first-letter { }"
+PASS parseThenSerializeRule(':first-line { }') is "::first-line { }"
+PASS parseThenSerializeRule(':-webkit-any(    a.class1  ,  	#id,[attr]  ) { }') is ":-webkit-any(a.class1, #id, [attr]) { }"
 
-PASS parseThenSerializeRule(':is(single    ) { }') is ':is(single) { }'
-PASS parseThenSerializeRule(':is(a,b    ,p) { }') is ':is(a, b, p) { }'
-PASS parseThenSerializeRule(':is(#alice,                   #bob,#chris) { }') is ':is(#alice, #bob, #chris) { }'
-PASS parseThenSerializeRule(':is(  .selector,#tama,                #hanayo,#midoriko) { }') is ':is(.selector, #tama, #hanayo, #midoriko) { }'
-PASS parseThenSerializeRule(':is(    .name,#ok,:visited   ) { }') is ':is(.name, #ok, :visited) { }'
-PASS parseThenSerializeRule(':is(    .name,#ok,    :visited, :link) { }') is ':is(.name, #ok, :visited, :link) { }'
-PASS parseThenSerializeRule(':is(    .name,#ok,    :is(:visited    )) { }') is ':is(.name, #ok, :is(:visited)) { }'
-PASS parseThenSerializeRule(':is(.name,  #ok,:not(:link)) { }') is ':is(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':is(.name,#ok,:not(:link)) { }') is ':is(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':is(    .name,#ok,:-webkit-any(   hello)) { }') is ':is(.name, #ok, :-webkit-any(hello)) { }'
-PASS parseThenSerializeRule(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':is(       [type="file"]) { }') is ':is([type="file"]) { }'
-PASS parseThenSerializeRule(':is(  :hover    ) { }') is ':is(:hover) { }'
-PASS parseThenSerializeRule('input:is([type="file"],:hover,:focus):enabled { }') is 'input:is([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':is(input[type="file"], a:hover, button:focus) { }') is ':is(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':is( .class1.class2.class3   ) { }') is ':is(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':is(.class1:hover   ) { }') is ':is(.class1:hover) { }'
-PASS parseThenSerializeRule(':is(a.class1.class2.class3:hover   ) { }') is ':is(a.class1.class2.class3:hover) { }'
+PASS parseThenSerializeRule(':is(single    ) { }') is ":is(single) { }"
+PASS parseThenSerializeRule(':is(a,b    ,p) { }') is ":is(a, b, p) { }"
+PASS parseThenSerializeRule(':is(#alice,                   #bob,#chris) { }') is ":is(#alice, #bob, #chris) { }"
+PASS parseThenSerializeRule(':is(  .selector,#tama,                #hanayo,#midoriko) { }') is ":is(.selector, #tama, #hanayo, #midoriko) { }"
+PASS parseThenSerializeRule(':is(    .name,#ok,:visited   ) { }') is ":is(.name, #ok, :visited) { }"
+PASS parseThenSerializeRule(':is(    .name,#ok,    :visited, :link) { }') is ":is(.name, #ok, :visited, :link) { }"
+PASS parseThenSerializeRule(':is(    .name,#ok,    :is(:visited    )) { }') is ":is(.name, #ok, :is(:visited)) { }"
+PASS parseThenSerializeRule(':is(.name,  #ok,:not(:link)) { }') is ":is(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':is(.name,#ok,:not(:link)) { }') is ":is(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':is(    .name,#ok,:-webkit-any(   hello)) { }') is ":is(.name, #ok, :-webkit-any(hello)) { }"
+PASS parseThenSerializeRule(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ":is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':is(       [type="file"]) { }') is ":is([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':is(  :hover    ) { }') is ":is(:hover) { }"
+PASS parseThenSerializeRule('input:is([type="file"],:hover,:focus):enabled { }') is "input:is([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':is(input[type="file"], a:hover, button:focus) { }') is ":is(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':is( .class1.class2.class3   ) { }') is ":is(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':is(.class1:hover   ) { }') is ":is(.class1:hover) { }"
+PASS parseThenSerializeRule(':is(a.class1.class2.class3:hover   ) { }') is ":is(a.class1.class2.class3:hover) { }"
 
-PASS parseThenSerializeRule(':matches(single    ) { }') is ':matches(single) { }'
-PASS parseThenSerializeRule(':matches(a,b    ,p) { }') is ':matches(a, b, p) { }'
-PASS parseThenSerializeRule(':matches(#alice,                   #bob,#chris) { }') is ':matches(#alice, #bob, #chris) { }'
-PASS parseThenSerializeRule(':matches(  .selector,#tama,                #hanayo,#midoriko) { }') is ':matches(.selector, #tama, #hanayo, #midoriko) { }'
-PASS parseThenSerializeRule(':matches(    .name,#ok,:visited   ) { }') is ':matches(.name, #ok, :visited) { }'
-PASS parseThenSerializeRule(':matches(    .name,#ok,    :visited, :link) { }') is ':matches(.name, #ok, :visited, :link) { }'
-PASS parseThenSerializeRule(':matches(    .name,#ok,    :matches(:visited    )) { }') is ':matches(.name, #ok, :matches(:visited)) { }'
-PASS parseThenSerializeRule(':matches(.name,  #ok,:not(:link)) { }') is ':matches(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':matches(.name,#ok,:not(:link)) { }') is ':matches(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':matches(    .name,#ok,:-webkit-any(   hello)) { }') is ':matches(.name, #ok, :-webkit-any(hello)) { }'
-PASS parseThenSerializeRule(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':matches(       [type="file"]) { }') is ':matches([type="file"]) { }'
-PASS parseThenSerializeRule(':matches(  :hover    ) { }') is ':matches(:hover) { }'
-PASS parseThenSerializeRule('input:matches([type="file"],:hover,:focus):enabled { }') is 'input:matches([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':matches(input[type="file"], a:hover, button:focus) { }') is ':matches(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':matches( .class1.class2.class3   ) { }') is ':matches(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':matches(.class1:hover   ) { }') is ':matches(.class1:hover) { }'
-PASS parseThenSerializeRule(':matches(a.class1.class2.class3:hover   ) { }') is ':matches(a.class1.class2.class3:hover) { }'
+PASS parseThenSerializeRule(':matches(single    ) { }') is ":matches(single) { }"
+PASS parseThenSerializeRule(':matches(a,b    ,p) { }') is ":matches(a, b, p) { }"
+PASS parseThenSerializeRule(':matches(#alice,                   #bob,#chris) { }') is ":matches(#alice, #bob, #chris) { }"
+PASS parseThenSerializeRule(':matches(  .selector,#tama,                #hanayo,#midoriko) { }') is ":matches(.selector, #tama, #hanayo, #midoriko) { }"
+PASS parseThenSerializeRule(':matches(    .name,#ok,:visited   ) { }') is ":matches(.name, #ok, :visited) { }"
+PASS parseThenSerializeRule(':matches(    .name,#ok,    :visited, :link) { }') is ":matches(.name, #ok, :visited, :link) { }"
+PASS parseThenSerializeRule(':matches(    .name,#ok,    :matches(:visited    )) { }') is ":matches(.name, #ok, :matches(:visited)) { }"
+PASS parseThenSerializeRule(':matches(.name,  #ok,:not(:link)) { }') is ":matches(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':matches(.name,#ok,:not(:link)) { }') is ":matches(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':matches(    .name,#ok,:-webkit-any(   hello)) { }') is ":matches(.name, #ok, :-webkit-any(hello)) { }"
+PASS parseThenSerializeRule(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ":matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':matches(       [type="file"]) { }') is ":matches([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':matches(  :hover    ) { }') is ":matches(:hover) { }"
+PASS parseThenSerializeRule('input:matches([type="file"],:hover,:focus):enabled { }') is "input:matches([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':matches(input[type="file"], a:hover, button:focus) { }') is ":matches(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':matches( .class1.class2.class3   ) { }') is ":matches(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':matches(.class1:hover   ) { }') is ":matches(.class1:hover) { }"
+PASS parseThenSerializeRule(':matches(a.class1.class2.class3:hover   ) { }') is ":matches(a.class1.class2.class3:hover) { }"
 
-PASS parseThenSerializeRule(':not(single    ) { }') is ':not(single) { }'
-PASS parseThenSerializeRule(':not(a,b    ,p) { }') is ':not(a, b, p) { }'
-PASS parseThenSerializeRule(':not(#alice,                   #bob,#chris) { }') is ':not(#alice, #bob, #chris) { }'
-PASS parseThenSerializeRule(':not(  .selector,#tama,                #hanayo,#midoriko) { }') is ':not(.selector, #tama, #hanayo, #midoriko) { }'
-PASS parseThenSerializeRule(':not(    .name,#ok,:visited   ) { }') is ':not(.name, #ok, :visited) { }'
-PASS parseThenSerializeRule(':not(    .name,#ok,    :visited, :link) { }') is ':not(.name, #ok, :visited, :link) { }'
-PASS parseThenSerializeRule(':not(    .name,#ok,    :not(:visited    )) { }') is ':not(.name, #ok, :not(:visited)) { }'
-PASS parseThenSerializeRule(':not(.name,  #ok,:not(:link)) { }') is ':not(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':not(.name,#ok,:not(:link)) { }') is ':not(.name, #ok, :not(:link)) { }'
-PASS parseThenSerializeRule(':not(    .name,#ok,:-webkit-any(   hello)) { }') is ':not(.name, #ok, :-webkit-any(hello)) { }'
-PASS parseThenSerializeRule(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ':not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'
-PASS parseThenSerializeRule(':not(       [type="file"]) { }') is ':not([type="file"]) { }'
-PASS parseThenSerializeRule(':not(  :hover    ) { }') is ':not(:hover) { }'
-PASS parseThenSerializeRule('input:not([type="file"],:hover,:focus):enabled { }') is 'input:not([type="file"], :hover, :focus):enabled { }'
-PASS parseThenSerializeRule(':not(input[type="file"], a:hover, button:focus) { }') is ':not(input[type="file"], a:hover, button:focus) { }'
-PASS parseThenSerializeRule(':not( .class1.class2.class3   ) { }') is ':not(.class1.class2.class3) { }'
-PASS parseThenSerializeRule(':not(.class1:hover   ) { }') is ':not(.class1:hover) { }'
-PASS parseThenSerializeRule(':not(a.class1.class2.class3:hover   ) { }') is ':not(a.class1.class2.class3:hover) { }'
-PASS parseThenSerializeRule(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris)) { }') is ':not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris)) { }'
-PASS parseThenSerializeRule(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris)) { }') is ':not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris)) { }'
+PASS parseThenSerializeRule(':not(single    ) { }') is ":not(single) { }"
+PASS parseThenSerializeRule(':not(a,b    ,p) { }') is ":not(a, b, p) { }"
+PASS parseThenSerializeRule(':not(#alice,                   #bob,#chris) { }') is ":not(#alice, #bob, #chris) { }"
+PASS parseThenSerializeRule(':not(  .selector,#tama,                #hanayo,#midoriko) { }') is ":not(.selector, #tama, #hanayo, #midoriko) { }"
+PASS parseThenSerializeRule(':not(    .name,#ok,:visited   ) { }') is ":not(.name, #ok, :visited) { }"
+PASS parseThenSerializeRule(':not(    .name,#ok,    :visited, :link) { }') is ":not(.name, #ok, :visited, :link) { }"
+PASS parseThenSerializeRule(':not(    .name,#ok,    :not(:visited    )) { }') is ":not(.name, #ok, :not(:visited)) { }"
+PASS parseThenSerializeRule(':not(.name,  #ok,:not(:link)) { }') is ":not(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':not(.name,#ok,:not(:link)) { }') is ":not(.name, #ok, :not(:link)) { }"
+PASS parseThenSerializeRule(':not(    .name,#ok,:-webkit-any(   hello)) { }') is ":not(.name, #ok, :-webkit-any(hello)) { }"
+PASS parseThenSerializeRule(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }') is ":not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }"
+PASS parseThenSerializeRule(':not(       [type="file"]) { }') is ":not([type=\"file\"]) { }"
+PASS parseThenSerializeRule(':not(  :hover    ) { }') is ":not(:hover) { }"
+PASS parseThenSerializeRule('input:not([type="file"],:hover,:focus):enabled { }') is "input:not([type=\"file\"], :hover, :focus):enabled { }"
+PASS parseThenSerializeRule(':not(input[type="file"], a:hover, button:focus) { }') is ":not(input[type=\"file\"], a:hover, button:focus) { }"
+PASS parseThenSerializeRule(':not( .class1.class2.class3   ) { }') is ":not(.class1.class2.class3) { }"
+PASS parseThenSerializeRule(':not(.class1:hover   ) { }') is ":not(.class1:hover) { }"
+PASS parseThenSerializeRule(':not(a.class1.class2.class3:hover   ) { }') is ":not(a.class1.class2.class3:hover) { }"
+PASS parseThenSerializeRule(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris)) { }') is ":not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris)) { }"
+PASS parseThenSerializeRule(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris)) { }') is ":not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris)) { }"
 
-PASS parseThenSerializeRule(':lang(a    ) { }') is ':lang("a") { }'
-PASS parseThenSerializeRule(':lang(    a) { }') is ':lang("a") { }'
-PASS parseThenSerializeRule(':lang(a,    b,    c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(    a, b ,c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(  a  ,  b  ,  c  ) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(    a  ,b,c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(    a  ,b  ,c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(    a  ,b  ,c  ) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(a,b    ,c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(a,b,    c) { }') is ':lang("a", "b", "c") { }'
-PASS parseThenSerializeRule(':lang(a,b,    c    ) { }') is ':lang("a", "b", "c") { }'
+PASS parseThenSerializeRule(':lang(a    ) { }') is ":lang(a) { }"
+PASS parseThenSerializeRule(':lang(    a) { }') is ":lang(a) { }"
+PASS parseThenSerializeRule(':lang(a,    b,    c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(    a, b ,c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(  a  ,  b  ,  c  ) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(    a  ,b,c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(    a  ,b  ,c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(    a  ,b  ,c  ) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(a,b    ,c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(a,b,    c) { }') is ":lang(a, b, c) { }"
+PASS parseThenSerializeRule(':lang(a,b,    c    ) { }') is ":lang(a, b, c) { }"
 
-PASS parseThenSerializeRule(':lang(en, en, en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(en,en,en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(en,en,    en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(en,    en,en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(en,    en,en    ) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(    en,    en,en    ) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(en,   en,   en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(    en,    en,    en) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(    en,    en,    en    ) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(    en    ,    en    ,   en    ) { }') is ':lang("en", "en", "en") { }'
-PASS parseThenSerializeRule(':lang(    en,en,en    ) { }') is ':lang("en", "en", "en") { }'
+PASS parseThenSerializeRule(':lang(en, en, en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(en,en,en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(en,en,    en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(en,    en,en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(en,    en,en    ) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(    en,    en,en    ) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(en,   en,   en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(    en,    en,    en) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(    en,    en,    en    ) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(    en    ,    en    ,   en    ) { }') is ":lang(en, en, en) { }"
+PASS parseThenSerializeRule(':lang(    en,en,en    ) { }') is ":lang(en, en, en) { }"
 
-PASS parseThenSerializeRule(':lang("*-DE", "*-CH", "*-EN") { }') is ':lang("*-DE", "*-CH", "*-EN") { }'
-PASS parseThenSerializeRule(':lang("*-DE","*-CH","*-EN") { }') is ':lang("*-DE", "*-CH", "*-EN") { }'
-PASS parseThenSerializeRule(':lang(   "*-DE"  ,  "*-CH"  ,  "*-EN"  ) { }') is ':lang("*-DE", "*-CH", "*-EN") { }'
+PASS parseThenSerializeRule(':lang("*-DE", "*-CH", "*-EN") { }') is ":lang(\"*-DE\", \"*-CH\", \"*-EN\") { }"
+PASS parseThenSerializeRule(':lang("*-DE","*-CH","*-EN") { }') is ":lang(\"*-DE\", \"*-CH\", \"*-EN\") { }"
+PASS parseThenSerializeRule(':lang(   "*-DE"  ,  "*-CH"  ,  "*-EN"  ) { }') is ":lang(\"*-DE\", \"*-CH\", \"*-EN\") { }"
 
-PASS parseThenSerializeRule(':lang(\\*) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang("*-\\*") { }') is ':lang("*-*") { }'
-PASS parseThenSerializeRule(':lang("*-\\*-\\*") { }') is ':lang("*-*-*") { }'
-PASS parseThenSerializeRule(':lang("*-\\*-\\*-\\*") { }') is ':lang("*-*-*-*") { }'
+PASS parseThenSerializeRule(':lang(\\*) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang("*-\\*") { }') is ":lang(\"*-*\") { }"
+PASS parseThenSerializeRule(':lang("*-\\*-\\*") { }') is ":lang(\"*-*-*\") { }"
+PASS parseThenSerializeRule(':lang("*-\\*-\\*-\\*") { }') is ":lang(\"*-*-*-*\") { }"
 
-PASS parseThenSerializeRule(':lang(ab-\\*) { }') is ':lang("ab-*") { }'
-PASS parseThenSerializeRule(':lang("*-ab-\\*") { }') is ':lang("*-ab-*") { }'
-PASS parseThenSerializeRule(':lang("*-ab-\\*-") { }') is ':lang("*-ab-*-") { }'
-PASS parseThenSerializeRule(':lang("*-foo-\\3A") { }') is ':lang("*-foo-:") { }'
-PASS parseThenSerializeRule(':lang("*-foo-\\3A\\`\\)") { }') is ':lang("*-foo-:`)") { }'
-PASS parseThenSerializeRule(':lang("*-foo-\\*") { }') is ':lang("*-foo-*") { }'
-PASS parseThenSerializeRule(':lang("*-foo-\\0072 aisin") { }') is ':lang("*-foo-raisin") { }'
-PASS parseThenSerializeRule(':lang("*-foo-\\0062 \\0061 r") { }') is ':lang("*-foo-bar") { }'
-PASS parseThenSerializeRule(':lang("*-foo-col\\6Fr") { }') is ':lang("*-foo-color") { }'
+PASS parseThenSerializeRule(':lang(ab-\\*) { }') is ":lang(ab-\\*) { }"
+PASS parseThenSerializeRule(':lang("*-ab-\\*") { }') is ":lang(\"*-ab-*\") { }"
+PASS parseThenSerializeRule(':lang("*-ab-\\*-") { }') is ":lang(\"*-ab-*-\") { }"
+PASS parseThenSerializeRule(':lang("*-foo-\\3A") { }') is ":lang(\"*-foo-:\") { }"
+PASS parseThenSerializeRule(':lang("*-foo-\\3A\\`\\)") { }') is ":lang(\"*-foo-:`)\") { }"
+PASS parseThenSerializeRule(':lang("*-foo-\\*") { }') is ":lang(\"*-foo-*\") { }"
+PASS parseThenSerializeRule(':lang("*-foo-\\0072 aisin") { }') is ":lang(\"*-foo-raisin\") { }"
+PASS parseThenSerializeRule(':lang("*-foo-\\0062 \\0061 r") { }') is ":lang(\"*-foo-bar\") { }"
+PASS parseThenSerializeRule(':lang("*-foo-col\\6Fr") { }') is ":lang(\"*-foo-color\") { }"
 
-PASS parseThenSerializeRule(':lang(\\*    ) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang("*-en"    ) { }') is ':lang("*-en") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*"    ) { }') is ':lang("*-en-*") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr"    ) { }') is ':lang("*-en-*-fr") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",br    ) { }') is ':lang("*-en-*-fr", "br") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr", br    ) { }') is ':lang("*-en-*-fr", "br") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",   br    ) { }') is ':lang("*-en-*-fr", "br") { }'
-PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr",   br    ) { }') is ':lang("*-en-*-fr", "br") { }'
-PASS parseThenSerializeRule(':lang(    "*-en-\\*-fr",   br    ) { }') is ':lang("*-en-*-fr", "br") { }'
-PASS parseThenSerializeRule(':lang(    "*-en-\\*-fr"  ,   br    ) { }') is ':lang("*-en-*-fr", "br") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr","*-br-zh"    ) { }') is ':lang("*-en-*-fr", "*-br-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr", "*-br-zh"    ) { }') is ':lang("*-en-*-fr", "*-br-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",   "*-br-zh"    ) { }') is ':lang("*-en-*-fr", "*-br-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",     "*-br-zh"    ) { }') is ':lang("*-en-*-fr", "*-br-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",       "*-br-zh"    ) { }') is ':lang("*-en-*-fr", "*-br-zh") { }'
+PASS parseThenSerializeRule(':lang(\\*    ) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang("*-en"    ) { }') is ":lang(\"*-en\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*"    ) { }') is ":lang(\"*-en-*\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr"    ) { }') is ":lang(\"*-en-*-fr\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",br    ) { }') is ":lang(\"*-en-*-fr\", br) { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr", br    ) { }') is ":lang(\"*-en-*-fr\", br) { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",   br    ) { }') is ":lang(\"*-en-*-fr\", br) { }"
+PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr",   br    ) { }') is ":lang(\"*-en-*-fr\", br) { }"
+PASS parseThenSerializeRule(':lang(    "*-en-\\*-fr",   br    ) { }') is ":lang(\"*-en-*-fr\", br) { }"
+PASS parseThenSerializeRule(':lang(    "*-en-\\*-fr"  ,   br    ) { }') is ":lang(\"*-en-*-fr\", br) { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr","*-br-zh"    ) { }') is ":lang(\"*-en-*-fr\", \"*-br-zh\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr", "*-br-zh"    ) { }') is ":lang(\"*-en-*-fr\", \"*-br-zh\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",   "*-br-zh"    ) { }') is ":lang(\"*-en-*-fr\", \"*-br-zh\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",     "*-br-zh"    ) { }') is ":lang(\"*-en-*-fr\", \"*-br-zh\") { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",       "*-br-zh"    ) { }') is ":lang(\"*-en-*-fr\", \"*-br-zh\") { }"
 
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr", br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",   br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
-PASS parseThenSerializeRule(':lang("*-en-\\*-fr",      br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
-PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr",      br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
-PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr" ,      br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
-PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr"  ,      br-\\*-zh    ) { }') is ':lang("*-en-*-fr", "br-*-zh") { }'
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr", br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",   br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
+PASS parseThenSerializeRule(':lang("*-en-\\*-fr",      br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
+PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr",      br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
+PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr" ,      br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
+PASS parseThenSerializeRule(':lang(  "*-en-\\*-fr"  ,      br-\\*-zh    ) { }') is ":lang(\"*-en-*-fr\", br-\\*-zh) { }"
 
-PASS parseThenSerializeRule(':lang(\\*) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang(\\* ) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang(\\*   ) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang( \\*   ) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang(  \\*) { }') is ':lang("*") { }'
-PASS parseThenSerializeRule(':lang(   \\*   ) { }') is ':lang("*") { }'
+PASS parseThenSerializeRule(':lang(\\*) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang(\\* ) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang(\\*   ) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang( \\*   ) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang(  \\*) { }') is ":lang(\\*) { }"
+PASS parseThenSerializeRule(':lang(   \\*   ) { }') is ":lang(\\*) { }"
 
-PASS parseThenSerializeRule(':lang(   \\*,id-\\*-sumatra   ) { }') is ':lang("*", "id-*-sumatra") { }'
-PASS parseThenSerializeRule(':lang(   \\* ,id-\\*-sumatra) { }') is ':lang("*", "id-*-sumatra") { }'
-PASS parseThenSerializeRule(':lang(   \\*  ,  id-\\*-sumatra  ) { }') is ':lang("*", "id-*-sumatra") { }'
-PASS parseThenSerializeRule(':lang(   \\*   ,    id-\\*-sumatra  ) { }') is ':lang("*", "id-*-sumatra") { }'
+PASS parseThenSerializeRule(':lang(   \\*,id-\\*-sumatra   ) { }') is ":lang(\\*, id-\\*-sumatra) { }"
+PASS parseThenSerializeRule(':lang(   \\* ,id-\\*-sumatra) { }') is ":lang(\\*, id-\\*-sumatra) { }"
+PASS parseThenSerializeRule(':lang(   \\*  ,  id-\\*-sumatra  ) { }') is ":lang(\\*, id-\\*-sumatra) { }"
+PASS parseThenSerializeRule(':lang(   \\*   ,    id-\\*-sumatra  ) { }') is ":lang(\\*, id-\\*-sumatra) { }"
 
-PASS parseThenSerializeRule(':lang(en-\\*) { }') is ':lang("en-*") { }'
-PASS parseThenSerializeRule(':lang(en-\\*, fr-\\*) { }') is ':lang("en-*", "fr-*") { }'
-PASS parseThenSerializeRule(':lang(en-\\*, fr-\\* ) { }') is ':lang("en-*", "fr-*") { }'
-PASS parseThenSerializeRule(':lang(   en-\\*   ,  fr-\\*   ) { }') is ':lang("en-*", "fr-*") { }'
-PASS parseThenSerializeRule(':lang(   en-\\*   ,fr-\\*   ) { }') is ':lang("en-*", "fr-*") { }'
-PASS parseThenSerializeRule(':lang(   en-\\*,fr-\\*   ) { }') is ':lang("en-*", "fr-*") { }'
+PASS parseThenSerializeRule(':lang(en-\\*) { }') is ":lang(en-\\*) { }"
+PASS parseThenSerializeRule(':lang(en-\\*, fr-\\*) { }') is ":lang(en-\\*, fr-\\*) { }"
+PASS parseThenSerializeRule(':lang(en-\\*, fr-\\* ) { }') is ":lang(en-\\*, fr-\\*) { }"
+PASS parseThenSerializeRule(':lang(   en-\\*   ,  fr-\\*   ) { }') is ":lang(en-\\*, fr-\\*) { }"
+PASS parseThenSerializeRule(':lang(   en-\\*   ,fr-\\*   ) { }') is ":lang(en-\\*, fr-\\*) { }"
+PASS parseThenSerializeRule(':lang(   en-\\*,fr-\\*   ) { }') is ":lang(en-\\*, fr-\\*) { }"
 
 PASS parseThenSerializeRule(':lang() { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
 PASS parseThenSerializeRule(':lang(12, b, c) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
@@ -555,11 +555,11 @@ PASS parseThenSerializeRule(':lang(   *-1996,*-1997   ) { }') threw exception Ty
 
 PASS parseThenSerializeRule(':role(a) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
 
-PASS parseThenSerializeRule(':dir(ltr) { }') is ':dir(ltr) { }'
-PASS parseThenSerializeRule(':dir(rtl) { }') is ':dir(rtl) { }'
-PASS parseThenSerializeRule(':dir(LTR) { }') is ':dir(LTR) { }'
-PASS parseThenSerializeRule(':dir(aBcD) { }') is ':dir(aBcD) { }'
-PASS parseThenSerializeRule(':dir( a    ) { }') is ':dir(a) { }'
+PASS parseThenSerializeRule(':dir(ltr) { }') is ":dir(ltr) { }"
+PASS parseThenSerializeRule(':dir(rtl) { }') is ":dir(rtl) { }"
+PASS parseThenSerializeRule(':dir(LTR) { }') is ":dir(LTR) { }"
+PASS parseThenSerializeRule(':dir(aBcD) { }') is ":dir(aBcD) { }"
+PASS parseThenSerializeRule(':dir( a    ) { }') is ":dir(a) { }"
 
 PASS parseThenSerializeRule(':dir() { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').
 PASS parseThenSerializeRule(':dir(42) { }') threw exception TypeError: undefined is not an object (evaluating 'styleElement.sheet.cssRules[0].cssText').

--- a/LayoutTests/fast/css/css-selector-text.html
+++ b/LayoutTests/fast/css/css-selector-text.html
@@ -1,730 +1,723 @@
 <html>
 <head id="head">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
 
-description("This tests parsing and re-serialization of some CSS selectors.");
+description("This tests parsing and re-serialization of some CSS selectors.")
 
 function parseThenSerializeRule(rule)
 {
-    var styleElement = document.getElementById("style");
-    var head = document.getElementById("head");
+    var styleElement = document.getElementById("style")
+    var head = document.getElementById("head")
     if (styleElement)
-        head.removeChild(styleElement);
+        head.removeChild(styleElement)
 
-    styleElement = document.createElement("style");
-    styleElement.id = "style";
-    var head = document.getElementById("head");
-    head.appendChild(styleElement);
+    styleElement = document.createElement("style")
+    styleElement.id = "style"
+    var head = document.getElementById("head")
+    head.appendChild(styleElement)
     
-    styleElement.appendChild(document.createTextNode(rule));
-    return styleElement.sheet.cssRules[0].cssText;
+    styleElement.appendChild(document.createTextNode(rule))
+    return styleElement.sheet.cssRules[0].cssText
 }
 
 function expectedSerializedLangSelector(selector)
 {
-    var args = /:lang\(([^)]+)/.exec(selector);
+    var args = /:lang\(([^)]+)/.exec(selector)
     if (!args || !args[1])
-        return selector;
+        return selector
 
-    args = args[1].split(/\s*,\s*/);
-    var expected = ':lang(';
+    args = args[1].split(/\s*,\s*/)
+    var expected = ':lang('
     for (var i = 0; i < args.length; ++i) {
-        var arg = args[i];
-        var hasQuotes = arg.indexOf('"') == 0 && arg.lastIndexOf('"') == arg.length - 1;
-        if (!hasQuotes)
-            expected += '"';
-        expected += args[i];
-        if (!hasQuotes)
-            expected += '"';
+        expected += args[i]
         if (i < args.length - 1)
-            expected += ', ';
+            expected += ', '
     }
-    expected += ')';
-    return expected;
+    expected += ')'
+    return expected
 }
 
 function testSelectorSerialization(selector, expectedSelector)
 {
-    shouldBe("parseThenSerializeRule('" + selector + " { }')", "'" + expectedSelector + " { }'");
+    shouldBeEqualToString("parseThenSerializeRule('" + selector + " { }')", expectedSelector + " { }")
 }
 
 function testSelectorRoundTrip(selector)
 {
-    var expected = selector.indexOf(":lang") == 0 ? expectedSerializedLangSelector(selector) : selector;
-    shouldBe("parseThenSerializeRule('" + selector + " { }')", "'" + expected + " { }'");
+    var expected = selector.indexOf(":lang") == 0 ? expectedSerializedLangSelector(selector) : selector
+    shouldBeEqualToString("parseThenSerializeRule('" + selector + " { }')", expected + " { }")
 }
 
-testSelectorRoundTrip('*');
-testSelectorRoundTrip('a');
-testSelectorRoundTrip('#a');
-testSelectorRoundTrip('.a');
-testSelectorRoundTrip(':active');
-testSelectorRoundTrip('[a]');
-testSelectorRoundTrip('[a="b"]');
-testSelectorRoundTrip('[a~="b"]');
-testSelectorRoundTrip('[a|="b"]');
-testSelectorRoundTrip('[a^="b"]');
-testSelectorRoundTrip('[a$="b"]');
-testSelectorRoundTrip('[a*="b"]');
-testSelectorRoundTrip('[a="b" i]');
-testSelectorRoundTrip('[a~="b" i]');
-testSelectorRoundTrip('[a|="b" i]');
-testSelectorRoundTrip('[a^="b" i]');
-testSelectorRoundTrip('[a$="b" i]');
-testSelectorRoundTrip('[a*="b" i]');
-
-debug('');
-
-shouldBe("parseThenSerializeRule('*|a { }')", "'a { }'");
-shouldBe("parseThenSerializeRule('*|* { }')", "'* { }'");
-testSelectorRoundTrip('|a');
-testSelectorRoundTrip('|*');
-testSelectorRoundTrip('[*|a]');
-shouldBe("parseThenSerializeRule('[|a] { }')", "'[a] { }'");
-
-debug('');
-
-testSelectorRoundTrip('a:active');
-testSelectorRoundTrip('a b');
-testSelectorRoundTrip('a + b');
-testSelectorRoundTrip('a ~ b');
-testSelectorRoundTrip('a > b');
-
-debug('');
-
-testSelectorRoundTrip(":active");
-testSelectorRoundTrip(":any-link");
-testSelectorRoundTrip(":checked");
-testSelectorRoundTrip(":disabled");
-testSelectorRoundTrip(":empty");
-testSelectorRoundTrip(":enabled");
-testSelectorRoundTrip(":first-child");
-testSelectorRoundTrip(":first-of-type");
-testSelectorRoundTrip(":focus");
-testSelectorRoundTrip(":hover");
-testSelectorRoundTrip(":indeterminate");
-testSelectorRoundTrip(":link");
-testSelectorRoundTrip(":not(:placeholder-shown)");
-testSelectorRoundTrip(":placeholder-shown");
-testSelectorRoundTrip(":root");
-testSelectorRoundTrip(":target");
-testSelectorRoundTrip(":visited");
-
-debug('');
-
-testSelectorRoundTrip(':lang("*-ab")');
-testSelectorRoundTrip(':lang("*-ab-")');
-testSelectorRoundTrip(':lang("*-DE-1996")');
-
-debug('');
-
-testSelectorRoundTrip(":lang(a)");
-testSelectorRoundTrip(":lang(a, b, c)");
-testSelectorRoundTrip(":lang(fr, de, en, id)");
-testSelectorRoundTrip(":lang(fr, fr-ca, fr-be)");
-testSelectorRoundTrip(":lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996)");
-testSelectorRoundTrip(":lang(de-CH, it-CH, fr-CH, rm-CH)");
-testSelectorRoundTrip(":lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996, de-CH, it-CH, fr-CH, rm-CH)");
-
-debug('');
-
-testSelectorRoundTrip(":lang(a, a, a)");
-testSelectorRoundTrip(":lang(en, en, en)");
-testSelectorRoundTrip(":lang(en-us, en-us, en-us)");
-testSelectorRoundTrip(":lang(de-DE-1996, de-DE-1996, de-DE-1996)");
-testSelectorRoundTrip(":lang(de-Latn-DE-1996, de-Latn-DE-1996, de-Latn-DE-1996)");
-testSelectorRoundTrip(":lang(java, java, java)");
-
-debug('');
-
-testSelectorRoundTrip(":not(a)");
-testSelectorRoundTrip(":-webkit-any(a, b, p)");
-
-debug('');
-
-testSelectorRoundTrip("::after");
-testSelectorRoundTrip("::before");
-testSelectorRoundTrip("::first-letter");
-testSelectorRoundTrip("::first-line");
-testSelectorRoundTrip("::selection");
-
-debug('');
-
-testSelectorRoundTrip(":-webkit-any-link");
-testSelectorRoundTrip(":-webkit-drag");
-testSelectorRoundTrip(":autofill");
-testSelectorSerialization(":-webkit-autofill", ":autofill");
-
-debug('');
-
-testSelectorSerialization(":nth-child(odd)", ":nth-child(2n+1)");
-testSelectorSerialization(":nth-child(even)", ":nth-child(2n)");
-testSelectorRoundTrip(":nth-child(n)");
-testSelectorRoundTrip(":nth-child(-n)");
-testSelectorRoundTrip(":nth-child(5)");
-testSelectorRoundTrip(":nth-child(-5)");
-testSelectorRoundTrip(":nth-child(5n+7)");
-testSelectorRoundTrip(":nth-child(-5n+7)");
-testSelectorRoundTrip(":nth-child(5n-7)");
-testSelectorRoundTrip(":nth-child(-5n-7)");
-
-debug('');
-
-testSelectorSerialization(":nth-child(odd of .foo, :nth-child(odd))", ":nth-child(2n+1 of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(even of .foo, :nth-child(odd))", ":nth-child(2n of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(n of .foo, :nth-child(odd))", ":nth-child(n of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(-n of .foo, :nth-child(odd))", ":nth-child(-n of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(5 of .foo, :nth-child(odd))", ":nth-child(5 of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(-5 of .foo, :nth-child(odd))", ":nth-child(-5 of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(5n+7 of .foo, :nth-child(odd))", ":nth-child(5n+7 of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(-5n+7 of .foo, :nth-child(odd))", ":nth-child(-5n+7 of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(5n-7 of .foo, :nth-child(odd))", ":nth-child(5n-7 of .foo, :nth-child(2n+1))");
-testSelectorSerialization(":nth-child(-5n-7 of .foo, :nth-child(odd))", ":nth-child(-5n-7 of .foo, :nth-child(2n+1))");
-
-debug('');
-
-testSelectorSerialization(":nth-last-child(odd of .foo, :nth-last-child(odd))", ":nth-last-child(2n+1 of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(even of .foo, :nth-last-child(odd))", ":nth-last-child(2n of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(n of .foo, :nth-last-child(odd))", ":nth-last-child(n of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(-n of .foo, :nth-last-child(odd))", ":nth-last-child(-n of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(5 of .foo, :nth-last-child(odd))", ":nth-last-child(5 of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(-5 of .foo, :nth-last-child(odd))", ":nth-last-child(-5 of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(5n+7 of .foo, :nth-last-child(odd))", ":nth-last-child(5n+7 of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(-5n+7 of .foo, :nth-last-child(odd))", ":nth-last-child(-5n+7 of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(5n-7 of .foo, :nth-last-child(odd))", ":nth-last-child(5n-7 of .foo, :nth-last-child(2n+1))");
-testSelectorSerialization(":nth-last-child(-5n-7 of .foo, :nth-last-child(odd))", ":nth-last-child(-5n-7 of .foo, :nth-last-child(2n+1))");
-
-debug('');
-
-testSelectorRoundTrip(':is(single)');
-testSelectorRoundTrip(':is(a, b, p)');
-testSelectorRoundTrip(':is(#alice, #bob, #chris)');
-testSelectorRoundTrip(':is(.selector, #tama, #hanayo, #midoriko)');
-testSelectorRoundTrip(':is(.name, #ok, :visited)');
-testSelectorRoundTrip(':is(.name, #ok, :visited, :link)');
-testSelectorRoundTrip(':is(.name, #ok, :is(:visited))');
-testSelectorRoundTrip(':is(.name, #ok, :not(:link))');
-testSelectorRoundTrip(':is(.name, #ok, :not(:link))');
-testSelectorRoundTrip(':is(.name, #ok, :-webkit-any(hello))');
-testSelectorRoundTrip(':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':is([type="file"])');
-testSelectorRoundTrip(':is(:hover)');
-testSelectorRoundTrip('input:is([type="file"], :hover, :focus):enabled');
-testSelectorRoundTrip(':is(input[type="file"], a:hover, button:focus)');
-testSelectorRoundTrip(':is(.class1.class2.class3)');
-testSelectorRoundTrip(':is(.class1:hover)');
-testSelectorRoundTrip(':is(a.class1.class2.class3:hover)');
-testSelectorRoundTrip(':where(single)');
-testSelectorRoundTrip(':where(a, b, p)');
-testSelectorRoundTrip(':where(#alice, #bob, #chris)');
-testSelectorRoundTrip(':where(.selector, #tama, #hanayo, #midoriko)');
-testSelectorRoundTrip(':where(.name, #ok, :visited)');
-testSelectorRoundTrip(':where(.name, #ok, :visited, :link)');
-testSelectorRoundTrip(':where(.name, #ok, :where(:visited))');
-testSelectorRoundTrip(':where(.name, #ok, :not(:link))');
-testSelectorRoundTrip(':where(.name, #ok, :not(:link))');
-testSelectorRoundTrip(':where(.name, #ok, :where(hello))');
-testSelectorRoundTrip(':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':where([type="file"])');
-testSelectorRoundTrip(':where(:hover)');
-testSelectorRoundTrip('input:where([type="file"], :hover, :focus):enabled');
-testSelectorRoundTrip(':where(input[type="file"], a:hover, button:focus)');
-testSelectorRoundTrip(':where(.class1.class2.class3)');
-testSelectorRoundTrip(':where(.class1:hover)');
-testSelectorRoundTrip(':where(a.class1.class2.class3:hover)');
-testSelectorRoundTrip(':matches(:is(single))');
-testSelectorRoundTrip(':matches(:is(a, b, p))');
-testSelectorRoundTrip(':matches(:is(#alice, #bob, #chris))');
-testSelectorRoundTrip(':matches(:is(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :visited))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :visited, :link))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :is(:visited)))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :matches(hello)))');
-testSelectorRoundTrip(':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko)))');
-testSelectorRoundTrip(':matches(:is([type="file"]))');
-testSelectorRoundTrip(':matches(:is(:hover))');
-testSelectorRoundTrip(':matches(input:is([type="file"], :hover, :focus):enabled)');
-testSelectorRoundTrip(':matches(:is(input[type="file"], a:hover, button:focus))');
-testSelectorRoundTrip(':matches(:is(.class1.class2.class3))');
-testSelectorRoundTrip(':matches(:is(.class1:hover))');
-testSelectorRoundTrip(':matches(:is(a.class1.class2.class3:hover))');
-testSelectorRoundTrip(':-webkit-any(:is(single))');
-testSelectorRoundTrip(':-webkit-any(:is(a, b, p))');
-testSelectorRoundTrip(':-webkit-any(:is(#alice, #bob, #chris))');
-testSelectorRoundTrip(':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :visited))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :visited, :link))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :is(:visited)))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :-webkit-any(hello)))');
-testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))');
-testSelectorRoundTrip(':-webkit-any(:is([type="file"]))');
-testSelectorRoundTrip(':-webkit-any(:is(:hover))');
-testSelectorRoundTrip(':-webkit-any(input:is([type="file"], :hover, :focus):enabled)');
-testSelectorRoundTrip(':-webkit-any(:is(input[type="file"], a:hover, button:focus))');
-testSelectorRoundTrip(':-webkit-any(:is(.class1.class2.class3))');
-testSelectorRoundTrip(':-webkit-any(:is(.class1:hover))');
-testSelectorRoundTrip(':-webkit-any(:is(a.class1.class2.class3:hover))');
-
-debug('');
-
-testSelectorRoundTrip(':matches(single)');
-testSelectorRoundTrip(':matches(a, b, p)');
-testSelectorRoundTrip(':matches(#alice, #bob, #chris)');
-testSelectorRoundTrip(':matches(.selector, #tama, #hanayo, #midoriko)');
-testSelectorRoundTrip(':matches(.name, #ok, :visited)');
-testSelectorRoundTrip(':matches(.name, #ok, :visited, :link)');
-testSelectorRoundTrip(':matches(.name, #ok, :matches(:visited))');
-testSelectorRoundTrip(':matches(.name, #ok, :not(:link))');
-testSelectorRoundTrip(':matches(.name, #ok, :not(:link))');
-testSelectorRoundTrip(':matches(.name, #ok, :-webkit-any(hello))');
-testSelectorRoundTrip(':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':matches([type="file"])');
-testSelectorRoundTrip(':matches(:hover)');
-testSelectorRoundTrip('input:matches([type="file"], :hover, :focus):enabled');
-testSelectorRoundTrip(':matches(input[type="file"], a:hover, button:focus)');
-testSelectorRoundTrip(':matches(.class1.class2.class3)');
-testSelectorRoundTrip(':matches(.class1:hover)');
-testSelectorRoundTrip(':matches(a.class1.class2.class3:hover)');
-testSelectorRoundTrip(':is(:matches(single))');
-testSelectorRoundTrip(':is(:matches(a, b, p))');
-testSelectorRoundTrip(':is(:matches(#alice, #bob, #chris))');
-testSelectorRoundTrip(':is(:matches(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :visited))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :visited, :link))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :matches(:visited)))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :is(hello)))');
-testSelectorRoundTrip(':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko)))');
-testSelectorRoundTrip(':is(:matches([type="file"]))');
-testSelectorRoundTrip(':is(:matches(:hover))');
-testSelectorRoundTrip(':is(input:matches([type="file"], :hover, :focus):enabled)');
-testSelectorRoundTrip(':is(:matches(input[type="file"], a:hover, button:focus))');
-testSelectorRoundTrip(':is(:matches(.class1.class2.class3))');
-testSelectorRoundTrip(':is(:matches(.class1:hover))');
-testSelectorRoundTrip(':is(:matches(a.class1.class2.class3:hover))');
-testSelectorRoundTrip(':-webkit-any(:matches(single))');
-testSelectorRoundTrip(':-webkit-any(:matches(a, b, p))');
-testSelectorRoundTrip(':-webkit-any(:matches(#alice, #bob, #chris))');
-testSelectorRoundTrip(':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :visited))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :visited, :link))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :matches(:visited)))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :not(:link)))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :-webkit-any(hello)))');
-testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))');
-testSelectorRoundTrip(':-webkit-any(:matches([type="file"]))');
-testSelectorRoundTrip(':-webkit-any(:matches(:hover))');
-testSelectorRoundTrip(':-webkit-any(input:matches([type="file"], :hover, :focus):enabled)');
-testSelectorRoundTrip(':-webkit-any(:matches(input[type="file"], a:hover, button:focus))');
-testSelectorRoundTrip(':-webkit-any(:matches(.class1.class2.class3))');
-testSelectorRoundTrip(':-webkit-any(:matches(.class1:hover))');
-testSelectorRoundTrip(':-webkit-any(:matches(a.class1.class2.class3:hover))');
-
-debug('');
-
-testSelectorRoundTrip(':not(div)');
-testSelectorRoundTrip(':not(.div)');
-testSelectorRoundTrip(':not(#div)');
-testSelectorRoundTrip(':not([div])');
-testSelectorRoundTrip(':not(:empty)');
-testSelectorRoundTrip(':not(div.div#div[div]:empty)');
-testSelectorRoundTrip(':not(div.div:empty[div]#div)');
-testSelectorRoundTrip(':not(div.div, #div[div], :empty)');
-testSelectorRoundTrip(':not(div, .div, #div, [div], :empty)');
-
-testSelectorRoundTrip(':not(:not(div))');
-testSelectorRoundTrip(':not(:not(div)):not(:not(foo)):not(:not(bar))');
-testSelectorRoundTrip(':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz))');
-
-testSelectorRoundTrip(':not(:is(*))');
-testSelectorRoundTrip(':not(:is(foo, bar))');
-testSelectorRoundTrip(':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar]))');
-testSelectorRoundTrip(':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar]))');
-
-testSelectorRoundTrip(':not(:matches(*))');
-testSelectorRoundTrip(':not(:matches(foo, bar))');
-testSelectorRoundTrip(':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar]))');
-testSelectorRoundTrip(':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar]))');
-
-testSelectorRoundTrip(':nth-child(2n of :not(a.b, c#d.e))');
-testSelectorRoundTrip(':not(:nth-child(2n of :not(a.b, c#d.e)))');
-
-testSelectorRoundTrip(':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)');
-testSelectorRoundTrip('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)');
-
-debug('');
-
-shouldBe("parseThenSerializeRule('::-webkit-file-upload-button { }')", "'::-webkit-file-upload-button { }'");
-shouldBe("parseThenSerializeRule('::-webkit-search-cancel-button { }')", "'::-webkit-search-cancel-button { }'");
-shouldBe("parseThenSerializeRule('::-webkit-search-decoration { }')", "'::-webkit-search-decoration { }'");
-shouldBe("parseThenSerializeRule('::-webkit-search-results-button { }')", "'::-webkit-search-results-button { }'");
-shouldBe("parseThenSerializeRule('::-webkit-search-results-decoration { }')", "'::-webkit-search-results-decoration { }'");
-shouldBe("parseThenSerializeRule('::-webkit-slider-thumb { }')", "'::-webkit-slider-thumb { }'");
-shouldBe("parseThenSerializeRule('::file-selector-button { }')", "'::file-selector-button { }'");
-
-debug('');
-
-testSelectorRoundTrip("a::-webkit-slider-thumb");
-shouldBe("parseThenSerializeRule('a ::-webkit-slider-thumb { }')", "'a ::-webkit-slider-thumb { }'");
-testSelectorRoundTrip("[a]::-webkit-slider-thumb");
-shouldBe("parseThenSerializeRule('[a] ::-webkit-slider-thumb { }')", "'[a] ::-webkit-slider-thumb { }'");
-testSelectorRoundTrip(".a::-webkit-slider-thumb");
-shouldBe("parseThenSerializeRule('.a ::-webkit-slider-thumb { }')", "'.a ::-webkit-slider-thumb { }'");
-testSelectorRoundTrip("#a::-webkit-slider-thumb");
-shouldBe("parseThenSerializeRule('#a ::-webkit-slider-thumb { }')", "'#a ::-webkit-slider-thumb { }'");
-shouldBe("parseThenSerializeRule('* ::-webkit-slider-thumb { }')", "'* ::-webkit-slider-thumb { }'");
-
-debug('');
-
-testSelectorRoundTrip("a[b]::-webkit-slider-thumb");
-testSelectorRoundTrip("a.b::-webkit-slider-thumb");
-testSelectorRoundTrip("a#b::-webkit-slider-thumb");
-testSelectorRoundTrip("a[b].c#d::-webkit-slider-thumb");
-
-debug('');
-
-testSelectorRoundTrip("a[b]::placeholder");
-testSelectorRoundTrip("a.b::placeholder");
-testSelectorRoundTrip("a#b::placeholder");
-testSelectorRoundTrip("a[b].c#d::placeholder");
-testSelectorRoundTrip("a[b]::-webkit-input-placeholder");
-testSelectorRoundTrip("a.b::-webkit-input-placeholder");
-testSelectorRoundTrip("a#b::-webkit-input-placeholder");
-testSelectorRoundTrip("a[b].c#d::-webkit-input-placeholder");
-
-debug('');
-
-testSelectorRoundTrip("a[b]:default");
-testSelectorRoundTrip("a.b:default");
-testSelectorRoundTrip("a#b:default");
-testSelectorRoundTrip("a[b].c#d:default");
-
-debug('');
-
-testSelectorRoundTrip("a[b]:in-range");
-testSelectorRoundTrip("a.b:in-range");
-testSelectorRoundTrip("a#b:in-range");
-testSelectorRoundTrip("a[b].c#d:in-range");
-
-debug('');
-
-testSelectorRoundTrip("a[b]:out-of-range");
-testSelectorRoundTrip("a.b:out-of-range");
-testSelectorRoundTrip("a#b:out-of-range");
-testSelectorRoundTrip("a[b].c#d:out-of-range");
-
-debug('');
-
-testSelectorRoundTrip("a[b]:focus-within");
-testSelectorRoundTrip("a.b:focus-within");
-testSelectorRoundTrip("a#b:focus-within");
-testSelectorRoundTrip("a[b].c#d:focus-within");
-
-debug('');
-
-testSelectorRoundTrip('input:not([type="file"]):focus');
-testSelectorRoundTrip(':-webkit-any([type="file"])');
-testSelectorRoundTrip(':-webkit-any(:hover)');
-testSelectorRoundTrip('input:-webkit-any([type="file"], :hover, :focus):enabled');
-testSelectorRoundTrip(':-webkit-any(input[type="file"], a:hover, button:focus)');
-testSelectorRoundTrip(':-webkit-any(.class1.class2.class3)');
-testSelectorRoundTrip(':-webkit-any(.class1:hover)');
-testSelectorRoundTrip(':-webkit-any(a.class1.class2.class3:hover)');
-testSelectorRoundTrip('a:any-link');
-testSelectorRoundTrip('a :any-link');
-testSelectorRoundTrip('div:any-link');
-testSelectorRoundTrip('div :any-link');
-testSelectorRoundTrip(':any-link > div');
-testSelectorRoundTrip(':any-link + div');
-testSelectorRoundTrip(':not(:any-link)');
-
-debug('');
-
-shouldBe("parseThenSerializeRule('*:active { }')", "':active { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule('input[type=file]:focus { }')", "'input[type=\"file\"]:focus { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule('a+b { }')", "'a + b { }'");
-shouldBe("parseThenSerializeRule('a~b { }')", "'a ~ b { }'");
-shouldBe("parseThenSerializeRule('a>b { }')", "'a > b { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':after { }')", "'::after { }'");
-shouldBe("parseThenSerializeRule(':before { }')", "'::before { }'");
-shouldBe("parseThenSerializeRule(':first-letter { }')", "'::first-letter { }'");
-shouldBe("parseThenSerializeRule(':first-line { }')", "'::first-line { }'");
-shouldBe("parseThenSerializeRule(':-webkit-any(    a.class1  ,  	#id,[attr]  ) { }')","':-webkit-any(a.class1, #id, [attr]) { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':is(single    ) { }')", "':is(single) { }'");
-shouldBe("parseThenSerializeRule(':is(a,b    ,p) { }')", "':is(a, b, p) { }'");
-shouldBe("parseThenSerializeRule(':is(#alice,                   #bob,#chris) { }')", "':is(#alice, #bob, #chris) { }'");
-shouldBe("parseThenSerializeRule(':is(  .selector,#tama,                #hanayo,#midoriko) { }')", "':is(.selector, #tama, #hanayo, #midoriko) { }'");
-shouldBe("parseThenSerializeRule(':is(    .name,#ok,:visited   ) { }')", "':is(.name, #ok, :visited) { }'");
-shouldBe("parseThenSerializeRule(':is(    .name,#ok,    :visited, :link) { }')", "':is(.name, #ok, :visited, :link) { }'");
-shouldBe("parseThenSerializeRule(':is(    .name,#ok,    :is(:visited    )) { }')", "':is(.name, #ok, :is(:visited)) { }'");
-shouldBe("parseThenSerializeRule(':is(.name,  #ok,:not(:link)) { }')", "':is(.name, #ok, :not(:link)) { }'");
-shouldBe("parseThenSerializeRule(':is(.name,#ok,:not(:link)) { }')", "':is(.name, #ok, :not(:link)) { }'");
-shouldBe("parseThenSerializeRule(':is(    .name,#ok,:-webkit-any(   hello)) { }')", "':is(.name, #ok, :-webkit-any(hello)) { }'");
-shouldBe("parseThenSerializeRule(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }')", "':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'");
-shouldBe("parseThenSerializeRule(':is(       [type=\"file\"]) { }')", "':is([type=\"file\"]) { }'");
-shouldBe("parseThenSerializeRule(':is(  :hover    ) { }')", "':is(:hover) { }'");
-shouldBe("parseThenSerializeRule('input:is([type=\"file\"],:hover,:focus):enabled { }')", "'input:is([type=\"file\"], :hover, :focus):enabled { }'");
-shouldBe("parseThenSerializeRule(':is(input[type=\"file\"], a:hover, button:focus) { }')", "':is(input[type=\"file\"], a:hover, button:focus) { }'");
-shouldBe("parseThenSerializeRule(':is( .class1.class2.class3   ) { }')", "':is(.class1.class2.class3) { }'");
-shouldBe("parseThenSerializeRule(':is(.class1:hover   ) { }')", "':is(.class1:hover) { }'");
-shouldBe("parseThenSerializeRule(':is(a.class1.class2.class3:hover   ) { }')", "':is(a.class1.class2.class3:hover) { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':matches(single    ) { }')", "':matches(single) { }'");
-shouldBe("parseThenSerializeRule(':matches(a,b    ,p) { }')", "':matches(a, b, p) { }'");
-shouldBe("parseThenSerializeRule(':matches(#alice,                   #bob,#chris) { }')", "':matches(#alice, #bob, #chris) { }'");
-shouldBe("parseThenSerializeRule(':matches(  .selector,#tama,                #hanayo,#midoriko) { }')", "':matches(.selector, #tama, #hanayo, #midoriko) { }'");
-shouldBe("parseThenSerializeRule(':matches(    .name,#ok,:visited   ) { }')", "':matches(.name, #ok, :visited) { }'");
-shouldBe("parseThenSerializeRule(':matches(    .name,#ok,    :visited, :link) { }')", "':matches(.name, #ok, :visited, :link) { }'");
-shouldBe("parseThenSerializeRule(':matches(    .name,#ok,    :matches(:visited    )) { }')", "':matches(.name, #ok, :matches(:visited)) { }'");
-shouldBe("parseThenSerializeRule(':matches(.name,  #ok,:not(:link)) { }')", "':matches(.name, #ok, :not(:link)) { }'");
-shouldBe("parseThenSerializeRule(':matches(.name,#ok,:not(:link)) { }')", "':matches(.name, #ok, :not(:link)) { }'");
-shouldBe("parseThenSerializeRule(':matches(    .name,#ok,:-webkit-any(   hello)) { }')", "':matches(.name, #ok, :-webkit-any(hello)) { }'");
-shouldBe("parseThenSerializeRule(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }')", "':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'");
-shouldBe("parseThenSerializeRule(':matches(       [type=\"file\"]) { }')", "':matches([type=\"file\"]) { }'");
-shouldBe("parseThenSerializeRule(':matches(  :hover    ) { }')", "':matches(:hover) { }'");
-shouldBe("parseThenSerializeRule('input:matches([type=\"file\"],:hover,:focus):enabled { }')", "'input:matches([type=\"file\"], :hover, :focus):enabled { }'");
-shouldBe("parseThenSerializeRule(':matches(input[type=\"file\"], a:hover, button:focus) { }')", "':matches(input[type=\"file\"], a:hover, button:focus) { }'");
-shouldBe("parseThenSerializeRule(':matches( .class1.class2.class3   ) { }')", "':matches(.class1.class2.class3) { }'");
-shouldBe("parseThenSerializeRule(':matches(.class1:hover   ) { }')", "':matches(.class1:hover) { }'");
-shouldBe("parseThenSerializeRule(':matches(a.class1.class2.class3:hover   ) { }')", "':matches(a.class1.class2.class3:hover) { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':not(single    ) { }')", "':not(single) { }'");
-shouldBe("parseThenSerializeRule(':not(a,b    ,p) { }')", "':not(a, b, p) { }'");
-shouldBe("parseThenSerializeRule(':not(#alice,                   #bob,#chris) { }')", "':not(#alice, #bob, #chris) { }'");
-shouldBe("parseThenSerializeRule(':not(  .selector,#tama,                #hanayo,#midoriko) { }')", "':not(.selector, #tama, #hanayo, #midoriko) { }'");
-shouldBe("parseThenSerializeRule(':not(    .name,#ok,:visited   ) { }')", "':not(.name, #ok, :visited) { }'");
-shouldBe("parseThenSerializeRule(':not(    .name,#ok,    :visited, :link) { }')", "':not(.name, #ok, :visited, :link) { }'");
-shouldBe("parseThenSerializeRule(':not(    .name,#ok,    :not(:visited    )) { }')", "':not(.name, #ok, :not(:visited)) { }'");
-shouldBe("parseThenSerializeRule(':not(.name,  #ok,:not(:link)) { }')", "':not(.name, #ok, :not(:link)) { }'");
-shouldBe("parseThenSerializeRule(':not(.name,#ok,:not(:link)) { }')", "':not(.name, #ok, :not(:link)) { }'");
-shouldBe("parseThenSerializeRule(':not(    .name,#ok,:-webkit-any(   hello)) { }')", "':not(.name, #ok, :-webkit-any(hello)) { }'");
-shouldBe("parseThenSerializeRule(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }')", "':not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }'");
-shouldBe("parseThenSerializeRule(':not(       [type=\"file\"]) { }')", "':not([type=\"file\"]) { }'");
-shouldBe("parseThenSerializeRule(':not(  :hover    ) { }')", "':not(:hover) { }'");
-shouldBe("parseThenSerializeRule('input:not([type=\"file\"],:hover,:focus):enabled { }')", "'input:not([type=\"file\"], :hover, :focus):enabled { }'");
-shouldBe("parseThenSerializeRule(':not(input[type=\"file\"], a:hover, button:focus) { }')", "':not(input[type=\"file\"], a:hover, button:focus) { }'");
-shouldBe("parseThenSerializeRule(':not( .class1.class2.class3   ) { }')", "':not(.class1.class2.class3) { }'");
-shouldBe("parseThenSerializeRule(':not(.class1:hover   ) { }')", "':not(.class1:hover) { }'");
-shouldBe("parseThenSerializeRule(':not(a.class1.class2.class3:hover   ) { }')", "':not(a.class1.class2.class3:hover) { }'");
-shouldBe("parseThenSerializeRule(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris)) { }')", "':not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris)) { }'");
-shouldBe("parseThenSerializeRule(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris)) { }')", "':not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris)) { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(a    ) { }')", "':lang(\"a\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    a) { }')", "':lang(\"a\") { }'");
-shouldBe("parseThenSerializeRule(':lang(a,    b,    c) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    a, b ,c) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(  a  ,  b  ,  c  ) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    a  ,b,c) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    a  ,b  ,c) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    a  ,b  ,c  ) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(a,b    ,c) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(a,b,    c) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-shouldBe("parseThenSerializeRule(':lang(a,b,    c    ) { }')", "':lang(\"a\", \"b\", \"c\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(en, en, en) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en,en,en) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en,en,    en) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en,    en,en) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en,    en,en    ) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    en,    en,en    ) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en,   en,   en) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    en,    en,    en) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    en,    en,    en    ) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    en    ,    en    ,   en    ) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    en,en,en    ) { }')", "':lang(\"en\", \"en\", \"en\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(\"*-DE\", \"*-CH\", \"*-EN\") { }')", "':lang(\"*-DE\", \"*-CH\", \"*-EN\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-DE\",\"*-CH\",\"*-EN\") { }')", "':lang(\"*-DE\", \"*-CH\", \"*-EN\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   \"*-DE\"  ,  \"*-CH\"  ,  \"*-EN\"  ) { }')", "':lang(\"*-DE\", \"*-CH\", \"*-EN\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(\\\\*) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-\\\\*\") { }')", "':lang(\"*-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-\\\\*-\\\\*\") { }')", "':lang(\"*-*-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-\\\\*-\\\\*-\\\\*\") { }')", "':lang(\"*-*-*-*\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(ab-\\\\*) { }')", "':lang(\"ab-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-ab-\\\\*\") { }')", "':lang(\"*-ab-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-ab-\\\\*-\") { }')", "':lang(\"*-ab-*-\") { }'");
-
-shouldBe("parseThenSerializeRule(':lang(\"*-foo-\\\\3A\") { }')", "':lang(\"*-foo-:\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-foo-\\\\3A\\\\`\\\\)\") { }')", "':lang(\"*-foo-:`)\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-foo-\\\\*\") { }')", "':lang(\"*-foo-*\") { }'");
-
-shouldBe("parseThenSerializeRule(':lang(\"*-foo-\\\\0072 aisin\") { }')", "':lang(\"*-foo-raisin\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-foo-\\\\0062 \\\\0061 r\") { }')", "':lang(\"*-foo-bar\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-foo-col\\\\6Fr\") { }')", "':lang(\"*-foo-color\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(\\\\*    ) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en\"    ) { }')", "':lang(\"*-en\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*\"    ) { }')", "':lang(\"*-en-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\"    ) { }')", "':lang(\"*-en-*-fr\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",br    ) { }')", "':lang(\"*-en-*-fr\", \"br\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\", br    ) { }')", "':lang(\"*-en-*-fr\", \"br\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",   br    ) { }')", "':lang(\"*-en-*-fr\", \"br\") { }'");
-shouldBe("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\",   br    ) { }')", "':lang(\"*-en-*-fr\", \"br\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    \"*-en-\\\\*-fr\",   br    ) { }')", "':lang(\"*-en-*-fr\", \"br\") { }'");
-shouldBe("parseThenSerializeRule(':lang(    \"*-en-\\\\*-fr\"  ,   br    ) { }')", "':lang(\"*-en-*-fr\", \"br\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",\"*-br-zh\"    ) { }')", "':lang(\"*-en-*-fr\", \"*-br-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\", \"*-br-zh\"    ) { }')", "':lang(\"*-en-*-fr\", \"*-br-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",   \"*-br-zh\"    ) { }')", "':lang(\"*-en-*-fr\", \"*-br-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",     \"*-br-zh\"    ) { }')", "':lang(\"*-en-*-fr\", \"*-br-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",       \"*-br-zh\"    ) { }')", "':lang(\"*-en-*-fr\", \"*-br-zh\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\", br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",   br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",      br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\",      br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\" ,      br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-shouldBe("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\"  ,      br-\\\\*-zh    ) { }')", "':lang(\"*-en-*-fr\", \"br-*-zh\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(\\\\*) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\\\\* ) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(\\\\*   ) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang( \\\\*   ) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(  \\\\*) { }')", "':lang(\"*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   \\\\*   ) { }')", "':lang(\"*\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(   \\\\*,id-\\\\*-sumatra   ) { }')", "':lang(\"*\", \"id-*-sumatra\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   \\\\* ,id-\\\\*-sumatra) { }')", "':lang(\"*\", \"id-*-sumatra\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   \\\\*  ,  id-\\\\*-sumatra  ) { }')", "':lang(\"*\", \"id-*-sumatra\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   \\\\*   ,    id-\\\\*-sumatra  ) { }')", "':lang(\"*\", \"id-*-sumatra\") { }'");
-
-debug('');
-
-shouldBe("parseThenSerializeRule(':lang(en-\\\\*) { }')", "':lang(\"en-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en-\\\\*, fr-\\\\*) { }')", "':lang(\"en-*\", \"fr-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(en-\\\\*, fr-\\\\* ) { }')", "':lang(\"en-*\", \"fr-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   en-\\\\*   ,  fr-\\\\*   ) { }')", "':lang(\"en-*\", \"fr-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   en-\\\\*   ,fr-\\\\*   ) { }')", "':lang(\"en-*\", \"fr-*\") { }'");
-shouldBe("parseThenSerializeRule(':lang(   en-\\\\*,fr-\\\\*   ) { }')", "':lang(\"en-*\", \"fr-*\") { }'");
-
-debug('');
-
-shouldThrow("parseThenSerializeRule(':lang() { }')");
-shouldThrow("parseThenSerializeRule(':lang(12, b, c) { }')");
-shouldThrow("parseThenSerializeRule(':lang(a, 12, c) { }')");
-shouldThrow("parseThenSerializeRule(':lang(a, b, 12) { }')");
-shouldThrow("parseThenSerializeRule(':lang(a, 12, 12) { }')");
-shouldThrow("parseThenSerializeRule(':lang(12, b, 12) { }')");
-shouldThrow("parseThenSerializeRule(':lang(12, 12, 12) { }')");
-shouldThrow("parseThenSerializeRule(':lang(lang()) { }')");
-shouldThrow("parseThenSerializeRule(':lang(:lang()) { }')");
-shouldThrow("parseThenSerializeRule(':lang(:lang(id)) { }')");
-shouldThrow("parseThenSerializeRule(':lang(:lang(en, br)) { }')");
-shouldThrow("parseThenSerializeRule(':lang(<0_0>) { }')");
-shouldThrow("parseThenSerializeRule(':lang(99) { }')");
-shouldThrow("parseThenSerializeRule(':lang(88) { }')");
-shouldThrow("parseThenSerializeRule(':lang(00) { }')");
-shouldThrow("parseThenSerializeRule(':lang(}) { }')");
-shouldThrow("parseThenSerializeRule(':lang({) { }')");
-shouldThrow("parseThenSerializeRule(':lang({}) { }')");
-shouldThrow("parseThenSerializeRule(':lang(]) { }')");
-shouldThrow("parseThenSerializeRule(':lang([) { }')");
-shouldThrow("parseThenSerializeRule(':lang([]) { }')");
-shouldThrow("parseThenSerializeRule(':lang(@media screen {}) { }')");
-
-shouldThrow("parseThenSerializeRule(':lang(*-) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-    ) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*--) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*---) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*----) { }')");
-
-shouldThrow("parseThenSerializeRule(':lang(*)' { })");
-shouldThrow("parseThenSerializeRule(':lang(**) { }')");
-shouldThrow("parseThenSerializeRule(':lang(-*-) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(de-*)')");
-shouldThrow("parseThenSerializeRule(':lang(*-en-*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-en-fr-*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-en-*fr) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-*en-fr) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-1997) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-1997-*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*a*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*a) { }')");
-shouldThrow("parseThenSerializeRule(':lang(a*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-a, a*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-a, a**) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-a, *a) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-a, **a) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*- a*) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-a, br fr) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-a, br fr en *) { }')");
-
-shouldThrow("parseThenSerializeRule(':lang(*-1996, *-1997) { }')");
-shouldThrow("parseThenSerializeRule(':lang(*-1996, *-1997 ) { }')");
-shouldThrow("parseThenSerializeRule(':lang(   *-1996   ,  *-1997   ) { }')");
-shouldThrow("parseThenSerializeRule(':lang(   *-1996   ,*-1997   ) { }')");
-shouldThrow("parseThenSerializeRule(':lang(   *-1996,*-1997   ) { }')");
-
-debug('');
-
-shouldThrow("parseThenSerializeRule(':role(a) { }')");
-
-debug('');
-
-testSelectorRoundTrip(":dir(ltr)");
-testSelectorRoundTrip(":dir(rtl)");
-testSelectorRoundTrip(":dir(LTR)");
-testSelectorRoundTrip(":dir(aBcD)");
-shouldBe("parseThenSerializeRule(':dir( a    ) { }')", "':dir(a) { }'");
-
-debug('');
-
-shouldThrow("parseThenSerializeRule(':dir() { }')");
-shouldThrow("parseThenSerializeRule(':dir(42) { }')");
-shouldThrow("parseThenSerializeRule(':dir(a, b) { }')");
-shouldThrow("parseThenSerializeRule(':dir(}) { }')");
-shouldThrow("parseThenSerializeRule(':dir()) { }')");
-shouldThrow("parseThenSerializeRule(':dir(dir()) { }')");
-shouldThrow("parseThenSerializeRule(':dir(:dir()) { }')");
-shouldThrow("parseThenSerializeRule(':dir(:dir(ltr)) { }')");
+testSelectorRoundTrip('*')
+testSelectorRoundTrip('a')
+testSelectorRoundTrip('#a')
+testSelectorRoundTrip('.a')
+testSelectorRoundTrip(':active')
+testSelectorRoundTrip('[a]')
+testSelectorRoundTrip('[a="b"]')
+testSelectorRoundTrip('[a~="b"]')
+testSelectorRoundTrip('[a|="b"]')
+testSelectorRoundTrip('[a^="b"]')
+testSelectorRoundTrip('[a$="b"]')
+testSelectorRoundTrip('[a*="b"]')
+testSelectorRoundTrip('[a="b" i]')
+testSelectorRoundTrip('[a~="b" i]')
+testSelectorRoundTrip('[a|="b" i]')
+testSelectorRoundTrip('[a^="b" i]')
+testSelectorRoundTrip('[a$="b" i]')
+testSelectorRoundTrip('[a*="b" i]')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule('*|a { }')", "a { }")
+shouldBeEqualToString("parseThenSerializeRule('*|* { }')", "* { }")
+testSelectorRoundTrip('|a')
+testSelectorRoundTrip('|*')
+testSelectorRoundTrip('[*|a]')
+shouldBeEqualToString("parseThenSerializeRule('[|a] { }')", "[a] { }")
+
+debug('')
+
+testSelectorRoundTrip('a:active')
+testSelectorRoundTrip('a b')
+testSelectorRoundTrip('a + b')
+testSelectorRoundTrip('a ~ b')
+testSelectorRoundTrip('a > b')
+
+debug('')
+
+testSelectorRoundTrip(":active")
+testSelectorRoundTrip(":any-link")
+testSelectorRoundTrip(":checked")
+testSelectorRoundTrip(":disabled")
+testSelectorRoundTrip(":empty")
+testSelectorRoundTrip(":enabled")
+testSelectorRoundTrip(":first-child")
+testSelectorRoundTrip(":first-of-type")
+testSelectorRoundTrip(":focus")
+testSelectorRoundTrip(":hover")
+testSelectorRoundTrip(":indeterminate")
+testSelectorRoundTrip(":link")
+testSelectorRoundTrip(":not(:placeholder-shown)")
+testSelectorRoundTrip(":placeholder-shown")
+testSelectorRoundTrip(":root")
+testSelectorRoundTrip(":target")
+testSelectorRoundTrip(":visited")
+
+debug('')
+
+testSelectorRoundTrip(':lang("*-ab")')
+testSelectorRoundTrip(':lang("*-ab-")')
+testSelectorRoundTrip(':lang("*-DE-1996")')
+
+debug('')
+
+testSelectorRoundTrip(":lang(a)")
+testSelectorRoundTrip(":lang(a, b, c)")
+testSelectorRoundTrip(":lang(fr, de, en, id)")
+testSelectorRoundTrip(":lang(fr, fr-ca, fr-be)")
+testSelectorRoundTrip(":lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996)")
+testSelectorRoundTrip(":lang(de-CH, it-CH, fr-CH, rm-CH)")
+testSelectorRoundTrip(":lang(de-DE, de-DE-1996, de-Latn-DE, de-Latf-DE, de-Latn-DE-1996, de-CH, it-CH, fr-CH, rm-CH)")
+
+debug('')
+
+testSelectorRoundTrip(":lang(a, a, a)")
+testSelectorRoundTrip(":lang(en, en, en)")
+testSelectorRoundTrip(":lang(en-us, en-us, en-us)")
+testSelectorRoundTrip(":lang(de-DE-1996, de-DE-1996, de-DE-1996)")
+testSelectorRoundTrip(":lang(de-Latn-DE-1996, de-Latn-DE-1996, de-Latn-DE-1996)")
+testSelectorRoundTrip(":lang(java, java, java)")
+
+debug('')
+
+testSelectorRoundTrip(":not(a)")
+testSelectorRoundTrip(":-webkit-any(a, b, p)")
+
+debug('')
+
+testSelectorRoundTrip("::after")
+testSelectorRoundTrip("::before")
+testSelectorRoundTrip("::first-letter")
+testSelectorRoundTrip("::first-line")
+testSelectorRoundTrip("::selection")
+
+debug('')
+
+testSelectorRoundTrip(":-webkit-any-link")
+testSelectorRoundTrip(":-webkit-drag")
+testSelectorRoundTrip(":autofill")
+testSelectorSerialization(":-webkit-autofill", ":autofill")
+
+debug('')
+
+testSelectorSerialization(":nth-child(odd)", ":nth-child(2n+1)")
+testSelectorSerialization(":nth-child(even)", ":nth-child(2n)")
+testSelectorRoundTrip(":nth-child(n)")
+testSelectorRoundTrip(":nth-child(-n)")
+testSelectorRoundTrip(":nth-child(5)")
+testSelectorRoundTrip(":nth-child(-5)")
+testSelectorRoundTrip(":nth-child(5n+7)")
+testSelectorRoundTrip(":nth-child(-5n+7)")
+testSelectorRoundTrip(":nth-child(5n-7)")
+testSelectorRoundTrip(":nth-child(-5n-7)")
+
+debug('')
+
+testSelectorSerialization(":nth-child(odd of .foo, :nth-child(odd))", ":nth-child(2n+1 of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(even of .foo, :nth-child(odd))", ":nth-child(2n of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(n of .foo, :nth-child(odd))", ":nth-child(n of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(-n of .foo, :nth-child(odd))", ":nth-child(-n of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(5 of .foo, :nth-child(odd))", ":nth-child(5 of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(-5 of .foo, :nth-child(odd))", ":nth-child(-5 of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(5n+7 of .foo, :nth-child(odd))", ":nth-child(5n+7 of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(-5n+7 of .foo, :nth-child(odd))", ":nth-child(-5n+7 of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(5n-7 of .foo, :nth-child(odd))", ":nth-child(5n-7 of .foo, :nth-child(2n+1))")
+testSelectorSerialization(":nth-child(-5n-7 of .foo, :nth-child(odd))", ":nth-child(-5n-7 of .foo, :nth-child(2n+1))")
+
+debug('')
+
+testSelectorSerialization(":nth-last-child(odd of .foo, :nth-last-child(odd))", ":nth-last-child(2n+1 of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(even of .foo, :nth-last-child(odd))", ":nth-last-child(2n of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(n of .foo, :nth-last-child(odd))", ":nth-last-child(n of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(-n of .foo, :nth-last-child(odd))", ":nth-last-child(-n of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(5 of .foo, :nth-last-child(odd))", ":nth-last-child(5 of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(-5 of .foo, :nth-last-child(odd))", ":nth-last-child(-5 of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(5n+7 of .foo, :nth-last-child(odd))", ":nth-last-child(5n+7 of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(-5n+7 of .foo, :nth-last-child(odd))", ":nth-last-child(-5n+7 of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(5n-7 of .foo, :nth-last-child(odd))", ":nth-last-child(5n-7 of .foo, :nth-last-child(2n+1))")
+testSelectorSerialization(":nth-last-child(-5n-7 of .foo, :nth-last-child(odd))", ":nth-last-child(-5n-7 of .foo, :nth-last-child(2n+1))")
+
+debug('')
+
+testSelectorRoundTrip(':is(single)')
+testSelectorRoundTrip(':is(a, b, p)')
+testSelectorRoundTrip(':is(#alice, #bob, #chris)')
+testSelectorRoundTrip(':is(.selector, #tama, #hanayo, #midoriko)')
+testSelectorRoundTrip(':is(.name, #ok, :visited)')
+testSelectorRoundTrip(':is(.name, #ok, :visited, :link)')
+testSelectorRoundTrip(':is(.name, #ok, :is(:visited))')
+testSelectorRoundTrip(':is(.name, #ok, :not(:link))')
+testSelectorRoundTrip(':is(.name, #ok, :not(:link))')
+testSelectorRoundTrip(':is(.name, #ok, :-webkit-any(hello))')
+testSelectorRoundTrip(':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':is([type="file"])')
+testSelectorRoundTrip(':is(:hover)')
+testSelectorRoundTrip('input:is([type="file"], :hover, :focus):enabled')
+testSelectorRoundTrip(':is(input[type="file"], a:hover, button:focus)')
+testSelectorRoundTrip(':is(.class1.class2.class3)')
+testSelectorRoundTrip(':is(.class1:hover)')
+testSelectorRoundTrip(':is(a.class1.class2.class3:hover)')
+testSelectorRoundTrip(':where(single)')
+testSelectorRoundTrip(':where(a, b, p)')
+testSelectorRoundTrip(':where(#alice, #bob, #chris)')
+testSelectorRoundTrip(':where(.selector, #tama, #hanayo, #midoriko)')
+testSelectorRoundTrip(':where(.name, #ok, :visited)')
+testSelectorRoundTrip(':where(.name, #ok, :visited, :link)')
+testSelectorRoundTrip(':where(.name, #ok, :where(:visited))')
+testSelectorRoundTrip(':where(.name, #ok, :not(:link))')
+testSelectorRoundTrip(':where(.name, #ok, :not(:link))')
+testSelectorRoundTrip(':where(.name, #ok, :where(hello))')
+testSelectorRoundTrip(':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':where([type="file"])')
+testSelectorRoundTrip(':where(:hover)')
+testSelectorRoundTrip('input:where([type="file"], :hover, :focus):enabled')
+testSelectorRoundTrip(':where(input[type="file"], a:hover, button:focus)')
+testSelectorRoundTrip(':where(.class1.class2.class3)')
+testSelectorRoundTrip(':where(.class1:hover)')
+testSelectorRoundTrip(':where(a.class1.class2.class3:hover)')
+testSelectorRoundTrip(':matches(:is(single))')
+testSelectorRoundTrip(':matches(:is(a, b, p))')
+testSelectorRoundTrip(':matches(:is(#alice, #bob, #chris))')
+testSelectorRoundTrip(':matches(:is(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :visited))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :visited, :link))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :is(:visited)))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :matches(hello)))')
+testSelectorRoundTrip(':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko)))')
+testSelectorRoundTrip(':matches(:is([type="file"]))')
+testSelectorRoundTrip(':matches(:is(:hover))')
+testSelectorRoundTrip(':matches(input:is([type="file"], :hover, :focus):enabled)')
+testSelectorRoundTrip(':matches(:is(input[type="file"], a:hover, button:focus))')
+testSelectorRoundTrip(':matches(:is(.class1.class2.class3))')
+testSelectorRoundTrip(':matches(:is(.class1:hover))')
+testSelectorRoundTrip(':matches(:is(a.class1.class2.class3:hover))')
+testSelectorRoundTrip(':-webkit-any(:is(single))')
+testSelectorRoundTrip(':-webkit-any(:is(a, b, p))')
+testSelectorRoundTrip(':-webkit-any(:is(#alice, #bob, #chris))')
+testSelectorRoundTrip(':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :visited))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :visited, :link))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :is(:visited)))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :-webkit-any(hello)))')
+testSelectorRoundTrip(':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))')
+testSelectorRoundTrip(':-webkit-any(:is([type="file"]))')
+testSelectorRoundTrip(':-webkit-any(:is(:hover))')
+testSelectorRoundTrip(':-webkit-any(input:is([type="file"], :hover, :focus):enabled)')
+testSelectorRoundTrip(':-webkit-any(:is(input[type="file"], a:hover, button:focus))')
+testSelectorRoundTrip(':-webkit-any(:is(.class1.class2.class3))')
+testSelectorRoundTrip(':-webkit-any(:is(.class1:hover))')
+testSelectorRoundTrip(':-webkit-any(:is(a.class1.class2.class3:hover))')
+
+debug('')
+
+testSelectorRoundTrip(':matches(single)')
+testSelectorRoundTrip(':matches(a, b, p)')
+testSelectorRoundTrip(':matches(#alice, #bob, #chris)')
+testSelectorRoundTrip(':matches(.selector, #tama, #hanayo, #midoriko)')
+testSelectorRoundTrip(':matches(.name, #ok, :visited)')
+testSelectorRoundTrip(':matches(.name, #ok, :visited, :link)')
+testSelectorRoundTrip(':matches(.name, #ok, :matches(:visited))')
+testSelectorRoundTrip(':matches(.name, #ok, :not(:link))')
+testSelectorRoundTrip(':matches(.name, #ok, :not(:link))')
+testSelectorRoundTrip(':matches(.name, #ok, :-webkit-any(hello))')
+testSelectorRoundTrip(':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':matches([type="file"])')
+testSelectorRoundTrip(':matches(:hover)')
+testSelectorRoundTrip('input:matches([type="file"], :hover, :focus):enabled')
+testSelectorRoundTrip(':matches(input[type="file"], a:hover, button:focus)')
+testSelectorRoundTrip(':matches(.class1.class2.class3)')
+testSelectorRoundTrip(':matches(.class1:hover)')
+testSelectorRoundTrip(':matches(a.class1.class2.class3:hover)')
+testSelectorRoundTrip(':is(:matches(single))')
+testSelectorRoundTrip(':is(:matches(a, b, p))')
+testSelectorRoundTrip(':is(:matches(#alice, #bob, #chris))')
+testSelectorRoundTrip(':is(:matches(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :visited))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :visited, :link))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :matches(:visited)))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :is(hello)))')
+testSelectorRoundTrip(':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko)))')
+testSelectorRoundTrip(':is(:matches([type="file"]))')
+testSelectorRoundTrip(':is(:matches(:hover))')
+testSelectorRoundTrip(':is(input:matches([type="file"], :hover, :focus):enabled)')
+testSelectorRoundTrip(':is(:matches(input[type="file"], a:hover, button:focus))')
+testSelectorRoundTrip(':is(:matches(.class1.class2.class3))')
+testSelectorRoundTrip(':is(:matches(.class1:hover))')
+testSelectorRoundTrip(':is(:matches(a.class1.class2.class3:hover))')
+testSelectorRoundTrip(':-webkit-any(:matches(single))')
+testSelectorRoundTrip(':-webkit-any(:matches(a, b, p))')
+testSelectorRoundTrip(':-webkit-any(:matches(#alice, #bob, #chris))')
+testSelectorRoundTrip(':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :visited))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :visited, :link))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :matches(:visited)))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :not(:link)))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :-webkit-any(hello)))')
+testSelectorRoundTrip(':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))')
+testSelectorRoundTrip(':-webkit-any(:matches([type="file"]))')
+testSelectorRoundTrip(':-webkit-any(:matches(:hover))')
+testSelectorRoundTrip(':-webkit-any(input:matches([type="file"], :hover, :focus):enabled)')
+testSelectorRoundTrip(':-webkit-any(:matches(input[type="file"], a:hover, button:focus))')
+testSelectorRoundTrip(':-webkit-any(:matches(.class1.class2.class3))')
+testSelectorRoundTrip(':-webkit-any(:matches(.class1:hover))')
+testSelectorRoundTrip(':-webkit-any(:matches(a.class1.class2.class3:hover))')
+
+debug('')
+
+testSelectorRoundTrip(':not(div)')
+testSelectorRoundTrip(':not(.div)')
+testSelectorRoundTrip(':not(#div)')
+testSelectorRoundTrip(':not([div])')
+testSelectorRoundTrip(':not(:empty)')
+testSelectorRoundTrip(':not(div.div#div[div]:empty)')
+testSelectorRoundTrip(':not(div.div:empty[div]#div)')
+testSelectorRoundTrip(':not(div.div, #div[div], :empty)')
+testSelectorRoundTrip(':not(div, .div, #div, [div], :empty)')
+
+testSelectorRoundTrip(':not(:not(div))')
+testSelectorRoundTrip(':not(:not(div)):not(:not(foo)):not(:not(bar))')
+testSelectorRoundTrip(':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz))')
+
+testSelectorRoundTrip(':not(:is(*))')
+testSelectorRoundTrip(':not(:is(foo, bar))')
+testSelectorRoundTrip(':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar]))')
+testSelectorRoundTrip(':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar]))')
+
+testSelectorRoundTrip(':not(:matches(*))')
+testSelectorRoundTrip(':not(:matches(foo, bar))')
+testSelectorRoundTrip(':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar]))')
+testSelectorRoundTrip(':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar]))')
+
+testSelectorRoundTrip(':nth-child(2n of :not(a.b, c#d.e))')
+testSelectorRoundTrip(':not(:nth-child(2n of :not(a.b, c#d.e)))')
+
+testSelectorRoundTrip(':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)')
+testSelectorRoundTrip('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule('::-webkit-file-upload-button { }')", "::-webkit-file-upload-button { }")
+shouldBeEqualToString("parseThenSerializeRule('::-webkit-search-cancel-button { }')", "::-webkit-search-cancel-button { }")
+shouldBeEqualToString("parseThenSerializeRule('::-webkit-search-decoration { }')", "::-webkit-search-decoration { }")
+shouldBeEqualToString("parseThenSerializeRule('::-webkit-search-results-button { }')", "::-webkit-search-results-button { }")
+shouldBeEqualToString("parseThenSerializeRule('::-webkit-search-results-decoration { }')", "::-webkit-search-results-decoration { }")
+shouldBeEqualToString("parseThenSerializeRule('::-webkit-slider-thumb { }')", "::-webkit-slider-thumb { }")
+shouldBeEqualToString("parseThenSerializeRule('::file-selector-button { }')", "::file-selector-button { }")
+
+debug('')
+
+testSelectorRoundTrip("a::-webkit-slider-thumb")
+shouldBeEqualToString("parseThenSerializeRule('a ::-webkit-slider-thumb { }')", "a ::-webkit-slider-thumb { }")
+testSelectorRoundTrip("[a]::-webkit-slider-thumb")
+shouldBeEqualToString("parseThenSerializeRule('[a] ::-webkit-slider-thumb { }')", "[a] ::-webkit-slider-thumb { }")
+testSelectorRoundTrip(".a::-webkit-slider-thumb")
+shouldBeEqualToString("parseThenSerializeRule('.a ::-webkit-slider-thumb { }')", ".a ::-webkit-slider-thumb { }")
+testSelectorRoundTrip("#a::-webkit-slider-thumb")
+shouldBeEqualToString("parseThenSerializeRule('#a ::-webkit-slider-thumb { }')", "#a ::-webkit-slider-thumb { }")
+shouldBeEqualToString("parseThenSerializeRule('* ::-webkit-slider-thumb { }')", "* ::-webkit-slider-thumb { }")
+
+debug('')
+
+testSelectorRoundTrip("a[b]::-webkit-slider-thumb")
+testSelectorRoundTrip("a.b::-webkit-slider-thumb")
+testSelectorRoundTrip("a#b::-webkit-slider-thumb")
+testSelectorRoundTrip("a[b].c#d::-webkit-slider-thumb")
+
+debug('')
+
+testSelectorRoundTrip("a[b]::placeholder")
+testSelectorRoundTrip("a.b::placeholder")
+testSelectorRoundTrip("a#b::placeholder")
+testSelectorRoundTrip("a[b].c#d::placeholder")
+testSelectorRoundTrip("a[b]::-webkit-input-placeholder")
+testSelectorRoundTrip("a.b::-webkit-input-placeholder")
+testSelectorRoundTrip("a#b::-webkit-input-placeholder")
+testSelectorRoundTrip("a[b].c#d::-webkit-input-placeholder")
+
+debug('')
+
+testSelectorRoundTrip("a[b]:default")
+testSelectorRoundTrip("a.b:default")
+testSelectorRoundTrip("a#b:default")
+testSelectorRoundTrip("a[b].c#d:default")
+
+debug('')
+
+testSelectorRoundTrip("a[b]:in-range")
+testSelectorRoundTrip("a.b:in-range")
+testSelectorRoundTrip("a#b:in-range")
+testSelectorRoundTrip("a[b].c#d:in-range")
+
+debug('')
+
+testSelectorRoundTrip("a[b]:out-of-range")
+testSelectorRoundTrip("a.b:out-of-range")
+testSelectorRoundTrip("a#b:out-of-range")
+testSelectorRoundTrip("a[b].c#d:out-of-range")
+
+debug('')
+
+testSelectorRoundTrip("a[b]:focus-within")
+testSelectorRoundTrip("a.b:focus-within")
+testSelectorRoundTrip("a#b:focus-within")
+testSelectorRoundTrip("a[b].c#d:focus-within")
+
+debug('')
+
+testSelectorRoundTrip('input:not([type="file"]):focus')
+testSelectorRoundTrip(':-webkit-any([type="file"])')
+testSelectorRoundTrip(':-webkit-any(:hover)')
+testSelectorRoundTrip('input:-webkit-any([type="file"], :hover, :focus):enabled')
+testSelectorRoundTrip(':-webkit-any(input[type="file"], a:hover, button:focus)')
+testSelectorRoundTrip(':-webkit-any(.class1.class2.class3)')
+testSelectorRoundTrip(':-webkit-any(.class1:hover)')
+testSelectorRoundTrip(':-webkit-any(a.class1.class2.class3:hover)')
+testSelectorRoundTrip('a:any-link')
+testSelectorRoundTrip('a :any-link')
+testSelectorRoundTrip('div:any-link')
+testSelectorRoundTrip('div :any-link')
+testSelectorRoundTrip(':any-link > div')
+testSelectorRoundTrip(':any-link + div')
+testSelectorRoundTrip(':not(:any-link)')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule('*:active { }')", ":active { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule('input[type=file]:focus { }')", 'input[type="file"]:focus { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule('a+b { }')", "a + b { }")
+shouldBeEqualToString("parseThenSerializeRule('a~b { }')", "a ~ b { }")
+shouldBeEqualToString("parseThenSerializeRule('a>b { }')", "a > b { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':after { }')", "::after { }")
+shouldBeEqualToString("parseThenSerializeRule(':before { }')", "::before { }")
+shouldBeEqualToString("parseThenSerializeRule(':first-letter { }')", "::first-letter { }")
+shouldBeEqualToString("parseThenSerializeRule(':first-line { }')", "::first-line { }")
+shouldBeEqualToString("parseThenSerializeRule(':-webkit-any(    a.class1  ,  	#id,[attr]  ) { }')", ":-webkit-any(a.class1, #id, [attr]) { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':is(single    ) { }')", ":is(single) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(a,b    ,p) { }')", ":is(a, b, p) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(#alice,                   #bob,#chris) { }')", ":is(#alice, #bob, #chris) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(  .selector,#tama,                #hanayo,#midoriko) { }')", ":is(.selector, #tama, #hanayo, #midoriko) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(    .name,#ok,:visited   ) { }')", ":is(.name, #ok, :visited) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(    .name,#ok,    :visited, :link) { }')", ":is(.name, #ok, :visited, :link) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(    .name,#ok,    :is(:visited    )) { }')", ":is(.name, #ok, :is(:visited)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(.name,  #ok,:not(:link)) { }')", ":is(.name, #ok, :not(:link)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(.name,#ok,:not(:link)) { }')", ":is(.name, #ok, :not(:link)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(    .name,#ok,:-webkit-any(   hello)) { }')", ":is(.name, #ok, :-webkit-any(hello)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }')", ":is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(       [type=\"file\"]) { }')", ':is([type="file"]) { }')
+shouldBeEqualToString("parseThenSerializeRule(':is(  :hover    ) { }')", ":is(:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule('input:is([type=\"file\"],:hover,:focus):enabled { }')", 'input:is([type="file"], :hover, :focus):enabled { }')
+shouldBeEqualToString("parseThenSerializeRule(':is(input[type=\"file\"], a:hover, button:focus) { }')", ':is(input[type="file"], a:hover, button:focus) { }')
+shouldBeEqualToString("parseThenSerializeRule(':is( .class1.class2.class3   ) { }')", ":is(.class1.class2.class3) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(.class1:hover   ) { }')", ":is(.class1:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule(':is(a.class1.class2.class3:hover   ) { }')", ":is(a.class1.class2.class3:hover) { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':matches(single    ) { }')", ":matches(single) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(a,b    ,p) { }')", ":matches(a, b, p) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(#alice,                   #bob,#chris) { }')", ":matches(#alice, #bob, #chris) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(  .selector,#tama,                #hanayo,#midoriko) { }')", ":matches(.selector, #tama, #hanayo, #midoriko) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(    .name,#ok,:visited   ) { }')", ":matches(.name, #ok, :visited) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(    .name,#ok,    :visited, :link) { }')", ":matches(.name, #ok, :visited, :link) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(    .name,#ok,    :matches(:visited    )) { }')", ":matches(.name, #ok, :matches(:visited)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(.name,  #ok,:not(:link)) { }')", ":matches(.name, #ok, :not(:link)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(.name,#ok,:not(:link)) { }')", ":matches(.name, #ok, :not(:link)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(    .name,#ok,:-webkit-any(   hello)) { }')", ":matches(.name, #ok, :-webkit-any(hello)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }')", ":matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(       [type=\"file\"]) { }')", ':matches([type="file"]) { }')
+shouldBeEqualToString("parseThenSerializeRule(':matches(  :hover    ) { }')", ":matches(:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule('input:matches([type=\"file\"],:hover,:focus):enabled { }')", 'input:matches([type="file"], :hover, :focus):enabled { }')
+shouldBeEqualToString("parseThenSerializeRule(':matches(input[type=\"file\"], a:hover, button:focus) { }')", ':matches(input[type="file"], a:hover, button:focus) { }')
+shouldBeEqualToString("parseThenSerializeRule(':matches( .class1.class2.class3   ) { }')", ":matches(.class1.class2.class3) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(.class1:hover   ) { }')", ":matches(.class1:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule(':matches(a.class1.class2.class3:hover   ) { }')", ":matches(a.class1.class2.class3:hover) { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':not(single    ) { }')", ":not(single) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(a,b    ,p) { }')", ":not(a, b, p) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(#alice,                   #bob,#chris) { }')", ":not(#alice, #bob, #chris) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(  .selector,#tama,                #hanayo,#midoriko) { }')", ":not(.selector, #tama, #hanayo, #midoriko) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(    .name,#ok,:visited   ) { }')", ":not(.name, #ok, :visited) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(    .name,#ok,    :visited, :link) { }')", ":not(.name, #ok, :visited, :link) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(    .name,#ok,    :not(:visited    )) { }')", ":not(.name, #ok, :not(:visited)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(.name,  #ok,:not(:link)) { }')", ":not(.name, #ok, :not(:link)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(.name,#ok,:not(:link)) { }')", ":not(.name, #ok, :not(:link)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(    .name,#ok,:-webkit-any(   hello)) { }')", ":not(.name, #ok, :-webkit-any(hello)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }')", ":not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(       [type=\"file\"]) { }')", ':not([type="file"]) { }')
+shouldBeEqualToString("parseThenSerializeRule(':not(  :hover    ) { }')", ":not(:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule('input:not([type=\"file\"],:hover,:focus):enabled { }')", 'input:not([type="file"], :hover, :focus):enabled { }')
+shouldBeEqualToString("parseThenSerializeRule(':not(input[type=\"file\"], a:hover, button:focus) { }')", ':not(input[type="file"], a:hover, button:focus) { }')
+shouldBeEqualToString("parseThenSerializeRule(':not( .class1.class2.class3   ) { }')", ":not(.class1.class2.class3) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(.class1:hover   ) { }')", ":not(.class1:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(a.class1.class2.class3:hover   ) { }')", ":not(a.class1.class2.class3:hover) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris)) { }')", ":not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris)) { }")
+shouldBeEqualToString("parseThenSerializeRule(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris)) { }')", ":not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris)) { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(a    ) { }')", ":lang(a) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    a) { }')", ":lang(a) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(a,    b,    c) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    a, b ,c) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(  a  ,  b  ,  c  ) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    a  ,b,c) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    a  ,b  ,c) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    a  ,b  ,c  ) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(a,b    ,c) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(a,b,    c) { }')", ":lang(a, b, c) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(a,b,    c    ) { }')", ":lang(a, b, c) { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(en, en, en) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(en,en,en) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(en,en,    en) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(en,    en,en) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(en,    en,en    ) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    en,    en,en    ) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(en,   en,   en) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    en,    en,    en) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    en,    en,    en    ) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    en    ,    en    ,   en    ) { }')", ":lang(en, en, en) { }")
+shouldBeEqualToString("parseThenSerializeRule(':lang(    en,en,en    ) { }')", ":lang(en, en, en) { }")
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-DE\", \"*-CH\", \"*-EN\") { }')", ':lang("*-DE", "*-CH", "*-EN") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-DE\",\"*-CH\",\"*-EN\") { }')", ':lang("*-DE", "*-CH", "*-EN") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   \"*-DE\"  ,  \"*-CH\"  ,  \"*-EN\"  ) { }')", ':lang("*-DE", "*-CH", "*-EN") { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\\\\*) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-\\\\*\") { }')", ':lang("*-*") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-\\\\*-\\\\*\") { }')", ':lang("*-*-*") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-\\\\*-\\\\*-\\\\*\") { }')", ':lang("*-*-*-*") { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(ab-\\\\*) { }')", ':lang(ab-\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-ab-\\\\*\") { }')", ':lang("*-ab-*") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-ab-\\\\*-\") { }')", ':lang("*-ab-*-") { }')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-foo-\\\\3A\") { }')", ':lang("*-foo-:") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-foo-\\\\3A\\\\`\\\\)\") { }')", ':lang("*-foo-:`)") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-foo-\\\\*\") { }')", ':lang("*-foo-*") { }')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-foo-\\\\0072 aisin\") { }')", ':lang("*-foo-raisin") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-foo-\\\\0062 \\\\0061 r\") { }')", ':lang("*-foo-bar") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-foo-col\\\\6Fr\") { }')", ':lang("*-foo-color") { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\\\\*    ) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en\"    ) { }')", ':lang("*-en") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*\"    ) { }')", ':lang("*-en-*") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\"    ) { }')", ':lang("*-en-*-fr") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",br    ) { }')", ':lang("*-en-*-fr", br) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\", br    ) { }')", ':lang("*-en-*-fr", br) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",   br    ) { }')", ':lang("*-en-*-fr", br) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\",   br    ) { }')", ':lang("*-en-*-fr", br) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(    \"*-en-\\\\*-fr\",   br    ) { }')", ':lang("*-en-*-fr", br) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(    \"*-en-\\\\*-fr\"  ,   br    ) { }')", ':lang("*-en-*-fr", br) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",\"*-br-zh\"    ) { }')", ':lang("*-en-*-fr", "*-br-zh") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\", \"*-br-zh\"    ) { }')", ':lang("*-en-*-fr", "*-br-zh") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",   \"*-br-zh\"    ) { }')", ':lang("*-en-*-fr", "*-br-zh") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",     \"*-br-zh\"    ) { }')", ':lang("*-en-*-fr", "*-br-zh") { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",       \"*-br-zh\"    ) { }')", ':lang("*-en-*-fr", "*-br-zh") { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\", br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",   br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\"*-en-\\\\*-fr\",      br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\",      br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\" ,      br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(  \"*-en-\\\\*-fr\"  ,      br-\\\\*-zh    ) { }')", ':lang("*-en-*-fr", br-\\*-zh) { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(\\\\*) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\\\\* ) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(\\\\*   ) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang( \\\\*   ) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(  \\\\*) { }')", ':lang(\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   \\\\*   ) { }')", ':lang(\\*) { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(   \\\\*,id-\\\\*-sumatra   ) { }')", ':lang(\\*, id-\\*-sumatra) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   \\\\* ,id-\\\\*-sumatra) { }')", ':lang(\\*, id-\\*-sumatra) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   \\\\*  ,  id-\\\\*-sumatra  ) { }')", ':lang(\\*, id-\\*-sumatra) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   \\\\*   ,    id-\\\\*-sumatra  ) { }')", ':lang(\\*, id-\\*-sumatra) { }')
+
+debug('')
+
+shouldBeEqualToString("parseThenSerializeRule(':lang(en-\\\\*) { }')", ':lang(en-\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(en-\\\\*, fr-\\\\*) { }')", ':lang(en-\\*, fr-\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(en-\\\\*, fr-\\\\* ) { }')", ':lang(en-\\*, fr-\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   en-\\\\*   ,  fr-\\\\*   ) { }')", ':lang(en-\\*, fr-\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   en-\\\\*   ,fr-\\\\*   ) { }')", ':lang(en-\\*, fr-\\*) { }')
+shouldBeEqualToString("parseThenSerializeRule(':lang(   en-\\\\*,fr-\\\\*   ) { }')", ':lang(en-\\*, fr-\\*) { }')
+
+debug('')
+
+shouldThrow("parseThenSerializeRule(':lang() { }')")
+shouldThrow("parseThenSerializeRule(':lang(12, b, c) { }')")
+shouldThrow("parseThenSerializeRule(':lang(a, 12, c) { }')")
+shouldThrow("parseThenSerializeRule(':lang(a, b, 12) { }')")
+shouldThrow("parseThenSerializeRule(':lang(a, 12, 12) { }')")
+shouldThrow("parseThenSerializeRule(':lang(12, b, 12) { }')")
+shouldThrow("parseThenSerializeRule(':lang(12, 12, 12) { }')")
+shouldThrow("parseThenSerializeRule(':lang(lang()) { }')")
+shouldThrow("parseThenSerializeRule(':lang(:lang()) { }')")
+shouldThrow("parseThenSerializeRule(':lang(:lang(id)) { }')")
+shouldThrow("parseThenSerializeRule(':lang(:lang(en, br)) { }')")
+shouldThrow("parseThenSerializeRule(':lang(<0_0>) { }')")
+shouldThrow("parseThenSerializeRule(':lang(99) { }')")
+shouldThrow("parseThenSerializeRule(':lang(88) { }')")
+shouldThrow("parseThenSerializeRule(':lang(00) { }')")
+shouldThrow("parseThenSerializeRule(':lang(}) { }')")
+shouldThrow("parseThenSerializeRule(':lang({) { }')")
+shouldThrow("parseThenSerializeRule(':lang({}) { }')")
+shouldThrow("parseThenSerializeRule(':lang(]) { }')")
+shouldThrow("parseThenSerializeRule(':lang([) { }')")
+shouldThrow("parseThenSerializeRule(':lang([]) { }')")
+shouldThrow("parseThenSerializeRule(':lang(@media screen {}) { }')")
+
+shouldThrow("parseThenSerializeRule(':lang(*-) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-    ) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*--) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*---) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*----) { }')")
+
+shouldThrow("parseThenSerializeRule(':lang(*)' { })")
+shouldThrow("parseThenSerializeRule(':lang(**) { }')")
+shouldThrow("parseThenSerializeRule(':lang(-*-) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(de-*)')")
+shouldThrow("parseThenSerializeRule(':lang(*-en-*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-en-fr-*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-en-*fr) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-*en-fr) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-1997) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-1997-*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*a*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*a) { }')")
+shouldThrow("parseThenSerializeRule(':lang(a*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-a, a*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-a, a**) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-a, *a) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-a, **a) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*- a*) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-a, br fr) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-a, br fr en *) { }')")
+
+shouldThrow("parseThenSerializeRule(':lang(*-1996, *-1997) { }')")
+shouldThrow("parseThenSerializeRule(':lang(*-1996, *-1997 ) { }')")
+shouldThrow("parseThenSerializeRule(':lang(   *-1996   ,  *-1997   ) { }')")
+shouldThrow("parseThenSerializeRule(':lang(   *-1996   ,*-1997   ) { }')")
+shouldThrow("parseThenSerializeRule(':lang(   *-1996,*-1997   ) { }')")
+
+debug('')
+
+shouldThrow("parseThenSerializeRule(':role(a) { }')")
+
+debug('')
+
+testSelectorRoundTrip(":dir(ltr)")
+testSelectorRoundTrip(":dir(rtl)")
+testSelectorRoundTrip(":dir(LTR)")
+testSelectorRoundTrip(":dir(aBcD)")
+shouldBeEqualToString("parseThenSerializeRule(':dir( a    ) { }')", ":dir(a) { }")
+
+debug('')
+
+shouldThrow("parseThenSerializeRule(':dir() { }')")
+shouldThrow("parseThenSerializeRule(':dir(42) { }')")
+shouldThrow("parseThenSerializeRule(':dir(a, b) { }')")
+shouldThrow("parseThenSerializeRule(':dir(}) { }')")
+shouldThrow("parseThenSerializeRule(':dir()) { }')")
+shouldThrow("parseThenSerializeRule(':dir(dir()) { }')")
+shouldThrow("parseThenSerializeRule(':dir(:dir()) { }')")
+shouldThrow("parseThenSerializeRule(':dir(:dir(ltr)) { }')")
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/css/css-set-selector-text-expected.txt
+++ b/LayoutTests/fast/css/css-set-selector-text-expected.txt
@@ -3,408 +3,408 @@ This tests setting and re-serialization of some CSS selectors.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS setThenReadSelectorText('') is '_foo'
-PASS setThenReadSelectorText('123') is '_foo'
-PASS setThenReadSelectorText('-') is '_foo'
-PASS setThenReadSelectorText('$') is '_foo'
-PASS setThenReadSelectorText(':') is '_foo'
-PASS setThenReadSelectorText('.') is '_foo'
-PASS setThenReadSelectorText('#') is '_foo'
-PASS setThenReadSelectorText('[]') is '_foo'
-PASS setThenReadSelectorText('()') is '_foo'
+PASS setThenReadSelectorText('') is "_foo"
+PASS setThenReadSelectorText('123') is "_foo"
+PASS setThenReadSelectorText('-') is "_foo"
+PASS setThenReadSelectorText('$') is "_foo"
+PASS setThenReadSelectorText(':') is "_foo"
+PASS setThenReadSelectorText('.') is "_foo"
+PASS setThenReadSelectorText('#') is "_foo"
+PASS setThenReadSelectorText('[]') is "_foo"
+PASS setThenReadSelectorText('()') is "_foo"
 
-PASS setThenReadSelectorText('*') is '*'
-PASS setThenReadSelectorText('a') is 'a'
-PASS setThenReadSelectorText('#a') is '#a'
-PASS setThenReadSelectorText('.a') is '.a'
-PASS setThenReadSelectorText(':active') is ':active'
-PASS setThenReadSelectorText('[a]') is '[a]'
-PASS setThenReadSelectorText('[a="b"]') is '[a="b"]'
-PASS setThenReadSelectorText('[a~="b"]') is '[a~="b"]'
-PASS setThenReadSelectorText('[a|="b"]') is '[a|="b"]'
-PASS setThenReadSelectorText('[a^="b"]') is '[a^="b"]'
-PASS setThenReadSelectorText('[a$="b"]') is '[a$="b"]'
-PASS setThenReadSelectorText('[a*="b"]') is '[a*="b"]'
-PASS setThenReadSelectorText('[a="b" i]') is '[a="b" i]'
-PASS setThenReadSelectorText('[a~="b" i]') is '[a~="b" i]'
-PASS setThenReadSelectorText('[a|="b" i]') is '[a|="b" i]'
-PASS setThenReadSelectorText('[a^="b" i]') is '[a^="b" i]'
-PASS setThenReadSelectorText('[a$="b" i]') is '[a$="b" i]'
-PASS setThenReadSelectorText('[a*="b" i]') is '[a*="b" i]'
+PASS setThenReadSelectorText('*') is "*"
+PASS setThenReadSelectorText('a') is "a"
+PASS setThenReadSelectorText('#a') is "#a"
+PASS setThenReadSelectorText('.a') is ".a"
+PASS setThenReadSelectorText(':active') is ":active"
+PASS setThenReadSelectorText('[a]') is "[a]"
+PASS setThenReadSelectorText('[a="b"]') is "[a=\"b\"]"
+PASS setThenReadSelectorText('[a~="b"]') is "[a~=\"b\"]"
+PASS setThenReadSelectorText('[a|="b"]') is "[a|=\"b\"]"
+PASS setThenReadSelectorText('[a^="b"]') is "[a^=\"b\"]"
+PASS setThenReadSelectorText('[a$="b"]') is "[a$=\"b\"]"
+PASS setThenReadSelectorText('[a*="b"]') is "[a*=\"b\"]"
+PASS setThenReadSelectorText('[a="b" i]') is "[a=\"b\" i]"
+PASS setThenReadSelectorText('[a~="b" i]') is "[a~=\"b\" i]"
+PASS setThenReadSelectorText('[a|="b" i]') is "[a|=\"b\" i]"
+PASS setThenReadSelectorText('[a^="b" i]') is "[a^=\"b\" i]"
+PASS setThenReadSelectorText('[a$="b" i]') is "[a$=\"b\" i]"
+PASS setThenReadSelectorText('[a*="b" i]') is "[a*=\"b\" i]"
 
-PASS setThenReadSelectorText('*|a') is 'a'
-PASS setThenReadSelectorText('*|*') is '*'
-PASS setThenReadSelectorText('[*|a]') is '[*|a]'
-PASS setThenReadSelectorText('|*') is '|*'
-PASS setThenReadSelectorText('[*|a]') is '[*|a]'
-PASS setThenReadSelectorText('[|a]') is '[a]'
+PASS setThenReadSelectorText('*|a') is "a"
+PASS setThenReadSelectorText('*|*') is "*"
+PASS setThenReadSelectorText('[*|a]') is "[*|a]"
+PASS setThenReadSelectorText('|*') is "|*"
+PASS setThenReadSelectorText('[*|a]') is "[*|a]"
+PASS setThenReadSelectorText('[|a]') is "[a]"
 
-PASS setThenReadSelectorText('a:active') is 'a:active'
-PASS setThenReadSelectorText('a b') is 'a b'
-PASS setThenReadSelectorText('a + b') is 'a + b'
-PASS setThenReadSelectorText('a ~ b') is 'a ~ b'
-PASS setThenReadSelectorText('a > b') is 'a > b'
+PASS setThenReadSelectorText('a:active') is "a:active"
+PASS setThenReadSelectorText('a b') is "a b"
+PASS setThenReadSelectorText('a + b') is "a + b"
+PASS setThenReadSelectorText('a ~ b') is "a ~ b"
+PASS setThenReadSelectorText('a > b') is "a > b"
 
-PASS setThenReadSelectorText(':active') is ':active'
-PASS setThenReadSelectorText(':any-link') is ':any-link'
-PASS setThenReadSelectorText(':checked') is ':checked'
-PASS setThenReadSelectorText(':disabled') is ':disabled'
-PASS setThenReadSelectorText(':empty') is ':empty'
-PASS setThenReadSelectorText(':enabled') is ':enabled'
-PASS setThenReadSelectorText(':first-child') is ':first-child'
-PASS setThenReadSelectorText(':first-of-type') is ':first-of-type'
-PASS setThenReadSelectorText(':focus') is ':focus'
-PASS setThenReadSelectorText(':hover') is ':hover'
-PASS setThenReadSelectorText(':indeterminate') is ':indeterminate'
-PASS setThenReadSelectorText(':link') is ':link'
-PASS setThenReadSelectorText(':not(:placeholder-shown)') is ':not(:placeholder-shown)'
-PASS setThenReadSelectorText(':placeholder-shown') is ':placeholder-shown'
-PASS setThenReadSelectorText(':root') is ':root'
-PASS setThenReadSelectorText(':target') is ':target'
-PASS setThenReadSelectorText(':visited') is ':visited'
+PASS setThenReadSelectorText(':active') is ":active"
+PASS setThenReadSelectorText(':any-link') is ":any-link"
+PASS setThenReadSelectorText(':checked') is ":checked"
+PASS setThenReadSelectorText(':disabled') is ":disabled"
+PASS setThenReadSelectorText(':empty') is ":empty"
+PASS setThenReadSelectorText(':enabled') is ":enabled"
+PASS setThenReadSelectorText(':first-child') is ":first-child"
+PASS setThenReadSelectorText(':first-of-type') is ":first-of-type"
+PASS setThenReadSelectorText(':focus') is ":focus"
+PASS setThenReadSelectorText(':hover') is ":hover"
+PASS setThenReadSelectorText(':indeterminate') is ":indeterminate"
+PASS setThenReadSelectorText(':link') is ":link"
+PASS setThenReadSelectorText(':not(:placeholder-shown)') is ":not(:placeholder-shown)"
+PASS setThenReadSelectorText(':placeholder-shown') is ":placeholder-shown"
+PASS setThenReadSelectorText(':root') is ":root"
+PASS setThenReadSelectorText(':target') is ":target"
+PASS setThenReadSelectorText(':visited') is ":visited"
 
-PASS setThenReadSelectorText(':dir(a)') is ':dir(a)'
-PASS setThenReadSelectorText(':lang("a")') is ':lang("a")'
-PASS setThenReadSelectorText(':lang(a)') is ':lang("a")'
-PASS setThenReadSelectorText(':not(a)') is ':not(a)'
-PASS setThenReadSelectorText(':-webkit-any(a, b, p)') is ':-webkit-any(a, b, p)'
+PASS setThenReadSelectorText(':dir(a)') is ":dir(a)"
+PASS setThenReadSelectorText(':lang("a")') is ":lang(\"a\")"
+PASS setThenReadSelectorText(':lang(a)') is ":lang(a)"
+PASS setThenReadSelectorText(':not(a)') is ":not(a)"
+PASS setThenReadSelectorText(':-webkit-any(a, b, p)') is ":-webkit-any(a, b, p)"
 
-PASS setThenReadSelectorText('::after') is '::after'
-PASS setThenReadSelectorText('::before') is '::before'
-PASS setThenReadSelectorText('::first-letter') is '::first-letter'
-PASS setThenReadSelectorText('::first-line') is '::first-line'
-PASS setThenReadSelectorText('::selection') is '::selection'
+PASS setThenReadSelectorText('::after') is "::after"
+PASS setThenReadSelectorText('::before') is "::before"
+PASS setThenReadSelectorText('::first-letter') is "::first-letter"
+PASS setThenReadSelectorText('::first-line') is "::first-line"
+PASS setThenReadSelectorText('::selection') is "::selection"
 
-PASS setThenReadSelectorText(':-webkit-any-link') is ':-webkit-any-link'
-PASS setThenReadSelectorText(':-webkit-drag') is ':-webkit-drag'
-PASS setThenReadSelectorText(':autofill') is ':autofill'
-PASS setThenReadSelectorText(':-webkit-autofill') is ':autofill'
-PASS setThenReadSelectorText('a:any-link') is 'a:any-link'
-PASS setThenReadSelectorText('a :any-link') is 'a :any-link'
-PASS setThenReadSelectorText('div:any-link') is 'div:any-link'
-PASS setThenReadSelectorText('div :any-link') is 'div :any-link'
-PASS setThenReadSelectorText(':any-link > div') is ':any-link > div'
-PASS setThenReadSelectorText(':any-link + div') is ':any-link + div'
-PASS setThenReadSelectorText(':not(:any-link)') is ':not(:any-link)'
+PASS setThenReadSelectorText(':-webkit-any-link') is ":-webkit-any-link"
+PASS setThenReadSelectorText(':-webkit-drag') is ":-webkit-drag"
+PASS setThenReadSelectorText(':autofill') is ":autofill"
+PASS setThenReadSelectorText(':-webkit-autofill') is ":autofill"
+PASS setThenReadSelectorText('a:any-link') is "a:any-link"
+PASS setThenReadSelectorText('a :any-link') is "a :any-link"
+PASS setThenReadSelectorText('div:any-link') is "div:any-link"
+PASS setThenReadSelectorText('div :any-link') is "div :any-link"
+PASS setThenReadSelectorText(':any-link > div') is ":any-link > div"
+PASS setThenReadSelectorText(':any-link + div') is ":any-link + div"
+PASS setThenReadSelectorText(':not(:any-link)') is ":not(:any-link)"
 
-PASS setThenReadSelectorText(':nth-child(odd)') is ':nth-child(2n+1)'
-PASS setThenReadSelectorText(':nth-child(even)') is ':nth-child(2n)'
-PASS setThenReadSelectorText(':nth-child(n)') is ':nth-child(n)'
-PASS setThenReadSelectorText(':nth-child(-n)') is ':nth-child(-n)'
-PASS setThenReadSelectorText(':nth-child(5)') is ':nth-child(5)'
-PASS setThenReadSelectorText(':nth-child(-5)') is ':nth-child(-5)'
-PASS setThenReadSelectorText(':nth-child(5n+7)') is ':nth-child(5n+7)'
-PASS setThenReadSelectorText(':nth-child(-5n+7)') is ':nth-child(-5n+7)'
-PASS setThenReadSelectorText(':nth-child(5n-7)') is ':nth-child(5n-7)'
-PASS setThenReadSelectorText(':nth-child(-5n-7)') is ':nth-child(-5n-7)'
+PASS setThenReadSelectorText(':nth-child(odd)') is ":nth-child(2n+1)"
+PASS setThenReadSelectorText(':nth-child(even)') is ":nth-child(2n)"
+PASS setThenReadSelectorText(':nth-child(n)') is ":nth-child(n)"
+PASS setThenReadSelectorText(':nth-child(-n)') is ":nth-child(-n)"
+PASS setThenReadSelectorText(':nth-child(5)') is ":nth-child(5)"
+PASS setThenReadSelectorText(':nth-child(-5)') is ":nth-child(-5)"
+PASS setThenReadSelectorText(':nth-child(5n+7)') is ":nth-child(5n+7)"
+PASS setThenReadSelectorText(':nth-child(-5n+7)') is ":nth-child(-5n+7)"
+PASS setThenReadSelectorText(':nth-child(5n-7)') is ":nth-child(5n-7)"
+PASS setThenReadSelectorText(':nth-child(-5n-7)') is ":nth-child(-5n-7)"
 
-PASS setThenReadSelectorText(':nth-child(odd of .foo, :nth-child(odd))') is ':nth-child(2n+1 of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(even of .foo, :nth-child(odd))') is ':nth-child(2n of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(n of .foo, :nth-child(odd))') is ':nth-child(n of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(-n of .foo, :nth-child(odd))') is ':nth-child(-n of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(5 of .foo, :nth-child(odd))') is ':nth-child(5 of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(-5 of .foo, :nth-child(odd))') is ':nth-child(-5 of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(5n+7 of .foo, :nth-child(odd))') is ':nth-child(5n+7 of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(-5n+7 of .foo, :nth-child(odd))') is ':nth-child(-5n+7 of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(5n-7 of .foo, :nth-child(odd))') is ':nth-child(5n-7 of .foo, :nth-child(2n+1))'
-PASS setThenReadSelectorText(':nth-child(-5n-7 of .foo, :nth-child(odd))') is ':nth-child(-5n-7 of .foo, :nth-child(2n+1))'
+PASS setThenReadSelectorText(':nth-child(odd of .foo, :nth-child(odd))') is ":nth-child(2n+1 of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(even of .foo, :nth-child(odd))') is ":nth-child(2n of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(n of .foo, :nth-child(odd))') is ":nth-child(n of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(-n of .foo, :nth-child(odd))') is ":nth-child(-n of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(5 of .foo, :nth-child(odd))') is ":nth-child(5 of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(-5 of .foo, :nth-child(odd))') is ":nth-child(-5 of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(5n+7 of .foo, :nth-child(odd))') is ":nth-child(5n+7 of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(-5n+7 of .foo, :nth-child(odd))') is ":nth-child(-5n+7 of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(5n-7 of .foo, :nth-child(odd))') is ":nth-child(5n-7 of .foo, :nth-child(2n+1))"
+PASS setThenReadSelectorText(':nth-child(-5n-7 of .foo, :nth-child(odd))') is ":nth-child(-5n-7 of .foo, :nth-child(2n+1))"
 
-PASS setThenReadSelectorText(':nth-last-child(odd of .foo, :nth-last-child(odd))') is ':nth-last-child(2n+1 of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(even of .foo, :nth-last-child(odd))') is ':nth-last-child(2n of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(n of .foo, :nth-last-child(odd))') is ':nth-last-child(n of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(-n of .foo, :nth-last-child(odd))') is ':nth-last-child(-n of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(5 of .foo, :nth-last-child(odd))') is ':nth-last-child(5 of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(-5 of .foo, :nth-last-child(odd))') is ':nth-last-child(-5 of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(5n+7 of .foo, :nth-last-child(odd))') is ':nth-last-child(5n+7 of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(-5n+7 of .foo, :nth-last-child(odd))') is ':nth-last-child(-5n+7 of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(5n-7 of .foo, :nth-last-child(odd))') is ':nth-last-child(5n-7 of .foo, :nth-last-child(2n+1))'
-PASS setThenReadSelectorText(':nth-last-child(-5n-7 of .foo, :nth-last-child(odd))') is ':nth-last-child(-5n-7 of .foo, :nth-last-child(2n+1))'
+PASS setThenReadSelectorText(':nth-last-child(odd of .foo, :nth-last-child(odd))') is ":nth-last-child(2n+1 of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(even of .foo, :nth-last-child(odd))') is ":nth-last-child(2n of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(n of .foo, :nth-last-child(odd))') is ":nth-last-child(n of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(-n of .foo, :nth-last-child(odd))') is ":nth-last-child(-n of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(5 of .foo, :nth-last-child(odd))') is ":nth-last-child(5 of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(-5 of .foo, :nth-last-child(odd))') is ":nth-last-child(-5 of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(5n+7 of .foo, :nth-last-child(odd))') is ":nth-last-child(5n+7 of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(-5n+7 of .foo, :nth-last-child(odd))') is ":nth-last-child(-5n+7 of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(5n-7 of .foo, :nth-last-child(odd))') is ":nth-last-child(5n-7 of .foo, :nth-last-child(2n+1))"
+PASS setThenReadSelectorText(':nth-last-child(-5n-7 of .foo, :nth-last-child(odd))') is ":nth-last-child(-5n-7 of .foo, :nth-last-child(2n+1))"
 
-PASS setThenReadSelectorText(':is(single)') is ':is(single)'
-PASS setThenReadSelectorText(':is(a, b, p)') is ':is(a, b, p)'
-PASS setThenReadSelectorText(':is(#alice, #bob, #chris)') is ':is(#alice, #bob, #chris)'
-PASS setThenReadSelectorText(':is(.selector, #tama, #hanayo, #midoriko)') is ':is(.selector, #tama, #hanayo, #midoriko)'
-PASS setThenReadSelectorText(':is(.name, #ok, :visited)') is ':is(.name, #ok, :visited)'
-PASS setThenReadSelectorText(':is(.name, #ok, :visited, :link)') is ':is(.name, #ok, :visited, :link)'
-PASS setThenReadSelectorText(':is(.name, #ok, :is(:visited))') is ':is(.name, #ok, :is(:visited))'
-PASS setThenReadSelectorText(':is(.name, #ok, :not(:link))') is ':is(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':is(.name, #ok, :not(:link))') is ':is(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':is(.name, #ok, :-webkit-any(hello))') is ':is(.name, #ok, :-webkit-any(hello))'
-PASS setThenReadSelectorText(':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':is([type="file"])') is ':is([type="file"])'
-PASS setThenReadSelectorText(':is(:hover)') is ':is(:hover)'
-PASS setThenReadSelectorText('input:is([type="file"], :hover, :focus):enabled') is 'input:is([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':is(input[type="file"], a:hover, button:focus)') is ':is(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':is(.class1.class2.class3)') is ':is(.class1.class2.class3)'
-PASS setThenReadSelectorText(':is(.class1:hover)') is ':is(.class1:hover)'
-PASS setThenReadSelectorText(':is(a.class1.class2.class3:hover)') is ':is(a.class1.class2.class3:hover)'
-PASS setThenReadSelectorText(':where(single)') is ':where(single)'
-PASS setThenReadSelectorText(':where(a, b, p)') is ':where(a, b, p)'
-PASS setThenReadSelectorText(':where(#alice, #bob, #chris)') is ':where(#alice, #bob, #chris)'
-PASS setThenReadSelectorText(':where(.selector, #tama, #hanayo, #midoriko)') is ':where(.selector, #tama, #hanayo, #midoriko)'
-PASS setThenReadSelectorText(':where(.name, #ok, :visited)') is ':where(.name, #ok, :visited)'
-PASS setThenReadSelectorText(':where(.name, #ok, :visited, :link)') is ':where(.name, #ok, :visited, :link)'
-PASS setThenReadSelectorText(':where(.name, #ok, :where(:visited))') is ':where(.name, #ok, :where(:visited))'
-PASS setThenReadSelectorText(':where(.name, #ok, :not(:link))') is ':where(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':where(.name, #ok, :not(:link))') is ':where(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':where(.name, #ok, :where(hello))') is ':where(.name, #ok, :where(hello))'
-PASS setThenReadSelectorText(':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko))') is ':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':where([type="file"])') is ':where([type="file"])'
-PASS setThenReadSelectorText(':where(:hover)') is ':where(:hover)'
-PASS setThenReadSelectorText('input:where([type="file"], :hover, :focus):enabled') is 'input:where([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':where(input[type="file"], a:hover, button:focus)') is ':where(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':where(.class1.class2.class3)') is ':where(.class1.class2.class3)'
-PASS setThenReadSelectorText(':where(.class1:hover)') is ':where(.class1:hover)'
-PASS setThenReadSelectorText(':where(a.class1.class2.class3:hover)') is ':where(a.class1.class2.class3:hover)'
-PASS setThenReadSelectorText(':matches(:is(single))') is ':matches(:is(single))'
-PASS setThenReadSelectorText(':matches(:is(a, b, p))') is ':matches(:is(a, b, p))'
-PASS setThenReadSelectorText(':matches(:is(#alice, #bob, #chris))') is ':matches(:is(#alice, #bob, #chris))'
-PASS setThenReadSelectorText(':matches(:is(.selector, #tama, #hanayo, #midoriko))') is ':matches(:is(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :visited))') is ':matches(:is(.name, #ok, :visited))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :visited, :link))') is ':matches(:is(.name, #ok, :visited, :link))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :is(:visited)))') is ':matches(:is(.name, #ok, :is(:visited)))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :not(:link)))') is ':matches(:is(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :not(:link)))') is ':matches(:is(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :matches(hello)))') is ':matches(:is(.name, #ok, :matches(hello)))'
-PASS setThenReadSelectorText(':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko)))') is ':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko)))'
-PASS setThenReadSelectorText(':matches(:is([type="file"]))') is ':matches(:is([type="file"]))'
-PASS setThenReadSelectorText(':matches(:is(:hover))') is ':matches(:is(:hover))'
-PASS setThenReadSelectorText(':matches(input:is([type="file"], :hover, :focus):enabled)') is ':matches(input:is([type="file"], :hover, :focus):enabled)'
-PASS setThenReadSelectorText(':matches(:is(input[type="file"], a:hover, button:focus))') is ':matches(:is(input[type="file"], a:hover, button:focus))'
-PASS setThenReadSelectorText(':matches(:is(.class1.class2.class3))') is ':matches(:is(.class1.class2.class3))'
-PASS setThenReadSelectorText(':matches(:is(.class1:hover))') is ':matches(:is(.class1:hover))'
-PASS setThenReadSelectorText(':matches(:is(a.class1.class2.class3:hover))') is ':matches(:is(a.class1.class2.class3:hover))'
-PASS setThenReadSelectorText(':-webkit-any(:is(single))') is ':-webkit-any(:is(single))'
-PASS setThenReadSelectorText(':-webkit-any(:is(a, b, p))') is ':-webkit-any(:is(a, b, p))'
-PASS setThenReadSelectorText(':-webkit-any(:is(#alice, #bob, #chris))') is ':-webkit-any(:is(#alice, #bob, #chris))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko))') is ':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :visited))') is ':-webkit-any(:is(.name, #ok, :visited))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :visited, :link))') is ':-webkit-any(:is(.name, #ok, :visited, :link))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :is(:visited)))') is ':-webkit-any(:is(.name, #ok, :is(:visited)))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :not(:link)))') is ':-webkit-any(:is(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :not(:link)))') is ':-webkit-any(:is(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :-webkit-any(hello)))') is ':-webkit-any(:is(.name, #ok, :-webkit-any(hello)))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))') is ':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))'
-PASS setThenReadSelectorText(':-webkit-any(:is([type="file"]))') is ':-webkit-any(:is([type="file"]))'
-PASS setThenReadSelectorText(':-webkit-any(:is(:hover))') is ':-webkit-any(:is(:hover))'
-PASS setThenReadSelectorText(':-webkit-any(input:is([type="file"], :hover, :focus):enabled)') is ':-webkit-any(input:is([type="file"], :hover, :focus):enabled)'
-PASS setThenReadSelectorText(':-webkit-any(:is(input[type="file"], a:hover, button:focus))') is ':-webkit-any(:is(input[type="file"], a:hover, button:focus))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.class1.class2.class3))') is ':-webkit-any(:is(.class1.class2.class3))'
-PASS setThenReadSelectorText(':-webkit-any(:is(.class1:hover))') is ':-webkit-any(:is(.class1:hover))'
-PASS setThenReadSelectorText(':-webkit-any(:is(a.class1.class2.class3:hover))') is ':-webkit-any(:is(a.class1.class2.class3:hover))'
+PASS setThenReadSelectorText(':is(single)') is ":is(single)"
+PASS setThenReadSelectorText(':is(a, b, p)') is ":is(a, b, p)"
+PASS setThenReadSelectorText(':is(#alice, #bob, #chris)') is ":is(#alice, #bob, #chris)"
+PASS setThenReadSelectorText(':is(.selector, #tama, #hanayo, #midoriko)') is ":is(.selector, #tama, #hanayo, #midoriko)"
+PASS setThenReadSelectorText(':is(.name, #ok, :visited)') is ":is(.name, #ok, :visited)"
+PASS setThenReadSelectorText(':is(.name, #ok, :visited, :link)') is ":is(.name, #ok, :visited, :link)"
+PASS setThenReadSelectorText(':is(.name, #ok, :is(:visited))') is ":is(.name, #ok, :is(:visited))"
+PASS setThenReadSelectorText(':is(.name, #ok, :not(:link))') is ":is(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':is(.name, #ok, :not(:link))') is ":is(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':is(.name, #ok, :-webkit-any(hello))') is ":is(.name, #ok, :-webkit-any(hello))"
+PASS setThenReadSelectorText(':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ":is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':is([type="file"])') is ":is([type=\"file\"])"
+PASS setThenReadSelectorText(':is(:hover)') is ":is(:hover)"
+PASS setThenReadSelectorText('input:is([type="file"], :hover, :focus):enabled') is "input:is([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':is(input[type="file"], a:hover, button:focus)') is ":is(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':is(.class1.class2.class3)') is ":is(.class1.class2.class3)"
+PASS setThenReadSelectorText(':is(.class1:hover)') is ":is(.class1:hover)"
+PASS setThenReadSelectorText(':is(a.class1.class2.class3:hover)') is ":is(a.class1.class2.class3:hover)"
+PASS setThenReadSelectorText(':where(single)') is ":where(single)"
+PASS setThenReadSelectorText(':where(a, b, p)') is ":where(a, b, p)"
+PASS setThenReadSelectorText(':where(#alice, #bob, #chris)') is ":where(#alice, #bob, #chris)"
+PASS setThenReadSelectorText(':where(.selector, #tama, #hanayo, #midoriko)') is ":where(.selector, #tama, #hanayo, #midoriko)"
+PASS setThenReadSelectorText(':where(.name, #ok, :visited)') is ":where(.name, #ok, :visited)"
+PASS setThenReadSelectorText(':where(.name, #ok, :visited, :link)') is ":where(.name, #ok, :visited, :link)"
+PASS setThenReadSelectorText(':where(.name, #ok, :where(:visited))') is ":where(.name, #ok, :where(:visited))"
+PASS setThenReadSelectorText(':where(.name, #ok, :not(:link))') is ":where(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':where(.name, #ok, :not(:link))') is ":where(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':where(.name, #ok, :where(hello))') is ":where(.name, #ok, :where(hello))"
+PASS setThenReadSelectorText(':where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko))') is ":where(.name, #ok, :where(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':where([type="file"])') is ":where([type=\"file\"])"
+PASS setThenReadSelectorText(':where(:hover)') is ":where(:hover)"
+PASS setThenReadSelectorText('input:where([type="file"], :hover, :focus):enabled') is "input:where([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':where(input[type="file"], a:hover, button:focus)') is ":where(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':where(.class1.class2.class3)') is ":where(.class1.class2.class3)"
+PASS setThenReadSelectorText(':where(.class1:hover)') is ":where(.class1:hover)"
+PASS setThenReadSelectorText(':where(a.class1.class2.class3:hover)') is ":where(a.class1.class2.class3:hover)"
+PASS setThenReadSelectorText(':matches(:is(single))') is ":matches(:is(single))"
+PASS setThenReadSelectorText(':matches(:is(a, b, p))') is ":matches(:is(a, b, p))"
+PASS setThenReadSelectorText(':matches(:is(#alice, #bob, #chris))') is ":matches(:is(#alice, #bob, #chris))"
+PASS setThenReadSelectorText(':matches(:is(.selector, #tama, #hanayo, #midoriko))') is ":matches(:is(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :visited))') is ":matches(:is(.name, #ok, :visited))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :visited, :link))') is ":matches(:is(.name, #ok, :visited, :link))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :is(:visited)))') is ":matches(:is(.name, #ok, :is(:visited)))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :not(:link)))') is ":matches(:is(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :not(:link)))') is ":matches(:is(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :matches(hello)))') is ":matches(:is(.name, #ok, :matches(hello)))"
+PASS setThenReadSelectorText(':matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko)))') is ":matches(:is(.name, #ok, :matches(.selector, #tama, #hanayo, #midoriko)))"
+PASS setThenReadSelectorText(':matches(:is([type="file"]))') is ":matches(:is([type=\"file\"]))"
+PASS setThenReadSelectorText(':matches(:is(:hover))') is ":matches(:is(:hover))"
+PASS setThenReadSelectorText(':matches(input:is([type="file"], :hover, :focus):enabled)') is ":matches(input:is([type=\"file\"], :hover, :focus):enabled)"
+PASS setThenReadSelectorText(':matches(:is(input[type="file"], a:hover, button:focus))') is ":matches(:is(input[type=\"file\"], a:hover, button:focus))"
+PASS setThenReadSelectorText(':matches(:is(.class1.class2.class3))') is ":matches(:is(.class1.class2.class3))"
+PASS setThenReadSelectorText(':matches(:is(.class1:hover))') is ":matches(:is(.class1:hover))"
+PASS setThenReadSelectorText(':matches(:is(a.class1.class2.class3:hover))') is ":matches(:is(a.class1.class2.class3:hover))"
+PASS setThenReadSelectorText(':-webkit-any(:is(single))') is ":-webkit-any(:is(single))"
+PASS setThenReadSelectorText(':-webkit-any(:is(a, b, p))') is ":-webkit-any(:is(a, b, p))"
+PASS setThenReadSelectorText(':-webkit-any(:is(#alice, #bob, #chris))') is ":-webkit-any(:is(#alice, #bob, #chris))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.selector, #tama, #hanayo, #midoriko))') is ":-webkit-any(:is(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :visited))') is ":-webkit-any(:is(.name, #ok, :visited))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :visited, :link))') is ":-webkit-any(:is(.name, #ok, :visited, :link))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :is(:visited)))') is ":-webkit-any(:is(.name, #ok, :is(:visited)))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :not(:link)))') is ":-webkit-any(:is(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :not(:link)))') is ":-webkit-any(:is(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :-webkit-any(hello)))') is ":-webkit-any(:is(.name, #ok, :-webkit-any(hello)))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))') is ":-webkit-any(:is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))"
+PASS setThenReadSelectorText(':-webkit-any(:is([type="file"]))') is ":-webkit-any(:is([type=\"file\"]))"
+PASS setThenReadSelectorText(':-webkit-any(:is(:hover))') is ":-webkit-any(:is(:hover))"
+PASS setThenReadSelectorText(':-webkit-any(input:is([type="file"], :hover, :focus):enabled)') is ":-webkit-any(input:is([type=\"file\"], :hover, :focus):enabled)"
+PASS setThenReadSelectorText(':-webkit-any(:is(input[type="file"], a:hover, button:focus))') is ":-webkit-any(:is(input[type=\"file\"], a:hover, button:focus))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.class1.class2.class3))') is ":-webkit-any(:is(.class1.class2.class3))"
+PASS setThenReadSelectorText(':-webkit-any(:is(.class1:hover))') is ":-webkit-any(:is(.class1:hover))"
+PASS setThenReadSelectorText(':-webkit-any(:is(a.class1.class2.class3:hover))') is ":-webkit-any(:is(a.class1.class2.class3:hover))"
 
-PASS setThenReadSelectorText(':matches(single)') is ':matches(single)'
-PASS setThenReadSelectorText(':matches(a, b, p)') is ':matches(a, b, p)'
-PASS setThenReadSelectorText(':matches(#alice, #bob, #chris)') is ':matches(#alice, #bob, #chris)'
-PASS setThenReadSelectorText(':matches(.selector, #tama, #hanayo, #midoriko)') is ':matches(.selector, #tama, #hanayo, #midoriko)'
-PASS setThenReadSelectorText(':matches(.name, #ok, :visited)') is ':matches(.name, #ok, :visited)'
-PASS setThenReadSelectorText(':matches(.name, #ok, :visited, :link)') is ':matches(.name, #ok, :visited, :link)'
-PASS setThenReadSelectorText(':matches(.name, #ok, :matches(:visited))') is ':matches(.name, #ok, :matches(:visited))'
-PASS setThenReadSelectorText(':matches(.name, #ok, :not(:link))') is ':matches(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':matches(.name, #ok, :not(:link))') is ':matches(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':matches(.name, #ok, :-webkit-any(hello))') is ':matches(.name, #ok, :-webkit-any(hello))'
-PASS setThenReadSelectorText(':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':matches([type="file"])') is ':matches([type="file"])'
-PASS setThenReadSelectorText(':matches(:hover)') is ':matches(:hover)'
-PASS setThenReadSelectorText('input:matches([type="file"], :hover, :focus):enabled') is 'input:matches([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':matches(input[type="file"], a:hover, button:focus)') is ':matches(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':matches(.class1.class2.class3)') is ':matches(.class1.class2.class3)'
-PASS setThenReadSelectorText(':matches(.class1:hover)') is ':matches(.class1:hover)'
-PASS setThenReadSelectorText(':matches(a.class1.class2.class3:hover)') is ':matches(a.class1.class2.class3:hover)'
-PASS setThenReadSelectorText(':is(:matches(single))') is ':is(:matches(single))'
-PASS setThenReadSelectorText(':is(:matches(a, b, p))') is ':is(:matches(a, b, p))'
-PASS setThenReadSelectorText(':is(:matches(#alice, #bob, #chris))') is ':is(:matches(#alice, #bob, #chris))'
-PASS setThenReadSelectorText(':is(:matches(.selector, #tama, #hanayo, #midoriko))') is ':is(:matches(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :visited))') is ':is(:matches(.name, #ok, :visited))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :visited, :link))') is ':is(:matches(.name, #ok, :visited, :link))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :matches(:visited)))') is ':is(:matches(.name, #ok, :matches(:visited)))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :not(:link)))') is ':is(:matches(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :not(:link)))') is ':is(:matches(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :is(hello)))') is ':is(:matches(.name, #ok, :is(hello)))'
-PASS setThenReadSelectorText(':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko)))') is ':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko)))'
-PASS setThenReadSelectorText(':is(:matches([type="file"]))') is ':is(:matches([type="file"]))'
-PASS setThenReadSelectorText(':is(:matches(:hover))') is ':is(:matches(:hover))'
-PASS setThenReadSelectorText(':is(input:matches([type="file"], :hover, :focus):enabled)') is ':is(input:matches([type="file"], :hover, :focus):enabled)'
-PASS setThenReadSelectorText(':is(:matches(input[type="file"], a:hover, button:focus))') is ':is(:matches(input[type="file"], a:hover, button:focus))'
-PASS setThenReadSelectorText(':is(:matches(.class1.class2.class3))') is ':is(:matches(.class1.class2.class3))'
-PASS setThenReadSelectorText(':is(:matches(.class1:hover))') is ':is(:matches(.class1:hover))'
-PASS setThenReadSelectorText(':is(:matches(a.class1.class2.class3:hover))') is ':is(:matches(a.class1.class2.class3:hover))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(single))') is ':-webkit-any(:matches(single))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(a, b, p))') is ':-webkit-any(:matches(a, b, p))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(#alice, #bob, #chris))') is ':-webkit-any(:matches(#alice, #bob, #chris))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko))') is ':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :visited))') is ':-webkit-any(:matches(.name, #ok, :visited))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :visited, :link))') is ':-webkit-any(:matches(.name, #ok, :visited, :link))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :matches(:visited)))') is ':-webkit-any(:matches(.name, #ok, :matches(:visited)))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :not(:link)))') is ':-webkit-any(:matches(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :not(:link)))') is ':-webkit-any(:matches(.name, #ok, :not(:link)))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :-webkit-any(hello)))') is ':-webkit-any(:matches(.name, #ok, :-webkit-any(hello)))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))') is ':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))'
-PASS setThenReadSelectorText(':-webkit-any(:matches([type="file"]))') is ':-webkit-any(:matches([type="file"]))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(:hover))') is ':-webkit-any(:matches(:hover))'
-PASS setThenReadSelectorText(':-webkit-any(input:matches([type="file"], :hover, :focus):enabled)') is ':-webkit-any(input:matches([type="file"], :hover, :focus):enabled)'
-PASS setThenReadSelectorText(':-webkit-any(:matches(input[type="file"], a:hover, button:focus))') is ':-webkit-any(:matches(input[type="file"], a:hover, button:focus))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.class1.class2.class3))') is ':-webkit-any(:matches(.class1.class2.class3))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(.class1:hover))') is ':-webkit-any(:matches(.class1:hover))'
-PASS setThenReadSelectorText(':-webkit-any(:matches(a.class1.class2.class3:hover))') is ':-webkit-any(:matches(a.class1.class2.class3:hover))'
+PASS setThenReadSelectorText(':matches(single)') is ":matches(single)"
+PASS setThenReadSelectorText(':matches(a, b, p)') is ":matches(a, b, p)"
+PASS setThenReadSelectorText(':matches(#alice, #bob, #chris)') is ":matches(#alice, #bob, #chris)"
+PASS setThenReadSelectorText(':matches(.selector, #tama, #hanayo, #midoriko)') is ":matches(.selector, #tama, #hanayo, #midoriko)"
+PASS setThenReadSelectorText(':matches(.name, #ok, :visited)') is ":matches(.name, #ok, :visited)"
+PASS setThenReadSelectorText(':matches(.name, #ok, :visited, :link)') is ":matches(.name, #ok, :visited, :link)"
+PASS setThenReadSelectorText(':matches(.name, #ok, :matches(:visited))') is ":matches(.name, #ok, :matches(:visited))"
+PASS setThenReadSelectorText(':matches(.name, #ok, :not(:link))') is ":matches(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':matches(.name, #ok, :not(:link))') is ":matches(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':matches(.name, #ok, :-webkit-any(hello))') is ":matches(.name, #ok, :-webkit-any(hello))"
+PASS setThenReadSelectorText(':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ":matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':matches([type="file"])') is ":matches([type=\"file\"])"
+PASS setThenReadSelectorText(':matches(:hover)') is ":matches(:hover)"
+PASS setThenReadSelectorText('input:matches([type="file"], :hover, :focus):enabled') is "input:matches([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':matches(input[type="file"], a:hover, button:focus)') is ":matches(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':matches(.class1.class2.class3)') is ":matches(.class1.class2.class3)"
+PASS setThenReadSelectorText(':matches(.class1:hover)') is ":matches(.class1:hover)"
+PASS setThenReadSelectorText(':matches(a.class1.class2.class3:hover)') is ":matches(a.class1.class2.class3:hover)"
+PASS setThenReadSelectorText(':is(:matches(single))') is ":is(:matches(single))"
+PASS setThenReadSelectorText(':is(:matches(a, b, p))') is ":is(:matches(a, b, p))"
+PASS setThenReadSelectorText(':is(:matches(#alice, #bob, #chris))') is ":is(:matches(#alice, #bob, #chris))"
+PASS setThenReadSelectorText(':is(:matches(.selector, #tama, #hanayo, #midoriko))') is ":is(:matches(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :visited))') is ":is(:matches(.name, #ok, :visited))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :visited, :link))') is ":is(:matches(.name, #ok, :visited, :link))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :matches(:visited)))') is ":is(:matches(.name, #ok, :matches(:visited)))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :not(:link)))') is ":is(:matches(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :not(:link)))') is ":is(:matches(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :is(hello)))') is ":is(:matches(.name, #ok, :is(hello)))"
+PASS setThenReadSelectorText(':is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko)))') is ":is(:matches(.name, #ok, :is(.selector, #tama, #hanayo, #midoriko)))"
+PASS setThenReadSelectorText(':is(:matches([type="file"]))') is ":is(:matches([type=\"file\"]))"
+PASS setThenReadSelectorText(':is(:matches(:hover))') is ":is(:matches(:hover))"
+PASS setThenReadSelectorText(':is(input:matches([type="file"], :hover, :focus):enabled)') is ":is(input:matches([type=\"file\"], :hover, :focus):enabled)"
+PASS setThenReadSelectorText(':is(:matches(input[type="file"], a:hover, button:focus))') is ":is(:matches(input[type=\"file\"], a:hover, button:focus))"
+PASS setThenReadSelectorText(':is(:matches(.class1.class2.class3))') is ":is(:matches(.class1.class2.class3))"
+PASS setThenReadSelectorText(':is(:matches(.class1:hover))') is ":is(:matches(.class1:hover))"
+PASS setThenReadSelectorText(':is(:matches(a.class1.class2.class3:hover))') is ":is(:matches(a.class1.class2.class3:hover))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(single))') is ":-webkit-any(:matches(single))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(a, b, p))') is ":-webkit-any(:matches(a, b, p))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(#alice, #bob, #chris))') is ":-webkit-any(:matches(#alice, #bob, #chris))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko))') is ":-webkit-any(:matches(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :visited))') is ":-webkit-any(:matches(.name, #ok, :visited))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :visited, :link))') is ":-webkit-any(:matches(.name, #ok, :visited, :link))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :matches(:visited)))') is ":-webkit-any(:matches(.name, #ok, :matches(:visited)))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :not(:link)))') is ":-webkit-any(:matches(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :not(:link)))') is ":-webkit-any(:matches(.name, #ok, :not(:link)))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :-webkit-any(hello)))') is ":-webkit-any(:matches(.name, #ok, :-webkit-any(hello)))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))') is ":-webkit-any(:matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko)))"
+PASS setThenReadSelectorText(':-webkit-any(:matches([type="file"]))') is ":-webkit-any(:matches([type=\"file\"]))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(:hover))') is ":-webkit-any(:matches(:hover))"
+PASS setThenReadSelectorText(':-webkit-any(input:matches([type="file"], :hover, :focus):enabled)') is ":-webkit-any(input:matches([type=\"file\"], :hover, :focus):enabled)"
+PASS setThenReadSelectorText(':-webkit-any(:matches(input[type="file"], a:hover, button:focus))') is ":-webkit-any(:matches(input[type=\"file\"], a:hover, button:focus))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.class1.class2.class3))') is ":-webkit-any(:matches(.class1.class2.class3))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(.class1:hover))') is ":-webkit-any(:matches(.class1:hover))"
+PASS setThenReadSelectorText(':-webkit-any(:matches(a.class1.class2.class3:hover))') is ":-webkit-any(:matches(a.class1.class2.class3:hover))"
 
-PASS setThenReadSelectorText(':not(div)') is ':not(div)'
-PASS setThenReadSelectorText(':not(.div)') is ':not(.div)'
-PASS setThenReadSelectorText(':not(#div)') is ':not(#div)'
-PASS setThenReadSelectorText(':not([div])') is ':not([div])'
-PASS setThenReadSelectorText(':not(:empty)') is ':not(:empty)'
-PASS setThenReadSelectorText(':not(div.div#div[div]:empty)') is ':not(div.div#div[div]:empty)'
-PASS setThenReadSelectorText(':not(div.div:empty[div]#div)') is ':not(div.div:empty[div]#div)'
-PASS setThenReadSelectorText(':not(div.div, #div[div], :empty)') is ':not(div.div, #div[div], :empty)'
-PASS setThenReadSelectorText(':not(div, .div, #div, [div], :empty)') is ':not(div, .div, #div, [div], :empty)'
-PASS setThenReadSelectorText(':not(:not(div))') is ':not(:not(div))'
-PASS setThenReadSelectorText(':not(:not(div)):not(:not(foo)):not(:not(bar))') is ':not(:not(div)):not(:not(foo)):not(:not(bar))'
-PASS setThenReadSelectorText(':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz))') is ':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz))'
-PASS setThenReadSelectorText(':not(:is(*))') is ':not(:is(*))'
-PASS setThenReadSelectorText(':not(:is(foo, bar))') is ':not(:is(foo, bar))'
-PASS setThenReadSelectorText(':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar]))') is ':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar]))'
-PASS setThenReadSelectorText(':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar]))') is ':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar]))'
-PASS setThenReadSelectorText(':not(:matches(*))') is ':not(:matches(*))'
-PASS setThenReadSelectorText(':not(:matches(foo, bar))') is ':not(:matches(foo, bar))'
-PASS setThenReadSelectorText(':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar]))') is ':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar]))'
-PASS setThenReadSelectorText(':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar]))') is ':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar]))'
-PASS setThenReadSelectorText(':nth-child(2n of :not(a.b, c#d.e))') is ':nth-child(2n of :not(a.b, c#d.e))'
-PASS setThenReadSelectorText(':not(:nth-child(2n of :not(a.b, c#d.e)))') is ':not(:nth-child(2n of :not(a.b, c#d.e)))'
-PASS setThenReadSelectorText(':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)') is ':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)'
-PASS setThenReadSelectorText('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)') is 'a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)'
+PASS setThenReadSelectorText(':not(div)') is ":not(div)"
+PASS setThenReadSelectorText(':not(.div)') is ":not(.div)"
+PASS setThenReadSelectorText(':not(#div)') is ":not(#div)"
+PASS setThenReadSelectorText(':not([div])') is ":not([div])"
+PASS setThenReadSelectorText(':not(:empty)') is ":not(:empty)"
+PASS setThenReadSelectorText(':not(div.div#div[div]:empty)') is ":not(div.div#div[div]:empty)"
+PASS setThenReadSelectorText(':not(div.div:empty[div]#div)') is ":not(div.div:empty[div]#div)"
+PASS setThenReadSelectorText(':not(div.div, #div[div], :empty)') is ":not(div.div, #div[div], :empty)"
+PASS setThenReadSelectorText(':not(div, .div, #div, [div], :empty)') is ":not(div, .div, #div, [div], :empty)"
+PASS setThenReadSelectorText(':not(:not(div))') is ":not(:not(div))"
+PASS setThenReadSelectorText(':not(:not(div)):not(:not(foo)):not(:not(bar))') is ":not(:not(div)):not(:not(foo)):not(:not(bar))"
+PASS setThenReadSelectorText(':not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz))') is ":not(:not(div, :not(foo, bar))):not(:not(foo)):not(:not(bar, baz))"
+PASS setThenReadSelectorText(':not(:is(*))') is ":not(:is(*))"
+PASS setThenReadSelectorText(':not(:is(foo, bar))') is ":not(:is(foo, bar))"
+PASS setThenReadSelectorText(':not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar]))') is ":not(:is(foo, bar), :is(.foo, .bar), :is(#foo, #bar), :is([foo], [bar]))"
+PASS setThenReadSelectorText(':not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar]))') is ":not(:is(foo, bar:not(:empty)), :is(.foo, .bar:not(:not(.mosaic))), :is(#foo, #bar), :is([foo], [bar]))"
+PASS setThenReadSelectorText(':not(:matches(*))') is ":not(:matches(*))"
+PASS setThenReadSelectorText(':not(:matches(foo, bar))') is ":not(:matches(foo, bar))"
+PASS setThenReadSelectorText(':not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar]))') is ":not(:matches(foo, bar), :matches(.foo, .bar), :matches(#foo, #bar), :matches([foo], [bar]))"
+PASS setThenReadSelectorText(':not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar]))') is ":not(:matches(foo, bar:not(:empty)), :matches(.foo, .bar:not(:not(.mosaic))), :matches(#foo, #bar), :matches([foo], [bar]))"
+PASS setThenReadSelectorText(':nth-child(2n of :not(a.b, c#d.e))') is ":nth-child(2n of :not(a.b, c#d.e))"
+PASS setThenReadSelectorText(':not(:nth-child(2n of :not(a.b, c#d.e)))') is ":not(:nth-child(2n of :not(a.b, c#d.e)))"
+PASS setThenReadSelectorText(':not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)') is ":not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)"
+PASS setThenReadSelectorText('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)') is "a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b + c:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) ~ d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) > d:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child)"
 
-PASS setThenReadSelectorText('::-webkit-file-upload-button') is '::-webkit-file-upload-button'
-PASS setThenReadSelectorText('::-webkit-search-cancel-button') is '::-webkit-search-cancel-button'
-PASS setThenReadSelectorText('::-webkit-search-decoration') is '::-webkit-search-decoration'
-PASS setThenReadSelectorText('::-webkit-search-results-button') is '::-webkit-search-results-button'
-PASS setThenReadSelectorText('::-webkit-search-results-decoration') is '::-webkit-search-results-decoration'
-PASS setThenReadSelectorText('::-webkit-slider-thumb') is '::-webkit-slider-thumb'
+PASS setThenReadSelectorText('::-webkit-file-upload-button') is "::-webkit-file-upload-button"
+PASS setThenReadSelectorText('::-webkit-search-cancel-button') is "::-webkit-search-cancel-button"
+PASS setThenReadSelectorText('::-webkit-search-decoration') is "::-webkit-search-decoration"
+PASS setThenReadSelectorText('::-webkit-search-results-button') is "::-webkit-search-results-button"
+PASS setThenReadSelectorText('::-webkit-search-results-decoration') is "::-webkit-search-results-decoration"
+PASS setThenReadSelectorText('::-webkit-slider-thumb') is "::-webkit-slider-thumb"
 
-PASS setThenReadSelectorText('a::-webkit-slider-thumb') is 'a::-webkit-slider-thumb'
-PASS setThenReadSelectorText('a ::-webkit-slider-thumb') is 'a ::-webkit-slider-thumb'
-PASS setThenReadSelectorText('[a]::-webkit-slider-thumb') is '[a]::-webkit-slider-thumb'
-PASS setThenReadSelectorText('[a] ::-webkit-slider-thumb') is '[a] ::-webkit-slider-thumb'
-PASS setThenReadSelectorText('.a::-webkit-slider-thumb') is '.a::-webkit-slider-thumb'
-PASS setThenReadSelectorText('.a ::-webkit-slider-thumb') is '.a ::-webkit-slider-thumb'
-PASS setThenReadSelectorText('#a::-webkit-slider-thumb') is '#a::-webkit-slider-thumb'
-PASS setThenReadSelectorText('#a ::-webkit-slider-thumb') is '#a ::-webkit-slider-thumb'
-PASS setThenReadSelectorText('* ::-webkit-slider-thumb') is '* ::-webkit-slider-thumb'
+PASS setThenReadSelectorText('a::-webkit-slider-thumb') is "a::-webkit-slider-thumb"
+PASS setThenReadSelectorText('a ::-webkit-slider-thumb') is "a ::-webkit-slider-thumb"
+PASS setThenReadSelectorText('[a]::-webkit-slider-thumb') is "[a]::-webkit-slider-thumb"
+PASS setThenReadSelectorText('[a] ::-webkit-slider-thumb') is "[a] ::-webkit-slider-thumb"
+PASS setThenReadSelectorText('.a::-webkit-slider-thumb') is ".a::-webkit-slider-thumb"
+PASS setThenReadSelectorText('.a ::-webkit-slider-thumb') is ".a ::-webkit-slider-thumb"
+PASS setThenReadSelectorText('#a::-webkit-slider-thumb') is "#a::-webkit-slider-thumb"
+PASS setThenReadSelectorText('#a ::-webkit-slider-thumb') is "#a ::-webkit-slider-thumb"
+PASS setThenReadSelectorText('* ::-webkit-slider-thumb') is "* ::-webkit-slider-thumb"
 
-PASS setThenReadSelectorText('a[b]::-webkit-slider-thumb') is 'a[b]::-webkit-slider-thumb'
-PASS setThenReadSelectorText('a.b::-webkit-slider-thumb') is 'a.b::-webkit-slider-thumb'
-PASS setThenReadSelectorText('a#b::-webkit-slider-thumb') is 'a#b::-webkit-slider-thumb'
-PASS setThenReadSelectorText('a[b].c#d::-webkit-slider-thumb') is 'a[b].c#d::-webkit-slider-thumb'
+PASS setThenReadSelectorText('a[b]::-webkit-slider-thumb') is "a[b]::-webkit-slider-thumb"
+PASS setThenReadSelectorText('a.b::-webkit-slider-thumb') is "a.b::-webkit-slider-thumb"
+PASS setThenReadSelectorText('a#b::-webkit-slider-thumb') is "a#b::-webkit-slider-thumb"
+PASS setThenReadSelectorText('a[b].c#d::-webkit-slider-thumb') is "a[b].c#d::-webkit-slider-thumb"
 
-PASS setThenReadSelectorText('a[b]::placeholder') is 'a[b]::placeholder'
-PASS setThenReadSelectorText('a.b::placeholder') is 'a.b::placeholder'
-PASS setThenReadSelectorText('a#b::placeholder') is 'a#b::placeholder'
-PASS setThenReadSelectorText('a[b].c#d::placeholder') is 'a[b].c#d::placeholder'
-PASS setThenReadSelectorText('a[b]::-webkit-input-placeholder') is 'a[b]::-webkit-input-placeholder'
-PASS setThenReadSelectorText('a.b::-webkit-input-placeholder') is 'a.b::-webkit-input-placeholder'
-PASS setThenReadSelectorText('a#b::-webkit-input-placeholder') is 'a#b::-webkit-input-placeholder'
-PASS setThenReadSelectorText('a[b].c#d::-webkit-input-placeholder') is 'a[b].c#d::-webkit-input-placeholder'
+PASS setThenReadSelectorText('a[b]::placeholder') is "a[b]::placeholder"
+PASS setThenReadSelectorText('a.b::placeholder') is "a.b::placeholder"
+PASS setThenReadSelectorText('a#b::placeholder') is "a#b::placeholder"
+PASS setThenReadSelectorText('a[b].c#d::placeholder') is "a[b].c#d::placeholder"
+PASS setThenReadSelectorText('a[b]::-webkit-input-placeholder') is "a[b]::-webkit-input-placeholder"
+PASS setThenReadSelectorText('a.b::-webkit-input-placeholder') is "a.b::-webkit-input-placeholder"
+PASS setThenReadSelectorText('a#b::-webkit-input-placeholder') is "a#b::-webkit-input-placeholder"
+PASS setThenReadSelectorText('a[b].c#d::-webkit-input-placeholder') is "a[b].c#d::-webkit-input-placeholder"
 
-PASS setThenReadSelectorText('a[b]:default') is 'a[b]:default'
-PASS setThenReadSelectorText('a.b:default') is 'a.b:default'
-PASS setThenReadSelectorText('a#b:default') is 'a#b:default'
-PASS setThenReadSelectorText('a[b].c#d:default') is 'a[b].c#d:default'
+PASS setThenReadSelectorText('a[b]:default') is "a[b]:default"
+PASS setThenReadSelectorText('a.b:default') is "a.b:default"
+PASS setThenReadSelectorText('a#b:default') is "a#b:default"
+PASS setThenReadSelectorText('a[b].c#d:default') is "a[b].c#d:default"
 
-PASS setThenReadSelectorText('a[b]:in-range') is 'a[b]:in-range'
-PASS setThenReadSelectorText('a.b:in-range') is 'a.b:in-range'
-PASS setThenReadSelectorText('a#b:in-range') is 'a#b:in-range'
-PASS setThenReadSelectorText('a[b].c#d:in-range') is 'a[b].c#d:in-range'
+PASS setThenReadSelectorText('a[b]:in-range') is "a[b]:in-range"
+PASS setThenReadSelectorText('a.b:in-range') is "a.b:in-range"
+PASS setThenReadSelectorText('a#b:in-range') is "a#b:in-range"
+PASS setThenReadSelectorText('a[b].c#d:in-range') is "a[b].c#d:in-range"
 
-PASS setThenReadSelectorText('a[b]:out-of-range') is 'a[b]:out-of-range'
-PASS setThenReadSelectorText('a.b:out-of-range') is 'a.b:out-of-range'
-PASS setThenReadSelectorText('a#b:out-of-range') is 'a#b:out-of-range'
-PASS setThenReadSelectorText('a[b].c#d:out-of-range') is 'a[b].c#d:out-of-range'
+PASS setThenReadSelectorText('a[b]:out-of-range') is "a[b]:out-of-range"
+PASS setThenReadSelectorText('a.b:out-of-range') is "a.b:out-of-range"
+PASS setThenReadSelectorText('a#b:out-of-range') is "a#b:out-of-range"
+PASS setThenReadSelectorText('a[b].c#d:out-of-range') is "a[b].c#d:out-of-range"
 
-PASS setThenReadSelectorText('a[b]:focus-within') is 'a[b]:focus-within'
-PASS setThenReadSelectorText('a.b:focus-within') is 'a.b:focus-within'
-PASS setThenReadSelectorText('a#b:focus-within') is 'a#b:focus-within'
-PASS setThenReadSelectorText('a[b].c#d:focus-within') is 'a[b].c#d:focus-within'
+PASS setThenReadSelectorText('a[b]:focus-within') is "a[b]:focus-within"
+PASS setThenReadSelectorText('a.b:focus-within') is "a.b:focus-within"
+PASS setThenReadSelectorText('a#b:focus-within') is "a#b:focus-within"
+PASS setThenReadSelectorText('a[b].c#d:focus-within') is "a[b].c#d:focus-within"
 
-PASS setThenReadSelectorText('input:not([type="file"]):focus') is 'input:not([type="file"]):focus'
-PASS setThenReadSelectorText(':-webkit-any([type="file"])') is ':-webkit-any([type="file"])'
-PASS setThenReadSelectorText(':-webkit-any(:hover)') is ':-webkit-any(:hover)'
-PASS setThenReadSelectorText('input:-webkit-any([type="file"], :hover, :focus):enabled') is 'input:-webkit-any([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':-webkit-any(input[type="file"], a:hover, button:focus)') is ':-webkit-any(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':-webkit-any(.class1.class2.class3)') is ':-webkit-any(.class1.class2.class3)'
-PASS setThenReadSelectorText(':-webkit-any(.class1:hover)') is ':-webkit-any(.class1:hover)'
-PASS setThenReadSelectorText(':-webkit-any(a.class1.class2.class3:hover)') is ':-webkit-any(a.class1.class2.class3:hover)'
+PASS setThenReadSelectorText('input:not([type="file"]):focus') is "input:not([type=\"file\"]):focus"
+PASS setThenReadSelectorText(':-webkit-any([type="file"])') is ":-webkit-any([type=\"file\"])"
+PASS setThenReadSelectorText(':-webkit-any(:hover)') is ":-webkit-any(:hover)"
+PASS setThenReadSelectorText('input:-webkit-any([type="file"], :hover, :focus):enabled') is "input:-webkit-any([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':-webkit-any(input[type="file"], a:hover, button:focus)') is ":-webkit-any(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':-webkit-any(.class1.class2.class3)') is ":-webkit-any(.class1.class2.class3)"
+PASS setThenReadSelectorText(':-webkit-any(.class1:hover)') is ":-webkit-any(.class1:hover)"
+PASS setThenReadSelectorText(':-webkit-any(a.class1.class2.class3:hover)') is ":-webkit-any(a.class1.class2.class3:hover)"
 
-PASS setThenReadSelectorText('*:active') is ':active'
+PASS setThenReadSelectorText('*:active') is ":active"
 
-PASS setThenReadSelectorText('input[type=file]:focus') is 'input[type="file"]:focus'
+PASS setThenReadSelectorText('input[type=file]:focus') is "input[type=\"file\"]:focus"
 
-PASS setThenReadSelectorText('a+b') is 'a + b'
-PASS setThenReadSelectorText('a~b') is 'a ~ b'
-PASS setThenReadSelectorText('a>b') is 'a > b'
+PASS setThenReadSelectorText('a+b') is "a + b"
+PASS setThenReadSelectorText('a~b') is "a ~ b"
+PASS setThenReadSelectorText('a>b') is "a > b"
 
-PASS setThenReadSelectorText(':after') is '::after'
-PASS setThenReadSelectorText(':before') is '::before'
-PASS setThenReadSelectorText(':first-letter') is '::first-letter'
-PASS setThenReadSelectorText(':first-line') is '::first-line'
-PASS setThenReadSelectorText(':-webkit-any(    a.class1  ,  	#id,[attr]  )') is ':-webkit-any(a.class1, #id, [attr])'
+PASS setThenReadSelectorText(':after') is "::after"
+PASS setThenReadSelectorText(':before') is "::before"
+PASS setThenReadSelectorText(':first-letter') is "::first-letter"
+PASS setThenReadSelectorText(':first-line') is "::first-line"
+PASS setThenReadSelectorText(':-webkit-any(    a.class1  ,  	#id,[attr]  )') is ":-webkit-any(a.class1, #id, [attr])"
 
-PASS setThenReadSelectorText(':is(single    )') is ':is(single)'
-PASS setThenReadSelectorText(':is(a,b    ,p)') is ':is(a, b, p)'
-PASS setThenReadSelectorText(':is(#alice,                   #bob,#chris)') is ':is(#alice, #bob, #chris)'
-PASS setThenReadSelectorText(':is(  .selector,#tama,                #hanayo,#midoriko)') is ':is(.selector, #tama, #hanayo, #midoriko)'
-PASS setThenReadSelectorText(':is(    .name,#ok,:visited   )') is ':is(.name, #ok, :visited)'
-PASS setThenReadSelectorText(':is(    .name,#ok,    :visited, :link)') is ':is(.name, #ok, :visited, :link)'
-PASS setThenReadSelectorText(':is(    .name,#ok,    :is(:visited    ))') is ':is(.name, #ok, :is(:visited))'
-PASS setThenReadSelectorText(':is(.name,  #ok,:not(:link))') is ':is(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':is(.name,#ok,:not(:link))') is ':is(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':is(    .name,#ok,:-webkit-any(   hello))') is ':is(.name, #ok, :-webkit-any(hello))'
-PASS setThenReadSelectorText(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':is(       [type="file"])') is ':is([type="file"])'
-PASS setThenReadSelectorText(':is(  :hover    )') is ':is(:hover)'
-PASS setThenReadSelectorText('input:is([type="file"],:hover,:focus):enabled') is 'input:is([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':is(input[type="file"], a:hover, button:focus)') is ':is(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':is( .class1.class2.class3   )') is ':is(.class1.class2.class3)'
-PASS setThenReadSelectorText(':is(.class1:hover   )') is ':is(.class1:hover)'
-PASS setThenReadSelectorText(':is(a.class1.class2.class3:hover   )') is ':is(a.class1.class2.class3:hover)'
+PASS setThenReadSelectorText(':is(single    )') is ":is(single)"
+PASS setThenReadSelectorText(':is(a,b    ,p)') is ":is(a, b, p)"
+PASS setThenReadSelectorText(':is(#alice,                   #bob,#chris)') is ":is(#alice, #bob, #chris)"
+PASS setThenReadSelectorText(':is(  .selector,#tama,                #hanayo,#midoriko)') is ":is(.selector, #tama, #hanayo, #midoriko)"
+PASS setThenReadSelectorText(':is(    .name,#ok,:visited   )') is ":is(.name, #ok, :visited)"
+PASS setThenReadSelectorText(':is(    .name,#ok,    :visited, :link)') is ":is(.name, #ok, :visited, :link)"
+PASS setThenReadSelectorText(':is(    .name,#ok,    :is(:visited    ))') is ":is(.name, #ok, :is(:visited))"
+PASS setThenReadSelectorText(':is(.name,  #ok,:not(:link))') is ":is(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':is(.name,#ok,:not(:link))') is ":is(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':is(    .name,#ok,:-webkit-any(   hello))') is ":is(.name, #ok, :-webkit-any(hello))"
+PASS setThenReadSelectorText(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ":is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':is(       [type="file"])') is ":is([type=\"file\"])"
+PASS setThenReadSelectorText(':is(  :hover    )') is ":is(:hover)"
+PASS setThenReadSelectorText('input:is([type="file"],:hover,:focus):enabled') is "input:is([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':is(input[type="file"], a:hover, button:focus)') is ":is(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':is( .class1.class2.class3   )') is ":is(.class1.class2.class3)"
+PASS setThenReadSelectorText(':is(.class1:hover   )') is ":is(.class1:hover)"
+PASS setThenReadSelectorText(':is(a.class1.class2.class3:hover   )') is ":is(a.class1.class2.class3:hover)"
 
-PASS setThenReadSelectorText(':matches(single    )') is ':matches(single)'
-PASS setThenReadSelectorText(':matches(a,b    ,p)') is ':matches(a, b, p)'
-PASS setThenReadSelectorText(':matches(#alice,                   #bob,#chris)') is ':matches(#alice, #bob, #chris)'
-PASS setThenReadSelectorText(':matches(  .selector,#tama,                #hanayo,#midoriko)') is ':matches(.selector, #tama, #hanayo, #midoriko)'
-PASS setThenReadSelectorText(':matches(    .name,#ok,:visited   )') is ':matches(.name, #ok, :visited)'
-PASS setThenReadSelectorText(':matches(    .name,#ok,    :visited, :link)') is ':matches(.name, #ok, :visited, :link)'
-PASS setThenReadSelectorText(':matches(    .name,#ok,    :matches(:visited    ))') is ':matches(.name, #ok, :matches(:visited))'
-PASS setThenReadSelectorText(':matches(.name,  #ok,:not(:link))') is ':matches(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':matches(.name,#ok,:not(:link))') is ':matches(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':matches(    .name,#ok,:-webkit-any(   hello))') is ':matches(.name, #ok, :-webkit-any(hello))'
-PASS setThenReadSelectorText(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':matches(       [type="file"])') is ':matches([type="file"])'
-PASS setThenReadSelectorText(':matches(  :hover    )') is ':matches(:hover)'
-PASS setThenReadSelectorText('input:matches([type="file"],:hover,:focus):enabled') is 'input:matches([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':matches(input[type="file"], a:hover, button:focus)') is ':matches(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':matches( .class1.class2.class3   )') is ':matches(.class1.class2.class3)'
-PASS setThenReadSelectorText(':matches(.class1:hover   )') is ':matches(.class1:hover)'
-PASS setThenReadSelectorText(':matches(a.class1.class2.class3:hover   )') is ':matches(a.class1.class2.class3:hover)'
+PASS setThenReadSelectorText(':matches(single    )') is ":matches(single)"
+PASS setThenReadSelectorText(':matches(a,b    ,p)') is ":matches(a, b, p)"
+PASS setThenReadSelectorText(':matches(#alice,                   #bob,#chris)') is ":matches(#alice, #bob, #chris)"
+PASS setThenReadSelectorText(':matches(  .selector,#tama,                #hanayo,#midoriko)') is ":matches(.selector, #tama, #hanayo, #midoriko)"
+PASS setThenReadSelectorText(':matches(    .name,#ok,:visited   )') is ":matches(.name, #ok, :visited)"
+PASS setThenReadSelectorText(':matches(    .name,#ok,    :visited, :link)') is ":matches(.name, #ok, :visited, :link)"
+PASS setThenReadSelectorText(':matches(    .name,#ok,    :matches(:visited    ))') is ":matches(.name, #ok, :matches(:visited))"
+PASS setThenReadSelectorText(':matches(.name,  #ok,:not(:link))') is ":matches(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':matches(.name,#ok,:not(:link))') is ":matches(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':matches(    .name,#ok,:-webkit-any(   hello))') is ":matches(.name, #ok, :-webkit-any(hello))"
+PASS setThenReadSelectorText(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ":matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':matches(       [type="file"])') is ":matches([type=\"file\"])"
+PASS setThenReadSelectorText(':matches(  :hover    )') is ":matches(:hover)"
+PASS setThenReadSelectorText('input:matches([type="file"],:hover,:focus):enabled') is "input:matches([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':matches(input[type="file"], a:hover, button:focus)') is ":matches(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':matches( .class1.class2.class3   )') is ":matches(.class1.class2.class3)"
+PASS setThenReadSelectorText(':matches(.class1:hover   )') is ":matches(.class1:hover)"
+PASS setThenReadSelectorText(':matches(a.class1.class2.class3:hover   )') is ":matches(a.class1.class2.class3:hover)"
 
-PASS setThenReadSelectorText(':not(single    )') is ':not(single)'
-PASS setThenReadSelectorText(':not(a,b    ,p)') is ':not(a, b, p)'
-PASS setThenReadSelectorText(':not(#alice,                   #bob,#chris)') is ':not(#alice, #bob, #chris)'
-PASS setThenReadSelectorText(':not(  .selector,#tama,                #hanayo,#midoriko)') is ':not(.selector, #tama, #hanayo, #midoriko)'
-PASS setThenReadSelectorText(':not(    .name,#ok,:visited   )') is ':not(.name, #ok, :visited)'
-PASS setThenReadSelectorText(':not(    .name,#ok,    :visited, :link)') is ':not(.name, #ok, :visited, :link)'
-PASS setThenReadSelectorText(':not(    .name,#ok,    :not(:visited    ))') is ':not(.name, #ok, :not(:visited))'
-PASS setThenReadSelectorText(':not(.name,  #ok,:not(:link))') is ':not(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':not(.name,#ok,:not(:link))') is ':not(.name, #ok, :not(:link))'
-PASS setThenReadSelectorText(':not(    .name,#ok,:-webkit-any(   hello))') is ':not(.name, #ok, :-webkit-any(hello))'
-PASS setThenReadSelectorText(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ':not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'
-PASS setThenReadSelectorText(':not(       [type="file"])') is ':not([type="file"])'
-PASS setThenReadSelectorText(':not(  :hover    )') is ':not(:hover)'
-PASS setThenReadSelectorText('input:not([type="file"],:hover,:focus):enabled') is 'input:not([type="file"], :hover, :focus):enabled'
-PASS setThenReadSelectorText(':not(input[type="file"], a:hover, button:focus)') is ':not(input[type="file"], a:hover, button:focus)'
-PASS setThenReadSelectorText(':not( .class1.class2.class3   )') is ':not(.class1.class2.class3)'
-PASS setThenReadSelectorText(':not(.class1:hover   )') is ':not(.class1:hover)'
-PASS setThenReadSelectorText(':not(a.class1.class2.class3:hover   )') is ':not(a.class1.class2.class3:hover)'
-PASS setThenReadSelectorText(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris))') is ':not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris))'
-PASS setThenReadSelectorText(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris))') is ':not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris))'
+PASS setThenReadSelectorText(':not(single    )') is ":not(single)"
+PASS setThenReadSelectorText(':not(a,b    ,p)') is ":not(a, b, p)"
+PASS setThenReadSelectorText(':not(#alice,                   #bob,#chris)') is ":not(#alice, #bob, #chris)"
+PASS setThenReadSelectorText(':not(  .selector,#tama,                #hanayo,#midoriko)') is ":not(.selector, #tama, #hanayo, #midoriko)"
+PASS setThenReadSelectorText(':not(    .name,#ok,:visited   )') is ":not(.name, #ok, :visited)"
+PASS setThenReadSelectorText(':not(    .name,#ok,    :visited, :link)') is ":not(.name, #ok, :visited, :link)"
+PASS setThenReadSelectorText(':not(    .name,#ok,    :not(:visited    ))') is ":not(.name, #ok, :not(:visited))"
+PASS setThenReadSelectorText(':not(.name,  #ok,:not(:link))') is ":not(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':not(.name,#ok,:not(:link))') is ":not(.name, #ok, :not(:link))"
+PASS setThenReadSelectorText(':not(    .name,#ok,:-webkit-any(   hello))') is ":not(.name, #ok, :-webkit-any(hello))"
+PASS setThenReadSelectorText(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))') is ":not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))"
+PASS setThenReadSelectorText(':not(       [type="file"])') is ":not([type=\"file\"])"
+PASS setThenReadSelectorText(':not(  :hover    )') is ":not(:hover)"
+PASS setThenReadSelectorText('input:not([type="file"],:hover,:focus):enabled') is "input:not([type=\"file\"], :hover, :focus):enabled"
+PASS setThenReadSelectorText(':not(input[type="file"], a:hover, button:focus)') is ":not(input[type=\"file\"], a:hover, button:focus)"
+PASS setThenReadSelectorText(':not( .class1.class2.class3   )') is ":not(.class1.class2.class3)"
+PASS setThenReadSelectorText(':not(.class1:hover   )') is ":not(.class1:hover)"
+PASS setThenReadSelectorText(':not(a.class1.class2.class3:hover   )') is ":not(a.class1.class2.class3:hover)"
+PASS setThenReadSelectorText(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris))') is ":not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris))"
+PASS setThenReadSelectorText(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris))') is ":not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris))"
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/css-set-selector-text.html
+++ b/LayoutTests/fast/css/css-set-selector-text.html
@@ -1,6 +1,6 @@
 <html>
 <head id="head">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -37,13 +37,7 @@ function expectedSerializedLangSelector(selector)
     args = args[1].split(/\s*,\s*/);
     var expected = ':lang(';
     for (var i = 0; i < args.length; ++i) {
-        var arg = args[i];
-        var hasQuotes = arg.indexOf('"') == 0 && arg.lastIndexOf('"') == arg.length - 1;
-        if (!hasQuotes)
-            expected += '"';
         expected += args[i];
-        if (!hasQuotes)
-            expected += '"';
         if (i < args.length - 1)
             expected += ', ';
     }
@@ -53,13 +47,13 @@ function expectedSerializedLangSelector(selector)
 
 function testSelectorSerialization(selector, expectedSelector)
 {
-    shouldBe("setThenReadSelectorText('" + selector + "')", "'" + expectedSelector + "'");
+    shouldBeEqualToString("setThenReadSelectorText('" + selector + "')", expectedSelector);
 }
 
 function testSelectorRoundTrip(selector, expectFailure)
 {
     var expected = selector.indexOf(":lang") == 0 ? expectedSerializedLangSelector(selector) : selector;
-    shouldBe("setThenReadSelectorText('" + selector + "')", "'" + (expectFailure ? bogusSelector : expected) + "'");
+    shouldBeEqualToString("setThenReadSelectorText('" + selector + "')", expectFailure ? bogusSelector : expected);
 }
 
 testSelectorRoundTrip('', true);
@@ -95,12 +89,12 @@ testSelectorRoundTrip('[a*="b" i]');
 
 debug('');
 
-shouldBe("setThenReadSelectorText('*|a')", "'a'");
-shouldBe("setThenReadSelectorText('*|*')", "'*'");
+shouldBeEqualToString("setThenReadSelectorText('*|a')", "a");
+shouldBeEqualToString("setThenReadSelectorText('*|*')", "*");
 testSelectorRoundTrip('[*|a]');
 testSelectorRoundTrip('|*');
 testSelectorRoundTrip('[*|a]');
-shouldBe("setThenReadSelectorText('[|a]')", "'[a]'");
+shouldBeEqualToString("setThenReadSelectorText('[|a]')", "[a]");
 
 debug('');
 
@@ -133,7 +127,7 @@ testSelectorRoundTrip(":visited");
 debug('');
 
 testSelectorRoundTrip(":dir(a)");
-testSelectorRoundTrip(":lang(\"a\")");
+testSelectorRoundTrip(':lang("a")');
 testSelectorRoundTrip(":lang(a)");
 testSelectorRoundTrip(":not(a)");
 testSelectorRoundTrip(":-webkit-any(a, b, p)");
@@ -366,24 +360,24 @@ testSelectorRoundTrip('a:not(a .b, #c > [d], e + f:empty, .g ~ #h:first-child) b
 
 debug('');
 
-shouldBe("setThenReadSelectorText('::-webkit-file-upload-button')", "'::-webkit-file-upload-button'");
-shouldBe("setThenReadSelectorText('::-webkit-search-cancel-button')", "'::-webkit-search-cancel-button'");
-shouldBe("setThenReadSelectorText('::-webkit-search-decoration')", "'::-webkit-search-decoration'");
-shouldBe("setThenReadSelectorText('::-webkit-search-results-button')", "'::-webkit-search-results-button'");
-shouldBe("setThenReadSelectorText('::-webkit-search-results-decoration')", "'::-webkit-search-results-decoration'");
-shouldBe("setThenReadSelectorText('::-webkit-slider-thumb')", "'::-webkit-slider-thumb'");
+shouldBeEqualToString("setThenReadSelectorText('::-webkit-file-upload-button')", "::-webkit-file-upload-button");
+shouldBeEqualToString("setThenReadSelectorText('::-webkit-search-cancel-button')", "::-webkit-search-cancel-button");
+shouldBeEqualToString("setThenReadSelectorText('::-webkit-search-decoration')", "::-webkit-search-decoration");
+shouldBeEqualToString("setThenReadSelectorText('::-webkit-search-results-button')", "::-webkit-search-results-button");
+shouldBeEqualToString("setThenReadSelectorText('::-webkit-search-results-decoration')", "::-webkit-search-results-decoration");
+shouldBeEqualToString("setThenReadSelectorText('::-webkit-slider-thumb')", "::-webkit-slider-thumb");
 
 debug('');
 
 testSelectorRoundTrip("a::-webkit-slider-thumb");
-shouldBe("setThenReadSelectorText('a ::-webkit-slider-thumb')", "'a ::-webkit-slider-thumb'");
+shouldBeEqualToString("setThenReadSelectorText('a ::-webkit-slider-thumb')", "a ::-webkit-slider-thumb");
 testSelectorRoundTrip("[a]::-webkit-slider-thumb");
-shouldBe("setThenReadSelectorText('[a] ::-webkit-slider-thumb')", "'[a] ::-webkit-slider-thumb'");
+shouldBeEqualToString("setThenReadSelectorText('[a] ::-webkit-slider-thumb')", "[a] ::-webkit-slider-thumb");
 testSelectorRoundTrip(".a::-webkit-slider-thumb");
-shouldBe("setThenReadSelectorText('.a ::-webkit-slider-thumb')", "'.a ::-webkit-slider-thumb'");
+shouldBeEqualToString("setThenReadSelectorText('.a ::-webkit-slider-thumb')", ".a ::-webkit-slider-thumb");
 testSelectorRoundTrip("#a::-webkit-slider-thumb");
-shouldBe("setThenReadSelectorText('#a ::-webkit-slider-thumb')", "'#a ::-webkit-slider-thumb'");
-shouldBe("setThenReadSelectorText('* ::-webkit-slider-thumb')", "'* ::-webkit-slider-thumb'");
+shouldBeEqualToString("setThenReadSelectorText('#a ::-webkit-slider-thumb')", "#a ::-webkit-slider-thumb");
+shouldBeEqualToString("setThenReadSelectorText('* ::-webkit-slider-thumb')", "* ::-webkit-slider-thumb");
 
 debug('');
 
@@ -444,94 +438,93 @@ testSelectorRoundTrip(':-webkit-any(a.class1.class2.class3:hover)');
 
 debug('');
 
-shouldBe("setThenReadSelectorText('*:active')", "':active'");
+shouldBeEqualToString("setThenReadSelectorText('*:active')", ":active");
 
 debug('');
 
-shouldBe("setThenReadSelectorText('input[type=file]:focus')", "'input[type=\"file\"]:focus'");
+shouldBeEqualToString("setThenReadSelectorText('input[type=file]:focus')", 'input[type="file"]:focus');
 
 debug('');
 
-shouldBe("setThenReadSelectorText('a+b')", "'a + b'");
-shouldBe("setThenReadSelectorText('a~b')", "'a ~ b'");
-shouldBe("setThenReadSelectorText('a>b')", "'a > b'");
+shouldBeEqualToString("setThenReadSelectorText('a+b')", "a + b");
+shouldBeEqualToString("setThenReadSelectorText('a~b')", "a ~ b");
+shouldBeEqualToString("setThenReadSelectorText('a>b')", "a > b");
 
 debug('');
 
-shouldBe("setThenReadSelectorText(':after')", "'::after'");
-shouldBe("setThenReadSelectorText(':before')", "'::before'");
-shouldBe("setThenReadSelectorText(':first-letter')", "'::first-letter'");
-shouldBe("setThenReadSelectorText(':first-line')", "'::first-line'");
-shouldBe("setThenReadSelectorText(':-webkit-any(    a.class1  ,  	#id,[attr]  )')","':-webkit-any(a.class1, #id, [attr])'");
+shouldBeEqualToString("setThenReadSelectorText(':after')", "::after");
+shouldBeEqualToString("setThenReadSelectorText(':before')", "::before");
+shouldBeEqualToString("setThenReadSelectorText(':first-letter')", "::first-letter");
+shouldBeEqualToString("setThenReadSelectorText(':first-line')", "::first-line");
+shouldBeEqualToString("setThenReadSelectorText(':-webkit-any(    a.class1  ,  	#id,[attr]  )')", ":-webkit-any(a.class1, #id, [attr])");
 
 debug('');
 
-shouldBe("setThenReadSelectorText(':is(single    )')", "':is(single)'");
-shouldBe("setThenReadSelectorText(':is(a,b    ,p)')", "':is(a, b, p)'");
-shouldBe("setThenReadSelectorText(':is(#alice,                   #bob,#chris)')", "':is(#alice, #bob, #chris)'");
-shouldBe("setThenReadSelectorText(':is(  .selector,#tama,                #hanayo,#midoriko)')", "':is(.selector, #tama, #hanayo, #midoriko)'");
-shouldBe("setThenReadSelectorText(':is(    .name,#ok,:visited   )')", "':is(.name, #ok, :visited)'");
-shouldBe("setThenReadSelectorText(':is(    .name,#ok,    :visited, :link)')", "':is(.name, #ok, :visited, :link)'");
-shouldBe("setThenReadSelectorText(':is(    .name,#ok,    :is(:visited    ))')", "':is(.name, #ok, :is(:visited))'");
-shouldBe("setThenReadSelectorText(':is(.name,  #ok,:not(:link))')", "':is(.name, #ok, :not(:link))'");
-shouldBe("setThenReadSelectorText(':is(.name,#ok,:not(:link))')", "':is(.name, #ok, :not(:link))'");
-shouldBe("setThenReadSelectorText(':is(    .name,#ok,:-webkit-any(   hello))')", "':is(.name, #ok, :-webkit-any(hello))'");
-shouldBe("setThenReadSelectorText(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')", "':is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'");
-shouldBe("setThenReadSelectorText(':is(       [type=\"file\"])')", "':is([type=\"file\"])'");
-shouldBe("setThenReadSelectorText(':is(  :hover    )')", "':is(:hover)'");
-shouldBe("setThenReadSelectorText('input:is([type=\"file\"],:hover,:focus):enabled')", "'input:is([type=\"file\"], :hover, :focus):enabled'");
-shouldBe("setThenReadSelectorText(':is(input[type=\"file\"], a:hover, button:focus)')", "':is(input[type=\"file\"], a:hover, button:focus)'");
-shouldBe("setThenReadSelectorText(':is( .class1.class2.class3   )')", "':is(.class1.class2.class3)'");
-shouldBe("setThenReadSelectorText(':is(.class1:hover   )')", "':is(.class1:hover)'");
-shouldBe("setThenReadSelectorText(':is(a.class1.class2.class3:hover   )')", "':is(a.class1.class2.class3:hover)'");
+shouldBeEqualToString("setThenReadSelectorText(':is(single    )')", ":is(single)");
+shouldBeEqualToString("setThenReadSelectorText(':is(a,b    ,p)')", ":is(a, b, p)");
+shouldBeEqualToString("setThenReadSelectorText(':is(#alice,                   #bob,#chris)')", ":is(#alice, #bob, #chris)");
+shouldBeEqualToString("setThenReadSelectorText(':is(  .selector,#tama,                #hanayo,#midoriko)')", ":is(.selector, #tama, #hanayo, #midoriko)");
+shouldBeEqualToString("setThenReadSelectorText(':is(    .name,#ok,:visited   )')", ":is(.name, #ok, :visited)");
+shouldBeEqualToString("setThenReadSelectorText(':is(    .name,#ok,    :visited, :link)')", ":is(.name, #ok, :visited, :link)");
+shouldBeEqualToString("setThenReadSelectorText(':is(    .name,#ok,    :is(:visited    ))')", ":is(.name, #ok, :is(:visited))");
+shouldBeEqualToString("setThenReadSelectorText(':is(.name,  #ok,:not(:link))')", ":is(.name, #ok, :not(:link))");
+shouldBeEqualToString("setThenReadSelectorText(':is(.name,#ok,:not(:link))')", ":is(.name, #ok, :not(:link))");
+shouldBeEqualToString("setThenReadSelectorText(':is(    .name,#ok,:-webkit-any(   hello))')", ":is(.name, #ok, :-webkit-any(hello))");
+shouldBeEqualToString("setThenReadSelectorText(':is(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')", ":is(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))");
+shouldBeEqualToString("setThenReadSelectorText(':is(       [type=\"file\"])')", ':is([type="file"])');
+shouldBeEqualToString("setThenReadSelectorText(':is(  :hover    )')", ":is(:hover)");
+shouldBeEqualToString("setThenReadSelectorText('input:is([type=\"file\"],:hover,:focus):enabled')", 'input:is([type="file"], :hover, :focus):enabled');
+shouldBeEqualToString("setThenReadSelectorText(':is(input[type=\"file\"], a:hover, button:focus)')", ':is(input[type="file"], a:hover, button:focus)');
+shouldBeEqualToString("setThenReadSelectorText(':is( .class1.class2.class3   )')", ":is(.class1.class2.class3)");
+shouldBeEqualToString("setThenReadSelectorText(':is(.class1:hover   )')", ":is(.class1:hover)");
+shouldBeEqualToString("setThenReadSelectorText(':is(a.class1.class2.class3:hover   )')", ":is(a.class1.class2.class3:hover)");
 
 debug('');
 
-shouldBe("setThenReadSelectorText(':matches(single    )')", "':matches(single)'");
-shouldBe("setThenReadSelectorText(':matches(a,b    ,p)')", "':matches(a, b, p)'");
-shouldBe("setThenReadSelectorText(':matches(#alice,                   #bob,#chris)')", "':matches(#alice, #bob, #chris)'");
-shouldBe("setThenReadSelectorText(':matches(  .selector,#tama,                #hanayo,#midoriko)')", "':matches(.selector, #tama, #hanayo, #midoriko)'");
-shouldBe("setThenReadSelectorText(':matches(    .name,#ok,:visited   )')", "':matches(.name, #ok, :visited)'");
-shouldBe("setThenReadSelectorText(':matches(    .name,#ok,    :visited, :link)')", "':matches(.name, #ok, :visited, :link)'");
-shouldBe("setThenReadSelectorText(':matches(    .name,#ok,    :matches(:visited    ))')", "':matches(.name, #ok, :matches(:visited))'");
-shouldBe("setThenReadSelectorText(':matches(.name,  #ok,:not(:link))')", "':matches(.name, #ok, :not(:link))'");
-shouldBe("setThenReadSelectorText(':matches(.name,#ok,:not(:link))')", "':matches(.name, #ok, :not(:link))'");
-shouldBe("setThenReadSelectorText(':matches(    .name,#ok,:-webkit-any(   hello))')", "':matches(.name, #ok, :-webkit-any(hello))'");
-shouldBe("setThenReadSelectorText(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')", "':matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'");
-shouldBe("setThenReadSelectorText(':matches(       [type=\"file\"])')", "':matches([type=\"file\"])'");
-shouldBe("setThenReadSelectorText(':matches(  :hover    )')", "':matches(:hover)'");
-shouldBe("setThenReadSelectorText('input:matches([type=\"file\"],:hover,:focus):enabled')", "'input:matches([type=\"file\"], :hover, :focus):enabled'");
-shouldBe("setThenReadSelectorText(':matches(input[type=\"file\"], a:hover, button:focus)')", "':matches(input[type=\"file\"], a:hover, button:focus)'");
-shouldBe("setThenReadSelectorText(':matches( .class1.class2.class3   )')", "':matches(.class1.class2.class3)'");
-shouldBe("setThenReadSelectorText(':matches(.class1:hover   )')", "':matches(.class1:hover)'");
-shouldBe("setThenReadSelectorText(':matches(a.class1.class2.class3:hover   )')", "':matches(a.class1.class2.class3:hover)'");
+shouldBeEqualToString("setThenReadSelectorText(':matches(single    )')", ":matches(single)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(a,b    ,p)')", ":matches(a, b, p)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(#alice,                   #bob,#chris)')", ":matches(#alice, #bob, #chris)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(  .selector,#tama,                #hanayo,#midoriko)')", ":matches(.selector, #tama, #hanayo, #midoriko)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(    .name,#ok,:visited   )')", ":matches(.name, #ok, :visited)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(    .name,#ok,    :visited, :link)')", ":matches(.name, #ok, :visited, :link)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(    .name,#ok,    :matches(:visited    ))')", ":matches(.name, #ok, :matches(:visited))");
+shouldBeEqualToString("setThenReadSelectorText(':matches(.name,  #ok,:not(:link))')", ":matches(.name, #ok, :not(:link))");
+shouldBeEqualToString("setThenReadSelectorText(':matches(.name,#ok,:not(:link))')", ":matches(.name, #ok, :not(:link))");
+shouldBeEqualToString("setThenReadSelectorText(':matches(    .name,#ok,:-webkit-any(   hello))')", ":matches(.name, #ok, :-webkit-any(hello))");
+shouldBeEqualToString("setThenReadSelectorText(':matches(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')", ":matches(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))");
+shouldBeEqualToString("setThenReadSelectorText(':matches(       [type=\"file\"])')", ':matches([type="file"])');
+shouldBeEqualToString("setThenReadSelectorText(':matches(  :hover    )')", ":matches(:hover)");
+shouldBeEqualToString("setThenReadSelectorText('input:matches([type=\"file\"],:hover,:focus):enabled')", 'input:matches([type="file"], :hover, :focus):enabled');
+shouldBeEqualToString("setThenReadSelectorText(':matches(input[type=\"file\"], a:hover, button:focus)')", ':matches(input[type="file"], a:hover, button:focus)');
+shouldBeEqualToString("setThenReadSelectorText(':matches( .class1.class2.class3   )')", ":matches(.class1.class2.class3)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(.class1:hover   )')", ":matches(.class1:hover)");
+shouldBeEqualToString("setThenReadSelectorText(':matches(a.class1.class2.class3:hover   )')", ":matches(a.class1.class2.class3:hover)");
 
 debug('');
 
-shouldBe("setThenReadSelectorText(':not(single    )')", "':not(single)'");
-shouldBe("setThenReadSelectorText(':not(a,b    ,p)')", "':not(a, b, p)'");
-shouldBe("setThenReadSelectorText(':not(#alice,                   #bob,#chris)')", "':not(#alice, #bob, #chris)'");
-shouldBe("setThenReadSelectorText(':not(  .selector,#tama,                #hanayo,#midoriko)')", "':not(.selector, #tama, #hanayo, #midoriko)'");
-shouldBe("setThenReadSelectorText(':not(    .name,#ok,:visited   )')", "':not(.name, #ok, :visited)'");
-shouldBe("setThenReadSelectorText(':not(    .name,#ok,    :visited, :link)')", "':not(.name, #ok, :visited, :link)'");
-shouldBe("setThenReadSelectorText(':not(    .name,#ok,    :not(:visited    ))')", "':not(.name, #ok, :not(:visited))'");
-shouldBe("setThenReadSelectorText(':not(.name,  #ok,:not(:link))')", "':not(.name, #ok, :not(:link))'");
-shouldBe("setThenReadSelectorText(':not(.name,#ok,:not(:link))')", "':not(.name, #ok, :not(:link))'");
-shouldBe("setThenReadSelectorText(':not(    .name,#ok,:-webkit-any(   hello))')", "':not(.name, #ok, :-webkit-any(hello))'");
-shouldBe("setThenReadSelectorText(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')", "':not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))'");
-shouldBe("setThenReadSelectorText(':not(       [type=\"file\"])')", "':not([type=\"file\"])'");
-shouldBe("setThenReadSelectorText(':not(  :hover    )')", "':not(:hover)'");
-shouldBe("setThenReadSelectorText('input:not([type=\"file\"],:hover,:focus):enabled')", "'input:not([type=\"file\"], :hover, :focus):enabled'");
-shouldBe("setThenReadSelectorText(':not(input[type=\"file\"], a:hover, button:focus)')", "':not(input[type=\"file\"], a:hover, button:focus)'");
-shouldBe("setThenReadSelectorText(':not( .class1.class2.class3   )')", "':not(.class1.class2.class3)'");
-shouldBe("setThenReadSelectorText(':not(.class1:hover   )')", "':not(.class1:hover)'");
-shouldBe("setThenReadSelectorText(':not(a.class1.class2.class3:hover   )')", "':not(a.class1.class2.class3:hover)'");
-shouldBe("setThenReadSelectorText(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris))')", "':not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris))'");
-shouldBe("setThenReadSelectorText(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris))')", "':not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris))'");
+shouldBeEqualToString("setThenReadSelectorText(':not(single    )')", ":not(single)");
+shouldBeEqualToString("setThenReadSelectorText(':not(a,b    ,p)')", ":not(a, b, p)");
+shouldBeEqualToString("setThenReadSelectorText(':not(#alice,                   #bob,#chris)')", ":not(#alice, #bob, #chris)");
+shouldBeEqualToString("setThenReadSelectorText(':not(  .selector,#tama,                #hanayo,#midoriko)')", ":not(.selector, #tama, #hanayo, #midoriko)");
+shouldBeEqualToString("setThenReadSelectorText(':not(    .name,#ok,:visited   )')", ":not(.name, #ok, :visited)");
+shouldBeEqualToString("setThenReadSelectorText(':not(    .name,#ok,    :visited, :link)')", ":not(.name, #ok, :visited, :link)");
+shouldBeEqualToString("setThenReadSelectorText(':not(    .name,#ok,    :not(:visited    ))')", ":not(.name, #ok, :not(:visited))");
+shouldBeEqualToString("setThenReadSelectorText(':not(.name,  #ok,:not(:link))')", ":not(.name, #ok, :not(:link))");
+shouldBeEqualToString("setThenReadSelectorText(':not(.name,#ok,:not(:link))')", ":not(.name, #ok, :not(:link))");
+shouldBeEqualToString("setThenReadSelectorText(':not(    .name,#ok,:-webkit-any(   hello))')", ":not(.name, #ok, :-webkit-any(hello))");
+shouldBeEqualToString("setThenReadSelectorText(':not(    .name,#ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))')", ":not(.name, #ok, :-webkit-any(.selector, #tama, #hanayo, #midoriko))");
+shouldBeEqualToString("setThenReadSelectorText(':not(       [type=\"file\"])')", ':not([type="file"])');
+shouldBeEqualToString("setThenReadSelectorText(':not(  :hover    )')", ":not(:hover)");
+shouldBeEqualToString("setThenReadSelectorText('input:not([type=\"file\"],:hover,:focus):enabled')", 'input:not([type="file"], :hover, :focus):enabled');
+shouldBeEqualToString("setThenReadSelectorText(':not(input[type=\"file\"], a:hover, button:focus)')", ':not(input[type="file"], a:hover, button:focus)');
+shouldBeEqualToString("setThenReadSelectorText(':not( .class1.class2.class3   )')", ":not(.class1.class2.class3)");
+shouldBeEqualToString("setThenReadSelectorText(':not(.class1:hover   )')", ":not(.class1:hover)");
+shouldBeEqualToString("setThenReadSelectorText(':not(a.class1.class2.class3:hover   )')", ":not(a.class1.class2.class3:hover)");
+shouldBeEqualToString("setThenReadSelectorText(':not(:is(single    ),:is(a,b    ,p),:is(#alice,                   #bob,#chris))')", ":not(:is(single), :is(a, b, p), :is(#alice, #bob, #chris))");
+shouldBeEqualToString("setThenReadSelectorText(':not(:matches(single    ),:matches(a,b    ,p),:matches(#alice,                   #bob,#chris))')", ":not(:matches(single), :matches(a, b, p), :matches(#alice, #bob, #chris))");
 
 debug('');
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/css/parsing-css-lang-expected.txt
+++ b/LayoutTests/fast/css/parsing-css-lang-expected.txt
@@ -6,124 +6,124 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 valid language ranges
 PASS document.querySelector(':lang(e)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"e\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(e)"
 PASS document.querySelector(':lang(e    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"e\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(e)"
 PASS document.querySelector(':lang(en)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en)"
 PASS document.querySelector(':lang(en    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en)"
 PASS document.querySelector(':lang(en-)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-)"
 PASS document.querySelector(':lang(en-    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-)"
 PASS document.querySelector(':lang(en--)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en--\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en--)"
 PASS document.querySelector(':lang(en--    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en--\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en--)"
 PASS document.querySelector(':lang(en---)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en---\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en---)"
 PASS document.querySelector(':lang(en---    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en---\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en---)"
 PASS document.querySelector(':lang(en-fr)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-fr\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-fr)"
 PASS document.querySelector(':lang(en-fr    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-fr\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-fr)"
 PASS document.querySelector(':lang(en-fr-)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-fr-\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-fr-)"
 PASS document.querySelector(':lang(en-fr-    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-fr-\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-fr-)"
 PASS document.querySelector(':lang(en-fr--)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-fr--\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-fr--)"
 PASS document.querySelector(':lang(en-fr--    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en-fr--\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en-fr--)"
 PASS document.querySelector(':lang(en--fr)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en--fr\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en--fr)"
 PASS document.querySelector(':lang(en--fr    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en--fr\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en--fr)"
 PASS document.querySelector(':lang(en---fr)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en---fr\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en---fr)"
 PASS document.querySelector(':lang(en---fr    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en---fr\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en---fr)"
 PASS document.querySelector(':lang(en---fr---)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en---fr---\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en---fr---)"
 PASS document.querySelector(':lang(en---fr---    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"en---fr---\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(en---fr---)"
 PASS document.querySelector(':lang(de-DE)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-DE\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-DE)"
 PASS document.querySelector(':lang(de-DE    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-DE\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-DE)"
 PASS document.querySelector(':lang(de-DE-1996)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-DE-1996\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-DE-1996)"
 PASS document.querySelector(':lang(de-DE-1996    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-DE-1996\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-DE-1996)"
 PASS document.querySelector(':lang(de-Latn-DE)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-Latn-DE\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-Latn-DE)"
 PASS document.querySelector(':lang(de-Latn-DE    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-Latn-DE\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-Latn-DE)"
 PASS document.querySelector(':lang(de-Latf-DE)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-Latf-DE\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-Latf-DE)"
 PASS document.querySelector(':lang(de-Latf-DE    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-Latf-DE\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-Latf-DE)"
 PASS document.querySelector(':lang(de-Latn-DE-1996)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-Latn-DE-1996\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-Latn-DE-1996)"
 PASS document.querySelector(':lang(de-Latn-DE-1996    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-Latn-DE-1996\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-Latn-DE-1996)"
 PASS document.querySelector(':lang(de-CH)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-CH)"
 PASS document.querySelector(':lang(de-CH    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"de-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(de-CH)"
 PASS document.querySelector(':lang(it-CH)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"it-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(it-CH)"
 PASS document.querySelector(':lang(it-CH    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"it-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(it-CH)"
 PASS document.querySelector(':lang(fr-CH)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"fr-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(fr-CH)"
 PASS document.querySelector(':lang(fr-CH    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"fr-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(fr-CH)"
 PASS document.querySelector(':lang(rm-CH)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"rm-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(rm-CH)"
 PASS document.querySelector(':lang(rm-CH    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"rm-CH\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(rm-CH)"
 PASS document.querySelector(':lang("*-CH")') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
 PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*-CH\")"
@@ -144,10 +144,10 @@ PASS document.getElementById('style-container').sheet.cssRules.length is 1
 PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*-br-zh\")"
 PASS document.querySelector(':lang(id-\\*-sumatra)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"id-*-sumatra\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(id-\\*-sumatra)"
 PASS document.querySelector(':lang(id-\\*-sumatra    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"id-*-sumatra\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(id-\\*-sumatra)"
 PASS document.querySelector(':lang("*-en-\\*-fr")') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
 PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*-en-*-fr\")"
@@ -162,10 +162,10 @@ PASS document.getElementById('style-container').sheet.cssRules.length is 1
 PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*-en-*-*\")"
 PASS document.querySelector(':lang(\\*)') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\\*)"
 PASS document.querySelector(':lang(\\*    )') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
-PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*\")"
+PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\\*)"
 PASS document.querySelector(':lang("*-\\*")') did not throw exception.
 PASS document.getElementById('style-container').sheet.cssRules.length is 1
 PASS document.getElementById('style-container').sheet.cssRules[0].selectorText is ":lang(\"*-*\")"

--- a/LayoutTests/fast/css/parsing-css-lang.html
+++ b/LayoutTests/fast/css/parsing-css-lang.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style id="style-container">
 </style>
 </head>
@@ -16,11 +16,8 @@ function testValidLanguageRange(languageRangeString, expectedSerializedLanguageR
     var styleContainer = document.getElementById('style-container');
     styleContainer.innerHTML = ':lang(' + languageRangeString + ') { }';
     shouldBe("document.getElementById('style-container').sheet.cssRules.length", "1");
-    if (!expectedSerializedLanguageRange)
-        expectedSerializedLanguageRange = languageRangeString;
-    expectedSerializedLanguageRange = expectedSerializedLanguageRange.replace(/\\/g, '');
-    if (expectedSerializedLanguageRange.indexOf('"') != 0)
-        expectedSerializedLanguageRange = '"' + expectedSerializedLanguageRange + '"';
+    if (expectedSerializedLanguageRange.indexOf('"') == 0)
+        expectedSerializedLanguageRange = expectedSerializedLanguageRange.replace(/\\/g, "");
     shouldBeEqualToString("document.getElementById('style-container').sheet.cssRules[0].selectorText", ':lang(' + expectedSerializedLanguageRange + ')');
     styleContainer.innerHTML = '';
 }
@@ -79,10 +76,9 @@ var validLanguageRanges = [
 debug("valid language ranges");
 for (var i = 0; i < validLanguageRanges.length; ++i) {
     var languageRangeString = validLanguageRanges[i];
-    testValidLanguageRange(languageRangeString);
+    testValidLanguageRange(languageRangeString, languageRangeString);
     testValidLanguageRange(languageRangeString + "    ", languageRangeString);
 }
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </html>

--- a/LayoutTests/fast/dom/css-selectorText-expected.txt
+++ b/LayoutTests/fast/dom/css-selectorText-expected.txt
@@ -23,7 +23,7 @@ div span#foo.test div:hover#bar a
 :active
 :focus
 :target
-:lang("en")
+:lang(en)
 :not(table)
 :root
 :enabled

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSS-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSS-expected.txt
@@ -1,6 +1,0 @@
-
-PASS CSS.escape
-PASS CSS.supports, one argument form
-FAIL CSS.supports, two argument form assert_equals: CSS.supports: two argument form succeeds for custom property expected true but got false
-FAIL CSS.supports, selector function assert_equals: CSS.supports: selector() with unknown combinators expected false but got true
-

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-expected.txt
@@ -68,9 +68,9 @@ PASS CSSStyleRule: selectorText value: |p + div| isMatch: true
 PASS CSSStyleRule: selectorText value: |span + div| isMatch: false
 PASS CSSStyleRule: selectorText value: |p ~ div| isMatch: true
 PASS CSSStyleRule: selectorText value: |span ~ div| isMatch: false
-FAIL CSSStyleRule: selectorText value: |:lang(zh-CN)| isMatch: true assert_equals: expected ":lang(zh-CN)" but got ":lang(\"zh-CN\")"
-FAIL CSSStyleRule: selectorText value: |:lang(zh)| isMatch: true assert_equals: expected ":lang(zh)" but got ":lang(\"zh\")"
-FAIL CSSStyleRule: selectorText value: |:lang(tr-AZ)| isMatch: false assert_equals: expected ":lang(tr-AZ)" but got ":lang(\"tr-AZ\")"
+PASS CSSStyleRule: selectorText value: |:lang(zh-CN)| isMatch: true
+PASS CSSStyleRule: selectorText value: |:lang(zh)| isMatch: true
+PASS CSSStyleRule: selectorText value: |:lang(tr-AZ)| isMatch: false
 PASS CSSStyleRule: selectorText value: |::after| isMatch: false
 PASS CSSStyleRule: selectorText value: |:after| isMatch: false
 PASS CSSStyleRule: selectorText value: |::before| isMatch: false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize-expected.txt
@@ -5,7 +5,7 @@ PASS single type (simple) selector in the sequence of simple selectors that is n
 PASS single class (simple) selector in the sequence of simple selectors that is not a universal selector
 PASS single id (simple) selector in the sequence of simple selectors that is not a universal selector
 PASS single pseudo (simple) selector which does not accept arguments in the sequence of simple selectors that is not a universal selector
-FAIL single pseudo (simple) selector "lang" which accepts arguments in the sequence of simple selectors that is not a universal selector assert_equals: expected ":lang(ja)" but got ":lang(\"ja\")"
+PASS single pseudo (simple) selector "lang" which accepts arguments in the sequence of simple selectors that is not a universal selector
 PASS single pseudo (simple) selector "nth-child" which accepts arguments in the sequence of simple selectors that is not a universal selector
 PASS single pseudo (simple) selector "nth-last-child" which accepts arguments in the sequence of simple selectors that is not a universal selector
 PASS single pseudo (simple) selector "nth-of-child" which accepts arguments in the sequence of simple selectors that is not a universal selector

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1037,10 +1037,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 return true;
             break;
         case CSSSelector::PseudoClassLang:
-            {
-                ASSERT(selector.argumentList() && !selector.argumentList()->isEmpty());
-                return matchesLangPseudoClass(element, *selector.argumentList());
-            }
+            ASSERT(selector.argumentList() && !selector.argumentList()->isEmpty());
+            return matchesLangPseudoClass(element, *selector.argumentList());
 #if ENABLE(FULLSCREEN_API)
         case CSSSelector::PseudoClassFullScreen:
             return matchesFullScreenPseudoClass(element);

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -196,7 +196,7 @@ ALWAYS_INLINE bool containslanguageSubtagMatchingRange(StringView language, Stri
     return false;
 }
 
-ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const Vector<AtomString>& argumentList)
+ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVector<PossiblyQuotedIdentifier>& argumentList)
 {
     AtomString language;
 #if ENABLE(VIDEO)
@@ -209,21 +209,18 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const Vector<A
     if (language.isEmpty())
         return false;
 
-    // Implement basic and extended filterings of given language tags
-    // as specified in www.ietf.org/rfc/rfc4647.txt.
-    StringView languageStringView = language.string();
+    // Implement basic and extended filterings of given language tags as specified in www.ietf.org/rfc/rfc4647.txt.
+    StringView languageStringView = language;
     unsigned languageLength = language.length();
-    for (const AtomString& range : argumentList) {
-        if (range.isEmpty())
+    for (auto& range : argumentList) {
+        StringView rangeStringView = range.identifier;
+        if (rangeStringView.isEmpty())
             continue;
-
-        if (range == "*"_s)
+        if (rangeStringView == "*"_s)
             return true;
-
-        StringView rangeStringView = range.string();
         if (equalIgnoringASCIICase(languageStringView, rangeStringView) && !languageStringView.contains('-'))
             return true;
-        
+
         unsigned rangeLength = rangeStringView.length();
         unsigned rangeSubtagsStartIndex = 0;
         unsigned rangeSubtagsEndIndex = rangeLength;

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -125,10 +125,10 @@ void CSSParserSelector::adoptSelectorVector(Vector<std::unique_ptr<CSSParserSele
     m_selector->setSelectorList(makeUnique<CSSSelectorList>(WTFMove(selectorVector)));
 }
 
-void CSSParserSelector::setArgumentList(std::unique_ptr<Vector<AtomString>> argumentList)
+void CSSParserSelector::setArgumentList(FixedVector<PossiblyQuotedIdentifier> list)
 {
-    ASSERT_WITH_MESSAGE(!argumentList->isEmpty(), "No CSS Selector takes an empty argument list.");
-    m_selector->setArgumentList(WTFMove(argumentList));
+    ASSERT(!list.isEmpty());
+    m_selector->setArgumentList(WTFMove(list));
 }
 
 void CSSParserSelector::setSelectorList(std::unique_ptr<CSSSelectorList> selectorList)

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -63,7 +63,7 @@ public:
     void setPseudoClassType(CSSSelector::PseudoClassType type) { m_selector->setPseudoClassType(type); }
 
     void adoptSelectorVector(Vector<std::unique_ptr<CSSParserSelector>>&&);
-    void setArgumentList(std::unique_ptr<Vector<AtomString>>);
+    void setArgumentList(FixedVector<PossiblyQuotedIdentifier>);
     void setSelectorList(std::unique_ptr<CSSSelectorList>);
 
     CSSSelector::PseudoClassType pseudoClassType() const { return m_selector->pseudoClassType(); }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -174,26 +174,32 @@ CSSSelectorList CSSSelectorParser::consumeCompoundSelectorList(CSSParserTokenRan
     return CSSSelectorList { WTFMove(selectorList) };
 }
 
-static bool consumeLangArgumentList(std::unique_ptr<Vector<AtomString>>& argumentList, CSSParserTokenRange& range)
+static PossiblyQuotedIdentifier consumePossiblyQuotedIdentifer(CSSParserTokenRange& range)
 {
-    const CSSParserToken& ident = range.consumeIncludingWhitespace();
-    if (ident.type() != IdentToken && ident.type() != StringToken)
-        return false;
-    StringView string = ident.value();
+    auto& token = range.consumeIncludingWhitespace();
+    if (token.type() != IdentToken && token.type() != StringToken)
+        return { };
+    auto string = token.value();
     if (string.startsWith("--"_s))
-        return false;
-    argumentList->append(string.toAtomString());
+        return { };
+    return { string.toAtomString(), token.type() == StringToken };
+}
+
+static FixedVector<PossiblyQuotedIdentifier> consumeLangArgumentList(CSSParserTokenRange& range)
+{
+    Vector<PossiblyQuotedIdentifier> list;
+    auto item = consumePossiblyQuotedIdentifer(range);
+    if (item.isNull())
+        return { };
+    list.append(WTFMove(item));
     while (!range.atEnd() && range.peek().type() == CommaToken) {
         range.consumeIncludingWhitespace();
-        const CSSParserToken& ident = range.consumeIncludingWhitespace();
-        if (ident.type() != IdentToken && ident.type() != StringToken)
-            return false;
-        StringView string = ident.value();
-        if (string.startsWith("--"_s))
-            return false;
-        argumentList->append(string.toAtomString());
+        item = consumePossiblyQuotedIdentifer(range);
+        if (item.isNull())
+            return { };
+        list.append(WTFMove(item));
     }
-    return range.atEnd();
+    return FixedVector<PossiblyQuotedIdentifier> { WTFMove(list) };
 }
 
 enum class CompoundSelectorFlag {
@@ -726,11 +732,10 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             return selector;
         }
         case CSSSelector::PseudoClassLang: {
-            // FIXME: CSS Selectors Level 4 allows :lang(*-foo)
-            auto argumentList = makeUnique<Vector<AtomString>>();
-            if (!consumeLangArgumentList(argumentList, block))
+            auto list = consumeLangArgumentList(block);
+            if (list.isEmpty() || !block.atEnd())
                 return nullptr;
-            selector->setArgumentList(WTFMove(argumentList));
+            selector->setArgumentList(WTFMove(list));
             return selector;
         }
         case CSSSelector::PseudoClassIs:
@@ -793,23 +798,18 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             auto& ident = block.consumeIncludingWhitespace();
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;
-
-            auto argumentList = makeUnique<Vector<AtomString>>();
-            argumentList->append(ident.value().toAtomString());
-            selector->setArgumentList(WTFMove(argumentList));
-
+            selector->setArgumentList({ { ident.value().toAtomString() } });
             return selector;
         }
         case CSSSelector::PseudoElementPart: {
-            auto argumentList = makeUnique<Vector<AtomString>>();
+            Vector<PossiblyQuotedIdentifier> argumentList;
             do {
                 auto& ident = block.consumeIncludingWhitespace();
                 if (ident.type() != IdentToken)
                     return nullptr;
-                argumentList->append(ident.value().toAtomString());
+                argumentList.append({ ident.value().toAtomString() });
             } while (!block.atEnd());
-
-            selector->setArgumentList(WTFMove(argumentList));
+            selector->setArgumentList(FixedVector<PossiblyQuotedIdentifier> { WTFMove(argumentList) });
             return selector;
         }
         case CSSSelector::PseudoElementSlotted: {


### PR DESCRIPTION
#### 7e31f273a4e1bc368bb568101db621e4c9a084e2
<pre>
:lang() selectors should serialize without quotation marks if they were parsed without them
<a href="https://bugs.webkit.org/show_bug.cgi?id=247747">https://bugs.webkit.org/show_bug.cgi?id=247747</a>
rdar://problem/102198822

Reviewed by Ryosuke Niwa.

Changed so we keep a record of whether a language was specified as an identifier or a string
when parsing the lang selector. This affects serialization, otherwise ignored.

* LayoutTests/fast/css/css-lang-selector-with-string-arguments-text-expected.txt: Updated.
* LayoutTests/fast/css/css-lang-selector-with-string-arguments-text.html: Updated test to not
expect quotation marks around lang values that are unquoted identifiers.

* LayoutTests/fast/css/css-selector-text-expected.txt: Ditto.
* LayoutTests/fast/css/css-selector-text.html: Ditto.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSS-expected.txt: Removed.
There is no corresponding test for this expected result, presumably left behind by accident.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-expected.txt:
Expect more PASS.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize-expected.txt: Ditto.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::appendLangArgumentList): Use serializeIdentifier and serializeString for correct quoting
and select which one based on the wasQuoted flag in PossiblyQuotedIdentifier.
(WebCore::CSSSelector::selectorText const): Take an additional separator argument,
and rearranged code a bit. Also updated for PossiblyQuotedIdentifier.
(WebCore::CSSSelector::setArgumentList): New argument type.

* Source/WebCore/css/CSSSelector.h: Added PossiblyQuotedIdentifier. Initialize data members in the
class definition so we don&apos;t have to do it in all the constructors. Tweaked comment format a bit.
Changed type of argumentList. Moved inline function bodies out of the class. Deleted the assignment
operator instead of declaring it private an just not defining it. Use a FixedVector for
argumentList instead of a unique_ptr&lt;Vector&gt;.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const): Removed unneeded braces.

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLangPseudoClass): Updated for change in type.
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::setArgumentList): Ditto.
* Source/WebCore/css/parser/CSSParserSelector.h: Ditto.

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::consumePossiblyQuotedIdentifer): Added.
(WebCore::consumeLangArgumentList): Updated to return the new type, also cut down on repeated code
by using the consumePossiblyQuotedIdentifer function.
(WebCore::CSSSelectorParser::consumePseudo): Updated for the above.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType): Update for the new type.
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementIsInLanguage): Ditto.

Canonical link: <a href="https://commits.webkit.org/256603@main">https://commits.webkit.org/256603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bf9eb88edcc3409b0e75362e93147b202f591c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96303 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105844 "Built successfully") | [💥 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166187 "An unexpected error occured. Recent messages:Pull request contains relevant changes; Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5688 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34302 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102574 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4211 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82898 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31233 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40034 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20847 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4579 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/131 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40115 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->