### PR TITLE
Fix broken preferred widths optimization involving subtree layout roots

### DIFF
--- a/LayoutTests/fast/layout/nested-subtree-layout-preferred-widths-expected.txt
+++ b/LayoutTests/fast/layout/nested-subtree-layout-preferred-widths-expected.txt
@@ -1,0 +1,2 @@
+crbug.com/497178: This test ensures we properly recompute preferred widths for nested subtree roots. If this test is ever flaky, it should be considered failing due the the non-deterministic way we iterate over subtree layout roots.
+PASS

--- a/LayoutTests/fast/layout/nested-subtree-layout-preferred-widths.html
+++ b/LayoutTests/fast/layout/nested-subtree-layout-preferred-widths.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<style>
+div {
+    overflow: hidden;
+}
+#root {
+    width: 200px;
+    height: 400px;
+    background: red;
+}
+#content {
+    background: green;
+    width: 100%;
+    height: 400px;
+    display: block;
+}
+#container {
+    width: 400px;
+    height: 400px;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<div>
+    crbug.com/497178: This test ensures we properly recompute preferred widths for
+    nested subtree roots. If this test is ever flaky, it should be considered
+    failing due the the non-deterministic way we iterate over subtree layout roots.
+</div>
+<div id="container">
+    <div id="root">
+        <div data-expected-width="400" id="content">OriginalText</div>
+    </div>
+</div>
+<script>
+document.body.offsetTop;
+var rootElement = document.getElementById("root");
+var content = document.getElementById("content");
+content.innerText = "";
+rootElement.style.width = "400px";
+checkLayout("#content");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt
@@ -1,19 +1,19 @@
 
 FAIL Basic usage assert_equals: Sizing normally - clientWidth expected 100 but got 1
-FAIL Last remembered size can be 0 assert_equals: Using last remembered size - clientHeight expected 0 but got 2
-FAIL Last remembered size can be set to 0 after losing display:none assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Last remembered size is logical assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Last remembered size survives box destruction assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Last remembered size survives display type changes assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Losing cis:auto removes last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Losing cis:auto removes last remembered size even if size doesn't change assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Losing cis:auto removes last remembered size immediately assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Losing cis:auto during display:none doesn't remove last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Lack of cis:auto during box creation removes last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Last remembered size can be removed synchronously assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Disconnected element can briefly keep last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 0
-FAIL Disconnected element ends up losing last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 0
+FAIL Last remembered size can be 0 assert_equals: Using last remembered size - clientWidth expected 0 but got 1
+FAIL Last remembered size can be set to 0 after losing display:none assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Last remembered size is logical assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Last remembered size survives box destruction assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Last remembered size survives display type changes assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Losing cis:auto removes last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Losing cis:auto removes last remembered size even if size doesn't change assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Losing cis:auto removes last remembered size immediately assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Losing cis:auto during display:none doesn't remove last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Lack of cis:auto during box creation removes last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Last remembered size can be removed synchronously assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Disconnected element can briefly keep last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
+FAIL Disconnected element ends up losing last remembered size assert_equals: Sizing normally - clientWidth expected 100 but got 1
 PASS Disconnected element ends up losing last remembered size even if size was 0x0
 FAIL Last remembered size survives becoming inline assert_equals: Still using previous last remembered size - clientWidth expected 100 but got 1
-FAIL Last remembered size can be set to 0x0 after losing display:inline assert_equals: Last remembered size is now 0x0 - clientHeight expected 0 but got 2
+FAIL Last remembered size can be set to 0x0 after losing display:inline assert_equals: Last remembered size is now 0x0 - clientWidth expected 0 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Last remembered size supports multiple fragments assert_equals: Using last remembered size - fragment #1 height expected 150 but got 1
-FAIL Last remembered size is updated when 2nd fragment changes size assert_equals: Using updated last remembered size - fragment #1 height expected 175 but got 1
+FAIL Last remembered size supports multiple fragments assert_equals: Using last remembered size - fragment #1 width expected 50 but got 1
+FAIL Last remembered size is updated when 2nd fragment changes size assert_equals: Using updated last remembered size - fragment #1 width expected 50 but got 1
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2607,10 +2607,6 @@ void RenderBox::computeLogicalWidthInFragment(LogicalExtentComputedValues& compu
         return;
     }
 
-    // If layout is limited to a subtree, the subtree root's logical width does not change.
-    if (element() && !view().frameView().layoutContext().isLayoutPending() && view().frameView().layoutContext().subtreeLayoutRoot() == this)
-        return;
-
     // The parent box is flexing us, so it has increased or decreased our
     // width.  Use the width from the style context.
     // FIXME: Account for block-flow in flexible boxes.


### PR DESCRIPTION
#### 06fa3e82eb2e0267284e9c57342078a070e8016c
<pre>
Fix broken preferred widths optimization involving subtree layout roots

Fix broken preferred widths optimization involving subtree layout roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=247742">https://bugs.webkit.org/show_bug.cgi?id=247742</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/ed902d339fbff3a62e2f6124d8d40bbad45e97c0">https://chromium.googlesource.com/chromium/blink/+/ed902d339fbff3a62e2f6124d8d40bbad45e97c0</a>

This patch is to remove optimization or fix introduced in 2006, which is about RenderBox::computePreferredLogicalWidths
to bail when in a subtree layout.
This can result in a box not updating its preferred widths even when it
should in the case that its a subtree layout root that was marked for layout
of its children, then subsequently marked for layout itself.

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox:computeLogicalWidthInFragment): Remove &quot;subtree&apos; layout optimization
* LayoutTests/fast/layout/nested-subtree-layout-preferred-widths.html: Added Test Case
* LayoutTests/fast/layout/nested-subtree-layout-preferred-widths-expected.html: Added Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-006-expected.txt: Updated Test Expectations
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-010-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/256623@main">https://commits.webkit.org/256623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d9436db7323711781a3adf6e4bc71b25db46599

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105885 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166229 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5747 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34342 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102615 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4267 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82940 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31271 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74133 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40074 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19516 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20892 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4594 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1517 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43468 "Found 1 new test failure: imported/w3c/web-platform-tests/workers/constructors/Worker/Worker-constructor.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40160 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->