### PR TITLE
setting selectorText fails when passed a selector that includes namespace prefixes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-namespace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-namespace-expected.txt
@@ -1,8 +1,8 @@
 SVG text
 
-FAIL CSSStyleRule: selectorText value: |.style1| isMatch: false assert_equals: expected "rgb(255, 0, 255)" but got "rgb(0, 0, 255)"
-FAIL CSSStyleRule: selectorText value: |svg|*.style1  | isMatch: true assert_equals: expected "svg|*.style0" but got ".style1"
-FAIL CSSStyleRule: selectorText value: |*|*.style1  | isMatch: true assert_equals: expected "svg|*.style0" but got ".style1"
-FAIL CSSStyleRule: selectorText value: | *.style1  | isMatch: false assert_equals: expected "svg|*.style0" but got ".style1"
-FAIL CSSStyleRule: selectorText value: |p| isMatch: false assert_equals: expected "svg|*.style0" but got ".style1"
+PASS CSSStyleRule: selectorText value: |.style1| isMatch: false
+PASS CSSStyleRule: selectorText value: |svg|*.style1  | isMatch: true
+PASS CSSStyleRule: selectorText value: |*|*.style1  | isMatch: true
+PASS CSSStyleRule: selectorText value: | *.style1  | isMatch: false
+PASS CSSStyleRule: selectorText value: |p| isMatch: false
 

--- a/Source/WebCore/css/CSSPageRule.cpp
+++ b/Source/WebCore/css/CSSPageRule.cpp
@@ -65,7 +65,8 @@ String CSSPageRule::selectorText() const
 void CSSPageRule::setSelectorText(const String& selectorText)
 {
     CSSParser parser(parserContext());
-    auto selectorList = parser.parseSelector(selectorText);
+    auto* sheet = parentStyleSheet();
+    auto selectorList = parser.parseSelector(selectorText, sheet ? &sheet->contents() : nullptr);
     if (!selectorList)
         return;
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -98,7 +98,8 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
         return;
 
     CSSParser p(parserContext());
-    auto selectorList = p.parseSelector(selectorText);
+    auto* sheet = parentStyleSheet();
+    auto selectorList = p.parseSelector(selectorText, sheet ? &sheet->contents() : nullptr);
     if (!selectorList)
         return;
 

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -169,9 +169,9 @@ CSSParser::ParseResult CSSParser::parseValue(MutableStyleProperties& declaration
     return CSSParserImpl::parseValue(&declaration, propertyID, string, important, m_context);
 }
 
-std::optional<CSSSelectorList> CSSParser::parseSelector(const String& string)
+std::optional<CSSSelectorList> CSSParser::parseSelector(const String& string, StyleSheetContents* styleSheet)
 {
-    return parseCSSSelector(CSSTokenizer(string).tokenRange(), m_context, nullptr);
+    return parseCSSSelector(CSSTokenizer(string).tokenRange(), m_context, styleSheet);
 }
 
 Ref<ImmutableStyleProperties> CSSParser::parseInlineStyleDeclaration(const String& string, const Element* element)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -83,7 +83,7 @@ public:
     WEBCORE_EXPORT bool parseDeclaration(MutableStyleProperties&, const String&);
     static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element*);
 
-    std::optional<CSSSelectorList> parseSelector(const String&);
+    std::optional<CSSSelectorList> parseSelector(const String&, StyleSheetContents* = nullptr);
 
     RefPtr<CSSValue> parseValueWithVariableReferences(CSSPropertyID, const CSSValue&, Style::BuilderState&);
 


### PR DESCRIPTION
#### da821c38176a14cc22d0195fb8a45489d55defc6
<pre>
setting selectorText fails when passed a selector that includes namespace prefixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=247830">https://bugs.webkit.org/show_bug.cgi?id=247830</a>
rdar://problem/102260326

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-namespace-expected.txt:
Expect PASS.

* Source/WebCore/css/CSSPageRule.cpp:
(WebCore::CSSPageRule::setSelectorText): Pass the style sheet in.
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::setSelectorText): Ditto.
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseSelector): Pass the style sheet along.
* Source/WebCore/css/parser/CSSParser.h: Take an optional style sheet.

Canonical link: <a href="https://commits.webkit.org/256599@main">https://commits.webkit.org/256599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42ca96fe343109d70d486a9f7162bfbfc41df0e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105807 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5637 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34268 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88640 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101932 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82857 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31206 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/87940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/39993 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4575 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/89 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/97 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40084 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->