### PR TITLE
Fix "mouse" position selection in svg/text/resources/SelectionTestCase.js

### DIFF
--- a/LayoutTests/svg/text/resources/SelectionTestCase.js
+++ b/LayoutTests/svg/text/resources/SelectionTestCase.js
@@ -69,6 +69,11 @@ function selectRange(id, start, end, expectedText) {
         var absStartPos = toAbsoluteCoordinates(startPos, element);
         var absEndPos = toAbsoluteCoordinates(endPos, element);
 
+        // Round the points "inwards" to avoid being affected by the truncation taking place in 
+        // eventSender.mouseMoveTo(...).
+        absStartPos.x = Math.ceil(absStartPos.x);
+        absEndPos.x = Math.floor(absEndPos.x);
+
         // Move to selection origin and hold down mouse
         eventSender.mouseMoveTo(absStartPos.x, absStartPos.y);
         eventSender.mouseDown();


### PR DESCRIPTION
#### 5a9504aef82d929917a680a05a3fc17f7f6b4dde
<pre>
Fix &quot;mouse&quot; position selection in svg/text/resources/SelectionTestCase.js

Fix &quot;mouse&quot; position selection in svg/text/resources/SelectionTestCase.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=247772">https://bugs.webkit.org/show_bug.cgi?id=247772</a>

Reviewed by Nikolas Zimmermann.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/efcb293e9377de07e1329be3c84fcdba0d67ede6">https://chromium.googlesource.com/chromium/blink/+/efcb293e9377de07e1329be3c84fcdba0d67ede6</a>

eventSender.mouseMoveTo(...) truncates the coordinates it is passed, so
fractional coordinates could end being adjust by almost an entire pixel,
which could yield incorrect results.
Round the end-points such that they should reside within the intended
selection area.

* LayoutTests/svg/text/resources/SelectionTestCase.js: Update logic to round &apos;coordinates&apos;

Canonical link: <a href="https://commits.webkit.org/256617@main">https://commits.webkit.org/256617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60525a9d0d31cecfc2bbd3cfa76514cd36a54d64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105852 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166195 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5700 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34310 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102583 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4225 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82906 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31244 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74087 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40042 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37718 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20858 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4589 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43442 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40126 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->