### PR TITLE
Check if length isSpecified before accessing in RenderTableSection.cpp for minimumValueForLength

### DIFF
--- a/LayoutTests/fast/table/tr-min-content-crash-expected.txt
+++ b/LayoutTests/fast/table/tr-min-content-crash-expected.txt
@@ -1,0 +1,5 @@
+Test passes if it does not CRASH in debug.
+
+This test is verifying that setting a table rows height to [min|max|fit]-content does not ASSERT.
+
+

--- a/LayoutTests/fast/table/tr-min-content-crash.html
+++ b/LayoutTests/fast/table/tr-min-content-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.min { height: -webkit-min-content; }
+.max { height: -webkit-max-content; }
+.fit { height: -webkit-fit-content; }
+</style>
+<p>Test passes if it does not CRASH in debug.</p>
+<p>This test is verifying that setting a table rows height to [min|max|fit]-content does not ASSERT.</p>
+<table>
+  <tr class="min"></tr>
+  <tr class="max"></tr>
+  <tr class="fit"></tr>
+</table>

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -243,8 +243,13 @@ LayoutUnit RenderTableSection::calcRowLogicalHeight()
         m_grid[r].baseline = 0;
         LayoutUnit baselineDescent;
 
+        if (m_grid[r].logicalHeight.isSpecified()) {
         // Our base size is the biggest logical height from our cells' styles (excluding row spanning cells).
-        m_rowPos[r + 1] = std::max(m_rowPos[r] + resolveLogicalHeightForRow(m_grid[r].logicalHeight), 0_lu);
+            m_rowPos[r + 1] = std::max(m_rowPos[r] + resolveLogicalHeightForRow(m_grid[r].logicalHeight), 0_lu);
+        } else {
+        // Non-specified lengths are ignored because the row already accounts for the cells intrinsic logical height.
+            m_rowPos[r + 1] = std::max(m_rowPos[r], 0_lu);
+        }
 
         Row& row = m_grid[r].row;
         unsigned totalCols = row.size();


### PR DESCRIPTION
#### dcc214eccd588761bcaeee06f9d525bfb64c2f88
<pre>
Check if length isSpecified before accessing in RenderTableSection.cpp for minimumValueForLength

Check if length isSpecified before accessing in RenderTableSection.cpp for minimumValueForLength
<a href="https://bugs.webkit.org/show_bug.cgi?id=247840">https://bugs.webkit.org/show_bug.cgi?id=247840</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/33a620c7df6ac7ef4b7b4cbc94be07f70ae2e5f7">https://chromium.googlesource.com/chromium/blink/+/33a620c7df6ac7ef4b7b4cbc94be07f70ae2e5f7</a>

When calculating the minimumValueForLength, Webkit has to make sure
that the provided value is specified before using.

* Source/WebCore/rendering/RenderTableSection.cpp:
(RenderTableSection::calcRowLogicalHeight): Update logic of minimumValueForLength to ensure that the value is specified before use.
* LayoutTests/fast/table/tr-min-content-crash.html: Added Test Case
* LayoutTests/fast/table/tr-min-content-crash-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256614@main">https://commits.webkit.org/256614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0be1bf6b160184e413b97529cecb0e39802dd08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105840 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166180 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5681 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34298 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88677 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102570 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4205 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82893 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31232 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40030 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20844 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4586 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43430 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40112 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->