### PR TITLE
REGRESSION (256350@main): WebKit produces a broken symlink when building sandbox profiles

### DIFF
--- a/Source/WebKit/Scripts/generate-derived-sources.sh
+++ b/Source/WebKit/Scripts/generate-derived-sources.sh
@@ -9,12 +9,12 @@ cd "${BUILT_PRODUCTS_DIR}/DerivedSources/WebKit"
 
 export WebKit2="${SRCROOT}"
 
-/bin/ln -sfh "${WEBCORE_PRIVATE_HEADERS_DIR}" WebCorePrivateHeaders
-export WebCorePrivateHeaders="WebCorePrivateHeaders"
-
 if [ -z $1 ] || [ $1 != "sandbox-profiles-ios" ]; then
     /bin/ln -sfh "${JAVASCRIPTCORE_PRIVATE_HEADERS_DIR}" JavaScriptCorePrivateHeaders
     export JavaScriptCore_SCRIPTS_DIR="JavaScriptCorePrivateHeaders"
+
+    /bin/ln -sfh "${WEBCORE_PRIVATE_HEADERS_DIR}" WebCorePrivateHeaders
+    export WebCorePrivateHeaders="WebCorePrivateHeaders"
 fi
 
 if [ ! "$CC" ]; then


### PR DESCRIPTION
#### 50b63f352a0727a36aea7b4f380235a1048ffe7e
<pre>
REGRESSION (256350@main): WebKit produces a broken symlink when building sandbox profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=247836">https://bugs.webkit.org/show_bug.cgi?id=247836</a>
rdar://102265083

Reviewed by Timothy Hatcher.

* Source/WebKit/Scripts/generate-derived-sources.sh: Follow the same pattern that we use
for JavaScriptCorePrivateHeaders.

Canonical link: <a href="https://commits.webkit.org/256610@main">https://commits.webkit.org/256610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4509749cba9b25595f561af38ae7a60d5bb71ff8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105826 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5663 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34284 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102558 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4192 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82879 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31220 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/99873 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74050 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40017 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4584 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43420 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40095 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->