### PR TITLE
[AVIF Downlevels] AVIF image can't be opened as an ImageDocument

### DIFF
--- a/LayoutTests/fast/images/avif-image-document-expected.html
+++ b/LayoutTests/fast/images/avif-image-document-expected.html
@@ -1,0 +1,16 @@
+<style>
+    iframe {
+        width: 400px;
+        height: 400px;
+    }
+</style>
+<body>
+    <script>
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `<!DOCTYPE html>
+            <body style="margin: 0; overflow: hidden;">
+                <img src="resources/green-400x400.avif">
+            </body>`;
+        document.body.appendChild(iframe);
+    </script>
+</body>

--- a/LayoutTests/fast/images/avif-image-document.html
+++ b/LayoutTests/fast/images/avif-image-document.html
@@ -1,0 +1,7 @@
+<style>
+    iframe {
+        width: 400px;
+        height: 400px;
+    }
+</style>
+<iframe src="resources/green-400x400.avif">

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1632,6 +1632,9 @@ fast/images/decoding-attribute-async-small-image.html [ Skip ]
 fast/images/decoding-attribute-dynamic-async-small-image.html [ Skip ]
 fast/images/sprite-sheet-image-draw.html [ Skip ]
 
+# AVIF tests
+fast/images/avif-image-document.html [ Skip ]
+
 # <rdar://problem/42627562>
 media/video-restricted-invisible-autoplay-not-allowed-source.html [ Skip ]
 media/video-restricted-invisible-autoplay-not-allowed.html [ Skip ]

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -787,6 +787,7 @@ fast/images/avif-as-image.html [ Skip ]
 fast/images/avif-heif-container-as-image.html [ Skip ]
 fast/images/animated-avif.html [ Skip ]
 http/tests/images/avif-partial-load-crash.html [ Skip ]
+fast/images/avif-image-document.html [ Skip ]
 
 # TODO The following tests requires the DRT's dumpUserGestureInFrameLoadCallbacks
 # method. But that method is not implemented in win port since win port can't

--- a/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm
@@ -169,7 +169,12 @@ void ResourceResponse::platformLazyInit(InitLevel initLevel)
 
         if (m_initLevel < CommonFieldsOnly) {
             m_url = [m_nsResponse URL];
-            m_mimeType = [m_nsResponse MIMEType];
+#if USE(AVIF)
+            if (m_url.string().endsWithIgnoringASCIICase(".avif"_s) || m_url.string().endsWithIgnoringASCIICase(".avifs"_s))
+                m_mimeType = "image/avif"_s;
+            else
+#endif
+                m_mimeType = [m_nsResponse MIMEType];
             m_expectedContentLength = [m_nsResponse expectedContentLength];
             // Stripping double quotes as a workaround for <rdar://problem/8757088>, can be removed once that is fixed.
             m_textEncodingName = stripLeadingAndTrailingDoubleQuote([m_nsResponse textEncodingName]);


### PR DESCRIPTION
#### 45f050d36721b22da28b6cf25115c0ffaafbd574
<pre>
[AVIF Downlevels] AVIF image can&apos;t be opened as an ImageDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=247759">https://bugs.webkit.org/show_bug.cgi?id=247759</a>
rdar://102210682

Reviewed by Myles C. Maxfield.

On down levels macOS, we need to explicitly set the mime type for the requested
URL given its extension. We should not rely on NSURLResponse to tell us the correct
mime type since AVIF is only supported on macOS Ventura.

* LayoutTests/fast/images/avif-image-document-expected.html: Added.
* LayoutTests/fast/images/avif-image-document.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/platform/network/cocoa/ResourceResponseCocoa.mm:
(WebCore::ResourceResponse::platformLazyInit):

Canonical link: <a href="https://commits.webkit.org/256796@main">https://commits.webkit.org/256796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a8e0015b27bdf45404e1019cdfd062d7ddff701

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106300 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166589 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6250 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34769 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103004 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4673 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83385 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31643 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74584 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/73 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/66 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21286 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4854 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40571 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->