### PR TITLE
Revert 255044@main as it introduces crash in SQLiteStorageArea::removeItem

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp
@@ -97,7 +97,7 @@ bool SQLiteStorageArea::isEmpty()
     ASSERT(!isMainRunLoop());
 
     if (m_cache)
-        return m_cache->items.isEmpty();
+        return m_cache->isEmpty();
 
     if (!prepareDatabase(ShouldCreateIfNotExists::No))
         return true;
@@ -175,6 +175,9 @@ bool SQLiteStorageArea::prepareDatabase(ShouldCreateIfNotExists shouldCreateIfNo
         return false;
     }
 
+    if (quota() != WebCore::StorageMap::noQuota)
+        m_database->setMaximumSize(quota());
+
     return true;
 }
 
@@ -212,8 +215,8 @@ WebCore::SQLiteStatementAutoResetScope SQLiteStorageArea::cachedStatement(Statem
 Expected<String, StorageError> SQLiteStorageArea::getItem(const String& key)
 {
     if (m_cache) {
-        auto iterator = m_cache->items.find(key);
-        if (iterator == m_cache->items.end())
+        auto iterator = m_cache->find(key);
+        if (iterator == m_cache->end())
             return String();
 
         if (!iterator->value.isNull())
@@ -248,63 +251,17 @@ Expected<String, StorageError> SQLiteStorageArea::getItemFromDatabase(const Stri
     return makeUnexpected(StorageError::ItemNotFound);
 }
 
-Expected<HashMap<String, String>, StorageError> SQLiteStorageArea::getAllItemsFromDatabase()
-{
-    if (!prepareDatabase(ShouldCreateIfNotExists::No))
-        return makeUnexpected(StorageError::Database);
-
-    if (!m_database)
-        return HashMap<String, String> { };
-
-    auto statement = cachedStatement(StatementType::GetAllItems);
-    if (!statement) {
-        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::getAllItemsFromDatabase failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
-        return makeUnexpected(StorageError::Database);
-    }
-
-    HashMap<String, String> items;
-    int result = statement->step();
-    while (result == SQLITE_ROW) {
-        String key = statement->columnText(0);
-        String value = statement->columnBlobAsString(1);
-        if (!key.isNull() && !value.isNull())
-            items.add(WTFMove(key), WTFMove(value));
-
-        result = statement->step();
-    }
-
-    if (result != SQLITE_DONE) {
-        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::getAllItemsFromDatabase failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
-        return makeUnexpected(StorageError::Database);
-    }
-
-    return items;
-}
-
-void SQLiteStorageArea::initializeCache(const HashMap<String, String>& items)
-{
-    if (m_cache)
-        return;
-
-    m_cache = Cache { };
-    for (auto& [key, value] : items) {
-        ASSERT(!key.isNull() && !value.isNull());
-        CheckedUint64 newSize = m_cache->size;
-        newSize += key.sizeInBytes();
-        newSize += value.sizeInBytes();
-        m_cache->size = newSize;
-        m_cache->items.add(key, value.sizeInBytes() > maximumSizeForValuesKeptInMemory ? String() : value);
-    }
-}
-
 HashMap<String, String> SQLiteStorageArea::allItems()
 {
     ASSERT(!isMainRunLoop());
 
+    if (!prepareDatabase(ShouldCreateIfNotExists::No) || !m_database)
+        return HashMap<String, String> { };
+
+    HashMap<String, String> items;
     if (m_cache) {
-        HashMap<String, String> items;
-        items.reserveInitialCapacity(m_cache->items.size());
-        for (auto& [key, value] : m_cache->items) {
+        items.reserveInitialCapacity(m_cache->size());
+        for (auto& [key, value] : *m_cache) {
             if (!value.isNull()) {
                 items.add(key, value);
                 continue;
@@ -316,12 +273,30 @@ HashMap<String, String> SQLiteStorageArea::allItems()
         return items;
     }
 
-    auto result = getAllItemsFromDatabase();
-    if (!result)
-        return HashMap<String, String> { };
+    // Import from database.
+    auto statement = cachedStatement(StatementType::GetAllItems);
+    if (!statement) {
+        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::allItems failed on creating statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+        return { };
+    }
 
-    initializeCache(result.value());
-    return result.value();
+    m_cache = HashMap<String, String> { };
+    int result = statement->step();
+    while (result == SQLITE_ROW) {
+        String key = statement->columnText(0);
+        String value = statement->columnBlobAsString(1);
+        if (!key.isNull() && !value.isNull()) {
+            m_cache->add(key, value.sizeInBytes() > maximumSizeForValuesKeptInMemory ? String() : value);
+            items.add(WTFMove(key), WTFMove(value));
+        }
+
+        result = statement->step();
+    }
+
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::allItems failed on executing statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
+
+    return items;
 }
 
 Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueID connection, StorageAreaImplIdentifier storageAreaImplID, String&& key, String&& value, const String& urlString)
@@ -331,27 +306,10 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueI
     if (!prepareDatabase(ShouldCreateIfNotExists::Yes))
         return makeUnexpected(StorageError::Database);
 
-    if (!m_cache) {
-        auto result = getAllItemsFromDatabase();
-        if (!result)
-            return makeUnexpected(result.error());
-        initializeCache(result.value());
-    }
-
-    CheckedUint64 newSize = m_cache->size;
-    bool keyExists = m_cache->items.contains(key);
     startTransactionIfNecessary();
     String oldValue;
     if (auto valueOrError = getItem(key))
         oldValue = valueOrError.value();
-
-    if (keyExists)
-        newSize -= oldValue.sizeInBytes();
-    else
-        newSize += key.sizeInBytes();
-    newSize += value.sizeInBytes();
-    if (newSize.hasOverflowed() || newSize > quota())
-        return makeUnexpected(StorageError::QuotaExceeded);
 
     auto statement = cachedStatement(StatementType::SetItem);
     if (!statement || statement->bindText(1, key) || statement->bindBlob(2, value)) {
@@ -360,14 +318,16 @@ Expected<void, StorageError> SQLiteStorageArea::setItem(IPC::Connection::UniqueI
     }
 
     int result = statement->step();
+    if (result == SQLITE_FULL)
+        return makeUnexpected(StorageError::QuotaExceeded);
     if (result != SQLITE_DONE) {
         RELEASE_LOG_ERROR(Storage, "SQLiteStorageArea::setItem failed on stepping statement (%d) - %s", m_database->lastError(), m_database->lastErrorMsg());
         return makeUnexpected(StorageError::Database);
     }
 
     dispatchEvents(connection, storageAreaImplID, key, oldValue, value, urlString);
-    m_cache->items.set(WTFMove(key), value.sizeInBytes() > maximumSizeForValuesKeptInMemory ? String() : WTFMove(value));
-    m_cache->size = newSize;
+    if (m_cache)
+        m_cache->set(WTFMove(key), value.sizeInBytes() > maximumSizeForValuesKeptInMemory ? String() : WTFMove(value));
 
     return { };
 }
@@ -397,15 +357,6 @@ Expected<void, StorageError> SQLiteStorageArea::removeItem(IPC::Connection::Uniq
 
     dispatchEvents(connection, storageAreaImplID, key, oldValue, String(), urlString);
 
-    if (m_cache) {
-        if (m_cache->items.remove(key)) {
-            CheckedUint64 newSize = m_cache->size;
-            newSize -= key.sizeInBytes();
-            newSize -= oldValue.sizeInBytes();
-            m_cache->size = newSize;
-        }
-    }
-
     return { };
 }
 
@@ -416,13 +367,11 @@ Expected<void, StorageError> SQLiteStorageArea::clear(IPC::Connection::UniqueID 
     if (!prepareDatabase(ShouldCreateIfNotExists::No))
         return makeUnexpected(StorageError::Database);
 
-    if (m_cache && m_cache->items.isEmpty())
+    if (m_cache && m_cache->isEmpty())
         return makeUnexpected(StorageError::ItemNotFound);
 
-    if (m_cache) {
-        m_cache->items.clear();
-        m_cache->size = 0;
-    }
+    if (m_cache)
+        m_cache->clear();
 
     if (!m_database)
         return makeUnexpected(StorageError::ItemNotFound);

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -69,19 +69,13 @@ private:
     WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
     Expected<String, StorageError> getItem(const String& key);
     Expected<String, StorageError> getItemFromDatabase(const String& key);
-    Expected<HashMap<String, String>, StorageError> getAllItemsFromDatabase();
-    void initializeCache(const HashMap<String, String>&);
 
     String m_path;
     Ref<WorkQueue> m_queue;
     std::unique_ptr<WebCore::SQLiteDatabase> m_database;
     std::unique_ptr<WebCore::SQLiteTransaction> m_transaction;
     Vector<std::unique_ptr<WebCore::SQLiteStatement>> m_cachedStatements;
-    struct Cache {
-        HashMap<String, String> items;
-        uint64_t size { 0 };
-    };
-    std::optional<Cache> m_cache;
+    std::optional<HashMap<String, String>> m_cache;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 2cb930b2456b9bdd545fa5af440b652a89b59e55
<pre>
Revert 255044@main as it introduces crash in SQLiteStorageArea::removeItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=247767">https://bugs.webkit.org/show_bug.cgi?id=247767</a>
rdar://101927216

Reviewed by Ben Nham and Per Arne Vollan.

From 255044@main we started to track LocalStorage size manually for quota check instead of setting hard limit on
database file. However, LocalStorage might convert 16-bit string to 8-bit string when reading from database for memory
optimization (246784@main), and we didn&apos;t consider that in computation. This has let to overflow error in
SQLiteStorageArea::removeItem.

* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::isEmpty):
(WebKit::SQLiteStorageArea::prepareDatabase):
(WebKit::SQLiteStorageArea::getItem):
(WebKit::SQLiteStorageArea::allItems):
(WebKit::SQLiteStorageArea::setItem):
(WebKit::SQLiteStorageArea::removeItem):
(WebKit::SQLiteStorageArea::clear):
(WebKit::SQLiteStorageArea::getAllItemsFromDatabase): Deleted.
(WebKit::SQLiteStorageArea::initializeCache): Deleted.
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:

Canonical link: <a href="https://commits.webkit.org/256670@main">https://commits.webkit.org/256670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/961f514f3abf94a124ad9b679a7d831071beda5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105830 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5667 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34288 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102561 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4194 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82883 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31224 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74053 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40021 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19470 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20831 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43423 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40099 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->