### PR TITLE
Simplified BoxPainter edge adjacency test

### DIFF
--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -76,10 +76,8 @@ inline bool includesEdge(OptionSet<BoxSideFlag> flags, BoxSide side) { return fl
 
 inline bool includesAdjacentEdges(OptionSet<BoxSideFlag> flags)
 {
-    return flags.containsAll({ BoxSideFlag::Top, BoxSideFlag::Right })
-        || flags.containsAll({ BoxSideFlag::Right, BoxSideFlag::Bottom })
-        || flags.containsAll({ BoxSideFlag::Bottom, BoxSideFlag::Left })
-        || flags.containsAll({ BoxSideFlag::Left, BoxSideFlag::Top });
-}
+    // The set includes adjacent edges if and only if it contains at least one horizontal and one vertical edge.
+    return flags.containsAll({ BoxSideFlag::Top, BoxSideFlag::Bottom })
+        && flags.containsAll({ BoxSideFlag::Left, BoxSideFlag::Right });
 
 } // namespace WebCore


### PR DESCRIPTION
<pre>
Simplified BoxPainter edge adjacency test
<a href="https://bugs.webkit.org/show_bug.cgi?id=247856">https://bugs.webkit.org/show_bug.cgi?id=247856</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/45cd7b0546450187bb5f781d47778b739911341f">https://chromium.googlesource.com/chromium/blink/+/45cd7b0546450187bb5f781d47778b739911341f</a>

This patch is to simplify the "BorderEdge" adjacency test to reflect on the condition that
adjacent edge only exist if has at least one horizontal and vertical edge.

* Source/WebCore/rendering/BorderEdge.h: Refactor "includesEdge" to simpler form and add comment

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b003154c88f91af797efd0d3a776424b11f2ab7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96347 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5601 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29407 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105889 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166233 "Hash 1b003154 for PR 6442 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100329 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5752 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34346 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88727 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102619 "Hash 1b003154 for PR 6442 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102018 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/5752 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82945 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/88727 "Hash 1b003154 for PR 6442 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/5752 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/29407 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/88727 "Hash 1b003154 for PR 6442 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40078 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/29407 "Hash 1b003154 for PR 6442 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37754 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/29407 "Hash 1b003154 for PR 6442 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1536 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/82945 "Hash 1b003154 for PR 6442 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/283 "Hash 1b003154 for PR 6442 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/29407 "Hash 1b003154 for PR 6442 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->