### PR TITLE
REGRESSION (253809@main): Comment field on Engadget.com exhibits stutters while scrolling

### DIFF
--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed-expected.txt
@@ -1,0 +1,16 @@
+composited
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 1)
+    (vertical scroll elasticity 1)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (behavior for fixed 1)
+)
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed-expected.txt
@@ -1,0 +1,16 @@
+composited
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (behavior for fixed 1)
+)
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .fixed {
+            position: fixed;
+            top: -410px;
+            width: 500px;
+            height: 400px;
+            border: 1px solid black;
+        }
+
+        .container {
+            position: relative;
+        }
+
+        .composited {
+            transform: translateZ(0);
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        window.addEventListener('load', () => {
+            if (window.internals)
+                document.getElementById('tree').innerText = internals.scrollingStateTreeAsText();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="fixed">
+        <div class="container">
+            <div class="composited">
+                composited
+            </div>
+        </div>
+    </div>
+<pre id="tree"></pre>
+</body>
+</html>

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/scroll-coordinated-inside-fixed-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/scroll-coordinated-inside-fixed-expected.txt
@@ -1,0 +1,3 @@
+This test should not assert in debug builds.
+inner
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/scroll-coordinated-inside-fixed.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/scroll-coordinated-inside-fixed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+
+        .fixed {
+            position: fixed;
+            width: 300px;
+            height: 300px;
+            padding: 10px;
+            border: 1px solid black;
+        }
+
+        .scroller {
+            position: relative;
+            overflow: scroll;
+            width: 200px;
+            height: 200px;
+            border: 1px solid black;
+        }
+
+        .inner {
+            position: absolute;
+            will-change: transform;
+        }
+
+        .filler {
+            height: 200px;
+            width: 10px;
+            margin: 10px;
+            background-color: silver;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+    </script>
+</head>
+<body>
+    <div class="fixed">
+        This test should not assert in debug builds.
+        <div class="scroller">
+            <div class="filler"></div>
+            <div class="inner">inner</div>
+            <div class="filler"></div>
+        </div>
+    </div>
+<pre id="tree"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3484,7 +3484,7 @@ bool RenderLayerCompositor::isViewportConstrainedFixedOrStickyLayer(const Render
     if (layer.renderer().isStickilyPositioned())
         return isAsyncScrollableStickyLayer(layer);
 
-    if (!layer.behavesAsFixed())
+    if (!(layer.renderer().isFixedPositioned() && layer.behavesAsFixed()))
         return false;
 
     for (auto* ancestor = layer.parent(); ancestor; ancestor = ancestor->parent()) {


### PR DESCRIPTION
#### 24298004617128b4ce925aadf2af229de18deb7a
<pre>
REGRESSION (253809@main): Comment field on Engadget.com exhibits stutters while scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=247837">https://bugs.webkit.org/show_bug.cgi?id=247837</a>
rdar://102066231

Reviewed by Alan Baradlay.

Various sites (khanacademy.org, comments on engadget.com) showed incorrectly scroll-coordinated elements,
typically positioned nodes inside overflow:scroll inside position:fixed. On some other sites, we&apos;d hit an
assertion in RenderLayerCompositor::updateScrollingNodeForViewportConstrainedRole().

In all cases, we were trying to treat a layer that was some descendant of a position:fixed layer as if it
were the fixed layer itself, because of a logic error in 253809@main. The code in
`RenderLayerCompositor::isViewportConstrainedFixedOrStickyLayer()` needs to return early if the layer is
not both position:fixed, and behaving as fixed (i.e. no transformed ancestor).

Added two layout tests, both of which hit the assertion, and one of which showed incorrect scrolling
behavior.

* LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/composited-in-offscreen-fixed.html: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/scroll-coordinated-inside-fixed-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/scroll-coordinated-inside-fixed.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::isViewportConstrainedFixedOrStickyLayer const):

Canonical link: <a href="https://commits.webkit.org/256619@main">https://commits.webkit.org/256619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35fc272f3ff517783caa1398e7fcbd8bf0d13a37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105867 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166215 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5722 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34324 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88705 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102597 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4247 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82921 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31257 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74112 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40056 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19502 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20873 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4591 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/155 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43454 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/constructors/Worker/ctor-undefined.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40141 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->