### PR TITLE
Use formatting context root's writing mode and text orientation when synthesizing baselines.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4425,9 +4425,7 @@ webkit.org/b/221473 imported/w3c/web-platform-tests/css/css-flexbox/table-as-ite
 webkit.org/b/221474 imported/w3c/web-platform-tests/css/css-flexbox/svg-root-as-flex-item-002.html [ ImageOnlyFailure ]
 
 # align baseline in flexbox.
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-001.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-003.html [ ImageOnlyFailure ]
-webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/baseline-synthesis-004.html [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-006.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-align-self-baseline-horiz-008.xhtml [ ImageOnlyFailure ]
 webkit.org/b/221478 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-multi-line-vert-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
@@ -13,20 +13,18 @@ line2
 
 FAIL #target > div 1 assert_equals:
 <div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 0
+offsetLeft expected 120 but got 20
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 140
+offsetLeft expected 105 but got 125
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 161
-FAIL #target > div 4 assert_equals:
-<div data-offset-x="20">line1<br>line2</div>
-offsetLeft expected 20 but got 30
+offsetLeft expected 126 but got 146
+PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 125
+offsetLeft expected 35 but got 140
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 153
+offsetLeft expected 42 but got 154
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
@@ -11,22 +11,20 @@ line2
 line1
 line2
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 110
+PASS #target > div 1
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 15
+offsetLeft expected 105 but got 0
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 15
+offsetLeft expected 126 but got 14
 FAIL #target > div 4 assert_equals:
 <div data-offset-x="20">line1<br>line2</div>
-offsetLeft expected 20 but got 140
+offsetLeft expected 20 but got 120
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 0
+offsetLeft expected 35 but got 15
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 7
+offsetLeft expected 42 but got 22
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-006-expected.txt
@@ -8,5 +8,5 @@ FAIL #target > div 2 assert_equals:
 offsetTop expected 0 but got 20
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="55"><span></span><br><span></span></div>
-offsetTop expected 55 but got 65
+offsetTop expected 55 but got 35
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-007-expected.txt
@@ -8,5 +8,5 @@ FAIL #target > div 2 assert_equals:
 offsetTop expected 0 but got 20
 FAIL #target > div 3 assert_equals:
 <div data-offset-y="55"><span></span><br><span></span></div>
-offsetTop expected 55 but got 65
+offsetTop expected 55 but got 35
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-002.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-002.tentative-expected.txt
@@ -37,72 +37,36 @@ FAIL .target > * 1 assert_equals:
 <div data-offset-x="105"><span></span></div>
 offsetLeft expected 105 but got 40
 PASS .target > * 2
-FAIL .target > * 3 assert_equals:
-<div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 10
-FAIL .target > * 4 assert_equals:
-<div class="line-clamp" data-offset-x="10">
-    <span></span><br><span></span><br><span></span><br><span></span><br><span></span>
-  </div>
-offsetLeft expected 10 but got 25
+PASS .target > * 3
+PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="65"><span></span></div>
 offsetLeft expected 65 but got 40
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 10
-FAIL .target > * 8 assert_equals:
-<div class="line-clamp" data-offset-x="10">
-    <span></span><br><span></span>
-  </div>
-offsetLeft expected 10 but got 25
+PASS .target > * 7
+PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <div data-offset-x="105"><span></span></div>
 offsetLeft expected 105 but got 40
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 10
-FAIL .target > * 12 assert_equals:
-<div class="line-clamp" data-offset-x="10">
-    <span></span><br><span></span><br><span></span>
-  </div>
-offsetLeft expected 10 but got 25
+PASS .target > * 11
+PASS .target > * 12
 FAIL .target > * 13 assert_equals:
 <div data-offset-x="105"><span></span></div>
 offsetLeft expected 105 but got 40
 PASS .target > * 14
-FAIL .target > * 15 assert_equals:
-<div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 10
-FAIL .target > * 16 assert_equals:
-<div class="line-clamp" data-offset-x="10">
-    <div><span></span><br><span></span><br><span></span><br><span></span><br><span></span></div>
-  </div>
-offsetLeft expected 10 but got 25
+PASS .target > * 15
+PASS .target > * 16
 FAIL .target > * 17 assert_equals:
 <div data-offset-x="105"><span></span></div>
 offsetLeft expected 105 but got 40
 PASS .target > * 18
-FAIL .target > * 19 assert_equals:
-<div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 10
-FAIL .target > * 20 assert_equals:
-<div class="line-clamp" data-offset-x="10">
-    <span></span><div><span></span><br><span></span><br><span></span><br><span></span></div>
-  </div>
-offsetLeft expected 10 but got 25
+PASS .target > * 19
+PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <div data-offset-x="105"><span></span></div>
 offsetLeft expected 105 but got 40
 PASS .target > * 22
-FAIL .target > * 23 assert_equals:
-<div data-offset-x="25"><span></span></div>
-offsetLeft expected 25 but got 10
-FAIL .target > * 24 assert_equals:
-<div class="line-clamp" data-offset-x="10">
-    <span></span><br><i><span></span><div><span></span><br><span></span><br><span></span></div></i>
-  </div>
-offsetLeft expected 10 but got 25
+PASS .target > * 23
+PASS .target > * 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-003.tentative-expected.txt
@@ -39,7 +39,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 55
+offsetLeft expected 105 but got 25
 PASS .target > * 4
 FAIL .target > * 5 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -47,7 +47,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 6
 FAIL .target > * 7 assert_equals:
 <div data-offset-x="65"><span></span></div>
-offsetLeft expected 65 but got 55
+offsetLeft expected 65 but got 25
 PASS .target > * 8
 FAIL .target > * 9 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -55,7 +55,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 10
 FAIL .target > * 11 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 55
+offsetLeft expected 105 but got 25
 PASS .target > * 12
 FAIL .target > * 13 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -63,7 +63,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 55
+offsetLeft expected 105 but got 25
 PASS .target > * 16
 FAIL .target > * 17 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -71,7 +71,7 @@ offsetLeft expected 25 but got 10
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 55
+offsetLeft expected 105 but got 25
 PASS .target > * 20
 FAIL .target > * 21 assert_equals:
 <div data-offset-x="25"><span></span></div>
@@ -79,6 +79,6 @@ offsetLeft expected 25 but got 10
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-x="105"><span></span></div>
-offsetLeft expected 105 but got 55
+offsetLeft expected 105 but got 25
 PASS .target > * 24
 

--- a/Source/WebCore/platform/graphics/FontBaseline.h
+++ b/Source/WebCore/platform/graphics/FontBaseline.h
@@ -28,7 +28,9 @@
 
 namespace WebCore {
 
-enum FontBaseline { AlphabeticBaseline, IdeographicBaseline };
+enum FontBaseline { AlphabeticBaseline, IdeographicBaseline, CentralBaseline };
+
+enum BaselineSynthesisEdge { ContentBox, BorderBox, MarginBox };
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2563,7 +2563,7 @@ std::optional<LayoutUnit> RenderBlock::lastLineBaseline() const
 std::optional<LayoutUnit> RenderBlock::inlineBlockBaseline(LineDirectionMode lineDirection) const
 {
     if (shouldApplyLayoutContainment())
-        return synthesizedBaselineFromBorderBox(*this, lineDirection) + (lineDirection == HorizontalLine ? marginBottom() : marginLeft());
+        return synthesizedBaseline(*this, *parentStyle(), lineDirection, BorderBox) + (lineDirection == HorizontalLine ? marginBottom() : marginLeft());
 
     if (isWritingModeRoot() && !isRubyRun())
         return std::optional<LayoutUnit>();

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3049,8 +3049,8 @@ std::optional<LayoutUnit> RenderBlockFlow::inlineBlockBaseline(LineDirectionMode
             return std::nullopt;
     }
     // Note that here we only take the left and bottom into consideration. Our caller takes the right and top into consideration.
-    float boxHeight = synthesizedBaselineFromBorderBox(*this, lineDirection) + (lineDirection == HorizontalLine ? m_marginBox.bottom() : m_marginBox.left());
-    float lastBaseline = 0;
+    auto boxHeight = synthesizedBaseline(*this, *parentStyle(), lineDirection, BorderBox) + (lineDirection == HorizontalLine ? m_marginBox.bottom() : m_marginBox.left());
+    LayoutUnit lastBaseline;
     if (!childrenInline()) {
         auto inlineBlockBaseline = RenderBlock::inlineBlockBaseline(lineDirection);
         if (!inlineBlockBaseline)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -34,6 +34,7 @@
 #include "EventHandler.h"
 #include "FloatQuad.h"
 #include "FloatRoundedRect.h"
+#include "FontBaseline.h"
 #include "Frame.h"
 #include "FrameView.h"
 #include "GraphicsContext.h"
@@ -85,6 +86,7 @@
 #include "TransformState.h"
 #include <algorithm>
 #include <math.h>
+#include <wtf/Assertions.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StackStats.h>
 
@@ -5451,9 +5453,18 @@ LayoutBoxExtent RenderBox::scrollPaddingForViewportRect(const LayoutRect& viewpo
         minimumValueForLength(padding.bottom(), viewportRect.height()), minimumValueForLength(padding.left(), viewportRect.width()));
 }
 
-LayoutUnit synthesizedBaselineFromBorderBox(const RenderBox& box, LineDirectionMode direction)
+LayoutUnit synthesizedBaseline(const RenderBox& box, const RenderStyle& parentStyle, LineDirectionMode direction, BaselineSynthesisEdge edge)
 {
-    return direction == HorizontalLine ? box.height() : box.width();
+    auto boxSize = direction == HorizontalLine ? box.height() : box.width();
+
+    if (edge == ContentBox)
+        boxSize -= direction == HorizontalLine ? box.verticalBorderAndPaddingExtent() : box.horizontalBorderAndPaddingExtent();
+    else if (edge == MarginBox)
+        boxSize += direction == HorizontalLine ? box.verticalMarginExtent() : box.horizontalMarginExtent();
+    
+    if (parentStyle.isHorizontalWritingMode() || parentStyle.textOrientation() == TextOrientation::Sideways)
+        return boxSize;
+    return boxSize / 2;
 }
 
 LayoutUnit RenderBox::intrinsicLogicalWidth() const

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "FontBaseline.h"
 #include "FrameView.h"
 #include "RenderBoxModelObject.h"
 #include "RenderOverflow.h"
@@ -569,6 +570,7 @@ override;
     virtual std::optional<LayoutUnit> firstLineBaseline() const { return std::optional<LayoutUnit>(); }
     virtual std::optional<LayoutUnit> lastLineBaseline() const { return std::optional<LayoutUnit> (); }
     virtual std::optional<LayoutUnit> inlineBlockBaseline(LineDirectionMode) const { return std::optional<LayoutUnit>(); } // Returns empty if we should skip this box when computing the baseline of an inline-block.
+    LayoutUnit synthesizeBaseline(FontBaseline baselineType, BaselineSynthesisEdge) const;
 
     bool shrinkToAvoidFloats() const;
     virtual bool avoidsFloats() const;
@@ -921,7 +923,7 @@ inline void RenderBox::setInlineBoxWrapper(LegacyInlineElementBox* boxWrapper)
     m_inlineBoxWrapper = boxWrapper;
 }
 
-LayoutUnit synthesizedBaselineFromBorderBox(const RenderBox&, LineDirectionMode);
+LayoutUnit synthesizedBaseline(const RenderBox&, const RenderStyle& parentStyle, LineDirectionMode, BaselineSynthesisEdge);
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1516,7 +1516,7 @@ LayoutUnit RenderGrid::baselinePosition(FontBaseline, bool, LineDirectionMode di
     ASSERT_UNUSED(mode, mode == PositionOnContainingLine);
     auto baseline = firstLineBaseline();
     if (!baseline)
-        return synthesizedBaselineFromBorderBox(*this, direction) + marginLogicalHeight();
+        return synthesizedBaseline(*this, *parentStyle(), direction, BorderBox) + marginLogicalHeight();
 
     return baseline.value() + (direction == HorizontalLine ? marginTop() : marginRight()).toInt();
 }
@@ -1538,7 +1538,7 @@ std::optional<LayoutUnit> RenderGrid::firstLineBaseline() const
         // FIXME: We should pass |direction| into firstLineBaseline and stop bailing out if we're a writing
         // mode root. This would also fix some cases where the grid is orthogonal to its container.
         LineDirectionMode direction = isHorizontalWritingMode() ? HorizontalLine : VerticalLine;
-        return synthesizedBaselineFromBorderBox(*baselineChild, direction) + logicalTopForChild(*baselineChild);
+        return synthesizedBaseline(*baselineChild, style(), direction, BorderBox) + logicalTopForChild(*baselineChild);
     }
     return baseline.value() + baselineChild->logicalTop().toInt();
 }
@@ -1555,7 +1555,7 @@ std::optional<LayoutUnit> RenderGrid::lastLineBaseline() const
     auto baseline = GridLayoutFunctions::isOrthogonalChild(*this, *baselineChild) ? std::nullopt : baselineChild->lastLineBaseline();
     if (!baseline) {
         LineDirectionMode direction = isHorizontalWritingMode() ? HorizontalLine : VerticalLine;
-        return synthesizedBaselineFromBorderBox(*baselineChild, direction) + logicalTopForChild(*baselineChild);
+        return synthesizedBaseline(*baselineChild, style(), direction, BorderBox) + logicalTopForChild(*baselineChild);
 
     }
 


### PR DESCRIPTION
#### c994ed0a39843aa33c3e125b9b3379ec90bc02f4
<pre>
Use formatting context root&apos;s writing mode and text orientation when synthesizing baselines.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247815">https://bugs.webkit.org/show_bug.cgi?id=247815</a>
rdar://102245183

Reviewed by Alan Baradlay.

When synthesizing baselines for boxes we must take into consideration
the writing mode and text orientation of the formatting context root to
synthesize the correct type of baseline. The formatting context is also
used to determine which edges (content, border, or margin) of the box
to use.

The formatting context root&apos;s writing mode is used to determine which
type of baseline to synthesize. We could either synthesize the
alphabetic baseline or the central baseline depending on the scenario.
Previously, we were only synthesizing the alphabetic baseline. Now if
the writing mode is vertical with a text-orientation of &quot;mixed,&quot; or
&quot;upright,&quot; we will synthesize the central baseline.

Spec references:
<a href="https://drafts.csswg.org/css-align-3/#baseline-export">https://drafts.csswg.org/css-align-3/#baseline-export</a>
<a href="https://drafts.csswg.org/css-inline-3/#alignment-baseline-property">https://drafts.csswg.org/css-inline-3/#alignment-baseline-property</a>
<a href="https://drafts.csswg.org/css-inline-3/#dominant-baseline-property">https://drafts.csswg.org/css-inline-3/#dominant-baseline-property</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-002.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-003.tentative-expected.txt:
* Source/WebCore/platform/graphics/FontBaseline.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::inlineBlockBaseline const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::inlineBlockBaseline const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::synthesizedBaseline):
(WebCore::synthesizedBaselineFromBorderBox): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::baselinePosition const):
(WebCore::RenderFlexibleBox::firstLineBaseline const):
(WebCore::RenderFlexibleBox::lastLineBaseline const):
(WebCore::RenderFlexibleBox::marginBoxAscentForChild):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::baselinePosition const):
(WebCore::RenderGrid::firstLineBaseline const):
(WebCore::RenderGrid::lastLineBaseline const):

Canonical link: <a href="https://commits.webkit.org/257239@main">https://commits.webkit.org/257239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b9b523347f87de54eabfa157eacfd633ce6c205

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107637 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167899 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7884 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36155 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104225 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5920 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84773 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33032 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89499 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1354 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20931 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22434 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4987 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44891 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41856 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->