### PR TITLE
Fix UnsafePointer comparisons

### DIFF
--- a/Source/WTF/wtf/UnsafePointer.h
+++ b/Source/WTF/wtf/UnsafePointer.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 namespace WTF {
 
 // A UnsafePointer<> can be used to hold a pointer whose lifetime is not guaranteed
@@ -40,25 +42,21 @@ public:
     UnsafePointer() : m_pointer(nullptr) { }
     UnsafePointer(PtrType pointer) : m_pointer(pointer) { }
 
-    bool operator==(PtrType pointer) const { return pointer == m_pointer; }
-    bool operator!=(PtrType pointer) const { return pointer != m_pointer; }
-    operator bool() const { return m_pointer; }
+    explicit operator bool() const { return m_pointer; }
+
+    friend bool operator==(const UnsafePointer& lhs, const UnsafePointer& rhs)
+    {
+        return lhs.m_pointer == rhs.m_pointer;
+    }
+
+    friend bool operator!=(const UnsafePointer& lhs, const UnsafePointer& rhs)
+    {
+        return lhs.m_pointer != rhs.m_pointer;
+    }
 
 private:
     PtrType m_pointer;
 };
-
-template<typename T>
-bool operator==(typename UnsafePointer<T>::PtrType barePointer, const UnsafePointer<T>& unsafePointer)
-{
-    return unsafePointer == barePointer;
-}
-
-template<typename T>
-bool operator!=(typename UnsafePointer<T>::PtrType barePointer, const UnsafePointer<T>& unsafePointer)
-{
-    return unsafePointer != barePointer;
-}
 
 } // namespace WTF
 

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp
@@ -607,7 +607,7 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
         return false;
 
     auto orientation = videoFrame.orientation();
-    TextureContent content { reinterpret_cast<intptr_t>(surface), IOSurfaceGetSeed(surface), level, internalFormat, format, type, unpackFlipY, orientation };
+    TextureContent content { surface, IOSurfaceGetSeed(surface), level, internalFormat, format, type, unpackFlipY, orientation };
     auto it = m_knownContent.find(outputTexture);
     if (it != m_knownContent.end() && it->value == content) {
         // If the texture hasn't been modified since the last time we copied to it, and the

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
@@ -30,6 +30,7 @@
 #include "GraphicsContextGLCV.h"
 #include "ImageOrientation.h"
 #include <memory>
+#include <wtf/UnsafePointer.h>
 
 namespace WebCore {
 class GraphicsContextGLCocoa;
@@ -68,9 +69,7 @@ private:
     GCGLint m_uvTextureSizeUniformLocation { -1 };
 
     struct TextureContent {
-        // FIXME: Switch back to UnsafePointer<IOSurfaceRef> once UnsafePointer is safe to compare.
-        // http://webkit.org/b/235435
-        intptr_t surface { 0 };
+        UnsafePointer<IOSurfaceRef> surface;
         uint32_t surfaceSeed { 0 };
         GCGLint level { 0 };
         GCGLenum internalFormat { 0 };

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -119,6 +119,7 @@ set(TestWTF_SOURCES
     Tests/WTF/UniqueArray.cpp
     Tests/WTF/UniqueRef.cpp
     Tests/WTF/UniqueRefVector.cpp
+    Tests/WTF/UnsafePointer.cpp
     Tests/WTF/Vector.cpp
     Tests/WTF/WTFString.cpp
     Tests/WTF/WeakPtr.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -518,6 +518,7 @@
 		71E88C4524B534B700665160 /* img-with-base64-url.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 71E88C4324B533EC00665160 /* img-with-base64-url.html */; };
 		725C3EF322058A5B007C36FC /* AdditionalSupportedImageTypes.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */; };
 		7283A9D222FB1E0600B21C7D /* exif-orientation-8-llo.jpg in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */; };
+		743BC877291DB6FC002C0165 /* UnsafePointer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 743BC86F291DB6FC002C0165 /* UnsafePointer.cpp */; };
 		751B05D61F8EAC410028A09E /* DatabaseTrackerTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */; };
 		754CEC811F6722F200D0039A /* AutoFillAvailable.mm in Sources */ = {isa = PBXBuildFile; fileRef = 754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */; };
 		7673499D1930C5BB00E44DF9 /* StopLoadingDuringDidFailProvisionalLoad_bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7673499A1930182E00E44DF9 /* StopLoadingDuringDidFailProvisionalLoad_bundle.cpp */; };
@@ -2656,6 +2657,7 @@
 		725C3EF2220584BA007C36FC /* AdditionalSupportedImageTypes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = AdditionalSupportedImageTypes.html; sourceTree = "<group>"; };
 		7283A9D122FB1D9700B21C7D /* exif-orientation-8-llo.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "exif-orientation-8-llo.jpg"; sourceTree = "<group>"; };
 		73BD731723A846500020F450 /* DisplayName.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DisplayName.mm; sourceTree = "<group>"; };
+		743BC86F291DB6FC002C0165 /* UnsafePointer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnsafePointer.cpp; sourceTree = "<group>"; };
 		751B05D51F8EAC1A0028A09E /* DatabaseTrackerTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DatabaseTrackerTest.mm; sourceTree = "<group>"; };
 		754CEC801F6722DC00D0039A /* AutoFillAvailable.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AutoFillAvailable.mm; sourceTree = "<group>"; };
 		75F3133F18C171B70041CAEC /* EphemeralSessionPushStateNoHistoryCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EphemeralSessionPushStateNoHistoryCallback.cpp; sourceTree = "<group>"; };
@@ -5097,6 +5099,7 @@
 				E398BC0F2041C76300387136 /* UniqueArray.cpp */,
 				5C5E633D1D0B67940085A025 /* UniqueRef.cpp */,
 				3A1337AB28F9177600F29B73 /* UniqueRefVector.cpp */,
+				743BC86F291DB6FC002C0165 /* UnsafePointer.cpp */,
 				E3A1E78021B25B79008C6007 /* URL.cpp */,
 				E3A1E78421B25B91008C6007 /* URLParser.cpp */,
 				144D40EC221B46A7004B474F /* UUID.cpp */,
@@ -6067,6 +6070,7 @@
 				44652CB726FCD405005EC272 /* TypeCastsCocoaARC.mm in Sources */,
 				E324A6F02041C82000A76593 /* UniqueArray.cpp in Sources */,
 				3A1337B328F9177600F29B73 /* UniqueRefVector.cpp in Sources */,
+				743BC877291DB6FC002C0165 /* UnsafePointer.cpp in Sources */,
 				E3A1E78221B25B7A008C6007 /* URL.cpp in Sources */,
 				E3C21A7C21B25CA2003B31A3 /* URLExtras.mm in Sources */,
 				E3A1E78521B25B91008C6007 /* URLParser.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/UnsafePointer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UnsafePointer.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2013-2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/UnsafePointer.h>
+
+#include <gtest/gtest.h>
+#include <type_traits>
+
+namespace TestWebKitAPI {
+
+// Only declarations before the test, to ensure that UnsafePointer can work with pointers to incomplete types.
+class UnsafeObject;
+UnsafeObject* GetNullUnsafeObject();
+UnsafeObject* GetUnsafeObjectA();
+UnsafeObject* GetUnsafeObjectB();
+
+TEST(WTF_UnsafePointer, Basic)
+{
+    UnsafeObject* n = GetNullUnsafeObject();
+    ASSERT_EQ(n, nullptr);
+    UnsafeObject* a = GetUnsafeObjectA();
+    ASSERT_NE(a, nullptr);
+    UnsafeObject* b = GetUnsafeObjectB();
+    ASSERT_NE(b, nullptr);
+    ASSERT_NE(a, b);
+
+    using UP = UnsafePointer<UnsafeObject*>;
+
+    static_assert(std::is_constructible_v<bool, UP>, "explicit UnsafePointer conversion to bool should be allowed");
+    static_assert(!std::is_convertible_v<UP, bool>, "implicit UnsafePointer conversion to bool should not be allowed");
+
+    ASSERT_FALSE(UP(n));
+    ASSERT_TRUE(!UP(n));
+
+    ASSERT_TRUE(UP(a));
+    ASSERT_FALSE(!UP(a));
+
+    static_assert(std::is_convertible_v<UnsafeObject*, UP>, "implicit UnsafePointer construction from pointer should be allowed");
+    static_assert(!std::is_convertible_v<UP, UnsafeObject*>, "UnsafePointer conversion to pointer should not be allowed");
+
+    for (UnsafeObject* p1 : { n, a, b }) {
+        for (UnsafeObject* p2 : { n, a, b }) {
+            EXPECT_EQ(UP(p1) == UP(p2), p1 == p2);
+            EXPECT_EQ(UP(p1) == p2, p1 == p2);
+            EXPECT_EQ(p1 == UP(p2), p1 == p2);
+
+            EXPECT_EQ(UP(p1) != UP(p2), p1 != p2);
+            EXPECT_EQ(UP(p1) != p2, p1 != p2);
+            EXPECT_EQ(p1 != UP(p2), p1 != p2);
+        }
+    }
+}
+
+// Object that can only be explicitly constructed, other accesses are forbidden.
+// This is to ensure that UnsafePointer doesn't dereferences it.
+class UnsafeObject {
+public:
+    struct ConstructionToken { };
+    explicit UnsafeObject(ConstructionToken) { }
+
+    UnsafeObject(const UnsafeObject&) = delete;
+    UnsafeObject(UnsafeObject&&) = delete;
+};
+
+UnsafeObject* GetNullUnsafeObject()
+{
+    return nullptr;
+}
+
+UnsafeObject* GetUnsafeObjectA()
+{
+    static UnsafeObject a { UnsafeObject::ConstructionToken { } };
+    return &a;
+}
+
+UnsafeObject* GetUnsafeObjectB()
+{
+    static UnsafeObject b { UnsafeObject::ConstructionToken { } };
+    return &b;
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 1f348c946a758e690692dc2fdd0ef31c07bc3832
<pre>
Fix UnsafePointer comparisons
<a href="https://bugs.webkit.org/show_bug.cgi?id=235435">https://bugs.webkit.org/show_bug.cgi?id=235435</a>
&lt;rdar://problem/88183155&gt;

Reviewed by NOBODY (OOPS!).

Made UnsafePointer::operator bool() `explicit`, to avoid implicit conversions to pointers (which was effectively converting any non-null UnsafePointer to a 0x1 pointer!)
Because of this, the (incorrect) comparison functions didn&apos;t compile anymore; Reworked by always taking UnsafePointers, and avoided code duplication by using `friend` functions.

Added tests.

Re-added the UnsafePointer use inside GraphicsContextGLCVCocoa::TextureContent.

* Source/WTF/wtf/UnsafePointer.h:
(WTF::UnsafePointer::operator bool const):
(WTF::UnsafePointer::operator==):
(WTF::UnsafePointer::operator!=):
(WTF::UnsafePointer::operator== const): Deleted.
(WTF::UnsafePointer::operator!= const): Deleted.
(WTF::operator==): Deleted.
(WTF::operator!=): Deleted.
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.cpp:
(WebCore::GraphicsContextGLCVCocoa::copyVideoSampleToTexture):
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/UnsafePointer.cpp: Added.
(TestWebKitAPI::TEST):
(TestWebKitAPI::UnsafeObject::UnsafeObject):
(TestWebKitAPI::GetNullUnsafeObject):
(TestWebKitAPI::GetUnsafeObjectA):
(TestWebKitAPI::GetUnsafeObjectB):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f348c946a758e690692dc2fdd0ef31c07bc3832

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105717 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5546 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34186 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101537 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101828 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82775 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31138 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/73967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39910 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82546 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37584 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28256 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/7 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85226 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/7 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40004 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19226 "Passed tests") | 
<!--EWS-Status-Bubble-End-->