### PR TITLE
Fix order between initializing x and this.x in strict mode

### DIFF
--- a/JSTests/stress/put-to-scope-reference-error.js
+++ b/JSTests/stress/put-to-scope-reference-error.js
@@ -1,0 +1,50 @@
+function shouldThrow(test, func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error(`test ${test} not thrown`);
+    if (String(error) !== errorMessage)
+        throw new Error(`test ${test} bad error: ${String(error)}`);
+}
+
+function shouldNotThrow(func) {
+    func();
+}
+
+shouldThrow(1, () => {
+    "use strict";
+    a = this.a = 0;
+}, "ReferenceError: Can't find variable: a");
+
+shouldThrow(2, () => {
+    "use strict";
+    this.b = 0;
+    b = 0;
+}, "ReferenceError: Can't find variable: b");
+
+shouldThrow(3, () => {
+    "use strict";
+    eval(`
+        let c = 0;
+    `);
+    c = 0;
+}, "ReferenceError: Can't find variable: c");
+
+shouldNotThrow(() => {
+    eval(`
+        let d = 0;
+    `);
+    d = 0;
+});
+
+shouldNotThrow(() => {
+    "use strict";
+    let e = 0;
+    e = 0;
+});

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2243,6 +2243,12 @@ LLINT_SLOW_PATH_DECL(slow_path_put_to_scope)
 
     if (metadata.m_getPutInfo.resolveMode() == ThrowIfNotFound && !hasProperty)
         LLINT_THROW(createUndefinedVariableError(globalObject, ident));
+    
+    // https://tc39.es/ecma262/2022/multipage/ecmascript-data-types-and-values.html#sec-putvalue
+    // 4. If IsUnresolvableReference(V) is true, then
+    //      a. If V.[[Strict]] is true, throw a ReferenceError exception.
+    if (metadata.m_getPutInfo.ecmaMode().isStrict() && metadata.m_getPutInfo.resolveType() == UnresolvedProperty && !scope->isGlobalLexicalEnvironment())
+        LLINT_THROW(createUndefinedVariableError(globalObject, ident));
 
     PutPropertySlot slot(scope, metadata.m_getPutInfo.ecmaMode().isStrict(), PutPropertySlot::UnknownContext, isInitialization(metadata.m_getPutInfo.initializationMode()));
     scope->methodTable()->put(scope, globalObject, ident, value, slot);


### PR DESCRIPTION
#### 6b1504abf694f20c9169373c8d95cad0dd4c6e7a
<pre>
Fix order between initializing x and this.x in strict mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=247493">https://bugs.webkit.org/show_bug.cgi?id=247493</a>
rdar://102064848

Reviewed by NOBODY (OOPS!).

Given following JavaScript program:
```
&quot;use strict&quot;;
x = this.x = 0;
```

It should throw ReferenceError since

<a href="https://tc39.es/ecma262/2022/multipage/ecmascript-language-expressions.html#sec-assignment-operators-runtime-semantics-evaluation">https://tc39.es/ecma262/2022/multipage/ecmascript-language-expressions.html#sec-assignment-operators-runtime-semantics-evaluation</a>
```
AssignmentExpression : LeftHandSideExpression = AssignmentExpression
1. If LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral, then
    ...
    e. Perform ? PutValue(lref, rval).
```

and

<a href="https://tc39.es/ecma262/2022/multipage/ecmascript-data-types-and-values.html#sec-putvalue">https://tc39.es/ecma262/2022/multipage/ecmascript-data-types-and-values.html#sec-putvalue</a>
```
4. If IsUnresolvableReference(V) is true, then
    a. If V.[[Strict]] is true, throw a ReferenceError exception
```

* JSTests/stress/put-to-scope-reference-error.js: Added.
(shouldThrow):
(shouldNotThrow):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b1504abf694f20c9169373c8d95cad0dd4c6e7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105880 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166224 "Found 1 new test failure: js/mozilla/eval/exhaustive-global-strictcaller-indirect-normalcode.html (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5739 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34337 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102610 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102009 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4261 "Found 4 new test failures: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html, imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/message-module-DOMException.html, js/mozilla/eval/exhaustive-global-strictcaller-indirect-normalcode.html, webgl/2.0.y/conformance2/state/gl-object-get-calls.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82935 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31266 "Found 3 new test failures: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html, imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/message-module-DOMException.html, js/mozilla/eval/exhaustive-global-strictcaller-indirect-normalcode.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74126 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87327 "Found 1 new JSC stress test failure: stress/put-to-scope-reference-error.js.no-llint (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40069 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19510 "Found 3 new test failures: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html, imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/message-module-DOMException.html, js/mozilla/eval/exhaustive-global-strictcaller-indirect-normalcode.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82718 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37745 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20886 "Found 4 new test failures: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html, imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/message-module-DOMException.html, js/mozilla/eval/exhaustive-global-strictcaller-indirect-normalcode.html, webgl/2.0.y/conformance2/state/gl-object-get-calls.html (failure)") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28287 "Found 2 new JSC stress test failures: stress/put-to-scope-reference-error.js.bytecode-cache, stress/put-to-scope-reference-error.js.no-llint (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1490 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43463 "Found 4 new test failures: imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html, imported/w3c/web-platform-tests/workers/interfaces/WorkerGlobalScope/onerror/message-module-DOMException.html, js/mozilla/eval/exhaustive-global-strictcaller-indirect-normalcode.html, webgl/2.0.y/conformance2/state/gl-object-get-calls.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85397 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40154 "Passed tests") | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19259 "Found 2 new JSC stress test failures: stress/put-to-scope-reference-error.js.bytecode-cache, stress/put-to-scope-reference-error.js.no-llint (failure)") | 
<!--EWS-Status-Bubble-End-->