### PR TITLE
Fix form associated behavior for option.form when it is select on "select" element parent

### DIFF
--- a/LayoutTests/fast/forms/option-form-expected.txt
+++ b/LayoutTests/fast/forms/option-form-expected.txt
@@ -1,0 +1,16 @@
+This tests option element's form IDL attribute returns null when it's not associated with a select element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS option1.form is null
+PASS option2.form is null
+PASS option3.form is form3
+PASS option4.form is form4
+PASS option5.form is form5a
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/fast/forms/option-form.html
+++ b/LayoutTests/fast/forms/option-form.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<form id="form1"><option id="option1"></form>
+<form id="form2"><optgroup><option id="option2"></optgroup></form>
+<form id="form3"><select><option id="option3"></select></form>
+<form id="form4"><select><optgroup><option id="option4"></optgroup></select></form>
+<form id="form5a"></form><form id="form5b"><select form="form5a"><option id="option5"></select></form>
+<script>
+description(`This tests option element's form IDL attribute returns null when it's not associated with a select element.`);
+shouldBeNull('option1.form');
+shouldBeNull('option2.form');
+shouldBe('option3.form', 'form3');
+shouldBe('option4.form', 'form4');
+shouldBe('option5.form', 'form5a');
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -146,6 +146,13 @@ bool HTMLOptionElement::accessKeyAction(bool)
     return false;
 }
 
+HTMLFormElement* HTMLOptionElement::form() const
+{
+    if (RefPtr selectElement = ownerSelectElement())
+        return selectElement->form();
+    return nullptr;
+}
+
 int HTMLOptionElement::index() const
 {
     // It would be faster to cache the index, but harder to get it right in all cases.

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -42,6 +42,8 @@ public:
     WEBCORE_EXPORT String text() const;
     void setText(String&&);
 
+    WEBCORE_EXPORT HTMLFormElement* form() const final;
+
     WEBCORE_EXPORT int index() const;
 
     WEBCORE_EXPORT String value() const;


### PR DESCRIPTION
#### 9d95887793091302a86a3dcc627c213d6b1080a7
<pre>
Fix form associated behavior for option.form when it is select on &quot;select&quot; element parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=247651">https://bugs.webkit.org/show_bug.cgi?id=247651</a>

Reviewed by Wenson Hsieh.

Make HTMLOptionElement&apos;s form IDL attribute return null when it&apos;s not associated with a select element.
New behavior matches the specification and the behaviors of Firefox and Chrome.

Spec: <a href="https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-form">https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-form</a>

* LayoutTests/fast/forms/option-form-expected.txt: Added.
* LayoutTests/fast/forms/option-form.html: Added.
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::form const):
* Source/WebCore/html/HTMLOptionElement.h:

Canonical link: <a href="https://commits.webkit.org/256612@main">https://commits.webkit.org/256612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0835d933916e2328c95325e36d2929f28c9807c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105836 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166173 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5674 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34294 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88673 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102566 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101966 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82889 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31228 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40026 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20839 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43426 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2195 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40107 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->