### PR TITLE
Fix reassigning to class name during static field initialization

### DIFF
--- a/JSTests/stress/destructuring-array-class-static.js
+++ b/JSTests/stress/destructuring-array-class-static.js
@@ -1,0 +1,130 @@
+function shouldThrow(test, func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error(`test ${test} not thrown`);
+    if (String(error) !== errorMessage)
+        throw new Error(`test ${test} bad error: ${String(error)}`);
+}
+
+let expected = "TypeError: Attempted to assign to readonly property.";
+
+shouldThrow(1, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static #y = [ b = 0, x = 0 ] = [0];
+        }
+    `);
+}, expected);
+
+shouldThrow(2, () => {
+    eval(`
+        class x {
+            static #y = [ x = 0 ] = [0];
+        }
+    `);
+}, expected);
+
+shouldThrow(3, () => {
+    eval(`
+        let b = 0;
+        class x {
+            y = [ b = 1, x = 0 ] = [0];
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(4, () => {
+    eval(`
+        class x {
+            y = [ x = 0 ] = [0];
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(5, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static {
+                let a = [ b = 1, x = 0 ] = [0];
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(6, () => {
+    eval(`
+        class x {
+            static {
+                let a = [ x = 0 ] = [0];
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(7, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static #y = [ b, x ] = [0];
+        }
+    `);
+}, expected);
+
+shouldThrow(8, () => {
+    eval(`
+        class x {
+            static #y = [ x ] = [0];
+        }
+    `);
+}, expected);
+
+shouldThrow(9, () => {
+    eval(`
+        let b = 0;
+        class x {
+            y = [ b, x ] = [0];
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(10, () => {
+    eval(`
+        class x {
+            y = [ x ] = [0];
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(11, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static {
+                let a = [ b, x ] = [0];
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(12, () => {
+    eval(`
+        class x {
+            static {
+                let a = [ x ] = [0];
+            }
+        }
+    `);
+}, expected);

--- a/JSTests/stress/destructuring-object-class-static.js
+++ b/JSTests/stress/destructuring-object-class-static.js
@@ -1,0 +1,191 @@
+function shouldThrow(test, func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error(`test ${test} not thrown`);
+    if (String(error) !== errorMessage)
+        throw new Error(`test ${test} bad error: ${String(error)}`);
+}
+
+let expected = "TypeError: Attempted to assign to readonly property.";
+
+shouldThrow(1, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static #y = { b = 0, x = 0 } = 0;
+        }
+    `);
+}, expected);
+
+shouldThrow(2, () => {
+    eval(`
+        class x {
+            static #y = { x = 0 } = 0;
+        }
+    `);
+}, expected);
+
+shouldThrow(3, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static #y = { b, x } = 0;
+        }
+    `);
+}, expected);
+
+shouldThrow(4, () => {
+    eval(`
+        class x {
+            static #y = { x } = 0;
+        }
+    `);
+}, expected);
+
+shouldThrow(5, () => {
+    eval(`
+        let b = 0;
+        class x {
+            y = { b = 1, x = 0 } = 0;
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(6, () => {
+    eval(`
+        class x {
+            y = { x = 0 } = 0;
+        }
+        let a = new x();
+    `);
+}, expected);
+
+
+shouldThrow(7, () => {
+    eval(`
+        let b = 0;
+        class x {
+            y = { b = 1, x = 0 } = 0;
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(8, () => {
+    eval(`
+        class x {
+            y = { x } = 0;
+        }
+        let a = new x();
+    `);
+}, expected);
+
+shouldThrow(9, () => {
+    eval(`
+        let b = 0;
+        class x {
+            static {
+                let a = { b, x } = 0;
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(10, () => {
+    eval(`
+        class x {
+            static {
+                let a = { x = 0 } = 0;
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(11, () => {
+    eval(`
+        class x {
+            static {
+                let b = 0;
+                let a = { b = 1, x = 0 } = 0;
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(12, () => {
+    eval(`
+        const obj = { a: 1, b: { c: 2 } };
+        let a = 0;
+        class x {
+            static #y = { a, b: { c: x } } = obj;
+        }
+    `);
+}, expected);
+
+shouldThrow(13, () => {
+    eval(`
+        let a = 0;
+        class x {
+            static #y = { a, ...x } = 0;
+        }
+    `);
+}, expected);
+
+shouldThrow(14, () => {
+    eval(`
+        let a = 0;
+        class x {
+            static #y = { a = 1, ...x } = 0;
+        }
+    `);
+}, expected);
+
+shouldThrow(15, () => {
+    eval(`
+        class foo {
+            static {
+                ({ foo = 1 } = {});
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(16, () => {
+    eval(`
+        let bar = 0;
+        class foo {
+            static {
+                ({ bar = 1, foo = 1 } = {});
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(17, () => {
+    eval(`
+        class foo {
+            static {
+                ({ foo } = {});
+            }
+        }
+    `);
+}, expected);
+
+shouldThrow(18, () => {
+    eval(`
+        let bar = 0;
+        class foo {
+            static {
+                ({ bar, foo } = {});
+            }
+        }
+    `);
+}, expected);

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -1295,13 +1295,16 @@ template <class TreeBuilder> TreeDestructuringPattern Parser<LexerType>::parseDe
                     innerPattern = parseBindingOrAssignmentElement(context, kind, exportType, duplicateIdentifier, hasDestructuringPattern, bindingContext, depth + 1);
                 else {
                     semanticFailIfTrue(escapedKeyword, "Cannot use abbreviated destructuring syntax for keyword '", propertyName->impl(), "'");
+                    semanticFailIfTrue(isDisallowedIdentifierAwait(identifierToken), "Cannot use 'await' as a ", destructuringKindToVariableKindName(kind), " ", disallowedIdentifierAwaitReason());
                     if (kind == DestructuringKind::DestructureToExpressions) {
                         bool isEvalOrArguments = m_vm.propertyNames->eval == *propertyName || m_vm.propertyNames->arguments == *propertyName;
                         if (isEvalOrArguments && strictMode())
                             reclassifyExpressionError(ErrorIndicatesPattern, ErrorIndicatesNothing);
                         failIfTrueIfStrict(isEvalOrArguments, "Cannot modify '", propertyName->impl(), "' in strict mode");
+
+                        if (match(EQUAL))
+                            currentScope()->useVariable(propertyName, m_vm.propertyNames->eval == *propertyName);
                     }
-                    semanticFailIfTrue(isDisallowedIdentifierAwait(identifierToken), "Cannot use 'await' as a ", destructuringKindToVariableKindName(kind), " ", disallowedIdentifierAwaitReason());
                     innerPattern = createBindingPattern(context, kind, exportType, *propertyName, identifierToken, bindingContext, duplicateIdentifier);
                 }
             } else {


### PR DESCRIPTION
#### 68f502ba813d3162e60f92023084d72c167bbc7f
<pre>
Fix reassigning to class name during static field initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=247428">https://bugs.webkit.org/show_bug.cgi?id=247428</a>
rdar://102193862

Reviewed by Alexey Shvayka.

Our investigation shows that there is a different path for `{ x = 0 } = 0`
by comparing to `{ x } = 0`, which go through `parseMemberExpression`
=&gt; `parsePrimaryExpression` =&gt; `createResolveAndUseVariable` =&gt;
`currentScope()-&gt;useVariable()`. `useVariable` is necessary so the
BytecodeGenerator would know it&apos;s used via scope VarKind::Scope and
set it up via op_put_to_scope rather than simple mov, which used to
trigger TDZ error.

For `{ x = 0 } = 0`, the parser will go through `parseProperty` and step
into the branch
```
if (match(EQUAL))
    classifyExpressionError(ErrorIndicatesPattern);
```
which fails to updating the used variables when encountering the
object destructuring with assignment expressions. This fix is to
handle those edge cases. In this case, symbolTablePut will check
for read-only variable without ignoring.

* JSTests/stress/destructuring-array-class-static.js: Added.
(shouldThrow):
(x):
* JSTests/stress/destructuring-object-class-static.js: Added.
(shouldThrow):
(x):
(eval.x):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):

Canonical link: <a href="https://commits.webkit.org/256663@main">https://commits.webkit.org/256663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c9a75b7de43874230b611832c3d8175b6d2d746

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105995 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166347 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5886 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34452 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102720 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102124 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83056 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31366 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74265 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87436 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40182 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82833 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21002 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28303 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4130 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85511 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40272 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19275 "Passed tests") | 
<!--EWS-Status-Bubble-End-->