### PR TITLE
With UI-side compositing, many tests hit ASSERT(m_scrollingTrees.contains(webPage->identifier()));

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -113,6 +113,9 @@ public:
     virtual bool usesDelegatedPageScaling() const { return false; }
     virtual WebCore::DelegatedScrollingMode delegatedScrollingMode() const;
 
+    virtual void registerScrollingTree() { }
+    virtual void unregisterScrollingTree() { }
+
     virtual bool shouldUseTiledBackingForFrameView(const WebCore::FrameView&) const { return false; }
 
     virtual WebCore::GraphicsLayerFactory* graphicsLayerFactory() { return nullptr; }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -71,25 +71,25 @@ EventDispatcher::~EventDispatcher()
 }
 
 #if ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)
-void EventDispatcher::addScrollingTreeForPage(WebPage* webPage)
+void EventDispatcher::addScrollingTreeForPage(WebPage& webPage)
 {
     Locker locker { m_scrollingTreesLock };
 
-    ASSERT(webPage->corePage()->scrollingCoordinator());
-    ASSERT(!m_scrollingTrees.contains(webPage->identifier()));
+    ASSERT(webPage.scrollingCoordinator());
+    ASSERT(!m_scrollingTrees.contains(webPage.identifier()));
 
-    AsyncScrollingCoordinator& scrollingCoordinator = downcast<AsyncScrollingCoordinator>(*webPage->corePage()->scrollingCoordinator());
+    auto& scrollingCoordinator = downcast<AsyncScrollingCoordinator>(*webPage.scrollingCoordinator());
     auto* scrollingTree = dynamicDowncast<ThreadedScrollingTree>(scrollingCoordinator.scrollingTree());
-    if (scrollingTree)
-        m_scrollingTrees.set(webPage->identifier(), scrollingTree);
+    ASSERT(scrollingTree);
+    m_scrollingTrees.set(webPage.identifier(), scrollingTree);
 }
 
-void EventDispatcher::removeScrollingTreeForPage(WebPage* webPage)
+void EventDispatcher::removeScrollingTreeForPage(WebPage& webPage)
 {
     Locker locker { m_scrollingTreesLock };
-    ASSERT(m_scrollingTrees.contains(webPage->identifier()));
+    ASSERT(m_scrollingTrees.contains(webPage.identifier()));
 
-    m_scrollingTrees.remove(webPage->identifier());
+    m_scrollingTrees.remove(webPage.identifier());
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -68,8 +68,8 @@ public:
     WorkQueue& queue() { return m_queue.get(); }
 
 #if ENABLE(SCROLLING_THREAD)
-    void addScrollingTreeForPage(WebPage*);
-    void removeScrollingTreeForPage(WebPage*);
+    void addScrollingTreeForPage(WebPage&);
+    void removeScrollingTreeForPage(WebPage&);
 #endif
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -78,6 +78,9 @@ private:
 
     bool supportsAsyncScrolling() const override { return true; }
 
+    void registerScrollingTree() override;
+    void unregisterScrollingTree() override;
+
     void dispatchAfterEnsuringUpdatedScrollPosition(WTF::Function<void ()>&&) override;
 
     bool shouldUseTiledBackingForFrameView(const WebCore::FrameView&) const override;

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -30,6 +30,7 @@
 
 #import "DisplayRefreshMonitorMac.h"
 #import "DrawingAreaProxyMessages.h"
+#import "EventDispatcher.h"
 #import "LayerHostingContext.h"
 #import "LayerTreeContext.h"
 #import "Logging.h"
@@ -134,6 +135,16 @@ void TiledCoreAnimationDrawingArea::sendEnterAcceleratedCompositingModeIfNeeded(
     LayerTreeContext layerTreeContext;
     layerTreeContext.contextID = m_layerHostingContext->contextID();
     send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(0, layerTreeContext));
+}
+
+void TiledCoreAnimationDrawingArea::registerScrollingTree()
+{
+    WebProcess::singleton().eventDispatcher().addScrollingTreeForPage(m_webPage);
+}
+
+void TiledCoreAnimationDrawingArea::unregisterScrollingTree()
+{
+    WebProcess::singleton().eventDispatcher().removeScrollingTreeForPage(m_webPage);
 }
 
 void TiledCoreAnimationDrawingArea::setNeedsDisplay()


### PR DESCRIPTION
#### 82e5917868fa066744774abe4e292959f375fd02
<pre>
With UI-side compositing, many tests hit ASSERT(m_scrollingTrees.contains(webPage-&gt;identifier()));
<a href="https://bugs.webkit.org/show_bug.cgi?id=247766">https://bugs.webkit.org/show_bug.cgi?id=247766</a>
rdar://102214322

Reviewed by Cameron McCormack.

With UI-side compositing, the web process ScrollingCoordinator doesn&apos;t have a ScrollingTree,
so the assertion in `EventDispatcher::removeScrollingTreeForPage()` is wrong.

To fix this, delegate the registration and unregistration of the scrolling tree
to the DrawingArea. Then DrawingArea subclasses that have a WebContent process scrolling
tree can do the registration/unregistration (currently TiledCoreAnimationDrawingArea and
DrawingAreaCoordinatedGraphics).

Make the WebPage argument to the EventDispatcher functions be a reference.

* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::registerScrollingTree):
(WebKit::DrawingArea::unregisterScrollingTree):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::addScrollingTreeForPage):
(WebKit::EventDispatcher::removeScrollingTreeForPage):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::close):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::registerScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::unregisterScrollingTree):

Canonical link: <a href="https://commits.webkit.org/256571@main">https://commits.webkit.org/256571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4702c9a0d9a9e66a14947ed29dd74fc23d56963a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105701 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5530 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34172 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101525 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101815 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82759 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31127 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73957 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39896 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37570 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20729 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4552 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/63/builds/42166 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/65/builds/44057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/39991 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->