### PR TITLE
Fix form association behavior when a form and a control with form= are removed from a document together

### DIFF
--- a/LayoutTests/fast/forms/form-associated-element-removal-with-form-attribute-expected.txt
+++ b/LayoutTests/fast/forms/form-associated-element-removal-with-form-attribute-expected.txt
@@ -1,0 +1,12 @@
+This tests removing an input element with form content attribute from the document.
+The input element should be dissociated from the form element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.form is null
+PASS form.elements.length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/form-associated-element-removal-with-form-attribute.html
+++ b/LayoutTests/fast/forms/form-associated-element-removal-with-form-attribute.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<body>
+<div><input form="formOwner"><form id="formOwner"></form></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+description(`This tests removing an input element with form content attribute from the document.<br>
+The input element should be dissociated from the form element.`);
+owner = document.getElementById('owner');
+input = document.querySelector('input');
+form = document.querySelector('form');
+input.parentNode.remove();
+shouldBeNull('input.form');
+shouldBe('form.elements.length', '0');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/form-control-form-attribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/form-control-form-attribute-expected.txt
@@ -2,6 +2,6 @@ form
 
 
 PASS Form control's form attribute should point to the form element.
-FAIL Shadow form control's form attribute should work also in shadow DOM. assert_equals: expected null but got Element node <form id="form">form</form>
+PASS Shadow form control's form attribute should work also in shadow DOM.
 PASS Form element as form control's ancestor should work also in shadow DOM.
 

--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -89,15 +89,19 @@ void FormAssociatedElement::insertedIntoAncestor(Node::InsertionType insertionTy
         resetFormAttributeTargetObserver();
 }
 
-void FormAssociatedElement::removedFromAncestor(Node::RemovalType, ContainerNode&)
+void FormAssociatedElement::removedFromAncestor(Node::RemovalType removalType, ContainerNode&)
 {
+    auto& element = asHTMLElement();
     m_formAttributeTargetObserver = nullptr;
 
     // If the form and element are both in the same tree, preserve the connection to the form.
     // Otherwise, null out our form and remove ourselves from the form's list of elements.
     // Do not rely on rootNode() because our IsInTreeScope is outdated.
-    if (m_form && &asHTMLElement().traverseToRootNode() != &m_form->traverseToRootNode())
+    if ((m_form && &element.traverseToRootNode() != &m_form->traverseToRootNode())
+        || (removalType.disconnectedFromDocument && element.hasAttributeWithoutSynchronization(formAttr))) {
         setForm(nullptr);
+        resetFormOwner();
+    }
 }
 
 HTMLFormElement* FormAssociatedElement::findAssociatedForm(const HTMLElement* element, HTMLFormElement* currentAssociatedForm)


### PR DESCRIPTION
#### d16d7ec796839625be5b5a686c5c82b55ba620b3
<pre>
Fix form association behavior when a form and a control with form= are removed from a document together
<a href="https://bugs.webkit.org/show_bug.cgi?id=247593">https://bugs.webkit.org/show_bug.cgi?id=247593</a>

Reviewed by Darin Adler.

Fix the bug that a form associated element with form content attribute were not disassociated from
its form owner if both elements are removed together in a same subtree.

New behavior matches the spec as well as behaviors of Chrome and Firefox:
<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-element-removing-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#html-element-removing-steps</a>
<a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#reset-the-form-owner">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#reset-the-form-owner</a>

* LayoutTests/fast/forms/form-associated-element-removal-with-form-attribute-expected.txt: Added.
* LayoutTests/fast/forms/form-associated-element-removal-with-form-attribute.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/form-control-form-attribute-expected.txt: Rebaselined.

* Source/WebCore/html/FormAssociatedElement.cpp:
(WebCore::FormAssociatedElement::removedFromAncestor):

Canonical link: <a href="https://commits.webkit.org/256620@main">https://commits.webkit.org/256620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca3d3a443946504be05ad307cdf96e2868baedbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105879 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166222 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5738 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34336 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102609 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4258 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82934 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31265 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74123 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40068 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19508 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20884 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43462 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40152 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->