### PR TITLE
Update PGO scripts to refer to run-benchmarks' renamed --generate-pgo-profiles flag

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -85,21 +85,21 @@ fi
 jsargs=(
     --plan jetstream2
     --diagnose-directory="$BASE/jetstream"
-    --generate-profiles
+    --generate-pgo-profiles
     --count 1
 )
 
 spargs=(
     --plan speedometer2
     --diagnose-directory="$BASE/speedometer"
-    --generate-profiles
+    --generate-pgo-profiles
     --count 1
 )
 
 mmargs=(
     --plan motionmark1.1
     --diagnose-directory="$BASE/motionmark"
-    --generate-profiles
+    --generate-pgo-profiles
     --count 1
 )
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -55,7 +55,7 @@ def config_argument_parser():
     parser.add_argument('--diagnose-directory', dest='diagnose_dir', default=diagnose_directory, help='Directory for storing diagnose information on test failure. Defaults to {}.'.format(diagnose_directory))
     parser.add_argument('--no-adjust-unit', dest='scale_unit', action='store_false', help="Don't convert to scientific notation.")
     parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
-    parser.add_argument('--generate-pgo-profiles', '--generate-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
+    parser.add_argument('--generate-pgo-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
     parser.add_argument('--profile', action='store_true', help="Collect profiling traces, and copy them to the diagnostic directory.")
 
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
#### bb52774d658ff6d0f32d1630d9f1682ea1d7457a
<pre>
Update PGO scripts to refer to run-benchmarks&apos; renamed --generate-pgo-profiles flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=247753">https://bugs.webkit.org/show_bug.cgi?id=247753</a>
rdar://102202608

Reviewed by Dewei Zhu and Stephanie Lewis.

<a href="https://bugs.webkit.org/show_bug.cgi?id=247496">https://bugs.webkit.org/show_bug.cgi?id=247496</a> introduced profiling into run-benchmarks, so we&apos;ve had to rename --generate-profiles to --generate-pgo-profiles to avoid confusion.

 - Update `Tools/Scripts/build-and-collect-pgo-profiles` to refer to the new --generate-pgo-profiles flag
 - Remove the --generate-profiles alias from run-benchmarks.

* Tools/Scripts/build-and-collect-pgo-profiles:
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):

Canonical link: <a href="https://commits.webkit.org/256583@main">https://commits.webkit.org/256583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e15d9556376abc8f737ebc1ff74802833cc9552

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105663 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/165998 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5486 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34127 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101485 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4065 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82722 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31112 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99703 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73947 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39856 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37531 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4562 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43300 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/44017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39959 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->