### PR TITLE
Add out-of-flow objects under the inline in a continuation chain, when possible

### DIFF
--- a/LayoutTests/fast/inline/add-abspos-before-block-inside-inline-expected.html
+++ b/LayoutTests/fast/inline/add-abspos-before-block-inside-inline-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>There should be a green square below, and no red.</p>
+<div style="width:40px; height:40px; background:green;"></div>

--- a/LayoutTests/fast/inline/add-abspos-before-block-inside-inline.html
+++ b/LayoutTests/fast/inline/add-abspos-before-block-inside-inline.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+    #container { overflow:hidden; width:40px; height:40px; background:red; }
+    #abspos { position:absolute; display:none; width:40px; height:20px; background:green; }
+    #sibling { margin-top:20px; width:40px; height:20px; background:green; }
+</style>
+<p>There should be a green square below, and no red.</p>
+<div id="container">
+    <span>
+        <div id="abspos"></div><div id="sibling"></div>
+    </span>
+</div>
+<script>
+    document.body.offsetTop;
+    abspos.style.display = "block";
+</script>


### PR DESCRIPTION
<pre>
Add out-of-flow objects under the inline in a continuation chain, when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=247681">https://bugs.webkit.org/show_bug.cgi?id=247681</a>

Reviewed by NOBODY (OOPS!).

This change is to match Webkit behavior with Blink / Chrome and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src/+/77ec19ddefb32688cd18277ed7412531b536401a">https://chromium.googlesource.com/chromium/src/+/77ec19ddefb32688cd18277ed7412531b536401a</a>

The same goes for floating objects. Only when a floating or out-of-flow
positioned object is to be added between two block-level children should we add
it to the anonymous block box holding the block-level children. If the new
child is to be added before a block-level child, and this beforeChild is the
first block-level child, we should rather make the new child the last child of
the preceding inline, rather than the first child of the anonymous block
containing block-level children. Also cleaned up and documented the code somewhat.

* Source/WebCore/rendering/udpating/RenderTreeBuilderBlock.cpp:
(RenderTreeBuilderBlock::insertChildToContinuation): Update Comments and logic to add 'out-of-flow' objects to continuation chain
* LayoutTests/fast/inline/add-abspos-before-block-inside-inline.html: Added Test Case
* LayoutTests/fast/inline/add-abspos-before-block-inside-inline-expected.html: Added Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95e63e490b146d0d343c208763a30f91715f51ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105855 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166198 "Found 1 new test failure: fast/inline/add-abspos-before-block-inside-inline.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5704 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34313 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102586 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101985 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4227 "Found 1 new test failure: fast/inline/add-abspos-before-block-inside-inline.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82909 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31245 "Found 1 new test failure: fast/inline/add-abspos-before-block-inside-inline.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40045 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19493 "Found 1 new test failure: fast/inline/add-abspos-before-block-inside-inline.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37721 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20860 "Found 1 new test failure: fast/inline/add-abspos-before-block-inside-inline.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/142 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43444 "Found 2 new test failures: fast/inline/add-abspos-before-block-inside-inline.html, http/wpt/service-workers/fetch-service-worker-preload.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40128 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->