### PR TITLE
[SVG] Escape non-ASCII characters in console messages

### DIFF
--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -584,6 +584,13 @@ void Value::escapeString(StringBuilder& builder, StringView string)
     }
 }
 
+String Value::quoteString(const StringView& string)
+{
+    StringBuilder result;
+    Value::appendDoubleQuotedString(&result, string);
+    return result.toString();
+}
+
 String Value::toJSONString() const
 {
     StringBuilder result;

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -104,6 +104,7 @@ public:
 
     static RefPtr<Value> parseJSON(StringView);
     static void escapeString(StringBuilder&, StringView);
+    static String quoteString(const StringView&);
 
     String toJSONString() const;
     virtual void writeJSON(StringBuilder& output) const;

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -60,6 +60,7 @@
 #include "XMLNames.h"
 #include <wtf/HashMap.h>
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/StdLibExtras.h>
@@ -243,7 +244,7 @@ void SVGElement::reportAttributeParsingError(SVGParsingError error, const Qualif
     if (error == NoError)
         return;
 
-    String errorString = "<" + tagName() + "> attribute " + name.toString() + "=\"" + value + "\"";
+    String errorString = "<" + tagName() + "> attribute " + name.toString() + "=" + JSON::Value::quoteString(value);
     SVGDocumentExtensions& extensions = document().accessSVGExtensions();
 
     if (error == NegativeValueForbiddenError) {


### PR DESCRIPTION
<pre>
[SVG] Escape non-ASCII characters in console messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=247814">https://bugs.webkit.org/show_bug.cgi?id=247814</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/a2db82039c609e1aac58a17e660aa10235331d23">https://chromium.googlesource.com/chromium/blink/+/a2db82039c609e1aac58a17e660aa10235331d23</a>

This is to align with Blink / Chrome behavior to allow escape non-ASCII characters in console messages.

* Source/WebCore/svg/SVGElement.cpp: Add "JSONValues.h" header
(SVGElement::reportAttributeParsingError): Update errorString to escape non-ASCII characters
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/516f408ee585157d4183747d4258a45e4edc7fd1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97046 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6314 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30161 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106566 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166839 "Hash 516f408e for PR 6402 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101019 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6545 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35045 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89437 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103258 "Hash 516f408e for PR 6402 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102716 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/6545 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83662 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/89437 "Hash 516f408e for PR 6402 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/6545 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/30161 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/89437 "Hash 516f408e for PR 6402 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87975 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/342 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/30161 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83419 "Hash 516f408e for PR 6402 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/325 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/30161 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/38/builds/83419 "Hash 516f408e for PR 6402 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5120 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/83662 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86121 "Hash 516f408e for PR 6402 does not build (failure)") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1563 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/30161 "Hash 516f408e for PR 6402 does not build (failure)") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/37/builds/86121 "Hash 516f408e for PR 6402 does not build (failure)") | 
<!--EWS-Status-Bubble-End-->