### PR TITLE
REGRESSION (255932@main): Text copied from Notes pastes as attachment in Mail compose

### DIFF
--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -304,14 +304,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 static bool shouldTreatAsAttachmentByDefault(const String& typeIdentifier)
 {
     auto type = [UTType typeWithIdentifier:typeIdentifier];
-    if ([type conformsToType:UTTypeVCard])
-        return true;
-
-    if ([type conformsToType:UTTypeCompositeContent]
-        && !([type conformsToType:UTTypeRTFD] || [type conformsToType:UTTypeFlatRTFD] || [type conformsToType:UTTypeWebArchive]))
-        return true;
-
-    return false;
+    return [type conformsToType:UTTypeVCard] || [type conformsToType:UTTypePDF];
 }
 
 static bool prefersAttachmentRepresentation(const PasteboardItemInfo& info)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -2728,6 +2728,20 @@ TEST(WKAttachmentTestsIOS, CopyAttachmentUsingElementAction)
     TestWebKitAPI::Util::run(&done);
 }
 
+TEST(WKAttachmentTestsIOS, PasteRichTextCopiedFromNotes)
+{
+    UIPasteboard.generalPasteboard.items = @[@{
+        @"com.apple.notes.richtext" : [@"foo" dataUsingEncoding:NSUTF8StringEncoding],
+        UTTypeHTML.identifier : [@"<p>foo</p>" dataUsingEncoding:NSUTF8StringEncoding]
+    }];
+
+    auto webView = webViewForTestingAttachments();
+    ObserveAttachmentUpdatesForScope observer(webView.get());
+    [webView _synchronouslyExecuteEditCommand:@"Paste" argument:nil];
+    EXPECT_EQ(0U, observer.observer().inserted.count);
+    EXPECT_WK_STREQ("foo", [webView contentsAsString]);
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### d7150a05e06e7ec60c42b1814acacdd7bdb91b8d
<pre>
REGRESSION (255932@main): Text copied from Notes pastes as attachment in Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=247778">https://bugs.webkit.org/show_bug.cgi?id=247778</a>
rdar://96853551

Reviewed by Aditya Keerthi.

After the fix in `255932@main`, copying rich text from Notes on iOS and pasting into Mail compose
results in an attachment being inserted into the document. This is because Notes writes the UTI
&quot;com.apple.notes.richtext&quot; to the pasteboard, which conforms to `UTTypeCompositeContent` but
isn&apos;t one of RTFD/WebArchive, so we treat it as an attachment by default.

To avoid this problem while preserving the original intent behind `255932@main`, we narrow the fix
to special case `UTTypePDF`, rather than adding blanket rules to treat composite content as
attachments.

Test: WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes

* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::shouldTreatAsAttachmentByDefault):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/256565@main">https://commits.webkit.org/256565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37be7317b4199caa3ae14cd348f4043314499a1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105713 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5542 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34181 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88547 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101534 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101824 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82771 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31134 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73964 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39906 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37580 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20738 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4547 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/3 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40001 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->