### PR TITLE
Link drag preview can be hard to read

### DIFF
--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.h
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.h
@@ -41,6 +41,7 @@ class LocalCurrentTraitCollection {
 
 public:
     WEBCORE_EXPORT LocalCurrentTraitCollection(bool useDarkAppearance, bool useElevatedUserInterfaceLevel);
+    WEBCORE_EXPORT LocalCurrentTraitCollection(UITraitCollection *);
     WEBCORE_EXPORT ~LocalCurrentTraitCollection();
 
 private:

--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
@@ -68,6 +68,17 @@ LocalCurrentTraitCollection::LocalCurrentTraitCollection(bool useDarkAppearance,
 #endif
 }
 
+LocalCurrentTraitCollection::LocalCurrentTraitCollection(UITraitCollection *traitCollection)
+{
+#if HAVE(OS_DARK_MODE_SUPPORT)
+    m_savedTraitCollection = [PAL::getUITraitCollectionClass() currentTraitCollection];
+    auto newTraitCollection = adjustedTraitCollection(traitCollection);
+    [PAL::getUITraitCollectionClass() setCurrentTraitCollection:newTraitCollection];
+#else
+    UNUSED_PARAM(traitCollection);
+#endif
+}
+
 LocalCurrentTraitCollection::~LocalCurrentTraitCollection()
 {
 #if HAVE(OS_DARK_MODE_SUPPORT)

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -32,6 +32,7 @@
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/DragItem.h>
 #import <WebCore/Image.h>
+#import <WebCore/LocalCurrentTraitCollection.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
@@ -406,6 +407,10 @@ void DragDropInteractionState::updatePreviewsForActiveDragSources()
                 UIURLDragPreviewView *previewView = [UIURLDragPreviewView viewWithTitle:title.get() URL:url.get()];
                 previewView.center = center;
                 auto parameters = adoptNS([[UIDragPreviewParameters alloc] initWithTextLineRects:@[ [NSValue valueWithCGRect:previewView.bounds] ]]);
+                [parameters setBackgroundColor:[UIColor colorWithDynamicProvider:[] (UITraitCollection *traitCollection) -> UIColor * {
+                    WebCore::LocalCurrentTraitCollection localCurrentTraitCollection(traitCollection);
+                    return [UIColor.systemBackgroundColor resolvedColorWithTraitCollection:UITraitCollection.currentTraitCollection];
+                }]];
                 return adoptNS([[UIDragPreview alloc] initWithView:previewView parameters:parameters.get()]).autorelease();
             };
         }


### PR DESCRIPTION
#### 20fb8c8624e81cef07300abc89f3685008254398
<pre>
Link drag preview can be hard to read
<a href="https://bugs.webkit.org/show_bug.cgi?id=247832">https://bugs.webkit.org/show_bug.cgi?id=247832</a>
rdar://101837369

Reviewed by Aditya Keerthi.

* Source/WebCore/platform/ios/LocalCurrentTraitCollection.h:
* Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm:
(WebCore::LocalCurrentTraitCollection::LocalCurrentTraitCollection):
Expose a version of LocalCurrentTraitCollection that takes a trait collection
and makes it current, while also applying `adjustedTraitCollection`&apos;s adjustments.

* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::updatePreviewsForActiveDragSources):
Adopt LocalCurrentTraitCollection here in order to make `adjustedTraitCollection`&apos;s
adjustments take effect for the UIURLDragPreviewView&apos;s background color.

Canonical link: <a href="https://commits.webkit.org/256608@main">https://commits.webkit.org/256608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d25b2c3dee0b09b8a2418a77662624b0a3a39946

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105816 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166153 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5649 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34276 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88651 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102550 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4185 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82867 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31212 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74038 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40004 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37680 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4583 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43415 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40087 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->