### PR TITLE
Crash in FormData::flatten

### DIFF
--- a/LayoutTests/fast/forms/submit-form-dialog-crash-expected.txt
+++ b/LayoutTests/fast/forms/submit-form-dialog-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+PASS

--- a/LayoutTests/fast/forms/submit-form-dialog-crash.html
+++ b/LayoutTests/fast/forms/submit-form-dialog-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function test()
+{
+    form.submit();
+    setTimeout(() => {
+        document.open();
+        document.write('<body><p>This test passes if WebKit does not crash.</p>PASS</body>');
+        document.close();
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+</script>
+<body onload="test()">
+<form id="form" action="#" target="_blank" method="dialog">

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -241,13 +241,11 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
 
 URL FormSubmission::requestURL() const
 {
-    ASSERT(m_method == Method::Post || m_method == Method::Get);
-
     if (m_method == Method::Post)
         return m_action;
 
     URL requestURL(m_action);
-    if (!requestURL.protocolIsJavaScript())
+    if (m_method == Method::Get && !requestURL.protocolIsJavaScript())
         requestURL.setQuery(m_formData->flattenToString());
     return requestURL;
 }


### PR DESCRIPTION
#### d44b5de990f9926f252451908f71528d37e681da
<pre>
Crash in FormData::flatten
<a href="https://bugs.webkit.org/show_bug.cgi?id=247652">https://bugs.webkit.org/show_bug.cgi?id=247652</a>

Reviewed by Youenn Fablet.

The bug was caused by FormSubmission::requestURL assuming that the method is GET
if it&apos;s not POST, and trying to serialize the form data as the URL query string.

Fixed the bug by adding method type check.

* LayoutTests/fast/forms/submit-form-dialog-crash-expected.txt: Added.
* LayoutTests/fast/forms/submit-form-dialog-crash.html: Added.
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::requestURL const):

Canonical link: <a href="https://commits.webkit.org/256613@main">https://commits.webkit.org/256613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f407c123d225f5c49242ce6e4f2a7d85a85f78ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105838 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166176 "Found 1 new test failure: js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5677 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34296 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88675 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102568 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4202 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82891 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31229 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74061 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40028 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37704 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20841 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/125 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43428 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/constructors/Worker/terminate.html (failure)") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2194 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40109 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->