### PR TITLE
[WK2] Allow lazy creation of default reply arguments in SendSyncResult<T>::takeReplyOr()

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -215,7 +215,7 @@ String WebPageProxy::stringSelectionForPasteboard()
     
     const Seconds messageTimeout(20);
     auto sendResult = sendSync(Messages::WebPage::GetStringSelectionForPasteboard(), messageTimeout);
-    auto [value] = sendResult.takeReplyOr(String { });
+    auto [value] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return value;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -209,7 +209,7 @@ void RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory()
 RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::getShareableBitmap(RenderingResourceIdentifier imageBuffer, PreserveResolution preserveResolution)
 {
     auto sendResult = sendSyncToStream(Messages::RemoteRenderingBackend::GetShareableBitmapForImageBuffer(imageBuffer, preserveResolution));
-    auto [handle] = sendResult.takeReplyOr(ShareableBitmapHandle { });
+    auto [handle] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (handle.isNull())
         return { };
     handle.takeOwnershipOfMemory(MemoryLedger::Graphics);
@@ -219,7 +219,7 @@ RefPtr<ShareableBitmap> RemoteRenderingBackendProxy::getShareableBitmap(Renderin
 RefPtr<Image> RemoteRenderingBackendProxy::getFilteredImage(RenderingResourceIdentifier imageBuffer, Filter& filter)
 {
     auto sendResult = sendSyncToStream(Messages::RemoteRenderingBackend::GetFilteredImageForImageBuffer(imageBuffer, IPC::FilterReference { filter }));
-    auto [handle] = sendResult.takeReplyOr(ShareableBitmapHandle { });
+    auto [handle] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (handle.isNull())
         return { };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp
@@ -49,7 +49,7 @@ RemoteShaderModuleProxy::~RemoteShaderModuleProxy()
 void RemoteShaderModuleProxy::compilationInfo(CompletionHandler<void(Ref<PAL::WebGPU::CompilationInfo>&&)>&& callback)
 {
     auto sendResult = sendSync(Messages::RemoteShaderModule::CompilationInfo());
-    auto [messages] = sendResult.takeReplyOr(Vector<CompilationMessage> { });
+    auto [messages] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
 
     auto backingMessages = messages.map([] (CompilationMessage compilationMessage) {
         return PAL::WebGPU::CompilationMessage::create(WTFMove(compilationMessage.message), compilationMessage.type, compilationMessage.lineNum, compilationMessage.linePos, compilationMessage.offset, compilationMessage.length);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -894,14 +894,20 @@ NSArray* MediaPlayerPrivateRemote::timedMetadata() const
 String MediaPlayerPrivateRemote::accessLog() const
 {
     auto sendResult = connection().sendSync(Messages::RemoteMediaPlayerProxy::AccessLog(), m_id);
-    auto [log] = sendResult.takeReplyOr(emptyString());
+    auto [log] = sendResult.takeReplyOr(
+        []() -> Messages::RemoteMediaPlayerProxy::AccessLog::ReplyArguments {
+            return { emptyString() };
+        });
     return log;
 }
 
 String MediaPlayerPrivateRemote::errorLog() const
 {
     auto sendResult = connection().sendSync(Messages::RemoteMediaPlayerProxy::ErrorLog(), m_id);
-    auto [log] = sendResult.takeReplyOr(emptyString());
+    auto [log] = sendResult.takeReplyOr(
+        []() -> Messages::RemoteMediaPlayerProxy::ErrorLog::ReplyArguments {
+            return { emptyString() };
+        });
     return log;
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -71,7 +71,7 @@ IPC::Connection& RemoteAudioSession::ensureConnection()
         m_gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteAudioSession::messageReceiverName(), *this);
 
         auto sendResult = ensureConnection().sendSync(Messages::GPUConnectionToWebProcess::EnsureAudioSession(), { });
-        std::tie(m_configuration) = sendResult.takeReplyOr(RemoteAudioSessionConfiguration { });
+        std::tie(m_configuration) = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     }
     return m_gpuProcessConnection->connection();
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -121,7 +121,7 @@ RefPtr<CDMInstance> RemoteCDM::createInstance()
         return nullptr;
 
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMProxy::CreateInstance(), m_identifier);
-    auto [identifier, configuration] = sendResult.takeReplyOr(RemoteCDMInstanceIdentifier { }, RemoteCDMInstanceConfiguration { });
+    auto [identifier, configuration] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (!identifier)
         return nullptr;
     return RemoteCDMInstance::create(m_factory.get(), WTFMove(identifier), WTFMove(configuration));

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -71,7 +71,7 @@ bool RemoteCDMFactory::supportsKeySystem(const String& keySystem)
 std::unique_ptr<CDMPrivate> RemoteCDMFactory::createCDM(const String& keySystem, const CDMPrivateClient&)
 {
     auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteCDMFactoryProxy::CreateCDM(keySystem), { });
-    auto [identifier, configuration] = sendResult.takeReplyOr(RemoteCDMIdentifier { }, RemoteCDMConfiguration { });
+    auto [identifier, configuration] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (!identifier)
         return nullptr;
     return RemoteCDM::create(*this, WTFMove(identifier), WTFMove(configuration));

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp
@@ -110,7 +110,7 @@ RefPtr<WebCore::CDMInstanceSession> RemoteCDMInstance::createSession()
 #endif
 
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteCDMInstanceProxy::CreateSession(logIdentifier), m_identifier);
-    auto [identifier] = sendResult.takeReplyOr(RemoteCDMInstanceSessionIdentifier { });
+    auto [identifier] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (!identifier)
         return nullptr;
     auto session = RemoteCDMInstanceSession::create(m_factory.get(), WTFMove(identifier));

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCor
 #endif
 
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::CreateSession(storageDirectory, logIdentifier), m_identifier);
-    auto [identifier] = sendResult.takeReplyOr(RemoteLegacyCDMSessionIdentifier { });
+    auto [identifier] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (!identifier)
         return nullptr;
     return RemoteLegacyCDMSession::create(m_factory, WTFMove(identifier), client);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
         playerId = gpuProcessConnection().mediaPlayerManager().findRemotePlayerId(player->playerPrivate());
 
     auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm->keySystem(), WTFMove(playerId)), { });
-    auto [identifier] = sendResult.takeReplyOr(RemoteLegacyCDMIdentifier { });
+    auto [identifier] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     if (!identifier)
         return nullptr;
     auto remoteCDM = RemoteLegacyCDM::create(*this, identifier);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -235,7 +235,7 @@ bool RemoteMediaPlayerManager::supportsKeySystem(MediaPlayerEnums::MediaEngineId
 HashSet<SecurityOriginData> RemoteMediaPlayerManager::originsInMediaCache(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, const String& path)
 {
     auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteMediaPlayerManagerProxy::OriginsInMediaCache(remoteEngineIdentifier, path), 0);
-    auto [originData] = sendResult.takeReplyOr(HashSet<SecurityOriginData> { });
+    auto [originData] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return originData;
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -76,7 +76,10 @@ WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()
         return DestinationColorSpace::SRGB();
 
     auto sendResult = connection().sendSync(Messages::RemoteMediaPlayerProxy::ColorSpace(), m_id);
-    auto [colorSpace] = sendResult.takeReplyOr(DestinationColorSpace::SRGB());
+    auto [colorSpace] = sendResult.takeReplyOr(
+        []() -> Messages::RemoteMediaPlayerProxy::ColorSpace::ReplyArguments {
+            return { DestinationColorSpace::SRGB() };
+        });
     return colorSpace;
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -166,7 +166,10 @@ RefPtr<NativeImage> RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage(con
         return nullptr;
     }
 
-    auto [destinationColorSpace] = sendResult.takeReplyOr(DestinationColorSpace { DestinationColorSpace::SRGB().platformColorSpace() });
+    auto [destinationColorSpace] = sendResult.takeReplyOr(
+        []() -> Messages::RemoteVideoFrameObjectHeap::ConvertFrameBuffer::ReplyArguments {
+            return { DestinationColorSpace { DestinationColorSpace::SRGB().platformColorSpace() } };
+        });
 
     m_conversionSemaphore.wait();
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -971,21 +971,21 @@ void WebLoaderStrategy::setCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 ResourceResponse WebLoaderStrategy::responseFromResourceLoadIdentifier(ResourceLoaderIdentifier resourceLoadIdentifier)
 {
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::GetNetworkLoadInformationResponse { resourceLoadIdentifier }, 0);
-    auto [response] = sendResult.takeReplyOr(ResourceResponse { });
+    auto [response] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return response;
 }
 
 Vector<NetworkTransactionInformation> WebLoaderStrategy::intermediateLoadInformationFromResourceLoadIdentifier(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
 {
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::GetNetworkLoadIntermediateInformation { resourceLoadIdentifier }, 0);
-    auto [information] = sendResult.takeReplyOr(Vector<NetworkTransactionInformation> { });
+    auto [information] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return information;
 }
 
 NetworkLoadMetrics WebLoaderStrategy::networkMetricsFromResourceLoadIdentifier(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
 {
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::TakeNetworkLoadInformationMetrics { resourceLoadIdentifier }, 0);
-    auto [networkMetrics] = sendResult.takeReplyOr(NetworkLoadMetrics { });
+    auto [networkMetrics] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return networkMetrics;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -188,7 +188,7 @@ FloatRect WebChromeClient::windowRect()
 #endif
 
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::GetWindowFrame(), m_page.identifier());
-    auto [newWindowFrame] = sendResult.takeReplyOr(FloatRect { });
+    auto [newWindowFrame] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return newWindowFrame;
 #endif
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -180,7 +180,7 @@ void WebEditorClient::didRemoveAttachmentWithIdentifier(const String& identifier
 Vector<SerializedAttachmentData> WebEditorClient::serializedAttachmentDataForIdentifiers(const Vector<String>& identifiers)
 {
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::SerializedAttachmentDataForIdentifiers(identifiers));
-    auto [serializedData] = sendResult.takeReplyOr(Vector<WebCore::SerializedAttachmentData> { });
+    auto [serializedData] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return serializedData;
 }
 
@@ -539,7 +539,7 @@ static uint64_t insertionPointFromCurrentSelection(const VisibleSelection& curre
 Vector<TextCheckingResult> WebEditorClient::checkTextOfParagraph(StringView stringView, OptionSet<WebCore::TextCheckingType> checkingTypes, const VisibleSelection& currentSelection)
 {
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::CheckTextOfParagraph(stringView.toStringWithoutCopying(), checkingTypes, insertionPointFromCurrentSelection(currentSelection)));
-    auto [results] = sendResult.takeReplyOr(Vector<TextCheckingResult> { });
+    auto [results] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return results;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -160,14 +160,14 @@ void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const
 String WebPlatformStrategies::stringForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardStringForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
-    auto [value] = sendResult.takeReplyOr(String { });
+    auto [value] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return value;
 }
 
 Vector<String> WebPlatformStrategies::allStringsForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardStringsForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
-    auto [values] = sendResult.takeReplyOr(Vector<String> { });
+    auto [values] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return values;
 }
 
@@ -182,14 +182,14 @@ int64_t WebPlatformStrategies::changeCount(const String& pasteboardName, const P
 Color WebPlatformStrategies::color(const String& pasteboardName, const PasteboardContext* context)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardColor(pasteboardName, pageIdentifier(context)), 0);
-    auto [color] = sendResult.takeReplyOr(Color { });
+    auto [color] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return color;
 }
 
 URL WebPlatformStrategies::url(const String& pasteboardName, const PasteboardContext* context)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardURL(pasteboardName, pageIdentifier(context)), 0);
-    auto [urlString] = sendResult.takeReplyOr(String { });
+    auto [urlString] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return URL({ }, urlString);
 }
 
@@ -301,21 +301,21 @@ void WebPlatformStrategies::updateSupportedTypeIdentifiers(const Vector<String>&
 Vector<String> WebPlatformStrategies::types(const String& pasteboardName)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetTypes(pasteboardName), 0);
-    auto [result] = sendResult.takeReplyOr(Vector<String> { });
+    auto [result] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return result;
 }
 
 String WebPlatformStrategies::readTextFromClipboard(const String& pasteboardName)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadText(pasteboardName), 0);
-    auto [result] = sendResult.takeReplyOr(String { });
+    auto [result] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return result;
 }
 
 Vector<String> WebPlatformStrategies::readFilePathsFromClipboard(const String& pasteboardName)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadFilePaths(pasteboardName), 0);
-    auto [result] = sendResult.takeReplyOr(Vector<String> { });
+    auto [result] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return result;
 }
 
@@ -363,7 +363,7 @@ void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, cons
 Vector<String> WebPlatformStrategies::typesSafeForDOMToReadAndWrite(const String& pasteboardName, const String& origin, const PasteboardContext* context)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::TypesSafeForDOMToReadAndWrite(pasteboardName, origin, pageIdentifier(context)), 0);
-    auto [types] = sendResult.takeReplyOr(Vector<String> { });
+    auto [types] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return types;
 }
 
@@ -436,7 +436,7 @@ URL WebPlatformStrategies::readURLFromPasteboard(size_t index, const String& pas
 String WebPlatformStrategies::readStringFromPasteboard(size_t index, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadStringFromPasteboard(index, pasteboardType, pasteboardName, pageIdentifier(context)), 0);
-    auto [value] = sendResult.takeReplyOr(String { });
+    auto [value] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return value;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
@@ -40,7 +40,7 @@ const Vector<RefPtr<WebCore::PlatformSpeechSynthesisVoice>>& WebSpeechSynthesisC
     // get the list of voices and pass it on to the WebContent processes, see
     // https://bugs.webkit.org/show_bug.cgi?id=195723
     auto sendResult = m_page.sendSync(Messages::WebPageProxy::SpeechSynthesisVoiceList());
-    auto [voiceList] = sendResult.takeReplyOr(Vector<WebSpeechSynthesisVoice> { });
+    auto [voiceList] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
 
     m_voices = voiceList.map([](auto& voice) -> RefPtr<WebCore::PlatformSpeechSynthesisVoice> {
         return WebCore::PlatformSpeechSynthesisVoice::create(voice.voiceURI, voice.name, voice.lang, voice.localService, voice.defaultLang);

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp
@@ -59,7 +59,7 @@ void WebAlternativeTextClient::dismissAlternative(ReasonForDismissingAlternative
 String WebAlternativeTextClient::dismissAlternativeSoon(ReasonForDismissingAlternativeText reason)
 {
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::DismissCorrectionPanelSoon(reason));
-    auto [result] = sendResult.takeReplyOr(String { });
+    auto [result] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return result;
 }
 
@@ -82,7 +82,7 @@ void WebAlternativeTextClient::showDictationAlternativeUI(const WebCore::FloatRe
 Vector<String> WebAlternativeTextClient::dictationAlternatives(WebCore::DictationContext dictationContext)
 {
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::DictationAlternatives(dictationContext));
-    auto [result] = sendResult.takeReplyOr(Vector<String> { });
+    auto [result] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -110,7 +110,7 @@ void WebBackForwardListProxy::goToItem(HistoryItem& item)
         return;
 
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::BackForwardGoToItem(item.identifier()));
-    auto [backForwardListCounts] = sendResult.takeReplyOr(WebBackForwardListCounts { });
+    auto [backForwardListCounts] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     m_cachedBackForwardListCounts = backForwardListCounts;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -145,8 +145,10 @@ String WebCookieJar::cookies(WebCore::Document& document, const URL& url) const
         return m_cache.cookiesForDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, includeSecureCookies);
 
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::CookiesForDOM(document.firstPartyForCookies(), sameSiteInfo, url, frameID, pageID, includeSecureCookies, applyTrackingPreventionInNetworkProcess, shouldRelaxThirdPartyCookieBlocking(webFrame)), 0);
-    auto [cookieString, secureCookiesAccessed] = sendResult.takeReplyOr(String { }, false);
-
+    auto [cookieString, secureCookiesAccessed] = sendResult.takeReplyOr(
+        []() -> Messages::NetworkConnectionToWebProcess::CookiesForDOM::ReplyArguments {
+            return { String { }, false };
+        });
     return cookieString;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3832,28 +3832,28 @@ void WebPage::resume(CompletionHandler<void(bool)>&& completionHandler)
 IntPoint WebPage::screenToRootView(const IntPoint& point)
 {
     auto sendResult = sendSync(Messages::WebPageProxy::ScreenToRootView(point));
-    auto [windowPoint] = sendResult.takeReplyOr(IntPoint { });
+    auto [windowPoint] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return windowPoint;
 }
     
 IntRect WebPage::rootViewToScreen(const IntRect& rect)
 {
     auto sendResult = sendSync(Messages::WebPageProxy::RootViewToScreen(rect));
-    auto [screenRect] = sendResult.takeReplyOr(IntRect { });
+    auto [screenRect] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return screenRect;
 }
     
 IntPoint WebPage::accessibilityScreenToRootView(const IntPoint& point)
 {
     auto sendResult = sendSync(Messages::WebPageProxy::AccessibilityScreenToRootView(point));
-    auto [windowPoint] = sendResult.takeReplyOr(IntPoint { });
+    auto [windowPoint] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return windowPoint;
 }
 
 IntRect WebPage::rootViewToAccessibilityScreen(const IntRect& rect)
 {
     auto sendResult = sendSync(Messages::WebPageProxy::RootViewToAccessibilityScreen(rect));
-    auto [screenRect] = sendResult.takeReplyOr(IntRect { });
+    auto [screenRect] = sendResult.takeReplyOr(sendResult.defaultReplyArguments);
     return screenRect;
 }
 

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -291,7 +291,10 @@ void StorageAreaMap::sendConnectMessage(SendMode mode)
 
     if (mode == SendMode::Sync) {
         auto sendResult = ipcConnection.sendSync(Messages::NetworkStorageManager::ConnectToStorageAreaSync(type, m_identifier, namespaceIdentifier, origin), 0);
-        auto [remoteAreaIdentifier, items, messageIdentifier] = sendResult.takeReplyOr(StorageAreaIdentifier { }, HashMap<String, String> { }, 0);
+        auto [remoteAreaIdentifier, items, messageIdentifier] = sendResult.takeReplyOr(
+            []() -> Messages::NetworkStorageManager::ConnectToStorageAreaSync::ReplyArguments {
+                return { StorageAreaIdentifier { }, HashMap<String, String> { }, 0 };
+            });
         didConnect(remoteAreaIdentifier, WTFMove(items), messageIdentifier);
         return;
     }


### PR DESCRIPTION
#### 0abf915b1f181282977c2bfda550616a0d48f73a
<pre>
[WK2] Allow lazy creation of default reply arguments in SendSyncResult&lt;T&gt;::takeReplyOr()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247847">https://bugs.webkit.org/show_bug.cgi?id=247847</a>

Reviewed by NOBODY (OOPS!).

Previous rework of SendSyncResult allowed added the takeReplyOr() method, which either
returned the reply values returned for the given synchronous message or used the
provided default values to construct the reply-arguments tuple. Downside of this is
that the default values are constructed regardless of whether they are used.

Another takeReplyOr() overload is added, only accepting invocable objects that return
the newly-constructed reply-arguments tuple with the desired default values. This
allows for these values to be constructed only when necessary, i.e. when there&apos;s no
values received through the IPC system.

Furthermore, the previous overload is now only enabled when all the provided values
are of trivial types, nullptr or nullopt. In any other case, the use of the invocable
object (usually a lambda) is enforced. This should prevent any user constructing
relatively heavier objects as default values when retrieving the reply arguments.

In many cases, the default values are simple default-constructed objects. For those
cases, a static SendSyncResult&lt;T&gt;::defaultReplyArguments() function is provided,
returning a default-constructed reply-arguments tuple which will default-construct
every contained object. This way the use of SendSyncResult&lt;T&gt;::takeReplyOr() can be
further simplified.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::SendSyncResult::std::enable_if_t&lt;):
(IPC::Connection::SendSyncResult::takeReplyOr):
(IPC::Connection::SendSyncResult::defaultReplyArguments):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::stringSelectionForPasteboard):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getShareableBitmap):
(WebKit::RemoteRenderingBackendProxy::getFilteredImage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.cpp:
(WebKit::WebGPU::RemoteShaderModuleProxy::compilationInfo):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::accessLog const):
(WebKit::MediaPlayerPrivateRemote::errorLog const):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::ensureConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
(WebKit::RemoteCDM::createInstance):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::createCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.cpp:
(WebKit::RemoteCDMInstance::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::createSession):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::createCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::originsInMediaCache):
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::colorSpace):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::responseFromResourceLoadIdentifier):
(WebKit::WebLoaderStrategy::intermediateLoadInformationFromResourceLoadIdentifier):
(WebKit::WebLoaderStrategy::networkMetricsFromResourceLoadIdentifier):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::windowRect):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::serializedAttachmentDataForIdentifiers):
(WebKit::WebEditorClient::checkTextOfParagraph):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::stringForType):
(WebKit::WebPlatformStrategies::allStringsForType):
(WebKit::WebPlatformStrategies::color):
(WebKit::WebPlatformStrategies::url):
(WebKit::WebPlatformStrategies::types):
(WebKit::WebPlatformStrategies::readTextFromClipboard):
(WebKit::WebPlatformStrategies::readFilePathsFromClipboard):
(WebKit::WebPlatformStrategies::typesSafeForDOMToReadAndWrite):
(WebKit::WebPlatformStrategies::readStringFromPasteboard):
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp:
(WebKit::WebSpeechSynthesisClient::voiceList):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebAlternativeTextClient.cpp:
(WebKit::WebAlternativeTextClient::dismissAlternativeSoon):
(WebKit::WebAlternativeTextClient::dictationAlternatives):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::goToItem):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::cookies const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::screenToRootView):
(WebKit::WebPage::rootViewToScreen):
(WebKit::WebPage::accessibilityScreenToRootView):
(WebKit::WebPage::rootViewToAccessibilityScreen):
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::sendConnectMessage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0abf915b1f181282977c2bfda550616a0d48f73a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106697 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6722 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35180 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103386 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5053 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83805 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32033 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74976 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/468 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20206 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21655 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44154 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40972 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->