### PR TITLE
Form-association for <img> is inconsistent

### DIFF
--- a/LayoutTests/fast/forms/image/image-named-access-expected.txt
+++ b/LayoutTests/fast/forms/image/image-named-access-expected.txt
@@ -1,0 +1,12 @@
+This tests removing an image element with a form element ancestor during parsing
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS form["img1"] is img1
+PASS form["img2"] is img2
+PASS form["img3"] is undefined.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/image/image-named-access.html
+++ b/LayoutTests/fast/forms/image/image-named-access.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<body>
+<div id="willBeRemoved">
+    <div>
+        <form id="form">
+        <img id="img1">
+    </div>
+    <img id="img2">
+</div>
+<img id="img3">
+<script src="../../../resources/js-test.js"></script>
+<script>
+description('This tests removing an image element with a form element ancestor during parsing');
+const form = document.getElementById('form');
+const img1 = document.getElementById('img1');
+const img2 = document.getElementById('img2');
+const img3 = document.getElementById('img3');
+const willBeRemoved = document.getElementById('willBeRemoved');
+willBeRemoved.remove();
+shouldBe('form["img1"]', 'img1');
+shouldBe('form["img2"]', 'img2');
+shouldBeUndefined('form["img3"]');
+</script>

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -174,6 +174,11 @@ void HTMLFormElement::removedFromAncestor(RemovalType removalType, ContainerNode
     auto associatedElements = copyAssociatedElementsVector();
     for (auto& associatedElement : associatedElements)
         associatedElement->formOwnerRemovedFromTree(root);
+    auto imageElements = WTF::compactMap(m_imageElements, [](auto& weakPtr) {
+        return RefPtr { weakPtr.get() };
+    });
+    for (auto& imageElement : imageElements)
+        imageElement->formOwnerRemovedFromTree(root);
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 }
 

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -56,6 +56,8 @@ public:
 
     virtual ~HTMLImageElement();
 
+    void formOwnerRemovedFromTree(const Node& formRoot);
+
     WEBCORE_EXPORT unsigned width(bool ignorePendingStylesheets = false);
     WEBCORE_EXPORT unsigned height(bool ignorePendingStylesheets = false);
 
@@ -165,6 +167,9 @@ protected:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 
 private:
+    HTMLFormElement* form() const final;
+    void setForm(HTMLFormElement*);
+
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void parseAttribute(const QualifiedName&, const AtomString&) override;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;


### PR DESCRIPTION
#### 36537bb39ed82312d1d971018950910fac8b8b6a
<pre>
Form-association for &lt;img&gt; is inconsistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=129742">https://bugs.webkit.org/show_bug.cgi?id=129742</a>

Reviewed by Darin Adler.

This patch updates the way HTMLImageElement associates itself with HTMLFormElement to be more consistent
with FormAssociatedElement. New behavior matches that of Gecko and Blink.

* LayoutTests/fast/forms/image/image-named-access-expected.txt: Added.
* LayoutTests/fast/forms/image/image-named-access.html: Added.

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::removedFromAncestor):

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::~HTMLImageElement):
(WebCore::HTMLImageElement::form const): Added. Returns m_form instead of returning the form ancestor.
(WebCore::HTMLImageElement::setForm): Extracted from insertedIntoAncestor. Automatically calls
removeImgElement and registerImgElement.
(WebCore::HTMLImageElement::formOwnerRemovedFromTree): Added. Clear m_form when the associated form element
is no longer in the same subtree as this element.
(WebCore::HTMLImageElement::insertedIntoAncestor): Don&apos;t associate this element with a from element set by
the parser if the form had been disconnected like FormAssociatedElement.
(WebCore::HTMLImageElement::removedFromAncestor): Don&apos;t remove this element from the form element if
the root node didn&apos;t change like FormAssociatedElement.

* Source/WebCore/html/HTMLImageElement.h:

Canonical link: <a href="https://commits.webkit.org/256629@main">https://commits.webkit.org/256629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7507c350352610d4da197f1e958274e45dbadc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105912 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166256 "Found 3 new test failures: fast/dom/tab-in-right-alignment.html, js/dfg-uint32array.html, js/dom/Promise-reject-large-string.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5788 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34369 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88750 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102640 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82970 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31294 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74173 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40101 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37775 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20917 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/2293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43491 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2197 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40186 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->