### PR TITLE
Refactor the code that handles selector specificity for simplicity and remove unused functions

### DIFF
--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1236,12 +1236,12 @@ static Ref<Protocol::CSS::CSSSelector> buildObjectForSelectorHelper(const String
         .setText(selectorText)
         .release();
 
-    auto specificity = selector.computeSpecificity();
+    auto specificity = selector.computeSpecificityTuple();
 
     auto tuple = JSON::ArrayOf<int>::create();
-    tuple->addItem(static_cast<int>((specificity & CSSSelector::idMask) >> 16));
-    tuple->addItem(static_cast<int>((specificity & CSSSelector::classMask) >> 8));
-    tuple->addItem(static_cast<int>(specificity & CSSSelector::elementMask));
+    tuple->addItem(specificity[0]);
+    tuple->addItem(specificity[1]);
+    tuple->addItem(specificity[2]);
     inspectorSelector->setSpecificity(WTFMove(tuple));
 
     return inspectorSelector;


### PR DESCRIPTION
#### 9adcbe8f12b9c117447569ca9d6e1cc28d934ae8
<pre>
Refactor the code that handles selector specificity for simplicity and remove unused functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247851">https://bugs.webkit.org/show_bug.cgi?id=247851</a>
rdar://problem/102281644

Reviewed by Sam Weinig.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::CSSSelector): Removed the m_ prefixes from struct members.
(WebCore::CSSSelector::createRareData): Get rid of the local AtomString here. Clearer without.
(WebCore::SelectorSpecificity): Added a struct to wrap a selector specificity value, so we can
convert from the enum without a static_cast and use the + and += operators for saturating
addition of each channel in parallel.
(WebCore::SelectorSpecificity::operator+=): Implemented. Replaces addSpecificities.
(WebCore::operator+): Implemented by calling +=.
(WebCore::selectorSpecificity): Use SelectorSpecificity.
(WebCore::maxSpecificity): Ditto. Also changed to take a pointer and check for null since that
simplifies the code below.
(WebCore::simpleSelectorSpecificity): Renamed from simpleSelectorSpecificityInternal and changed
the return value to SelectorSpecificity. Removed now-unneeded static_cast and use + instead of
CSSSelector::addSpecificities.
(WebCore::CSSSelector::simpleSelectorSpecificity const): Deleted.
(WebCore::CSSSelector::computeSpecificity const): Updated for SelectorSpecificity.
(WebCore::CSSSelector::computeSpecificityTuple const): Added. This is for the inspector code
that wants the three different components of specifity as separate integers.
(WebCore::CSSSelector::addSpecificities): Deleted.
(WebCore::appendPseudoClassFunctionTail): Removed the m_ prefixes from struct members.
(WebCore::CSSSelector::setAttribute): Ditto.
(WebCore::CSSSelector::setArgument): Ditto.
(WebCore::CSSSelector::setArgumentList): Ditto.
(WebCore::CSSSelector::setSelectorList): Ditto.
(WebCore::CSSSelector::setNth): Ditto.
(WebCore::CSSSelector::matchNth const): Ditto.
(WebCore::CSSSelector::nthA const): Ditto.
(WebCore::CSSSelector::nthB const): Ditto.
(WebCore::CSSSelector::RareData::RareData): Use WTFMove to eliminate a bit of reference count
churn. Moved more initialization to the class definition.
(WebCore::CSSSelector::RareData::create): Moved here from the header, since this is only called
from inside this file. Changed argument type to just AtomString, which is still compatible with
moving new values in and more straightforward.
(WebCore::CSSSelector::RareData::matchNth): Removed the m_ prefixes from struct members.

* Source/WebCore/css/CSSSelector.h: Removed idMask, classMask, simpleSelectorSpecificity, and
addSpecificities, none of which are needed outside the class. Added computeSpecificityTuple
for use by the inspector. Changed struct members to not use the m_ syntax; we do that for
private class members, not struct members. Updated the RareData::create function and initialized
a, and b in RareData.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::buildObjectForSelectorHelper): Use computeSpecificityTuple.

Canonical link: <a href="https://commits.webkit.org/256769@main">https://commits.webkit.org/256769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc76c6cdcc1c024a56c9af92d1eaff2f72e68ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105863 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166205 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5717 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34320 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88701 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102593 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4241 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82917 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31253 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74106 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40052 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37728 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20866 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43451 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40134 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->