### PR TITLE
[GStreamer] Monitor GstStream tags and minor test fix

### DIFF
--- a/LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py
+++ b/LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py
@@ -15,7 +15,7 @@ sys.stdout.write(
     'ETag: foo\r\n'
     'Last-Modified: Thu, 01 Jan 2000 00:00:00 GMT\r\n'
     'Cache-Control: max-age=0\r\n'
-    'Content-Type: text/html\r\n'
+    'Content-Type: video/mp4\r\n'
     'Content-Length: {}\r\n\r\n'.format(os.path.getsize(os.path.join(os.path.dirname(__file__), '../../media/resources/reference.mov')))
 )
 

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -97,10 +97,6 @@ private:
     bool getTag(GstTagList* tags, const gchar* tagName, StringType& value);
 
     void streamChanged();
-
-    static void activeChangedCallback(TrackPrivateBaseGStreamer*);
-    static void tagsChangedCallback(TrackPrivateBaseGStreamer*);
-
     void tagsChanged();
 
     TrackType m_type;


### PR DESCRIPTION
#### d6ad2e4228d07f612a6c30eb2c88af86710615da
<pre>
[GStreamer] Monitor GstStream tags and minor test fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=247800">https://bugs.webkit.org/show_bug.cgi?id=247800</a>

Reviewed by Xabier Rodriguez-Calvar.

For playbin2 case we have some code to keep track of sticky tag events in TrackPrivateBase. For
playbin3 case we can simply monitor the tags property on the GstStream.

* LayoutTests/http/tests/security/resources/reference-movie-cross-origin-allow.py: Fix content-type
for mp4 resource.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer):
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::disconnect):
(WebCore::TrackPrivateBaseGStreamer::tagsChangedCallback): Deleted.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/256649@main">https://commits.webkit.org/256649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8c529f18668b8b28b89cefddff7d0d21ee2205f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105736 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166071 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5565 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34206 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102492 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4136 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82794 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31154 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39929 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19403 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37603 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4613 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/26 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43362 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/26 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40025 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->