### PR TITLE
Fix the build after a PhotosUIPrivate change

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1072,8 +1072,9 @@
 
 #if PLATFORM(IOS)
 #define HAVE_PHOTOS_UI 1
-#if __has_include(<PhotosUIPrivate/PUActivityProgressController.h>)
-#define HAVE_PHOTOS_UI_PRIVATE 1
+// FIXME (102246762): Remove this have (and make it true everywhere) when possible.
+#if __has_include(<PhotosUICore/PXActivityProgressController.h>)
+#define HAVE_PX_ACTIVITY_PROGRESS_CONTROLLER 1
 #endif
 #endif
 

--- a/Source/WebKit/Platform/spi/ios/PhotosUISPI.h
+++ b/Source/WebKit/Platform/spi/ios/PhotosUISPI.h
@@ -29,10 +29,10 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
-#if HAVE(PHOTOS_UI_PRIVATE)
-#import <PhotosUIPrivate/PUActivityProgressController.h>
+#if HAVE(PX_ACTIVITY_PROGRESS_CONTROLLER)
+#import <PhotosUICore/PXActivityProgressController.h>
 #else
-#import <PhotosUI/PUActivityProgressController.h>
+#import <PhotosUIPrivate/PUActivityProgressController.h>
 #endif
 
 #import <PhotosUI/PHPicker_Private.h>
@@ -41,7 +41,11 @@
 
 #import "UIKitSPI.h"
 
+#if HAVE(PX_ACTIVITY_PROGRESS_CONTROLLER)
+@interface PXActivityProgressController : NSObject
+#else
 @interface PUActivityProgressController : NSObject
+#endif
 
 @property (nonatomic, copy) NSString *title;
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -56,16 +56,16 @@
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
-#if HAVE(PHOTOS_UI_PRIVATE)
+#if HAVE(PX_ACTIVITY_PROGRESS_CONTROLLER)
+SOFT_LINK_PRIVATE_FRAMEWORK(PhotosUICore)
+SOFT_LINK_CLASS(PhotosUICore, PXActivityProgressController)
+#else
 SOFT_LINK_PRIVATE_FRAMEWORK(PhotosUIPrivate)
 SOFT_LINK_CLASS(PhotosUIPrivate, PUActivityProgressController)
 #endif
 
 #if HAVE(PHOTOS_UI)
 SOFT_LINK_FRAMEWORK(PhotosUI)
-#if !HAVE(PHOTOS_UI_PRIVATE)
-SOFT_LINK_CLASS(PhotosUI, PUActivityProgressController)
-#endif
 SOFT_LINK_CLASS(PhotosUI, PHPickerConfiguration)
 SOFT_LINK_CLASS(PhotosUI, PHPickerViewController)
 SOFT_LINK_CLASS(PhotosUI, PHPickerResult)
@@ -204,7 +204,11 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
 
 @implementation WKFileUploadMediaTranscoder {
     RetainPtr<NSTimer> _progressTimer;
+#if HAVE(PX_ACTIVITY_PROGRESS_CONTROLLER)
+    RetainPtr<PXActivityProgressController> _progressController;
+#else
     RetainPtr<PUActivityProgressController> _progressController;
+#endif
     RetainPtr<AVAssetExportSession> _exportSession;
     RetainPtr<NSArray<_WKFileUploadItem *>> _items;
     RetainPtr<NSString> _temporaryDirectoryPath;
@@ -232,7 +236,11 @@ static NSString * firstUTIThatConformsTo(NSArray<NSString *> *typeIdentifiers, U
 
 - (void)start
 {
+#if HAVE(PX_ACTIVITY_PROGRESS_CONTROLLER)
+    _progressController = adoptNS([allocPXActivityProgressControllerInstance() init]);
+#else
     _progressController = adoptNS([allocPUActivityProgressControllerInstance() init]);
+#endif
     [_progressController setTitle:WEB_UI_STRING_KEY("Preparing…", "Preparing (file upload)", "Title for file upload progress view")];
     [_progressController showAnimated:YES allowDelay:YES];
 


### PR DESCRIPTION
#### 6f7a3cc4c150620d24659ad4e74a2f2ed8942425
<pre>
Fix the build after a PhotosUIPrivate change
<a href="https://bugs.webkit.org/show_bug.cgi?id=247817">https://bugs.webkit.org/show_bug.cgi?id=247817</a>
rdar://102222227

Reviewed by Wenson Hsieh.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebKit/Platform/spi/ios/PhotosUISPI.h:
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadMediaTranscoder start]):
We always have PhotosUIPrivate, so get rid of HAVE_PHOTOS_UI_PRIVATE.

PUActivityProgressController is now PXActivityProgressController,
so conditionally use the correct one.

Canonical link: <a href="https://commits.webkit.org/256585@main">https://commits.webkit.org/256585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/071a81116c88dcd839bc7922c1ccef3f47e591a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5486 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/29290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105778 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/5610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101902 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/5610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/82836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/88615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/5610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/29290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/1/builds/87239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/39972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/29290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/38/builds/82611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37646 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/29290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/38/builds/82611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/68 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/82836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85290 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2187 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/69 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/29290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/45/builds/19245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->