### PR TITLE
Add HeaderDoc comments to the Web Extension headers.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -38,8 +38,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! @abstract Indicates a @link WKWebExtension @/link error. */
 WK_EXTERN NSErrorDomain const _WKWebExtensionErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract Constants used by NSError to indicate errors in the @link WKWebExtension @/link domain.
+ @constant WKWebExtensionErrorUnknown  Indicates that an unknown error occurred.
+ @constant WKWebExtensionErrorResourceNotFound  Indicates that a specified resource was not found on disk.
+ @constant WKWebExtensionErrorInvalidResourceCodeSignature  Indicates that a resource failed the bundle's code signature checks.
+ @constant WKWebExtensionErrorInvalidManifest  Indicates that an invalid `manifest.json` was encountered.
+ @constant WKWebExtensionErrorUnsupportedManifestVersion  Indicates that a the manifest version is not supported.
+ @constant WKWebExtensionErrorInvalidManifestEntry  Indicates that an invalid manifest entry was encountered.
+ @constant WKWebExtensionErrorInvalidDeclarativeNetRequestEntry  Indicates that an invalid declarative net request entry was encountered.
+ @constant WKWebExtensionErrorInvalidBackgroundPersistence  Indicates that the extension specified background persistence that was not compatible with the platform or features requested.
+ @constant WKWebExtensionErrorBackgroundContentFailedToLoad  Indicates that an error occurred loading the background content.
+ */
 typedef NS_ERROR_ENUM(_WKWebExtensionErrorDomain, _WKWebExtensionError) {
     _WKWebExtensionErrorUnknown = 1,
     _WKWebExtensionErrorResourceNotFound,
@@ -52,52 +65,144 @@ typedef NS_ERROR_ENUM(_WKWebExtensionErrorDomain, _WKWebExtensionError) {
     _WKWebExtensionErrorBackgroundContentFailedToLoad,
 } NS_SWIFT_NAME(_WKWebExtension.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*! @abstract This notification is sent whenever a @link WKWebExtension @/link has new errors or errors were cleared. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification NS_SWIFT_NAME(_WKWebExtension.errorsWereUpdatedNotification);
 
+/*!
+ @abstract A `WKWebExtension` object encapsulates a web extension’s resources that are defined by a `manifest.json` file.
+ @discussion This class handles the reading and parsing of the manifest file along with the supporting resources like icons and localizations.
+ */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtension : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+/*!
+ @abstract Returns a web extension initialized with a specified app extension bundle.
+ @param bundle The bundle to use for the new web extension.
+ @result An initialized web extension, or nil if the object could not be initialized.
+ @discussion This is a designated initializer.
+ */
 - (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle NS_DESIGNATED_INITIALIZER;
+
+/*!
+ @abstract Returns a web extension initialized with a specified resource base URL.
+ @param resourceBaseURL The directory URL to use for the new web extension.
+ @result An initialized web extension, or nil if the object could not be initialized.
+ @discussion This is a designated initializer. The URL must be a file URL that points
+ to a directory containing a `manifest.json` file.
+ */
 - (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL NS_DESIGNATED_INITIALIZER;
 
-@property (readonly, nullable, nonatomic) NSArray<NSError *> *errors;
+/*! @abstract The active errors for the extension. Returns `nil` if there are no errors. */
+@property (nonatomic, nullable, readonly, copy) NSArray<NSError *> *errors;
 
-@property (readonly, nullable, nonatomic) NSDictionary<NSString *, id> *manifest;
+/*! @abstract The parsed manifest as a dictionary. Returns `nil` if the manifest was unable to be parsed. */
+@property (nonatomic, nullable, readonly, copy) NSDictionary<NSString *, id> *manifest;
 
-@property (readonly, nonatomic) double manifestVersion;
+/*! @abstract The parsed manifest version. */
+@property (nonatomic, readonly) double manifestVersion;
+
+/*!
+ @abstract Checks if a maniferst version is supported by the extension.
+ @param manifestVersion The version number to check.
+ @result Returns `YES` if the extension specified a manifest version that is is greater than or equal to `manifestVersion`.
+ */
 - (BOOL)usesManifestVersion:(double)manifestVersion;
 
-@property (readonly, nullable, nonatomic) NSString *displayName;
-@property (readonly, nullable, nonatomic) NSString *displayShortName;
-@property (readonly, nullable, nonatomic) NSString *displayVersion;
-@property (readonly, nullable, nonatomic) NSString *displayDescription;
-@property (readonly, nullable, nonatomic) NSString *displayActionLabel;
+/*! @abstract The parsed and localized extension name. Returns `nil` if the manifest was unable to be parsed or there was no name specified. */
+@property (nonatomic, nullable, readonly, copy) NSString *displayName;
 
-@property (readonly, nullable, nonatomic) NSString *version;
+/*! @abstract The parsed and localized extension short name. Returns `nil` if the manifest was unable to be parsed or there was no short name specified. */
+@property (nonatomic, nullable, readonly, copy) NSString *displayShortName;
+
+/*! @abstract The parsed and localized extension display version. Returns `nil` if the manifest was unable to be parsed or there was no display version specified. */
+@property (nonatomic, nullable, readonly, copy) NSString *displayVersion;
+
+/*! @abstract The parsed and localized extension description. Returns `nil` if the manifest was unable to be parsed or there was no description specified. */
+@property (nonatomic, nullable, readonly, copy) NSString *displayDescription;
+
+/*! @abstract The parsed and localized extension action label. Returns `nil` if the manifest was unable to be parsed or there was no action label specified. */
+@property (nonatomic, nullable, readonly, copy) NSString *displayActionLabel;
+
+/*! @abstract The parsed extension version. Returns `nil` if the manifest was unable to be parsed or there was no version specified. */
+@property (nonatomic, nullable, readonly, copy) NSString *version;
 
 #if TARGET_OS_IPHONE
+
+/*!
+ @abstract Returns an icon for the extension that is best for the specified size.
+ @param size The size the image should be able to fill.
+ @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
+ @discussion This icon should respesent the extension in Settings or other general user interface areas. If the extension does not specify an icon large enough
+ for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @seealso actionIconForSize:
+ */
 - (nullable UIImage *)iconForSize:(CGSize)size;
+
+/*!
+ @abstract Returns an action icon for the extension that is best for the specified size.
+ @param size The size the image should be able to fill.
+ @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
+ @discussion This icon should respesent the extension in action sheets or toolbars. If the extension does not specify an icon large enough
+ for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @seealso iconForSize:
+ */
 - (nullable UIImage *)actionIconForSize:(CGSize)size;
+
 #else
+
+/*!
+ @abstract Returns an icon for the extension that is best for the specified size.
+ @param size The size the image should be able to fill.
+ @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
+ @discussion This icon should respesent the extension in Settings or other general user interface areas. If the extension does not specify an icon large enough
+ for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @seealso actionIconForSize:
+ */
 - (nullable NSImage *)iconForSize:(CGSize)size;
+
+/*!
+ @abstract Returns an action icon for the extension that is best for the specified size.
+ @param size The size the image should be able to fill.
+ @result An image that is best for the size. Returns `nil` if the manifest was unable to be parsed or no icons were specified.
+ @discussion This icon should respesent the extension in action sheets or toolbars. If the extension does not specify an icon large enough
+ for the size, then the largest icon specified will be returned. No image scaling is performed.
+ @seealso iconForSize:
+ */
 - (nullable NSImage *)actionIconForSize:(CGSize)size;
+
 #endif
 
-@property (readonly, nonatomic) NSSet<_WKWebExtensionPermission> *requestedPermissions;
-@property (readonly, nonatomic) NSSet<_WKWebExtensionPermission> *optionalPermissions;
+/*! @abstract The permissions that the extension needs for base functionality. */
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionPermission> *requestedPermissions;
 
-@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *requestedPermissionMatchPatterns;
-@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *optionalPermissionMatchPatterns;
+/*! @abstract The permissions that the extension might need for optional functionality. These can be requested later by the extension when needed. */
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionPermission> *optionalPermissions;
 
-@property (readonly, nonatomic) NSSet<_WKWebExtensionMatchPattern *> *allRequestedMatchPatterns;
+/*! @abstract The websites that the extension needs to access for base functionality. */
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *requestedPermissionMatchPatterns;
 
-@property (readonly, nonatomic) BOOL hasBackgroundContent;
-@property (readonly, nonatomic) BOOL backgroundContentIsPersistent;
+/*! @abstract The websites that the extension might need to access for optional functionality. */
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *optionalPermissionMatchPatterns;
 
+/*! @abstract The websites that the extension needs to access for base functionality, including injected content and websites that can send messages to the extension. */
+@property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *allRequestedMatchPatterns;
+
+/*! @abstract A Boolean value indicating whether the extension has background content that can run when needed. */
+@property (nonatomic, readonly) BOOL hasBackgroundContent;
+
+/*! @abstract A Boolean value indicating whether the extension has background content that stays in memory as long as the extension is loaded. */
+@property (nonatomic, readonly) BOOL backgroundContentIsPersistent;
+
+/*!
+ @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.
+ @param url The webpage URL to check.
+ @result Returns `YES` if the extension has content that can be injected by matching the `url` against the extension's requested match patterns.
+ @discussion The extension will still need to be loaded and have granted website permissions for its content to actually be injected.
+ */
 - (BOOL)hasInjectedContentForURL:(NSURL *)url;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -36,8 +36,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! @abstract Indicates a @link WKWebExtensionContext @/link error. */
 WK_EXTERN NSErrorDomain const _WKWebExtensionContextErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract Constants used by NSError to indicate errors in the @link WKWebExtensionContext @/link domain.
+ @constant WKWebExtensionContextErrorUnknown  Indicates that an unknown error occurred.
+ @constant WKWebExtensionContextErrorAlreadyLoaded  Indicates that the context is already loaded by a @link WKWebExtensionController @/link.
+ @constant WKWebExtensionContextErrorNotLoaded  Indicates that the context is not loaded by a @link WKWebExtensionController @/link.
+ @constant WKWebExtensionContextErrorBaseURLTaken  Indicates that another context is already using the specified base URL.
+ */
 typedef NS_ERROR_ENUM(_WKWebExtensionContextErrorDomain, _WKWebExtensionContextError) {
     _WKWebExtensionContextErrorUnknown = 1,
     _WKWebExtensionContextErrorAlreadyLoaded,
@@ -45,117 +53,376 @@ typedef NS_ERROR_ENUM(_WKWebExtensionContextErrorDomain, _WKWebExtensionContextE
     _WKWebExtensionContextErrorBaseURLTaken,
 } NS_SWIFT_NAME(_WKWebExtensionContext.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract Constants used to indicate permission state in @link WKWebExtensionContext @/link.
+ @constant WKWebExtensionContextPermissionStateDeniedExplicitly  Indicates that the permission was explicitly denied.
+ @constant WKWebExtensionContextPermissionStateDeniedImplicitly  Indicates that the permission was implicitly denied because of another explicitly denied permission.
+ @constant WKWebExtensionContextPermissionStateRequestedImplicitly  Indicates that the permission was implicitly requested because of another explicitly requested permission.
+ @constant WKWebExtensionContextPermissionStateUnknown  Indicates that an unknown permission state.
+ @constant WKWebExtensionContextPermissionStateRequestedExplicitly  Indicates that the permission was explicitly requested.
+ @constant WKWebExtensionContextPermissionStateGrantedImplicitly  Indicates that the permission was implicitly granted because of another explicitly granted permission.
+ @constant WKWebExtensionContextPermissionStateGrantedExplicitly  Indicates that the permission was explicitly granted permission.
+ */
 typedef NS_ENUM(NSInteger, _WKWebExtensionContextPermissionState) {
     _WKWebExtensionContextPermissionStateDeniedExplicitly    = -3,
     _WKWebExtensionContextPermissionStateDeniedImplicitly    = -2,
     _WKWebExtensionContextPermissionStateRequestedImplicitly = -1,
-    _WKWebExtensionContextPermissionStateUnknown             = 0,
-    _WKWebExtensionContextPermissionStateRequestedExplicitly = 1,
-    _WKWebExtensionContextPermissionStateGrantedImplicitly   = 2,
-    _WKWebExtensionContextPermissionStateGrantedExplicitly   = 3,
+    _WKWebExtensionContextPermissionStateUnknown             =  0,
+    _WKWebExtensionContextPermissionStateRequestedExplicitly =  1,
+    _WKWebExtensionContextPermissionStateGrantedImplicitly   =  2,
+    _WKWebExtensionContextPermissionStateGrantedExplicitly   =  3,
 } NS_SWIFT_NAME(_WKWebExtensionContext.PermissionState) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionsWereGrantedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionsWereGrantedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly denied permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionsWereDeniedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionsWereDeniedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed granted permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextGrantedPermissionsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.grantedPermissionsWereRemovedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed denied permissions. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextDeniedPermissionsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.deniedPermissionsWereRemovedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly granted permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionMatchPatternsWereGrantedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly denied permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification NS_SWIFT_NAME(_WKWebExtensionContext.permissionMatchPatternsWereDeniedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed granted permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.grantedPermissionMatchPatternsWereRemovedNotification);
 
+/*! @abstract This notification is sent whenever a @link WKWebExtensionContext @/link has newly removed denied permission match patterns. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN NSNotificationName const _WKWebExtensionContextDeniedPermissionMatchPatternsWereRemovedNotification NS_SWIFT_NAME(_WKWebExtensionContext.deniedPermissionMatchPatternsWereRemovedNotification);
 
+/*! @abstract Constants for specifying @link WKWebExtensionContext @/link information in notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 typedef NSString * _WKWebExtensionContextNotificationUserInfoKey NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(_WKWebExtensionContext.NotificationUserInfoKey);
 
+/*! @abstract The corresponding value represents the affected permissions in @link WKWebExtensionContext @/link notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyPermissions;
 
+/*! @abstract The corresponding value represents the affected permission match patterns in @link WKWebExtensionContext @/link notifications. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionContextNotificationUserInfoKey const _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns;
 
+/*!
+ @abstract A `WKWebExtensionContext` object encapsulates a web extension’s runtime environment.
+ @discussion This class handles the access permissions, content injection, storage, and background logic for the extension.
+ */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtensionContext : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+/*!
+ @abstract Returns a web extension context initialized with the specified extension.
+ @param extension The extension to use for the new web extension context.
+ @result An initialized web extension context.
+ */
 + (instancetype)contextWithExtension:(_WKWebExtension *)extension;
 
+/*!
+ @abstract Returns a web extension context initialized with a specified extension.
+ @param extension The extension to use for the new web extension context.
+ @result An initialized web extension context.
+ @discussion This is a designated initializer.
+ */
 - (instancetype)initWithExtension:(_WKWebExtension *)extension NS_DESIGNATED_INITIALIZER;
 
+/*! @abstract The extension this context represents. */
 @property (nonatomic, readonly, strong) _WKWebExtension *extension;
+
+/*! @abstract The extension controller this context is loaded in, otherwise `nil` if it isn't loaded. */
 @property (nonatomic, readonly, weak) _WKWebExtensionController *extensionController;
 
+/*! @abstract A Boolean value indicating if this context is loaded in an extension controller. */
 @property (nonatomic, readonly, getter=isLoaded) BOOL loaded;
 
+/*!
+ @abstract The base URL the context uses for loading extension resources or injecting content into webpages.
+ @discussion The default value is a unique URL using the `webkit-extension` scheme.
+ The base URL can be set to any URL, but only the scheme and host will be used. The scheme cannot be a scheme that is
+ already supported by @link WKWebView @/link (e.g. http, https, etc.) Setting is only allowed when the context is not loaded.
+ */
 @property (nonatomic, copy) NSURL *baseURL;
+
+/*!
+ @abstract An unique identifier used to distinguish the extension from other extensions and target it for messages.
+ @discussion The default value is a unique value that matches the host in the default base URL. The identifier can be any
+ value that is unique. Setting is only allowed when the context is not loaded.
+
+ This value is accessable by the extension via `browser.runtime.id` and is used for messaging the extension as the first
+ argumet of `browser.runtime.sendMessage(extensionId, message, options)`.
+ */
 @property (nonatomic, copy) NSString *uniqueIdentifier;
 
-// Granted permissions with their expiration date. Never includes expired entries at time of access.
+/*!
+ @abstract The currently granted permissions and their expiration dates.
+ @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+
+ Permissions in this dictionary should be explicitly granted by the user before being added. Any permissions in this collection will not be
+ presented for approval again until they expire.
+ @seealso setPermissionState:forPermission:
+ @seealso setPermissionState:forPermission:expirationDate:
+ */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionPermission, NSDate *> *grantedPermissions;
+
+/*!
+ @abstract The currently granted permission match patterns and their expiration dates.
+ @discussion Match patterns that don't expire will have a distant future date. This will never include expired entries at time of access.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+
+ Match patterns in this dictionary should be explicitly granted by the user before being added. Any match pattern in this collection will not be
+ presented for approval again until they expire.
+ @seealso setPermissionState:forMatchPattern:
+ @seealso setPermissionState:forMatchPattern:expirationDate:
+ */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *grantedPermissionMatchPatterns;
 
-// Denied permissions with their expiration date. Never includes expired entries at time of access.
+/*!
+ @abstract The currently denied permissions and their expiration dates.
+ @discussion Permissions that don't expire will have a distant future date. This will never include expired entries at time of access.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+
+ Permissions in this dictionary should be explicitly denied by the user before being added. Any match pattern in this collection will not be
+ presented for approval again until they expire.
+ @seealso setPermissionState:forPermission:
+ @seealso setPermissionState:forPermission:expirationDate:
+ */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionPermission, NSDate *> *deniedPermissions;
+
+/*!
+ @abstract The currently denied permission match patterns and their expiration dates.
+ @discussion Match patterns that don't expire will have a distant future date. This will never include expired entries at time of access.
+ Setting this property will replace all existing entries. Use this property for saving and restoring permission state in bulk.
+
+ Match patterns in this dictionary should be explicitly denied by the user before being added. Any match pattern in this collection will not be
+ presented for approval again until they expire.
+ @seealso setPermissionState:forMatchPattern:
+ @seealso setPermissionState:forMatchPattern:expirationDate:
+ */
 @property (nonatomic, copy) NSDictionary<_WKWebExtensionMatchPattern *, NSDate *> *deniedPermissionMatchPatterns;
 
-// When set to YES, this allows an extension to upgrade to asking for all URLs
-// without actually granting all URLs from an optional permissions request.
+/*!
+ @abstract A Boolean value indicating if the extension has requested optional access to all hosts.
+ @discussion When this value is `YES` the extension has asked for access to all hosts in a call to `browser.runtime.permissions.request()`
+ and future permission checks will present discrete hosts for approval as being implicty requested. This value should be saved and restored as needed.
+ */
 @property (nonatomic) BOOL requestedOptionalAccessToAllHosts;
 
-// All permissions currently allowed, including non-expired granted permissions.
+/*!
+ @abstract The currently granted permissions that have not expired.
+ @seealso grantedPermissions
+ */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionPermission> *currentPermissions;
+
+/*!
+ @abstract The currently granted permission match patterns that have not expired.
+ @seealso grantedPermissionMatchPatterns
+ */
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionMatchPattern *> *currentPermissionMatchPatterns;
 
+/*!
+ @abstract Checks the specified permission against the currently granted permissions.
+ @seealso currentPermissions
+ @seealso hasPermission:inTab:
+ @seealso permissionStateForPermission:
+ @seealso permissionStateForPermission:inTab:
+*/
 - (BOOL)hasPermission:(_WKWebExtensionPermission)permission;
+
+/*!
+ @abstract Checks the specified permission against the currently granted permissions in a specific tab.
+ @discussion Permissions can be granted on a per-tab basis. When the tab is known, permission checks should always use this method.
+ @seealso currentPermissions
+ @seealso hasPermission:
+ @seealso permissionStateForPermission:
+ @seealso permissionStateForPermission:inTab:
+ */
 - (BOOL)hasPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
 
+/*!
+ @abstract Checks the specified URL against the currently granted permission match patterns.
+ @seealso currentPermissionMatchPatterns
+ @seealso hasAccessToURL:inTab:
+ @seealso permissionStateForURL:
+ @seealso permissionStateForURL:inTab:
+ @seealso permissionStateForMatchPattern:
+ @seealso permissionStateForMatchPattern:inTab:
+ */
 - (BOOL)hasAccessToURL:(NSURL *)url;
+
+/*!
+ @abstract Checks the specified URL against the currently granted permission match patterns in a specific tab.
+ @discussion Some match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
+ @seealso currentPermissionMatchPatterns
+ @seealso hasAccessToURL:
+ @seealso permissionStateForURL:
+ @seealso permissionStateForURL:inTab:
+ @seealso permissionStateForMatchPattern:
+ @seealso permissionStateForMatchPattern:inTab:
+ */
 - (BOOL)hasAccessToURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab;
 
-// Specifically checks for any <all_urls> patterns. It does not check for all hosts patterns.
-// This is needed for APIs like tabs.captureVisibleTab that need to check specifically for <all_urls>.
-// You likely want to use hasPermissionToAccessAllHosts instead.
+/*!
+ @abstract Checks if the currently granted permission match patterns set contains the `<all_urls>` pattern.
+ @discussion This does not check for any `*` host patterns. In most cases you should use the broader `hasAccessToAllHosts`.
+ This check is primarily needed for APIs like `browser.tabs.captureVisibleTab()` that need to check specifically for `<all_urls>`.
+ @seealso currentPermissionMatchPatterns
+ @seealso hasAccessToAllHosts
+ */
 @property (nonatomic, readonly) BOOL hasAccessToAllURLs;
 
-// Checks for any <all_urls>, or all hosts patterns.
+/*!
+ @abstract Checks if the currently granted permission match patterns set contains the `<all_urls>` pattern or any `*` host patterns.
+ @seealso currentPermissionMatchPatterns
+ @seealso hasAccessToAllURLs
+ */
 @property (nonatomic, readonly) BOOL hasAccessToAllHosts;
 
+/*!
+ @abstract Checks the specified permission against the currently denied, granted, and requested permissions.
+ @discussion Permissions can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
+ @seealso permissionStateForPermission:inTab:
+ @seealso hasPermission:
+*/
 - (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission;
+
+/*!
+ @abstract Checks the specified permission against the currently denied, granted, and requested permissions in a specific tab.
+ @discussion Permissions can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
+ @seealso permissionStateForPermission:
+ @seealso hasPermission:inTab:
+*/
 - (_WKWebExtensionContextPermissionState)permissionStateForPermission:(_WKWebExtensionPermission)permission inTab:(nullable id <_WKWebExtensionTab>)tab;
 
+/*!
+ @abstract Sets the state of a permission in all tabs and global contexts with a distant future expiration date.
+ @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's state.
+ Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`, and `WKWebExtensionContextPermissionStateGrantedExplicitly`
+ states are allowed to be set using this method.
+ @seealso setPermissionState:forPermission:expirationDate:
+ @seealso setPermissionState:forPermission:inTab:
+*/
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission;
+
+/*!
+ @abstract Sets the state of a permission in all tabs and global contexts with a specific expiration date.
+ @discussion This method will update `grantedPermissions` and `deniedPermissions`. Use this method for changing a single permission's state.
+ Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`,
+ and `WKWebExtensionContextPermissionStateGrantedExplicitly` states are allowed to be set using this method.
+ @seealso setPermissionState:forPermission:
+ @seealso setPermissionState:forPermission:inTab:
+*/
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forPermission:(_WKWebExtensionPermission)permission expirationDate:(nullable NSDate *)expirationDate;
 
+/*!
+ @abstract Checks the specified URL against the currently denied, granted, and requested permission match patterns.
+ @discussion URLs and match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
+ @seealso permissionStateForURL:inTab:
+ @seealso hasAccessToURL:
+*/
 - (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url NS_SWIFT_NAME(permissionState(forURL:));
+
+/*!
+ @abstract Checks the specified URL against the currently denied, granted, and requested permission match patterns in a specific tab.
+ @discussion URLs and match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
+ @seealso permissionStateForURL:
+ @seealso hasAccessToURL:inTab:
+*/
 - (_WKWebExtensionContextPermissionState)permissionStateForURL:(NSURL *)url inTab:(nullable id <_WKWebExtensionTab>)tab NS_SWIFT_NAME(permissionState(forURL:in:));
 
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url;
-- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(nullable NSDate *)expirationDate;
+/*!
+ @abstract Sets the state of a URL in all tabs and global contexts with a distant future expiration date.
+ @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's state.
+ Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`, and `WKWebExtensionContextPermissionStateGrantedExplicitly`
+ states are allowed to be set using this method.
+ @seealso setPermissionState:forURL:expirationDate:
+ @seealso setPermissionState:forURL:inTab:
+*/
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url NS_SWIFT_NAME(setPermissionState(_:forURL:));
 
+/*!
+ @abstract Sets the state of a URL in all tabs and global contexts with a specific expiration date.
+ @discussion The URL is converted into a match pattern and will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single URL's state.
+ Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`,
+ and `WKWebExtensionContextPermissionStateGrantedExplicitly` states are allowed to be set using this method.
+ @seealso setPermissionState:forURL:
+ @seealso setPermissionState:forURL:inTab:
+*/
+- (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(nullable NSDate *)expirationDate NS_SWIFT_NAME(setPermissionState(_:forURL:expirationDate:));
+
+/*!
+ @abstract Checks the specified match pattern against the currently denied, granted, and requested permission match patterns.
+ @discussion Match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
+ @seealso permissionStateForMatchPattern:inTab:
+ @seealso hasAccessToURL:inTab:
+*/
 - (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
+
+/*!
+ @abstract Checks the specified match pattern against the currently denied, granted, and requested permission match patterns in a specific tab.
+ @discussion Match patterns can be granted on a per-tab basis. When the tab is known, access checks should always use this method.
+ @seealso permissionStateForMatchPattern:
+ @seealso hasAccessToURL:inTab:
+*/
 - (_WKWebExtensionContextPermissionState)permissionStateForMatchPattern:(_WKWebExtensionMatchPattern *)pattern inTab:(nullable id <_WKWebExtensionTab>)tab;
 
+/*!
+ @abstract Sets the state of a match pattern in all tabs and global contexts with a distant future expiration date.
+ @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's state.
+ Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`, and `WKWebExtensionContextPermissionStateGrantedExplicitly`
+ states are allowed to be set using this method.
+ @seealso setPermissionState:forMatchPattern:expirationDate:
+ @seealso setPermissionState:forMatchPattern:inTab:
+*/
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern;
+
+/*!
+ @abstract Sets the state of a match pattern in all tabs and global contexts with a specific expiration date.
+ @discussion This method will update `grantedPermissionMatchPatterns` and `deniedPermissionMatchPatterns`. Use this method for changing a single match pattern's state.
+ Passing a `nil` expiration date will be treated as a distant future date. Only `WKWebExtensionContextPermissionStateDeniedExplicitly`, `WKWebExtensionContextPermissionStateUnknown`,
+ and `WKWebExtensionContextPermissionStateGrantedExplicitly` states are allowed to be set using this method.
+ @seealso setPermissionState:forMatchPattern:
+ @seealso setPermissionState:forMatchPattern:inTab:
+*/
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forMatchPattern:(_WKWebExtensionMatchPattern *)pattern expirationDate:(nullable NSDate *)expirationDate;
 
+/*!
+ @abstract Notes that a user gesture has been performed in the specified tab (e.g. interacting with a toolbar button, menu item, etc.)
+ @discussion This method might grant per-tab permissions and/or match patterns for the current website if the extension has the `activeTab` permission.
+ This method can also propagate the user gesture state to the tab's page when the extension sends a message to the tab.
+ @seealso hasActiveUserGestureInTab:
+ @seealso cancelUserGestureForTab:
+*/
 - (void)userGesturePerformedInTab:(id <_WKWebExtensionTab>)tab;
+
+/*!
+ @abstract Returns a Boolean value indicating if a user gesture has been noted for the specified tab.
+ @seealso userGesturePerformedInTab:
+ @seealso cancelUserGestureForTab:
+*/
 - (BOOL)hasActiveUserGestureInTab:(id <_WKWebExtensionTab>)tab;
+
+/*!
+ @abstract Clears the current user gesture state for the specified tab.
+ @seealso userGesturePerformedInTab:
+ @seealso hasActiveUserGestureInTab:
+*/
 - (void)cancelUserGestureForTab:(id <_WKWebExtensionTab>)tab;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -380,6 +380,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url
 {
+    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
     NSParameterAssert(url);
 
     [self setPermissionState:state forURL:url expirationDate:nil];
@@ -387,6 +388,7 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 
 - (void)setPermissionState:(_WKWebExtensionContextPermissionState)state forURL:(NSURL *)url expirationDate:(NSDate *)expirationDate
 {
+    NSParameterAssert(state == _WKWebExtensionContextPermissionStateDeniedExplicitly || state == _WKWebExtensionContextPermissionStateUnknown || state == _WKWebExtensionContextPermissionStateGrantedExplicitly);
     NSParameterAssert(url);
 
     _webExtensionContext->setPermissionState(toImpl(state), url, toImpl(expirationDate));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -33,20 +33,69 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*!
+ @abstract A `WKWebExtensionController` object manages a set of loaded extension contexts.
+ @discussion You can have one or more extension controller instances, allowing different parts of the app to use different sets of extensions.
+ A controller is associated with @link WKWebView @/link via the `webExtensionController` property on @link WKWebViewConfiguration @/link.
+ */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtensionController : NSObject <NSSecureCoding>
 
+/*! @abstract The extension controller delegate. */
 @property (nonatomic, weak) id <_WKWebExtensionControllerDelegate> delegate;
 
+/*!
+ @abstract Loads the specified extension context.
+ @discussion Causes the context to start, loading any background content, and injecting any content into relevant tabs.
+ @result A Boolean value indicating if the context was successfully loaded.
+ @seealso loadExtensionContext:error:
+*/
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_UNAVAILABLE("Use error version");
+
+/*!
+ @abstract Loads the specified extension context.
+ @discussion Causes the context to start, loading any background content, and injecting any content into relevant tabs.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result A Boolean value indicating if the context was successfully loaded.
+ @seealso loadExtensionContext:
+*/
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)error;
 
+/*!
+ @abstract Unloads the specified extension context.
+ @discussion Causes the context to stop running.
+ @result A Boolean value indicating if the context was successfully unloaded.
+ @seealso unloadExtensionContext:error:
+*/
 - (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext NS_SWIFT_UNAVAILABLE("Use error version");
+
+/*!
+ @abstract Unloads the specified extension context.
+ @discussion Causes the context to stop running.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result A Boolean value indicating if the context was successfully unloaded.
+ @seealso unloadExtensionContext:
+*/
 - (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)error;
 
+/*!
+ @abstract Returns a loaded extension context for the specified extension.
+ @param extension An extension to lookup.
+ @result An extension context or `nil` if no match was found.
+ @seealso extensions
+*/
 - (nullable _WKWebExtensionContext *)extensionContextForExtension:(_WKWebExtension *)extension NS_SWIFT_NAME(extensionContext(for:));
 
+/*!
+ @abstract A set of all the currently loaded extensions.
+ @seealso extensionContexts
+*/
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtension *> *extensions;
+
+/*!
+ @abstract A set of all the currently loaded extension contexts.
+ @seealso extensions
+*/
 @property (nonatomic, readonly, copy) NSSet<_WKWebExtensionContext *> *extensionContexts;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h
@@ -29,8 +29,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! @abstract Indicates a @link WKWebExtensionMatchPattern @/link error. */
 WK_EXTERN NSErrorDomain const _WKWebExtensionMatchPatternErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract Constants used by NSError to indicate errors in the @link WKWebExtensionMatchPattern @/link domain.
+ @constant WKWebExtensionMatchPatternErrorUnknown  Indicates that an unknown error occurred.
+ @constant WKWebExtensionMatchPatternErrorInvalidScheme  Indicates that the scheme component was invalid.
+ @constant WKWebExtensionMatchPatternErrorInvalidHost  Indicates that the host component was invalid.
+ @constant WKWebExtensionMatchPatternErrorInvalidPath  Indicates that the path component was invalid.
+ */
 typedef NS_ERROR_ENUM(_WKWebExtensionMatchPatternErrorDomain, _WKWebExtensionMatchPatternError) {
     _WKWebExtensionMatchPatternErrorUnknown,
     _WKWebExtensionMatchPatternErrorInvalidScheme,
@@ -38,6 +46,13 @@ typedef NS_ERROR_ENUM(_WKWebExtensionMatchPatternErrorDomain, _WKWebExtensionMat
     _WKWebExtensionMatchPatternErrorInvalidPath,
 } NS_SWIFT_NAME(_WKWebExtensionMatchPattern.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract Constants used by @link WKWebExtensionMatchPattern @/link to indicate matching options.
+ @constant WKWebExtensionMatchPatternOptionsNone  Indicates no special matching options.
+ @constant WKWebExtensionMatchPatternOptionsIgnoreSchemes  Indicates that the scheme components should be ignored while matching.
+ @constant WKWebExtensionMatchPatternOptionsIgnorePaths  Indicates that the host components should be ignored while matching.
+ @constant WKWebExtensionMatchPatternOptionsMatchBidirectionally  Indicates that two patterns should be checked in either direction while matching (A matches B, or B matches A). Invalid for matching URLs.
+ */
 typedef NS_OPTIONS(NSUInteger, _WKWebExtensionMatchPatternOptions) {
     _WKWebExtensionMatchPatternOptionsNone                 = 0,
     _WKWebExtensionMatchPatternOptionsIgnoreSchemes        = 1 << 0,
@@ -45,37 +60,117 @@ typedef NS_OPTIONS(NSUInteger, _WKWebExtensionMatchPatternOptions) {
     _WKWebExtensionMatchPatternOptionsMatchBidirectionally = 1 << 2,
 } NS_SWIFT_NAME(_WKWebExtensionMatchPattern.Options) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+/*!
+ @abstract A `WKWebExtensionMatchPattern` object represents a way to specify groups of URLs.
+ @discussion All match patterns are specified as strings. Apart from the special `<all_urls>` pattern, match patterns
+ consist of three parts: scheme, host, and path.
+ */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKWebExtensionMatchPattern : NSObject <NSSecureCoding, NSCopying>
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+/*! @abstract Returns a pattern object for `<all_urls>`. */
 + (instancetype)allURLsMatchPattern;
+
+/*! @abstract Returns a pattern object that has `*` for scheme, host, and path. */
 + (instancetype)allHostsAndSchemesMatchPattern;
 
+/*!
+ @abstract Returns a pattern object for the speficied pattern string.
+ @result Returns `nil` if the pattern string is invalid.
+ @seealso initWithString:error:
+ */
 + (nullable instancetype)matchPatternWithString:(NSString *)string NS_SWIFT_UNAVAILABLE("Use error version");
+
+/*!
+ @abstract Returns a pattern object for the speficied scheme, host, and path strings.
+ @result A pattern object, or `nil` if any of the strings are invalid.
+ @seealso initWithScheme:host:path:error:
+ */
 + (nullable instancetype)matchPatternWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path NS_SWIFT_UNAVAILABLE("Use error version");
 
+/*!
+ @abstract Returns a pattern object for the speficied pattern string.
+ @result A pattern object, or `nil` if the pattern string is invalid.
+ @seealso initWithString:error:
+ */
 - (nullable instancetype)initWithString:(NSString *)string NS_SWIFT_UNAVAILABLE("Use error version");
+
+/*!
+ @abstract Returns a pattern object for the speficied pattern string.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result A pattern object, or `nil` if the pattern string is invalid and `error` will be set.
+ @seealso initWithString:
+ */
 - (nullable instancetype)initWithString:(NSString *)string error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
+/*!
+ @abstract Returns a pattern object for the speficied scheme, host, and path strings.
+ @result A pattern object, or `nil` if any of the strings are invalid.
+ @seealso initWithScheme:host:path:error:
+ */
 - (nullable instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path NS_SWIFT_UNAVAILABLE("Use error version");
+
+/*!
+ @abstract Returns a pattern object for the speficied scheme, host, and path strings.
+ @param error Set to \c nil or an \c NSError instance if an error occurred.
+ @result A pattern object, or `nil` if any of the strings are invalid and `error` will be set.
+ @seealso initWithScheme:host:path:
+ */
 - (nullable instancetype)initWithScheme:(NSString *)scheme host:(NSString *)host path:(NSString *)path error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
-@property (nonatomic, readonly) NSString *string;
+/*! @abstract The original pattern string. */
+@property (nonatomic, readonly, copy) NSString *string;
 
-@property (nonatomic, nullable, readonly) NSString *scheme;
-@property (nonatomic, nullable, readonly) NSString *host;
-@property (nonatomic, nullable, readonly) NSString *path;
+/*! @abstract The scheme part of the pattern string, unless `matchesAllURLs` is `YES`. */
+@property (nonatomic, nullable, readonly, copy) NSString *scheme;
 
+/*! @abstract The host part of the pattern string, unless `matchesAllURLs` is `YES`. */
+@property (nonatomic, nullable, readonly, copy) NSString *host;
+
+/*! @abstract The path part of the pattern string, unless `matchesAllURLs` is `YES`. */
+@property (nonatomic, nullable, readonly, copy) NSString *path;
+
+/*! @abstract If the pattern is `<all_urls>`. */
 @property (nonatomic, readonly) BOOL matchesAllURLs;
+
+/*! @abstract If the pattern is `<all_urls>` or has `*` as the host. */
 @property (nonatomic, readonly) BOOL matchesAllHosts;
 
+/*!
+ @abstract Matches the reciever pattern against the specified URL.
+ @param url The URL to match the against the reciever pattern.
+ @result A Boolean value indicating if pattern matches the speficied URL.
+ @seealso matchesURL:options:
+ */
 - (BOOL)matchesURL:(NSURL *)url NS_SWIFT_NAME(matches(url:));
+
+/*!
+ @abstract Matches the reciever pattern against the specified URL with options.
+ @param url The URL to match the against the reciever pattern.
+ @param options The options to use while matching.
+ @result A Boolean value indicating if pattern matches the speficied URL.
+ @seealso matchesURL:
+ */
 - (BOOL)matchesURL:(NSURL *)url options:(_WKWebExtensionMatchPatternOptions)options NS_SWIFT_NAME(matches(url:options:));
 
+/*!
+ @abstract Matches the receiver pattern against the specified pattern.
+ @param pattern The pattern to match against the receiver pattern.
+ @result A Boolean value indicating if receiver pattern matches the specified pattern.
+ @seealso matchesPattern:options:
+ */
 - (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)pattern NS_SWIFT_NAME(matches(pattern:));
+
+/*!
+ @abstract Matches the receiver pattern against the specified pattern with options.
+ @param pattern The pattern to match against the receiver pattern.
+ @param options The options to use while matching.
+ @result A Boolean value indicating if receiver pattern matches the specified pattern.
+ @seealso matchesPattern:
+ */
 - (BOOL)matchesPattern:(_WKWebExtensionMatchPattern *)pattern options:(_WKWebExtensionMatchPatternOptions)options NS_SWIFT_NAME(matches(pattern:options:));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h
@@ -27,53 +27,70 @@
 
 #import <Foundation/Foundation.h>
 
+/*! @abstract Constants for specifying permission in a @link WKWebExtensionContext @/link. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 typedef NSString * _WKWebExtensionPermission NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(_WKWebExtension.Permission);
 
+/*! @abstract The `activeTab` permission requests that when the user interacts with the extension, the extension is granted extra permissions for the active tab only. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionActiveTab;
 
+/*! @abstract The `alarms` permission requests access to the `browser.alarms` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionAlarms;
 
+/*! @abstract The `clipboardWrite` permission requests access to write to the clipboard. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionClipboardWrite;
 
+/*! @abstract The `contextMenus` permission requests access to the `browser.contextMenus` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionContextMenus;
 
+/*! @abstract The `cookies` permission requests access to the `browser.cookies` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionCookies;
 
+/*! @abstract The `declarativeNetRequest` permission requests access to the `browser.declarativeNetRequest` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequest;
 
+/*! @abstract The `declarativeNetRequestFeedback` permission requests access to the `browser.declarativeNetRequest` APIs with extra information on matched rules. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestFeedback;
 
+/*! @abstract The `declarativeNetRequestWithHostAccess` permission requests access to the `browser.declarativeNetRequest` APIs with the ability to modify or redirect requests. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess;
 
+/*! @abstract The `menus` permission requests access to the `browser.menus` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionMenus;
 
+/*! @abstract The `nativeMessaging` permission requests access to send messages to the App Extension bundle. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionNativeMessaging;
 
+/*! @abstract The `scripting` permission requests access to the `browser.scripting` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionScripting;
 
+/*! @abstract The `storage` permission requests access to the `browser.storage` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionStorage;
 
+/*! @abstract The `tabs` permission requests access extra information on the `browser.tabs` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionTabs;
 
+/*! @abstract The `unlimitedStorage` permission requests access to an unlimited quota on the `browser.storage.local` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionUnlimitedStorage;
 
+/*! @abstract The `webNavigation` permission requests access to the `browser.webNavigation` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionWebNavigation;
 
+/*! @abstract The `webRequest` permission requests access to the `browser.webRequest` APIs. */
 WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionWebRequest;


### PR DESCRIPTION
#### 1e49c3463baf4ccdb7f56120c1af54d4564918df
<pre>
Add HeaderDoc comments to the Web Extension headers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247844">https://bugs.webkit.org/show_bug.cgi?id=247844</a>

Reviewed by Brian Weinstein.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext setPermissionState:forURL:]): Drive-by. Add missing assert.
(-[_WKWebExtensionContext setPermissionState:forURL:expirationDate:]): Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.h:

Canonical link: <a href="https://commits.webkit.org/256746@main">https://commits.webkit.org/256746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ddff710c8f4eda785fe07c2d76509c67d75233

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5987 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/29815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106249 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6200 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89106 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102397 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/83333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/25 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/22 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4807 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/83333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2242 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/1247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->