### PR TITLE
[WK2] Remove unused TupleMover, moveTuple() helpers

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -611,25 +611,6 @@ uint64_t Connection::sendWithAsyncReply(T&& message, C&& completionHandler, uint
     return 0;
 }
 
-template<size_t i, typename A, typename B> struct TupleMover {
-    static void move(A&& a, B& b)
-    {
-        std::get<i - 1>(b) = WTFMove(std::get<i - 1>(a));
-        TupleMover<i - 1, A, B>::move(WTFMove(a), b);
-    }
-};
-
-template<typename A, typename B> struct TupleMover<0, A, B> {
-    static void move(A&&, B&) { }
-};
-
-template<typename... A, typename... B>
-void moveTuple(std::tuple<A...>&& a, std::tuple<B...>& b)
-{
-    static_assert(sizeof...(A) == sizeof...(B), "Should be used with two tuples of same size");
-    TupleMover<sizeof...(A), std::tuple<A...>, std::tuple<B...>>::move(WTFMove(a), b);
-}
-
 template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& message, uint64_t destinationID, Timeout timeout, OptionSet<SendSyncOption> sendSyncOptions)
 {
     static_assert(T::isSync, "Sync message expected");


### PR DESCRIPTION
#### 1cd99af5f304d8adf1fd7340bb8ff9cf48305185
<pre>
[WK2] Remove unused TupleMover, moveTuple() helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=247845">https://bugs.webkit.org/show_bug.cgi?id=247845</a>

Reviewed by Timothy Hatcher.

Remove the unused helper TupleMover struct and moveTuple function. These haven&apos;t
been in use since one previous refactor of tuple handling in the Connection header.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::TupleMover::move): Deleted.
(IPC::moveTuple): Deleted.

Canonical link: <a href="https://commits.webkit.org/256616@main">https://commits.webkit.org/256616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b12df6156c3f1be04a68af139f38464e36b756cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105850 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5698 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34308 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102581 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4222 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82904 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31242 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74085 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40040 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4588 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43440 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40123 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->