### PR TITLE
[WPE][GTK] Fix several warnings when building for ARMv7 (32-bits)

### DIFF
--- a/PerformanceTests/MallocBench/MallocBench/stress_aligned.cpp
+++ b/PerformanceTests/MallocBench/MallocBench/stress_aligned.cpp
@@ -148,7 +148,7 @@ void benchmark_stress_aligned(CommandLine&)
     
     srandom(1); // For consistency between runs.
 
-    size_t limit = 0x00001ffffffffffful;
+    uint64_t limit = 0x00001ffffffffffful;
     
     for (size_t size = 0; size < limit; size = std::max(size, sizeof(void*)) * 2) {
         for (size_t alignment = sizeof(void*); alignment < limit; alignment *= 2) {

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -1372,7 +1372,7 @@ public:
             twoWordOp5i6Imm4Reg4EncodedImmSecond(right, lo16),
             twoWordOp5i6Imm4Reg4EncodedImmFirst(OP_MOVT, hi16),
             twoWordOp5i6Imm4Reg4EncodedImmSecond(right, hi16),
-            static_cast<uint16_t>(OP_CMP_reg_T2 | left)
+            static_cast<uint16_t>(static_cast<uint16_t>(OP_CMP_reg_T2) | static_cast<uint16_t>(left))
         };
         performJITMemcpy(address, instruction, sizeof(uint16_t) * 5);
         cacheFlush(address, sizeof(uint16_t) * 5);
@@ -3037,7 +3037,7 @@ private:
 
         ALWAYS_INLINE void twoWordOp12Reg4FourFours(OpcodeID1 op, RegisterID reg, FourFours ff)
         {
-            m_buffer.putShort(op | reg);
+            m_buffer.putShort(static_cast<uint16_t>(op) | static_cast<uint16_t>(reg));
             m_buffer.putShort(ff.m_u.value);
         }
         
@@ -3070,19 +3070,19 @@ private:
 
         ALWAYS_INLINE void twoWordOp12Reg4Reg4Imm12(OpcodeID1 op, RegisterID reg1, RegisterID reg2, uint16_t imm)
         {
-            m_buffer.putShort(op | reg1);
+            m_buffer.putShort(static_cast<uint16_t>(op) | static_cast<uint16_t>(reg1));
             m_buffer.putShort((reg2 << 12) | imm);
         }
 
         ALWAYS_INLINE void twoWordOp12Reg4Reg4Reg4Imm8(OpcodeID1 op, RegisterID reg1, RegisterID reg2, RegisterID reg3, uint8_t imm)
         {
-            m_buffer.putShort(op | reg1);
+            m_buffer.putShort(static_cast<uint16_t>(op) | static_cast<uint16_t>(reg1));
             m_buffer.putShort((reg2 << 12) | (reg3 << 8) | imm);
         }
 
         ALWAYS_INLINE void twoWordOp12Reg40Imm3Reg4Imm20Imm5(OpcodeID1 op, RegisterID reg1, RegisterID reg2, uint16_t imm1, uint16_t imm2, uint16_t imm3)
         {
-            m_buffer.putShort(op | reg1);
+            m_buffer.putShort(static_cast<uint16_t>(op) | static_cast<uint16_t>(reg1));
             m_buffer.putShort((imm1 << 12) | (reg2 << 8) | (imm2 << 6) | imm3);
         }
 

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -523,7 +523,7 @@ std::optional<unsigned> AccessibilityObjectAtspi::characterIndex(UChar character
     if (utf8Text.isNull())
         return std::nullopt;
 
-    auto length = g_utf8_strlen(utf8Text.data(), -1);
+    auto length = static_cast<unsigned>(g_utf8_strlen(utf8Text.data(), -1));
     if (offset >= length)
         return std::nullopt;
 
@@ -744,7 +744,7 @@ void AccessibilityObjectAtspi::selectionChanged(const VisibleSelection& selectio
     if (bounds.y() < 0)
         return;
 
-    auto length = g_utf8_strlen(utf8Text.data(), -1);
+    auto length = static_cast<unsigned>(g_utf8_strlen(utf8Text.data(), -1));
     auto mapping = offsetMapping(utf16Text);
     auto caretOffset = UTF16OffsetToUTF8(mapping, bounds.y());
     if (caretOffset <= length)

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp
@@ -140,12 +140,12 @@ bool FECompositeSoftwareApplier::applyArithmetic(FilterImage& input, FilterImage
     IntRect effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     input2.copyPixelBuffer(*destinationPixelBuffer, effectBDrawingRect);
 
+#if !HAVE(ARM_NEON_INTRINSICS)
     auto* sourcePixelBytes = sourcePixelBuffer->bytes();
     auto* destinationPixelBytes = destinationPixelBuffer->bytes();
 
     auto length = sourcePixelBuffer->sizeInBytes();
     ASSERT(length == destinationPixelBuffer->sizeInBytes());
-#if !HAVE(ARM_NEON_INTRINSICS)
     applyPlatformArithmetic(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
 #endif
     return true;

--- a/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h
@@ -28,6 +28,8 @@
 
 #include <sys/eventfd.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/text/CString.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebCore {
@@ -72,7 +74,8 @@ struct DMABufReleaseFlag {
             return;
 
         uint64_t value { 1 };
-        write(fd.value(), &value, sizeof(uint64_t));
+        if (write(fd.value(), &value, sizeof(value)) != sizeof(value))
+            WTFLogAlways("Error writing to the eventfd at DMABufReleaseFlag: %s", safeStrerror(errno).data());
     }
 
     UnixFileDescriptor fd;

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -142,6 +142,12 @@ if (COMPILER_IS_GCC_OR_CLANG)
                                          -Wno-misleading-indentation
                                          -Wno-psabi)
 
+    # GCC < 12.0 gives false warnings for mismatched-new-delete <https://webkit.org/b/241516>
+    if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0.0"))
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-mismatched-new-delete)
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-uninitialized)
+    endif ()
+
     WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-noexcept-type)
 
     # These GCC warnings produce too many false positives to be useful. We'll


### PR DESCRIPTION
#### 8e78751b47200105b5533f13fdf31339351c1b21
<pre>
[WPE][GTK] Fix several warnings when building for ARMv7 (32-bits)
<a href="https://bugs.webkit.org/show_bug.cgi?id=247873">https://bugs.webkit.org/show_bug.cgi?id=247873</a>

Reviewed by Michael Catanzaro.

This fixes several warnings that appear when building for ARMv7 (32-bits):
 - deprecated-enum-enum-conversion
 - unused-variable
 - unused-result
 - overflow
 - sign-compare

It also disables two warnings for old versions of GCC
(old versions give false positives).

* PerformanceTests/MallocBench/MallocBench/stress_aligned.cpp:
(benchmark_stress_aligned):
* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::revertJumpTo_movT3movtcmpT2):
(JSC::ARMv7Assembler::ARMInstructionFormatter::twoWordOp12Reg4FourFours):
(JSC::ARMv7Assembler::ARMInstructionFormatter::twoWordOp12Reg4Reg4Imm12):
(JSC::ARMv7Assembler::ARMInstructionFormatter::twoWordOp12Reg4Reg4Reg4Imm8):
(JSC::ARMv7Assembler::ARMInstructionFormatter::twoWordOp12Reg40Imm3Reg4Imm20Imm5):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::characterIndex const):
(WebCore::AccessibilityObjectAtspi::selectionChanged):
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareApplier.cpp:
(WebCore::FECompositeSoftwareApplier::applyArithmetic const):
* Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h:
(WebCore::DMABufReleaseFlag::release):
* Source/cmake/WebKitCompilerFlags.cmake:

Canonical link: <a href="https://commits.webkit.org/256792@main">https://commits.webkit.org/256792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f3083d6acb8de2d1d3ef02e2ae56d44f4874aa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106363 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166644 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6319 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34832 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103063 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102510 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83450 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31694 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88439 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87783 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/137 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83221 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/125 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21347 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4710 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85909 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40641 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19368 "Passed tests") | 
<!--EWS-Status-Bubble-End-->