### PR TITLE
RemoteAudioDestinationProxy base class is platform specific

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1489,6 +1489,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/audio/AudioBus.h
     platform/audio/AudioChannel.h
     platform/audio/AudioDestination.h
+    platform/audio/AudioDestinationResampler.h
     platform/audio/AudioHardwareListener.h
     platform/audio/AudioIOCallback.h
     platform/audio/AudioSession.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2022,6 +2022,7 @@ platform/animation/AnimationList.cpp
 platform/animation/TimingFunction.cpp
 platform/audio/AudioBus.cpp
 platform/audio/AudioChannel.cpp
+platform/audio/AudioDestinationResampler.cpp
 platform/audio/AudioDSPKernelProcessor.cpp
 platform/audio/AudioHardwareListener.cpp
 platform/audio/AudioResampler.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -246,6 +246,7 @@ platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
 platform/audio/cocoa/AudioSampleBufferList.cpp
 platform/audio/cocoa/AudioSampleDataConverter.mm
 platform/audio/cocoa/AudioSampleDataSource.mm
+platform/audio/cocoa/AudioUtilitiesCocoa.cpp
 platform/audio/cocoa/CAAudioStreamDescription.cpp
 platform/audio/cocoa/CARingBuffer.cpp
 platform/audio/cocoa/MediaSessionManagerCocoa.mm

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -59,7 +59,7 @@ public:
     virtual bool isPlaying() = 0;
 
     // Sample-rate conversion may happen in AudioDestination to the hardware sample-rate
-    virtual float sampleRate() const = 0;
+    virtual float sampleRate() const { return m_sampleRate; }
     WEBCORE_EXPORT static float hardwareSampleRate();
 
     virtual unsigned framesPerBuffer() const = 0;
@@ -75,13 +75,17 @@ public:
     void callRenderCallback(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition);
 
 protected:
-    explicit AudioDestination(AudioIOCallback&);
+    explicit AudioDestination(AudioIOCallback&, float sampleRate);
 
     Lock m_callbackLock;
     AudioIOCallback* m_callback WTF_GUARDED_BY_LOCK(m_callbackLock) { nullptr };
+
+private:
+    const float m_sampleRate;
 };
 
-inline AudioDestination::AudioDestination(AudioIOCallback& callback)
+inline AudioDestination::AudioDestination(AudioIOCallback& callback, float sampleRate)
+    : m_sampleRate(sampleRate)
 {
     Locker locker { m_callbackLock };
     m_callback = &callback;

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AudioDestinationResampler.h"
+
+#if ENABLE(WEB_AUDIO)
+
+#include "AudioBus.h"
+#include "AudioSession.h"
+#include "AudioUtilities.h"
+#include "Logging.h"
+#include "MultiChannelResampler.h"
+
+namespace WebCore {
+
+constexpr size_t fifoSize = 96 * AudioUtilities::renderQuantumSize;
+
+AudioDestinationResampler::AudioDestinationResampler(AudioIOCallback& callback, unsigned numberOfOutputChannels, float inputSampleRate, float outputSampleRate)
+    : AudioDestination(callback, inputSampleRate)
+    , m_outputBus(AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize, false).releaseNonNull())
+    , m_renderBus(AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull())
+    , m_fifo(numberOfOutputChannels, fifoSize)
+{
+    if (inputSampleRate != outputSampleRate) {
+        double scaleFactor = static_cast<double>(inputSampleRate) / outputSampleRate;
+        m_resampler = makeUnique<MultiChannelResampler>(scaleFactor, numberOfOutputChannels, AudioUtilities::renderQuantumSize, [this](AudioBus* bus, size_t framesToProcess) {
+            ASSERT_UNUSED(framesToProcess, framesToProcess == AudioUtilities::renderQuantumSize);
+            callRenderCallback(nullptr, bus, AudioUtilities::renderQuantumSize, m_outputTimestamp);
+        });
+    }
+}
+
+AudioDestinationResampler::~AudioDestinationResampler() = default;
+
+unsigned AudioDestinationResampler::framesPerBuffer() const
+{
+    return m_renderBus->length();
+}
+
+void AudioDestinationResampler::start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+    LOG(Media, "AudioDestinationResampler::start");
+    {
+        Locker locker { m_dispatchToRenderThreadLock };
+        m_dispatchToRenderThread = WTFMove(dispatchToRenderThread);
+    }
+    startRendering(WTFMove(completionHandler));
+}
+
+void AudioDestinationResampler::stop(CompletionHandler<void(bool)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+    LOG(Media, "AudioDestinationResampler::stop");
+    stopRendering(WTFMove(completionHandler));
+    {
+        Locker locker { m_dispatchToRenderThreadLock };
+        m_dispatchToRenderThread = nullptr;
+    }
+}
+
+void AudioDestinationResampler::setIsPlaying(bool isPlaying)
+{
+    ASSERT(isMainThread());
+
+    if (m_isPlaying == isPlaying)
+        return;
+
+    m_isPlaying = isPlaying;
+
+    {
+        Locker locker { m_callbackLock };
+        if (m_callback)
+            m_callback->isPlayingDidChange();
+    }
+}
+
+size_t AudioDestinationResampler::pullRendered(size_t numberOfFrames)
+{
+    ASSERT(!isMainThread());
+    numberOfFrames = std::min(numberOfFrames, fifoSize);
+    Locker locker { m_fifoLock };
+    return m_fifo.pull(m_outputBus.ptr(), numberOfFrames);
+}
+
+bool AudioDestinationResampler::render(double sampleTime, MonotonicTime hostTime,  size_t framesToRender)
+{
+    m_outputTimestamp = {
+        Seconds { sampleTime / sampleRate() },
+        hostTime
+    };
+    // When there is a AudioWorklet, we do rendering on the AudioWorkletThread.
+    if (!m_dispatchToRenderThreadLock.tryLock())
+        return false;
+
+    Locker locker { AdoptLock, m_dispatchToRenderThreadLock };
+    if (!m_dispatchToRenderThread)
+        renderOnRenderingThreadIfPlaying(framesToRender);
+    else {
+        m_dispatchToRenderThread([protectedThis = Ref { *this }, framesToRender]() mutable {
+            protectedThis->renderOnRenderingThreadIfPlaying(framesToRender);
+        });
+    }
+    return true;
+}
+
+// This runs on the AudioWorkletThread when AudioWorklet is enabled, on the audio device's rendering thread otherwise.
+void AudioDestinationResampler::renderOnRenderingThreadIfPlaying(size_t framesToRender)
+{
+    if (!m_isPlaying)
+        return;
+    for (size_t pushedFrames = 0; pushedFrames < framesToRender; pushedFrames += AudioUtilities::renderQuantumSize) {
+        if (m_resampler)
+            m_resampler->process(m_renderBus.ptr(), AudioUtilities::renderQuantumSize);
+        else
+            callRenderCallback(nullptr, m_renderBus.ptr(), AudioUtilities::renderQuantumSize, m_outputTimestamp);
+
+        Locker locker { m_fifoLock };
+        m_fifo.push(m_renderBus.ptr());
+    }
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.h
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUDIO)
+
+#include "AudioDestination.h"
+#include "PushPullFIFO.h"
+#include <wtf/Lock.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class AudioBus;
+class MultiChannelResampler;
+
+// Base class for audio destinations that may need resampling.
+// The subclass should use m_outputBus to access the rendering.
+class AudioDestinationResampler : public AudioDestination {
+public:
+    WEBCORE_EXPORT AudioDestinationResampler(AudioIOCallback&, unsigned numberOfOutputChannels, float inputSampleRate, float outputSampleRate);
+    WEBCORE_EXPORT virtual ~AudioDestinationResampler();
+
+    WEBCORE_EXPORT void start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&&) final;
+    WEBCORE_EXPORT void stop(CompletionHandler<void(bool)>&&) final;
+
+protected:
+    WEBCORE_EXPORT void setIsPlaying(bool);
+    bool isPlaying() final { return m_isPlaying; }
+    WEBCORE_EXPORT unsigned framesPerBuffer() const final;
+
+    // The caller is expected to call both pullRendered and render.
+    // The caller fills the m_outputBus channel data pointers before calling this.
+    // Returns the number of frames to render.
+    WEBCORE_EXPORT size_t pullRendered(size_t numberOfFrames);
+    WEBCORE_EXPORT bool render(double sampleTime, MonotonicTime hostTime, size_t framesToRender);
+
+private:
+    void renderOnRenderingThreadIfPlaying(size_t framesToRender);
+
+    virtual void startRendering(CompletionHandler<void(bool)>&&) = 0;
+    virtual void stopRendering(CompletionHandler<void(bool)>&&) = 0;
+
+protected:
+    // To pass the data from FIFO to the audio device callback.
+    Ref<AudioBus> m_outputBus;
+
+private:
+    // To push the rendered result from WebAudio graph into the FIFO.
+    Ref<AudioBus> m_renderBus;
+
+    // Resolves the buffer size mismatch between the WebAudio engine and
+    // the callback function from the actual audio device.
+    Lock m_fifoLock;
+    PushPullFIFO m_fifo WTF_GUARDED_BY_LOCK(m_fifoLock);
+
+    std::unique_ptr<MultiChannelResampler> m_resampler;
+    AudioIOPosition m_outputTimestamp;
+
+    Lock m_dispatchToRenderThreadLock;
+    Function<void(Function<void()>&&)> m_dispatchToRenderThread WTF_GUARDED_BY_LOCK(m_dispatchToRenderThreadLock);
+
+    std::atomic<bool> m_isPlaying;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/PushPullFIFO.h
+++ b/Source/WebCore/platform/audio/PushPullFIFO.h
@@ -37,7 +37,6 @@ class AudioBus;
 // varies on the platform, but the WebAudio always renders 128 frames (render
 // quantum, RQ) thus FIFO is needed to handle the general case.
 class PushPullFIFO {
-    WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PushPullFIFO);
 
 public:

--- a/Source/WebCore/platform/audio/cocoa/AudioUtilitiesCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioUtilitiesCocoa.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
+#include "AudioUtilitiesCocoa.h"
+
+#include "AudioBus.h"
+#include "AudioDestinationCocoa.h"
+
+namespace WebCore {
+    
+AudioStreamBasicDescription audioStreamBasicDescriptionForAudioBus(AudioBus& bus)
+{
+    const int bytesPerFloat = sizeof(Float32);
+    AudioStreamBasicDescription streamFormat { };
+    streamFormat.mSampleRate = AudioDestinationCocoa::hardwareSampleRate();
+    streamFormat.mFormatID = kAudioFormatLinearPCM;
+    streamFormat.mFormatFlags = static_cast<AudioFormatFlags>(kAudioFormatFlagsNativeFloatPacked) | static_cast<AudioFormatFlags>(kAudioFormatFlagIsNonInterleaved);
+    streamFormat.mBytesPerPacket = bytesPerFloat;
+    streamFormat.mFramesPerPacket = 1;
+    streamFormat.mBytesPerFrame = bytesPerFloat;
+    streamFormat.mChannelsPerFrame = bus.numberOfChannels();
+    streamFormat.mBitsPerChannel = 8 * bytesPerFloat;
+    return streamFormat;
+}
+
+}
+
+#endif

--- a/Source/WebCore/platform/audio/cocoa/AudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioUtilitiesCocoa.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUDIO)
+
+namespace WebCore {
+class AudioBus;
+
+WEBCORE_EXPORT AudioStreamBasicDescription audioStreamBasicDescriptionForAudioBus(AudioBus&);
+
+}
+
+#endif

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -110,9 +110,8 @@ unsigned long AudioDestination::maxChannelCount()
 }
 
 AudioDestinationGStreamer::AudioDestinationGStreamer(AudioIOCallback& callback, unsigned long numberOfOutputChannels, float sampleRate)
-    : AudioDestination(callback)
+    : AudioDestination(callback, sampleRate)
     , m_renderBus(AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize, false))
-    , m_sampleRate(sampleRate)
 {
     static Atomic<uint32_t> pipelineId;
     m_pipeline = gst_pipeline_new(makeString("audio-destination-", pipelineId.exchangeAdd(1)).ascii().data());

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
@@ -35,7 +35,6 @@ public:
     WEBCORE_EXPORT void stop(CompletionHandler<void(bool)>&&) final;
 
     bool isPlaying() override { return m_isPlaying; }
-    float sampleRate() const override { return m_sampleRate; }
     unsigned framesPerBuffer() const final;
 
     bool handleMessage(GstMessage*);
@@ -51,7 +50,6 @@ private:
 
     RefPtr<AudioBus> m_renderBus;
 
-    float m_sampleRate;
     bool m_isPlaying { false };
     bool m_audioSinkAvailable { false };
     GRefPtr<GstElement> m_pipeline;

--- a/Source/WebCore/platform/mock/MockAudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/mock/MockAudioDestinationCocoa.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_AUDIO)
 
+#include "AudioUtilitiesCocoa.h"
 #include "CAAudioStreamDescription.h"
 #include "WebAudioBufferList.h"
 
@@ -67,9 +68,7 @@ void MockAudioDestinationCocoa::stopRendering(CompletionHandler<void(bool)>&& co
 void MockAudioDestinationCocoa::tick()
 {
     m_workQueue->dispatch([this, protectedThis = Ref { *this }, sampleRate = sampleRate(), numberOfFramesToProcess = m_numberOfFramesToProcess] {
-        AudioStreamBasicDescription streamFormat;
-        getAudioStreamBasicDescription(streamFormat);
-
+        AudioStreamBasicDescription streamFormat = audioStreamBasicDescriptionForAudioBus(m_outputBus);
         WebAudioBufferList webAudioBufferList { streamFormat, numberOfFramesToProcess };
         render(0., 0, numberOfFramesToProcess, webAudioBufferList.list());
     });

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -35,8 +35,10 @@
 #include "WebProcess.h"
 #include <WebCore/AudioBus.h>
 #include <WebCore/AudioUtilities.h>
+#include <algorithm>
 
 #if PLATFORM(COCOA)
+#include <WebCore/AudioUtilitiesCocoa.h>
 #include <WebCore/CARingBuffer.h>
 #include <WebCore/WebAudioBufferList.h>
 #include <mach/mach_time.h>
@@ -47,26 +49,19 @@ namespace WebKit {
 // Allocate a ring buffer large enough to contain 2 seconds of audio.
 constexpr size_t ringBufferSizeInSecond = 2;
 
-using AudioDestination = WebCore::AudioDestination;
 using AudioIOCallback = WebCore::AudioIOCallback;
 
-Ref<AudioDestination> RemoteAudioDestinationProxy::create(AudioIOCallback& callback,
+Ref<RemoteAudioDestinationProxy> RemoteAudioDestinationProxy::create(AudioIOCallback& callback,
     const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate)
 {
     return adoptRef(*new RemoteAudioDestinationProxy(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate));
 }
 
 RemoteAudioDestinationProxy::RemoteAudioDestinationProxy(AudioIOCallback& callback, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate)
-#if PLATFORM(COCOA)
-    : WebCore::AudioDestinationCocoa(callback, numberOfOutputChannels, sampleRate, false)
-    , m_numberOfFrames(hardwareSampleRate() * ringBufferSizeInSecond)
-    , m_sampleRate(hardwareSampleRate())
-#else
-    : WebCore::AudioDestinationGStreamer(callback, numberOfOutputChannels, sampleRate)
-    , m_numberOfOutputChannels(numberOfOutputChannels)
-#endif
+    : WebCore::AudioDestinationResampler(callback, numberOfOutputChannels, sampleRate, hardwareSampleRate())
     , m_inputDeviceId(inputDeviceId)
     , m_numberOfInputChannels(numberOfInputChannels)
+    , m_remoteSampleRate(hardwareSampleRate())
 {
 }
 
@@ -102,8 +97,7 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
     if (!m_gpuProcessConnection) {
         m_gpuProcessConnection = WebProcess::singleton().ensureGPUProcessConnection();
         m_gpuProcessConnection->addClient(*this);
-
-        auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteAudioDestinationManager::CreateAudioDestination(m_inputDeviceId, m_numberOfInputChannels, numberOfOutputChannels(), sampleRate(), hardwareSampleRate(), m_renderSemaphore), 0);
+        auto sendResult = m_gpuProcessConnection->connection().sendSync(Messages::RemoteAudioDestinationManager::CreateAudioDestination(m_inputDeviceId, m_numberOfInputChannels, m_outputBus->numberOfChannels(), sampleRate(), m_remoteSampleRate, m_renderSemaphore), 0);
         if (!sendResult) {
             // The GPUProcess likely crashed during this synchronous IPC. gpuProcessConnectionDidClose() will get called to reconnect to the GPUProcess.
             RELEASE_LOG_ERROR(Media, "RemoteAudioDestinationProxy::destinationID: IPC to create the audio destination failed, the GPUProcess likely crashed.");
@@ -113,9 +107,9 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
 
 #if PLATFORM(COCOA)
         m_currentFrame = 0;
-        AudioStreamBasicDescription streamFormat;
-        getAudioStreamBasicDescription(streamFormat);
-        auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(streamFormat, m_numberOfFrames);
+        auto streamFormat = audioStreamBasicDescriptionForAudioBus(m_outputBus);
+        size_t numberOfFrames = m_remoteSampleRate * ringBufferSizeInSecond;
+        auto [ringBuffer, handle] = ProducerSharedCARingBuffer::allocate(streamFormat, numberOfFrames);
         m_ringBuffer = WTFMove(ringBuffer);
         m_gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle) }, 0);
         m_audioBufferList = makeUnique<WebCore::WebAudioBufferList>(streamFormat);
@@ -147,8 +141,12 @@ RemoteAudioDestinationProxy::~RemoteAudioDestinationProxy()
 void RemoteAudioDestinationProxy::startRendering(CompletionHandler<void(bool)>&& completionHandler)
 {
     auto* connection = this->connection();
-    if (!connection)
-        return completionHandler(false);
+    if (!connection) {
+        RunLoop::current().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(false);
+        });
+        return;
+    }
 
     connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StartAudioDestination(m_destinationID), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
         setIsPlaying(isPlaying);
@@ -159,8 +157,12 @@ void RemoteAudioDestinationProxy::startRendering(CompletionHandler<void(bool)>&&
 void RemoteAudioDestinationProxy::stopRendering(CompletionHandler<void(bool)>&& completionHandler)
 {
     auto* connection = this->connection();
-    if (!connection)
-        return completionHandler(false);
+    if (!connection) {
+        RunLoop::current().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
+            completionHandler(false);
+        });
+        return;
+    }
 
     connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StopAudioDestination(m_destinationID), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
         setIsPlaying(isPlaying);
@@ -173,8 +175,23 @@ void RemoteAudioDestinationProxy::renderQuantum()
     ASSERT(!isMainRunLoop());
 
 #if PLATFORM(COCOA)
-    AudioDestinationCocoa::render(m_currentFrame / static_cast<double>(m_sampleRate), mach_absolute_time(), WebCore::AudioUtilities::renderQuantumSize, m_audioBufferList->list());
+    auto sampleTime = m_currentFrame / static_cast<double>(m_remoteSampleRate);
+    auto hostTime =  MonotonicTime::fromMachAbsoluteTime(mach_absolute_time());
+    size_t numberOfFrames = WebCore::AudioUtilities::renderQuantumSize;
+    auto* ioData = m_audioBufferList->list();
+
+    auto* buffers = ioData->mBuffers;
+    auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
+
+    // Associate the destination data array with the output bus then fill the FIFO.
+    for (UInt32 i = 0; i < numberOfBuffers; ++i) {
+        auto* memory = reinterpret_cast<float*>(buffers[i].mData);
+        size_t channelNumberOfFrames = std::min<size_t>(numberOfFrames, buffers[i].mDataByteSize / sizeof(float));
+        m_outputBus->setChannelMemory(i, memory, channelNumberOfFrames);
+    }
+    size_t framesToRender = pullRendered(numberOfFrames);
     m_ringBuffer->store(m_audioBufferList->list(), WebCore::AudioUtilities::renderQuantumSize, m_currentFrame);
+    render(sampleTime, hostTime, framesToRender);
     m_currentFrame += WebCore::AudioUtilities::renderQuantumSize;
 #endif
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -31,6 +31,7 @@
 #include "GPUProcessConnection.h"
 #include "IPCSemaphore.h"
 #include "RemoteAudioDestinationIdentifier.h"
+#include <WebCore/AudioDestinationResampler.h>
 #include <WebCore/AudioIOCallback.h>
 #include <wtf/CrossThreadQueue.h>
 #include <wtf/MediaTime.h>
@@ -38,31 +39,22 @@
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
-#include <WebCore/AudioDestinationCocoa.h>
-#else
-#include <WebCore/AudioDestinationGStreamer.h>
 #endif
 
+#if PLATFORM(COCOA)
 namespace WebCore {
 class WebAudioBufferList;
 }
+#endif
 
 namespace WebKit {
 
-class RemoteAudioDestinationProxy final
-#if PLATFORM(COCOA)
-    : public WebCore::AudioDestinationCocoa
-#else
-    : public WebCore::AudioDestinationGStreamer
-#endif
-    , public GPUProcessConnection::Client {
+class RemoteAudioDestinationProxy final : public WebCore::AudioDestinationResampler, public GPUProcessConnection::Client {
     WTF_MAKE_NONCOPYABLE(RemoteAudioDestinationProxy);
 public:
     using AudioIOCallback = WebCore::AudioIOCallback;
-    using WebCore::AudioDestination::ref;
-    using WebCore::AudioDestination::deref;
 
-    static Ref<AudioDestination> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
+    static Ref<RemoteAudioDestinationProxy> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
 
     RemoteAudioDestinationProxy(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
     ~RemoteAudioDestinationProxy();
@@ -81,29 +73,19 @@ private:
     // GPUProcessConnection::Client.
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
-#if !PLATFORM(COCOA)
-    bool isPlaying() final { return false; }
-    void setIsPlaying(bool) { }
-    float sampleRate() const final { return 0; }
-    unsigned numberOfOutputChannels() const { return m_numberOfOutputChannels; }
-#endif
-
     RemoteAudioDestinationIdentifier m_destinationID; // Call destinationID() getter to make sure the destinationID is valid.
 
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 #if PLATFORM(COCOA)
-    uint64_t m_numberOfFrames { 0 };
     std::unique_ptr<ProducerSharedCARingBuffer> m_ringBuffer;
     std::unique_ptr<WebCore::WebAudioBufferList> m_audioBufferList;
     uint64_t m_currentFrame { 0 };
-    float m_sampleRate;
-#else
-    unsigned m_numberOfOutputChannels;
 #endif
     IPC::Semaphore m_renderSemaphore;
 
     String m_inputDeviceId;
     unsigned m_numberOfInputChannels;
+    float m_remoteSampleRate;
 
     RefPtr<Thread> m_renderThread;
     std::atomic<bool> m_shouldStopThread { false };


### PR DESCRIPTION
#### 3fac3faf1d5b167d9fbbd9bf4555c133718f5044
<pre>
RemoteAudioDestinationProxy base class is platform specific
<a href="https://bugs.webkit.org/show_bug.cgi?id=247802">https://bugs.webkit.org/show_bug.cgi?id=247802</a>
rdar://problem/102238646

Reviewed by Eric Carlson.

The ifdefing causes problems when passing the needed information to
RemoteAudioDestinationManager::CreateAudioDestination. Due to this,
the GPUP side instance is created with
CreateAudioDestination+AudioSamplesStorageChanged message, which
causes other problems.

Instead, extract the needed platform-agnostic logic from
AudioDestinationCocoa to AudioDestinationResampler.
Use AudioDestinationResampler as the base-class of
RemoteAudioDestinationProxy, as that is the way the data
is transferred currently.

This is preliminary work to be able to make CARingBuffer
as a platform-agnostic AudioRingBuffer, in order to pass
the ring buffer during the remote audio destination creation.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/AudioDestination.h:
(WebCore::AudioDestination::sampleRate const):
(WebCore::AudioDestination::AudioDestination):
* Source/WebCore/platform/audio/PushPullFIFO.h:
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
(WebCore::AudioDestinationCocoa::AudioDestinationCocoa):
(WebCore::AudioDestinationCocoa::render):
(WebCore::AudioDestinationCocoa::numberOfOutputChannels const): Deleted.
(WebCore::AudioDestinationCocoa::framesPerBuffer const): Deleted.
(WebCore::AudioDestinationCocoa::start): Deleted.
(WebCore::AudioDestinationCocoa::stop): Deleted.
(WebCore::AudioDestinationCocoa::setIsPlaying): Deleted.
(WebCore::AudioDestinationCocoa::getAudioStreamBasicDescription): Deleted.
(WebCore::assignAudioBuffersToBus): Deleted.
(WebCore::AudioDestinationCocoa::hasEnoughFrames const): Deleted.
(WebCore::AudioDestinationCocoa::renderOnRenderingTheadIfPlaying): Deleted.
(WebCore::AudioDestinationCocoa::renderOnRenderingThead): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h:
(): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h:
* Source/WebCore/platform/mock/MockAudioDestinationCocoa.cpp:
(WebCore::MockAudioDestinationCocoa::tick):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollingNodeForViewportConstrainedRole):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::create):
(WebKit::RemoteAudioDestinationProxy::RemoteAudioDestinationProxy):
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::startRendering):
(WebKit::RemoteAudioDestinationProxy::stopRendering):
(WebKit::RemoteAudioDestinationProxy::renderQuantum):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:

Canonical link: <a href="https://commits.webkit.org/256729@main">https://commits.webkit.org/256729@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3655419cd26dbae21eca13cc66a8bcb1edbb1017

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106205 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6145 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34675 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102915 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102357 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83285 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31553 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74472 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40403 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4671 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40487 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->