### PR TITLE
Web Inspector: Show "Device" menu for all sessions

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Images/Computer.svg
+++ b/Source/WebInspectorUI/UserInterface/Images/Computer.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright © 2022 Apple Inc. All rights reserved. -->
+<svg xmlns="http://www.w3.org/2000/svg" id="root" version="1.1" viewBox="0 0 16 16">
+    <path fill="currentColor" fill-rule="evenodd" d="M1.264,13L6,13L6,14.5L5.732,14.5C5.456,14.5 5.232,14.724 5.232,15C5.232,15.276 5.456,15.5 5.732,15.5L10.232,15.5C10.508,15.5 10.732,15.276 10.732,15C10.732,14.724 10.508,14.5 10.232,14.5L10,14.5L10,13L14.736,13C15.433,13 16,12.433 16,11.736L16,2.264C16,1.567 15.433,1 14.736,1L1.264,1C0.567,1 -0,1.567 -0,2.264L-0,11.736C-0,12.433 0.567,13 1.264,13ZM15,2L1,2L1,12L15,12L15,2Z"/>
+    <rect fill="currentColor" fill-opacity="0.25" x="1" y="2" width="14" height="10"/>
+</svg>


### PR DESCRIPTION
#### 93eafbf907d4c798d27490949b762d826870dab8
<pre>
Web Inspector: Show &quot;Device&quot; menu for all sessions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247808">https://bugs.webkit.org/show_bug.cgi?id=247808</a>
rdar://102241043

Reviewed by Timothy Hatcher.

The device menu allows for applying an array of options that can negatively affect other tabs/windows if those settings
are applied globally. We currently already show the Device menu for remote inspection (like iOS), and with this patch we
will do so for local inspection (like macOS) as well, allowing developers to continue to use the rest of the browser for
normal browsing tasks, instead of using the browser&apos;s global settings for disabling core features which will break other
pages, like documentation, they are viewing.

For now we hide the User Agent dropdown, as it is not currently correctly tracking the state of the view, causing some
browser features like Safari&apos;s Responsive Design Mode to change the UA without updating this UI at the same time.

* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Images/Computer.svg: Added.

Canonical link: <a href="https://commits.webkit.org/257426@main">https://commits.webkit.org/257426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3afd0854a3818c5fdae750ae55cf75819cb09fa1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105753 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166089 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82810 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88600 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102512 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/85982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74002 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20776 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43375 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5111 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/42 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40043 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/42 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->