### PR TITLE
[WK2] Polish IPC::callMemberFunction(), completion handler validation in HandleMessage.h

### DIFF
--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -79,7 +79,7 @@ void handleWebPushDaemonMessage(WebKit::WebPushD::Connection* connection, Span<c
     if (UNLIKELY(!arguments))
         return;
 
-    IPC::callMemberFunction(WTFMove(*arguments), connection, Info::MemberFunction);
+    IPC::callMemberFunction(connection, Info::MemberFunction, WTFMove(*arguments));
 }
 
 void Connection::connectionReceivedEvent(xpc_object_t request)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
@@ -204,7 +204,7 @@ void handlePCMMessage(Span<const uint8_t> encodedMessage)
     if (UNLIKELY(!arguments))
         return;
 
-    IPC::callMemberFunction(WTFMove(*arguments), &daemonManager(), Info::MemberFunction);
+    IPC::callMemberFunction(&daemonManager(), Info::MemberFunction, WTFMove(*arguments));
 }
 
 static void handlePCMMessageSetDebugModeIsEnabled(const Daemon::Connection& connection, Span<const uint8_t> encodedMessage)
@@ -241,7 +241,7 @@ void handlePCMMessageWithReply(Span<const uint8_t> encodedMessage, CompletionHan
         replySender(Info::encodeReply(args...));
     }};
 
-    IPC::callMemberFunction(WTFMove(*arguments), WTFMove(completionHandler), &daemonManager(), Info::MemberFunction);
+    IPC::callMemberFunction(&daemonManager(), Info::MemberFunction, WTFMove(*arguments), WTFMove(completionHandler));
 }
 
 void doDailyActivityInManager()

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -284,7 +284,7 @@ void handleWebPushDMessageWithReply(ClientConnection* connection, Span<const uin
         replySender(Info::encodeReply(std::forward<decltype(args)>(args)...));
     } };
 
-    IPC::callMemberFunction(tuple_cat(std::make_tuple(connection), WTFMove(*arguments)), WTFMove(completionHandler), &WebPushD::Daemon::singleton(), Info::MemberFunction);
+    IPC::callMemberFunction(&WebPushD::Daemon::singleton(), Info::MemberFunction, tuple_cat(std::make_tuple(connection), WTFMove(*arguments)), WTFMove(completionHandler));
 }
 
 template<typename Info>
@@ -297,7 +297,7 @@ void handleWebPushDMessage(ClientConnection* connection, Span<const uint8_t> enc
     if (UNLIKELY(!arguments))
         return;
 
-    IPC::callMemberFunction(tuple_cat(std::make_tuple(connection), WTFMove(*arguments)), &WebPushD::Daemon::singleton(), Info::MemberFunction);
+    IPC::callMemberFunction(&WebPushD::Daemon::singleton(), Info::MemberFunction, tuple_cat(std::make_tuple(connection), WTFMove(*arguments)));
 }
 
 Daemon& Daemon::singleton()


### PR DESCRIPTION
#### ff0da01502672fd664455452b504a5cc05fe6f25
<pre>
[WK2] Polish IPC::callMemberFunction(), completion handler validation in HandleMessage.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=247846">https://bugs.webkit.org/show_bug.cgi?id=247846</a>

Reviewed by Kimmo Kinnunen.

Change parameter sequence for IPC::callMemberFunction() overloads, with
the object and method pointers passed in first, and the other arguments
following in the order in which they are passed to that method
invocation.

Internally IPC::callMemberFunction() implementations are simplified,
using std::apply() to expand the passed-in tuple values that are then
used in the method call.

Throughout callMemberFunction() and different handle-message variants,
the member function pointer parameter type now immediately splits
between the class type of which the function pointer type is a member,
and the simplified function type. The latter also simplifies the
CompletionHandlerTypeDeduction template specializations.

Helper CompletionHandlerTypeDeduction template struct is tweaked so that
the parameter index is passed to the struct template, avoiding a
template alias internally.

CompletionHandlerValidation is simplified, a simple two-type template is
provided, and a specialization for two CompletionHandler types passes
validation as long as parameter types between the two CompletionHandler
types match once cv-qualifications and references are removed.

* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::handleWebPushDaemonMessage):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp:
(WebKit::PCM::handlePCMMessage):
(WebKit::PCM::handlePCMMessageWithReply):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::callMemberFunction):
(IPC::CompletionHandlerValidation&lt;CompletionHandler&lt;void):
(IPC::handleMessage):
(IPC::handleMessageWantsConnection):
(IPC::handleMessageSynchronous):
(IPC::handleMessageSynchronousWantsConnection):
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWantsConnection):
(IPC::callMemberFunctionImpl): Deleted.
(IPC::C::): Deleted.
(IPC::CompletionHandlerValidation::matchingParameters): Deleted.
(IPC::CompletionHandlerValidation::matchingTypes): Deleted.
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::handleWebPushDMessageWithReply):
(WebPushD::handleWebPushDMessage):

Canonical link: <a href="https://commits.webkit.org/256971@main">https://commits.webkit.org/256971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ab09dfeb4352a31bac32d9d3a48e609a6cfc03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106921 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6982 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35410 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103595 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103064 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84034 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32242 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75167 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/676 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/659 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4806 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5467 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41195 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->