### PR TITLE
Simplify includesAdjacentEdges in BorderEdge.h

### DIFF
--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -76,10 +76,9 @@ inline bool includesEdge(OptionSet<BoxSideFlag> flags, BoxSide side) { return fl
 
 inline bool includesAdjacentEdges(OptionSet<BoxSideFlag> flags)
 {
-    return flags.containsAll({ BoxSideFlag::Top, BoxSideFlag::Right })
-        || flags.containsAll({ BoxSideFlag::Right, BoxSideFlag::Bottom })
-        || flags.containsAll({ BoxSideFlag::Bottom, BoxSideFlag::Left })
-        || flags.containsAll({ BoxSideFlag::Left, BoxSideFlag::Top });
+    // The set includes adjacent edges if and only if it contains at least one horizontal and one vertical edge.
+    return flags.containsAny({ BoxSideFlag::Top, BoxSideFlag::Bottom })
+        && flags.containsAny({ BoxSideFlag::Left, BoxSideFlag::Right });
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### cf6c7427c39149e47f26278d01d90fc8d70e159c
<pre>
Simplify includesAdjacentEdges in BorderEdge.h

Simplify includesAdjacentEdges in BorderEdge.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=247856">https://bugs.webkit.org/show_bug.cgi?id=247856</a>

Reviewed by Tim Nguyen.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/45cd7b0546450187bb5f781d47778b739911341f">https://chromium.googlesource.com/chromium/blink/+/45cd7b0546450187bb5f781d47778b739911341f</a>

This patch is to simplify the &quot;BorderEdge&quot; adjacency test to reflect on the condition that
adjacent edge only exist if has at least one horizontal and vertical edge.

* Source/WebCore/rendering/BorderEdge.h: Refactor &quot;includesEdge&quot; to simpler form and add comment

Co-Authored-By: Tim Nguyen &lt;nt1m@users.noreply.github.com&gt;

Canonical link: <a href="https://commits.webkit.org/256631@main">https://commits.webkit.org/256631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9a08abe59da9aed9806b787bf10b88397ef08b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105897 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166241 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5770 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34355 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102627 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4289 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82955 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31282 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88025 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74158 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40086 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19521 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37762 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20904 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute-redirect-on-load.https.sub.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/1640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43480 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2198 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40172 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->