### PR TITLE
ASSERTION FAILED: !document().selection().selection().isOrphan() in ContainerNode::removeNodeWithScriptAssertion

### DIFF
--- a/LayoutTests/editing/selection/modify-extend-iframe-orphan-expected.txt
+++ b/LayoutTests/editing/selection/modify-extend-iframe-orphan-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not hit any assertions.
+PASS

--- a/LayoutTests/editing/selection/modify-extend-iframe-orphan.html
+++ b/LayoutTests/editing/selection/modify-extend-iframe-orphan.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest() {
+    const selection = document.getSelection();
+    selection.selectAllChildren(span);
+    selection.selectAllChildren(input);
+    selection.modify("extend", "forward", "documentboundary");
+    document.execCommand("insertUnorderedList", false, null);
+    setTimeout(() => {
+        document.body.innerHTML = 'This test passes if WebKit does not hit any assertions.<br>PASS';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+function focusOut() {
+    document.getSelection().selectAllChildren(span);
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.contentDocument.body.appendChild(spanContainer);
+}
+
+function deleteAndShowModal() {
+    document.execCommand("delete", false, null);
+    dialog.showModal();
+}
+
+</script>
+<body onload="runTest()">
+<dialog id="dialog" contenteditable="true"></dialog>
+<div id="spanContainer" contenteditable="true" onblur="deleteAndShowModal()">A<span id="span"></span></div>
+<div onfocusout="focusOut()" contenteditable="true"><iframe></iframe><input id="input"></div>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -722,6 +722,14 @@ TextDirection FrameSelection::directionOfSelection()
     return directionOfEnclosingBlock();
 }
 
+static bool selectionIsOrphanedOrBelongsToWrongDocument(const VisibleSelection& selection, RefPtr<Document>&& document)
+{
+    if (selection.isOrphan())
+        return true;
+    RefPtr documentOfSelection = selection.document();
+    return document && documentOfSelection && document != documentOfSelection;
+}
+
 void FrameSelection::willBeModified(EAlteration alter, SelectionDirection direction)
 {
     if (alter != AlterationExtend)
@@ -769,6 +777,8 @@ void FrameSelection::willBeModified(EAlteration alter, SelectionDirection direct
         m_selection.setBase(end);
         m_selection.setExtent(start);
     }
+    if (selectionIsOrphanedOrBelongsToWrongDocument(m_selection, m_document.get()))
+        clear();
 }
 
 VisiblePosition FrameSelection::positionForPlatform(bool isGetStart) const


### PR DESCRIPTION
#### 24defe70063740ced297cf16cd2099c55e6afed1
<pre>
ASSERTION FAILED: !document().selection().selection().isOrphan() in ContainerNode::removeNodeWithScriptAssertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=247781">https://bugs.webkit.org/show_bug.cgi?id=247781</a>
rdar://101497964

Reviewed by NOBODY (OOPS!).

The bug was caused by VisibleSelection::setBase setting selection ends to point to nodes
in a wrong document as a side effect of calling VisibleSelection::validate when m_anchor
isn&apos;t cleared due to a node removal when live range selection is disabled.

* LayoutTests/editing/selection/modify-extend-iframe-orphan-expected.txt: Added.
* LayoutTests/editing/selection/modify-extend-iframe-orphan.html: Added.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::selectionIsOrphanedOrBelongsToWrongDocument):
(WebCore::FrameSelection::willBeModified):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24defe70063740ced297cf16cd2099c55e6afed1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105724 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5553 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34193 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/101544 "Hash 24defe70 for PR 197 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101835 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82782 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31143 "Found 17 new test failures: imported/w3c/web-platform-tests/css/css-contain/contain-size-select-001.html, imported/w3c/web-platform-tests/css/css-contain/contain-size-select-002.html, imported/w3c/web-platform-tests/css/css-pseudo/backdrop-animate-002.html, imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-rotate.html, imported/w3c/web-platform-tests/css/css-transforms/group/svg-transform-nested-009.html, imported/w3c/web-platform-tests/css/css-transforms/individual-transform/animation/individual-transform-combine.html, imported/w3c/web-platform-tests/css/css-transforms/transform-3d-rotateY-stair-above-001.xht, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-color-input-background-color-001.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-background-color-001.html, imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-select-dropdown-box-border-bottom-left-radius-001.html ... (failure)") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39917 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20743 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/14 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/14 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40010 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->