### PR TITLE
MouseClick offsetX/offsetY different between Safari 15.5 and Safari 16

### DIFF
--- a/LayoutTests/fast/svg/foreign-object-offset-position-expected.txt
+++ b/LayoutTests/fast/svg/foreign-object-offset-position-expected.txt
@@ -1,0 +1,6 @@
+PASS event.offsetX is 10
+PASS event.offsetY is 10
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/svg/foreign-object-offset-position.html
+++ b/LayoutTests/fast/svg/foreign-object-offset-position.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0;">
+  <script src="../../resources/js-test-pre.js"></script>
+  <script src="../../resources/ui-helper.js"></script>
+  <script type="text/javascript">
+    function runTest() {
+      window.jsTestIsAsync = true;
+
+      setTimeout(() => {
+        UIHelper.activateAt(110, 110);
+      }, 0);
+    }
+
+    runTest();
+  </script>
+  <svg style="width: 200px; height: 200px;" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+    <polygon points="5,5 195,10 185,185 10,195" />
+
+    <foreignObject x="100" y="100" width="160" height="160">
+      <div id="target" style="background-color: blue; width: 20px; height: 20px" xmlns="http://www.w3.org/1999/xhtml">
+      </div>
+
+      <script type="text/javascript">
+        document.getElementById('target').addEventListener('click', (event) => {
+          shouldBe("event.offsetX", "10");
+          shouldBe("event.offsetY", "10");
+          finishJSTest();
+        })
+      </script>
+    </foreignObject>
+  </svg>
+  <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGForeignObject.cpp
@@ -183,4 +183,15 @@ bool LegacyRenderSVGForeignObject::nodeAtFloatPoint(const HitTestRequest& reques
         || RenderBlock::nodeAtPoint(request, result, hitTestLocation, LayoutPoint(), HitTestChildBlockBackgrounds);
 }
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+LayoutSize LegacyRenderSVGForeignObject::offsetFromContainer(RenderElement& container, const LayoutPoint&, bool*) const
+{
+    ASSERT_UNUSED(container, &container == this->container());
+    ASSERT(!isInFlowPositioned());
+    ASSERT(!isAbsolutelyPositioned());
+    ASSERT(!isInline());
+    return locationOffset();
+}
+#endif
+
 }

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGForeignObject.h
@@ -61,6 +61,10 @@ private:
     const AffineTransform& localToParentTransform() const override;
     AffineTransform localTransform() const override { return m_localTransform; }
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    LayoutSize offsetFromContainer(RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;
+#endif
+
     AffineTransform m_localTransform;
     mutable AffineTransform m_localToParentTransform;
     FloatRect m_viewport;


### PR DESCRIPTION
#### d5fba35fb6c5b86be5e46c41f7bd33df4a019745
<pre>
MouseClick offsetX/offsetY different between Safari 15.5 and Safari 16
<a href="https://bugs.webkit.org/show_bug.cgi?id=247829">https://bugs.webkit.org/show_bug.cgi?id=247829</a>
rdar://100517677

Reviewed by Simon Fraser.

When a foreign object is inside an SVG, any click event that occurs on the
object has it&apos;s offsetX and offsetY relative to the SVG container rather than
the element, which is incorrect behavior.

This is a regression from <a href="https://bugs.webkit.org/show_bug.cgi?id=234524">https://bugs.webkit.org/show_bug.cgi?id=234524</a>,
which overrode `offsetFromContainer` in `RenderSVGBlock`, causing the `RenderSVGForeignObject`
to use this override and return an offset of `(0, 0)` instead of its proper offset.
This value was then propogated within the calculation of the event&apos;s offset.

This PR fixes this by creating an override of `offsetFromContainer` in `RenderSVGForeignObject`,
which returns the correct offset of the foreign object, and so the event&apos;s
offset location is now relative to the foreign object.

* LayoutTests/fast/svg/foreign-object-offset-position-expected.txt: Added.
* LayoutTests/fast/svg/foreign-object-offset-position.html: Added.
* Source/WebCore/rendering/svg/LegacyRenderSVGForeignObject.cpp:
(WebCore::LegacyRenderSVGForeignObject::offsetFromContainer const):
* Source/WebCore/rendering/svg/LegacyRenderSVGForeignObject.h:

Canonical link: <a href="https://commits.webkit.org/256679@main">https://commits.webkit.org/256679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fa267b0d3ae817e24582f2ba0933a6d9d831feb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105864 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166206 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5719 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34321 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102594 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/101993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4244 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82918 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31254 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/87989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74108 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40053 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20868 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4632 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43452 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40136 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->