### PR TITLE
Resync web-platform-tests/user-activation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-crossorigin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-crossorigin.sub-expected.txt
@@ -12,7 +12,7 @@ PASS Child2 frame initial state
 PASS Grandchild frame initial state
 PASS Parent frame initial state
 FAIL Child2 frame final state assert_false: expected false got true
-FAIL Child1 frame final state assert_false: expected false got true
+FAIL Child1 frame final state assert_false: Child1 frame isActive expected false got true
 PASS Grand child frame final state
 FAIL Parent frame final state assert_false: expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-crossorigin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-crossorigin.sub.html
@@ -44,6 +44,10 @@
     }
 
     window.addEventListener("message", event => {
+
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {
@@ -65,8 +69,8 @@
             test_driver.click(document.getElementById("child-xo"));
         } else if (msg.type == 'child-one-report') {
             test(() => {
-                assert_false(msg.isActive);
-                assert_true(msg.hasBeenActive);
+                assert_false(msg.isActive, "Child1 frame isActive");
+                assert_true(msg.hasBeenActive, "Child1 frame hasBeenActive");
             }, "Child1 frame final state");
         } else if (msg.type == 'child-crossorigin-report') {
             // This msg was triggered by a user click followed by a window.open().
@@ -81,8 +85,8 @@
             frames[1].frames[0].postMessage(ask_report, "*");
         } else if (msg.type == 'child-two-report') {
             test(() => {
-                assert_false(msg.isActive);
-                assert_false(msg.hasBeenActive);
+                assert_false(msg.isActive, "isActive");
+                assert_false(msg.hasBeenActive, "hasBeenActive");
             }, "Grand child frame final state");
         }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-sameorigin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-sameorigin.html
@@ -41,6 +41,9 @@
     }
 
     window.addEventListener("message", async event => {
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-crossorigin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-crossorigin.sub.html
@@ -20,6 +20,9 @@
       var child = document.getElementById("child");
       child.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/html/user-activation/resources/child-one.html";
       window.addEventListener("message", t.step_func(event => {
+          // Test driver can send messages too...
+          if (typeof event.data !== "string") return;
+
           var msg = JSON.parse(event.data);
           if (msg.type == 'child-one-loaded') {
               assert_false(navigator.userActivation.isActive);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html
@@ -1,49 +1,62 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
-  <script src="/resources/testdriver.js"></script>
-  <script src="/resources/testdriver-vendor.js"></script>
-</head>
-<body>
-  <h1>Post-navigation activation state in child</h1>
-  <p>Tests that navigating a same-origin child frame resets its activation states.</p>
-  <ol id="instructions">
-    <li>Click inside the yellow area.
-  </ol>
-  <iframe id="child" width="200" height="50">
-  </iframe>
-  <script>
-    async_test(function(t) {
-      var child = document.getElementById("child");
-      child.src = "resources/child-one.html";
-      window.addEventListener("message", t.step_func(async event => {
-          var msg = JSON.parse(event.data);
-          if (msg.type == 'child-one-loaded') {
-              assert_false(navigator.userActivation.isActive);
-              assert_false(navigator.userActivation.hasBeenActive);
-              assert_false(msg.isActive);
-              assert_false(msg.hasBeenActive);
+  <head>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+  </head>
+  <body>
+    <h1>Post-navigation activation state in child</h1>
+    <p>
+      Tests that navigating a same-origin child frame resets its activation
+      states.
+    </p>
+    <ol id="instructions">
+      <li>Click inside the yellow area.</li>
+    </ol>
 
-              await test_driver.click(child);
-          } else if (msg.type == 'child-one-clicked') {
-              assert_true(navigator.userActivation.isActive);
-              assert_true(navigator.userActivation.hasBeenActive);
-              assert_true(msg.isActive);
-              assert_true(msg.hasBeenActive);
+    <iframe id="child" width="200" height="50"> </iframe>
+    <script>
+      function message(type) {
+        return new Promise((resolve) => {
+          window.addEventListener("message", function listener(event) {
+            const data = JSON.parse(event.data);
+            if (data.type === type) {
+              window.removeEventListener("message", listener);
+              resolve(data);
+            }
+          });
+        });
+      }
+      promise_test(async (t) => {
+        var child = document.getElementById("child");
+        child.src = "./resources/child-one.html";
+        const unclickeData = await message("child-one-loaded");
+        assert_false(navigator.userActivation.isActive);
+        assert_false(navigator.userActivation.hasBeenActive);
+        assert_false(unclickeData.isActive);
+        assert_false(unclickeData.hasBeenActive);
 
-              child.src = "resources/child-two.html";
-          } else if (msg.type == 'child-two-loaded') {
-              assert_true(navigator.userActivation.isActive);
-              assert_true(navigator.userActivation.hasBeenActive);
-              assert_false(msg.isActive);
-              assert_false(msg.hasBeenActive);
+        const [, child1Data] = await Promise.all([
+          test_driver.click(child),
+          message("child-one-clicked"),
+        ]);
 
-              t.done();
-          }
-      }));
-    }, "Post-navigation state reset.");
-  </script>
-</body>
+        assert_true(navigator.userActivation.isActive);
+        assert_true(navigator.userActivation.hasBeenActive);
+        assert_true(child1Data.isActive);
+        assert_true(child1Data.hasBeenActive);
+
+        child.src = "./resources/child-two.html";
+
+        const child2Data = await message("child-two-loaded");
+
+        assert_true(navigator.userActivation.isActive);
+        assert_true(navigator.userActivation.hasBeenActive);
+        assert_false(child2Data.isActive);
+        assert_false(child2Data.hasBeenActive);
+      }, "Post-navigation state reset.");
+    </script>
+  </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/propagation-crossorigin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/propagation-crossorigin.sub.html
@@ -43,6 +43,9 @@
     }
 
     window.addEventListener("message", event => {
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/propagation-sameorigin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/user-activation/propagation-sameorigin.html
@@ -41,6 +41,9 @@
     }
 
     window.addEventListener("message", event => {
+        // Test driver can send messages too...
+        if (typeof event.data !== "string") return;
+
         var msg = JSON.parse(event.data);
 
         if (msg.type == 'child-one-loaded') {


### PR DESCRIPTION
#### 9d1963f6290eaa2d4dec8e542039ca60b78d0ad2
<pre>
Resync web-platform-tests/user-activation
<a href="https://bugs.webkit.org/show_bug.cgi?id=247871">https://bugs.webkit.org/show_bug.cgi?id=247871</a>
rdar://102299880

Syncs to c82e314 on WPT.

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-crossorigin.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-crossorigin.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/consumption-sameorigin.html:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-crossorigin.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/navigation-state-reset-sameorigin.html:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/propagation-crossorigin.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/html/user-activation/propagation-sameorigin.html:

Canonical link: <a href="https://commits.webkit.org/256676@main">https://commits.webkit.org/256676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/259df2698e97b1ff7f16afbe9086a975ddf91e3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105926 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166270 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5804 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34383 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88762 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102652 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4316 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/82983 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31303 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40113 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19544 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20931 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/2905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43501 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40200 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->