### PR TITLE
Add floats to overflow of the direct containing block only

### DIFF
--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2141,7 +2141,7 @@ void RenderBlockFlow::addOverflowFromFloats()
     auto end = floatingObjectSet.end();
     for (auto it = floatingObjectSet.begin(); it != end; ++it) {
         const auto& floatingObject = *it->get();
-        if (floatingObject.isDescendant())
+        if (floatingObject.shouldPaint())
             addOverflowFromChild(&floatingObject.renderer(), floatingObject.locationOffsetOfBorderBox());
     }
 }


### PR DESCRIPTION
<pre>
Add floats to overflow of the direct containing block only
<a href="https://bugs.webkit.org/show_bug.cgi?id=247859">https://bugs.webkit.org/show_bug.cgi?id=247859</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=199543">https://src.chromium.org/viewvc/blink?view=revision&revision=199543</a>

As overflow will propagate up to ancestors, we only need to add floats
to overflow of the direct containing block only.

About layout tests - there will be expectation changes because we don't propagate
visual overflow across composited layer boundaries. Previously the
floats are added into visual overflow of grandparent which is not in
the same composited layer. This was unnecessary.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::addOverflowFromFloats): change logic of overflow from "isDescendant" to "shouldPaint"
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8af0022d9ebf02c212bd25b6b5165985275c2132

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105890 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166234 "Found 2 new test failures: fast/box-shadow/box-shadow-huge-area-crash.html, fast/multicol/transform-inside-opacity.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5754 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34347 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102620 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102019 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4275 "Found 1 new test failure: fast/multicol/transform-inside-opacity.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82946 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31275 "Found 1 new test failure: fast/multicol/transform-inside-opacity.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74141 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40079 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19518 "Found 2 new test failures: fast/box-shadow/box-shadow-huge-area-crash.html, fast/multicol/transform-inside-opacity.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37755 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20898 "Found 3 new test failures: fast/box-shadow/box-shadow-huge-area-crash.html, fast/multicol/transform-inside-opacity.html, tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43471 "Found 3 new test failures: fast/box-shadow/box-shadow-huge-area-crash.html, fast/multicol/transform-inside-opacity.html, tiled-drawing/scrolling/scroll-snap/scroll-snap-proximity-mainframe.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40166 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->