### PR TITLE
Guard USE(LIBWEBRTC) includes

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -47,7 +47,6 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/Modules/mediasession"
     "${WEBCORE_DIR}/Modules/mediasource"
     "${WEBCORE_DIR}/Modules/mediastream"
-    "${WEBCORE_DIR}/Modules/mediastream/libwebrtc"
     "${WEBCORE_DIR}/Modules/model-element"
     "${WEBCORE_DIR}/Modules/model-element/dummy"
     "${WEBCORE_DIR}/Modules/navigatorcontentutils"
@@ -157,7 +156,6 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/mediacapabilities"
     "${WEBCORE_DIR}/platform/mediarecorder"
     "${WEBCORE_DIR}/platform/mediastream"
-    "${WEBCORE_DIR}/platform/mediastream/libwebrtc"
     "${WEBCORE_DIR}/platform/mediarecorder"
     "${WEBCORE_DIR}/platform/mock"
     "${WEBCORE_DIR}/platform/mock/mediasource"
@@ -2040,10 +2038,16 @@ if (USE_XDGMIME)
 endif ()
 
 if (USE_LIBWEBRTC)
-    list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/libwebrtc/Source/"
+    list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
+        "${THIRDPARTY_DIR}/libwebrtc/Source"
         "${THIRDPARTY_DIR}/libwebrtc/Source/webrtc"
         "${THIRDPARTY_DIR}/libwebrtc/Source/third_party/libvpx/source/libvpx"
-        "${THIRDPARTY_DIR}/libwebrtc/Source/third_party/abseil-cpp")
+        "${THIRDPARTY_DIR}/libwebrtc/Source/third_party/abseil-cpp"
+    )
+    list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
+        "${WEBCORE_DIR}/Modules/mediastream/libwebrtc"
+        "${WEBCORE_DIR}/platform/mediastream/libwebrtc"
+    )
     list(APPEND WebCore_LIBRARIES webrtc)
     list(APPEND WebCore_SOURCES
         Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -36,7 +36,6 @@
 
 #include "EventNames.h"
 #include "JSRTCCertificate.h"
-#include "LibWebRTCCertificateGenerator.h"
 #include "Logging.h"
 #include "Page.h"
 #include "RTCDataChannelEvent.h"
@@ -55,6 +54,11 @@
 
 #if USE(GSTREAMER_WEBRTC)
 #include "GStreamerWebRTCUtils.h"
+#endif
+
+#if USE(LIBWEBRTC)
+#include "LibWebRTCCertificateGenerator.h"
+#include "LibWebRTCProvider.h"
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -34,7 +34,6 @@
 #if ENABLE(WEB_RTC)
 
 #include "IDLTypes.h"
-#include "LibWebRTCProvider.h"
 #include "RTCIceGatheringState.h"
 #include "RTCRtpCapabilities.h"
 #include "RTCRtpSendParameters.h"

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.h
@@ -33,7 +33,6 @@
 #if ENABLE(WEB_RTC)
 
 #include "ExceptionOr.h"
-#include "LibWebRTCUtils.h"
 #include "RTCIceCandidateFields.h"
 #include "ScriptWrappable.h"
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -71,6 +71,10 @@
 #include <wtf/UUID.h>
 #include <wtf/text/Base64.h>
 
+#if USE(LIBWEBRTC)
+#include "LibWebRTCProvider.h"
+#endif
+
 namespace WebCore {
 
 using namespace PeerConnection;

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "LibWebRTCStatsCollector.h"
 #include "RTCIceCandidateType.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
@@ -25,15 +25,20 @@
 #include "config.h"
 #include "LibWebRTCCertificateGenerator.h"
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
+#include "LibWebRTCProvider.h"
 #include "RTCCertificate.h"
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
+ALLOW_COMMA_BEGIN
 
+#include <webrtc/rtc_base/ref_counted_object.h>
 #include <webrtc/rtc_base/rtc_certificate_generator.h>
+#include <webrtc/rtc_base/ssl_certificate.h>
 
+ALLOW_COMMA_END
 ALLOW_UNUSED_PARAMETERS_END
 
 namespace WebCore {
@@ -121,4 +126,4 @@ void generateCertificate(Ref<SecurityOrigin>&& origin, LibWebRTCProvider& provid
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "PeerConnectionBackend.h"
 
@@ -41,4 +41,4 @@ void generateCertificate(Ref<SecurityOrigin>&&, LibWebRTCProvider&, const PeerCo
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "LibWebRTCDataChannelHandler.h"
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "EventNames.h"
 #include "LibWebRTCUtils.h"
@@ -226,4 +226,4 @@ void LibWebRTCDataChannelHandler::postTask(Function<void()>&& function)
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
 #include "ProcessQualified.h"
@@ -103,4 +103,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp
@@ -25,11 +25,11 @@
 #include "config.h"
 #include "LibWebRTCIceTransportBackend.h"
 
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+
 #include "LibWebRTCProvider.h"
 #include "LibWebRTCUtils.h"
 #include "RTCIceCandidate.h"
-
-#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "LibWebRTCMediaEndpoint.h"
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "DeprecatedGlobalSettings.h"
 #include "EventNames.h"
@@ -864,4 +864,4 @@ struct LogArgument<WebCore::RTCStatsLogger> {
 }; // namespace WTF
 
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCObservers.h"
 #include "LibWebRTCProvider.h"
@@ -205,4 +205,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCObservers.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCObservers.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "ExceptionCode.h"
 #include "LibWebRTCMacros.h"
@@ -110,4 +110,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "LibWebRTCPeerConnectionBackend.h"
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "Document.h"
 #include "IceCandidate.h"
@@ -411,4 +411,4 @@ std::optional<bool> LibWebRTCPeerConnectionBackend::canTrickleIceCandidates() co
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "PeerConnectionBackend.h"
 #include "RealtimeMediaSource.h"
@@ -118,4 +118,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "LibWebRTCRtpReceiverBackend.h"
 
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
+
 #include "Document.h"
 #include "LibWebRTCAudioModule.h"
 #include "LibWebRTCDtlsTransportBackend.h"
@@ -35,8 +37,6 @@
 #include "RTCRtpTransformBackend.h"
 #include "RealtimeIncomingAudioSource.h"
 #include "RealtimeIncomingVideoSource.h"
-
-#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_RTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
 #include "LibWebRTCPeerConnectionBackend.h"
@@ -82,4 +82,4 @@ private:
 
 } // namespace WebCore
 
-#endif // ENABLE(WEB_RTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if ENABLE(WEB_RTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "RTCRtpTransformableFrame.h"
 #include <wtf/Ref.h>
@@ -60,4 +60,4 @@ private:
 
 } // namespace WebCore
 
-#endif // ENABLE(WEB_RTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -25,10 +25,11 @@
 #include "config.h"
 #include "LibWebRTCStatsCollector.h"
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "JSDOMMapLike.h"
 #include "JSRTCStatsReport.h"
+#include "LibWebRTCUtils.h"
 #include "Performance.h"
 #include <wtf/MainThread.h>
 
@@ -47,11 +48,6 @@ LibWebRTCStatsCollector::~LibWebRTCStatsCollector()
     callOnMainThread([callback = WTFMove(m_callback)]() mutable {
         callback(nullptr);
     });
-}
-
-static inline String fromStdString(const std::string& value)
-{
-    return String::fromUTF8(value.data(), value.length());
 }
 
 static inline void fillRTCStats(RTCStatsReport::Stats& stats, const webrtc::RTCStats& rtcStats)
@@ -629,4 +625,4 @@ Ref<RTCStatsReport> LibWebRTCStatsCollector::createReport(const rtc::scoped_refp
 }; // namespace WTF
 
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
 #include <wtf/CompletionHandler.h>
@@ -65,4 +65,4 @@ private:
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "LibWebRTCUtils.h"
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "LibWebRTCMacros.h"
 #include "RTCDtlsTransportState.h"
@@ -37,11 +37,14 @@
 
 ALLOW_UNUSED_PARAMETERS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+ALLOW_COMMA_BEGIN
 
 #include <webrtc/api/rtp_parameters.h>
 #include <webrtc/api/rtp_transceiver_interface.h>
+#include <webrtc/p2p/base/p2p_constants.h>
 #include <webrtc/pc/webrtc_sdp.h>
 
+ALLOW_COMMA_END
 ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_UNUSED_PARAMETERS_END
 
@@ -455,4 +458,4 @@ RefPtr<RTCError> toRTCError(const webrtc::RTCError& rtcError)
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if USE(LIBWEBRTC)
+#if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "ExceptionCode.h"
 #include "RTCIceCandidateFields.h"
@@ -84,4 +84,4 @@ RTCIceCandidateFields convertIceCandidate(const cricket::Candidate&);
 
 } // namespace WebCore
 
-#endif // USE(LIBWEBRTC)
+#endif // ENABLE(WEB_RTC) && USE(LIBWEBRTC)

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -64,7 +64,6 @@
 #include "HTMLTableElement.h"
 #include "HTMLTextAreaElement.h"
 #include "HTMLTextFormControlElement.h"
-#include "LibWebRTCProvider.h"
 #include "MarkupAccumulator.h"
 #include "NodeList.h"
 #include "Page.h"

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -60,7 +60,6 @@
 #include "HistoryItem.h"
 #include "IDBConnectionToServer.h"
 #include "InspectorClient.h"
-#include "LibWebRTCAudioModule.h"
 #include "MediaRecorderPrivate.h"
 #include "MediaRecorderProvider.h"
 #include "ModalContainerTypes.h"

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -29,9 +29,12 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "AudioMediaStreamTrackRenderer.h"
-#include "LibWebRTCAudioModule.h"
 #include "Logging.h"
 #include "RealtimeIncomingAudioSource.h"
+
+#if USE(LIBWEBRTC)
+#include "LibWebRTCAudioModule.h"
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include "LibWebRTCProvider.h"
-
 #if USE(LIBWEBRTC) && USE(GSTREAMER)
 
 #include "GStreamerVideoDecoderFactory.h"

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -44,7 +44,6 @@
 #include "IntRect.h"
 #include "JSDOMWindowBase.h"
 #include "LegacyRenderSVGRoot.h"
-#include "LibWebRTCProvider.h"
 #include "Page.h"
 #include "PageConfiguration.h"
 #include "RenderSVGRoot.h"

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -307,6 +307,10 @@
 #include "RTCPeerConnection.h"
 #endif
 
+#if USE(LIBWEBRTC)
+#include "LibWebRTCProvider.h"
+#endif
+
 #if ENABLE(MEDIA_SOURCE)
 #include "MockMediaPlayerMediaSource.h"
 #endif


### PR DESCRIPTION
#### 34105586b430eb81aebf6af3d4708c9b504a521c
<pre>
Guard USE(LIBWEBRTC) includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=247833">https://bugs.webkit.org/show_bug.cgi?id=247833</a>

Reviewed by Eric Carlson.

Only add `libwebrtc` include directories if `USE_LIBWEBRTC` is `ON`.
Guard includes and sources with `USE(LIBWEBRTC)`. Remove includes that
aren&apos;t necessary.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCIceCandidate.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCObservers.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
* Source/WebCore/testing/Internals.cpp:

Canonical link: <a href="https://commits.webkit.org/256664@main">https://commits.webkit.org/256664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539141d2812498fd8c6575e176a46f2d030a8622

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105998 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166350 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5889 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34455 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102723 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102127 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83059 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31369 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74269 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40185 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4622 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4132 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40274 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->