### PR TITLE
[ews-app] Allow overriding buildbot hostname to send patches in specified in passwords.json

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -62,7 +62,7 @@ class Buildbot():
         buildbot_port = config.COMMIT_QUEUE_PORT if send_to_commit_queue else config.BUILDBOT_SERVER_PORT
         command = ['buildbot', 'try',
                    '--connect=pb',
-                   '--master={}:{}'.format(config.BUILDBOT_SERVER_HOST, buildbot_port),
+                   '--master={}:{}'.format(config.BUILDBOT_TRY_HOST, buildbot_port),
                    '--username={}'.format(config.BUILDBOT_TRY_USERNAME),
                    '--passwd={}'.format(config.BUILDBOT_TRY_PASSWORD),
                    '--diff={}'.format(patch_path),

--- a/Tools/CISupport/ews-app/ews/common/util.py
+++ b/Tools/CISupport/ews-app/ews/common/util.py
@@ -20,7 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 import logging
+import os
 import requests
 
 _log = logging.getLogger(__name__)
@@ -54,3 +56,14 @@ def is_valid_id(id, expected_data_type=int):
         _log.warn('Invalid id: {}, id should be positive integer.'.format(id))
         return False
     return True
+
+
+def load_password(name, default=None):
+    if os.getenv(name):
+        return os.getenv(name)
+    try:
+        passwords = json.load(open('passwords.json'))
+        return passwords.get(name, default)
+    except Exception as e:
+        _log.error('Error in finding {} in passwords.json'.format(name))
+        return default

--- a/Tools/CISupport/ews-app/ews/config.py
+++ b/Tools/CISupport/ews-app/ews/config.py
@@ -22,6 +22,8 @@
 
 import os
 
+import ews.common.util as util
+
 is_test_mode_enabled = os.getenv('EWS_PRODUCTION') is None
 is_dev_instance = (os.getenv('DEV_INSTANCE', '').lower() == 'true')
 
@@ -35,6 +37,9 @@ elif is_test_mode_enabled:
     BUILDBOT_SERVER_HOST = 'localhost'
 else:
     BUILDBOT_SERVER_HOST = 'ews-build.webkit.org'
+
+BUILDBOT_TRY_HOST = util.load_password('BUILDBOT_TRY_HOST', default=BUILDBOT_SERVER_HOST)
+
 BUILDBOT_SERVER_PORT = '5555'
 COMMIT_QUEUE_PORT = '5557'
 BUILDBOT_TRY_USERNAME = os.getenv('BUILDBOT_TRY_USERNAME', 'sampleuser')


### PR DESCRIPTION
#### c739b1b0fb37f24e22de7dfb6974159600e6a734
<pre>
[ews-app] Allow overriding buildbot hostname to send patches in specified in passwords.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=247801">https://bugs.webkit.org/show_bug.cgi?id=247801</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-app/ews/common/buildbot.py:
(Buildbot.send_patch_to_buildbot):
* Tools/CISupport/ews-app/ews/common/util.py:
(load_password): Method to load password either from env. variable or passwords.json
* Tools/CISupport/ews-app/ews/config.py:

Canonical link: <a href="https://commits.webkit.org/256577@main">https://commits.webkit.org/256577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b48991f0b8a3d0560e5ae23ca22572bc1467040

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105739 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166075 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5568 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34210 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88575 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101850 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82797 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31157 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/85974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/73983 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39932 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20764 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/29 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/29 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40031 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->