### PR TITLE
Rename FormAssociatedElement to FormListedElement

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -891,7 +891,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/DataListSuggestionInformation.h
     html/EnterKeyHint.h
     html/FeaturePolicy.h
-    html/FormAssociatedElement.h
+    html/FormListedElement.h
     html/FormNamedItem.h
     html/HTMLAnchorElement.h
     html/HTMLAnchorElementInlines.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1250,8 +1250,8 @@ html/EnterKeyHint.cpp
 html/FTPDirectoryDocument.cpp
 html/FeaturePolicy.cpp
 html/FileInputType.cpp
-html/FormAssociatedElement.cpp
 html/FormController.cpp
+html/FormListedElement.cpp
 html/GenericCachedHTMLCollection.cpp
 html/HTMLAllCollection.cpp
 html/HTMLAnchorElement.cpp

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.h
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.h
@@ -26,7 +26,7 @@
 
 namespace WebCore {
 
-// FIXME: Delete this class after fixing FormAssociatedElement to avoid calling getElementById during a tree removal.
+// FIXME: Delete this class after fixing FormListedElement to avoid calling getElementById during a tree removal.
 #if ASSERT_ENABLED
 class ContainerChildRemovalScope {
 public:

--- a/Source/WebCore/dom/TreeScopeOrderedMap.cpp
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.cpp
@@ -125,7 +125,7 @@ inline Element* TreeScopeOrderedMap::get(const AtomStringImpl& key, const TreeSc
     }
 
 #if ASSERT_ENABLED
-    // FormAssociatedElement may call getElementById to find its owner form in the middle of a tree removal.
+    // FormListedElement may call getElementById to find its owner form in the middle of a tree removal.
     if (auto* currentScope = ContainerChildRemovalScope::currentScope()) {
         ASSERT(&scope.rootNode() == &currentScope->parentOfRemovedTree().rootNode());
         Node& removedTree = currentScope->removedChild();

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -189,8 +189,8 @@ static String formSignature(const HTMLFormElement& form)
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     unsigned count = 0;
     builder.append(" [");
-    for (auto& control : form.unsafeAssociatedElements()) {
-        auto element = control->asFormAssociatedElement();
+    for (auto& control : form.unsafeListedElements()) {
+        auto element = control->asFormListedElement();
         if (!is<HTMLFormControlElementWithState>(element))
             continue;
         Ref controlWithState = downcast<HTMLFormControlElementWithState>(*element);
@@ -345,7 +345,7 @@ void FormController::restoreControlStateFor(HTMLFormControlElementWithState& con
 
 void FormController::restoreControlStateIn(HTMLFormElement& form)
 {
-    for (auto& element : form.copyAssociatedElementsVector()) {
+    for (auto& element : form.copyListedElementsVector()) {
         if (!is<HTMLFormControlElementWithState>(element))
             continue;
         auto& control = downcast<HTMLFormControlElementWithState>(element.get());

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -38,14 +38,12 @@ class HTMLElement;
 class HTMLFormElement;
 class ValidityState;
 
-class FormAssociatedElement : public FormNamedItem {
-    WTF_MAKE_NONCOPYABLE(FormAssociatedElement);
+// https://html.spec.whatwg.org/multipage/forms.html#category-listed
+class FormListedElement : public FormNamedItem {
+    WTF_MAKE_NONCOPYABLE(FormListedElement);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    virtual ~FormAssociatedElement();
-
-    void ref() { refFormAssociatedElement(); }
-    void deref() { derefFormAssociatedElement(); }
+    virtual ~FormListedElement();
 
     static HTMLFormElement* findAssociatedForm(const HTMLElement*, HTMLFormElement*);
     WEBCORE_EXPORT HTMLFormElement* form() const;
@@ -91,7 +89,7 @@ public:
     void formAttributeTargetChanged();
 
 protected:
-    FormAssociatedElement(HTMLFormElement*);
+    FormListedElement(HTMLFormElement*);
 
     void insertedIntoAncestor(Node::InsertionType, ContainerNode&);
     void removedFromAncestor(Node::RemovalType, ContainerNode&);
@@ -112,12 +110,10 @@ protected:
 private:
     // "willValidate" means "is a candidate for constraint validation".
     virtual bool willValidate() const = 0;
-    virtual void refFormAssociatedElement() = 0;
-    virtual void derefFormAssociatedElement() = 0;
 
     void resetFormAttributeTargetObserver();
 
-    bool isFormAssociatedElement() const final { return true; }
+    bool isFormListedElement() const final { return true; }
 
     std::unique_ptr<FormAttributeTargetObserver> m_formAttributeTargetObserver;
     WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_form;

--- a/Source/WebCore/html/FormNamedItem.h
+++ b/Source/WebCore/html/FormNamedItem.h
@@ -24,12 +24,20 @@ namespace WebCore {
 
 class HTMLElement;
 
+// FIXME: Rename this to FormAssociatedElement
 class FormNamedItem {
 public:
+    void ref() { refFormAssociatedElement(); }
+    void deref() { derefFormAssociatedElement(); }
+
     virtual ~FormNamedItem() = default;
     virtual HTMLElement& asHTMLElement() = 0;
     virtual const HTMLElement& asHTMLElement() const = 0;
-    virtual bool isFormAssociatedElement() const = 0;
+    virtual bool isFormListedElement() const = 0;
+
+private:
+    virtual void refFormAssociatedElement() = 0;
+    virtual void derefFormAssociatedElement() = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -767,7 +767,7 @@ FormNamedItem* HTMLElement::asFormNamedItem()
     return nullptr;
 }
 
-FormAssociatedElement* HTMLElement::asFormAssociatedElement()
+FormListedElement* HTMLElement::asFormListedElement()
 {
     return nullptr;
 }

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 class ElementInternals;
-class FormAssociatedElement;
+class FormListedElement;
 class FormNamedItem;
 class HTMLFormElement;
 class VisibleSelection;
@@ -101,7 +101,7 @@ public:
 
     virtual bool isLabelable() const { return false; }
     virtual FormNamedItem* asFormNamedItem();
-    virtual FormAssociatedElement* asFormAssociatedElement();
+    virtual FormListedElement* asFormListedElement();
 
     virtual bool isInteractiveContent() const { return false; }
 

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-class FormAssociatedElement;
+class FormListedElement;
 class HTMLFormControlsCollection;
 
 class HTMLFieldSetElement final : public HTMLFormControlElement {

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -62,7 +62,7 @@ using namespace HTMLNames;
 
 HTMLFormControlElement::HTMLFormControlElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
     : LabelableElement(tagName, document)
-    , FormAssociatedElement(form)
+    , FormListedElement(form)
     , m_disabled(false)
     , m_hasReadOnlyAttribute(false)
     , m_isRequired(false)
@@ -222,7 +222,7 @@ void HTMLFormControlElement::didAttachRenderers()
 
 void HTMLFormControlElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
-    FormAssociatedElement::didMoveToNewDocument(oldDocument);
+    FormListedElement::didMoveToNewDocument(oldDocument);
     HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 
@@ -255,7 +255,7 @@ Node::InsertedIntoAncestorResult HTMLFormControlElement::insertedIntoAncestor(In
     if (document().hasDisabledFieldsetElement())
         setAncestorDisabled(computeIsDisabledByFieldsetAncestor());
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    FormAssociatedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    FormListedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
@@ -280,7 +280,7 @@ void HTMLFormControlElement::removedFromAncestor(RemovalType removalType, Contai
     }
 
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    FormAssociatedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    FormListedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 
     if (wasMatchingInvalidPseudoClass)
         removeInvalidElementToAncestorFromInsertionPoint(*this, &oldParentOfRemovedTree);
@@ -420,7 +420,7 @@ void HTMLFormControlElement::updateWillValidateAndValidity()
     if (!m_willValidate && !wasValid) {
         removeInvalidElementToAncestorFromInsertionPoint(*this, parentNode());
         if (RefPtr<HTMLFormElement> form = this->form())
-            form->removeInvalidAssociatedFormControlIfNeeded(*this);
+            form->removeInvalidFormControlIfNeeded(*this);
     }
 
     if (!m_willValidate)
@@ -520,18 +520,18 @@ inline bool HTMLFormControlElement::isValidFormControlElement() const
 void HTMLFormControlElement::willChangeForm()
 {
     if (HTMLFormElement* form = this->form())
-        form->removeInvalidAssociatedFormControlIfNeeded(*this);
-    FormAssociatedElement::willChangeForm();
+        form->removeInvalidFormControlIfNeeded(*this);
+    FormListedElement::willChangeForm();
 }
 
 void HTMLFormControlElement::didChangeForm()
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-    FormAssociatedElement::didChangeForm();
+    FormListedElement::didChangeForm();
     if (auto* form = this->form()) {
         if (m_willValidateInitialized && m_willValidate && !isValidFormControlElement())
-            form->registerInvalidAssociatedFormControl(*this);
+            form->addInvalidFormControl(*this);
     }
 }
 
@@ -552,13 +552,13 @@ void HTMLFormControlElement::updateValidity()
             if (!m_isValid) {
                 if (isConnected())
                     addInvalidElementToAncestorFromInsertionPoint(*this, parentNode());
-                if (HTMLFormElement* form = this->form())
-                    form->registerInvalidAssociatedFormControl(*this);
+                if (auto* form = this->form())
+                    form->addInvalidFormControl(*this);
             } else {
                 if (isConnected())
                     removeInvalidElementToAncestorFromInsertionPoint(*this, parentNode());
-                if (HTMLFormElement* form = this->form())
-                    form->removeInvalidAssociatedFormControlIfNeeded(*this);
+                if (auto* form = this->form())
+                    form->removeInvalidFormControlIfNeeded(*this);
             }
         }
     }
@@ -573,7 +573,7 @@ void HTMLFormControlElement::updateValidity()
 
 void HTMLFormControlElement::setCustomValidity(const String& error)
 {
-    FormAssociatedElement::setCustomValidity(error);
+    FormListedElement::setCustomValidity(error);
     updateValidity();
 }
 

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "Autofill.h"
-#include "FormAssociatedElement.h"
+#include "FormListedElement.h"
 #include "LabelableElement.h"
 
 #if ENABLE(AUTOCAPITALIZE)
@@ -39,16 +39,16 @@ class HTMLFormElement;
 class HTMLLegendElement;
 class ValidationMessage;
 
-// HTMLFormControlElement is the default implementation of FormAssociatedElement,
+// HTMLFormControlElement is the default implementation of FormListedElement,
 // and form-associated element implementations should use HTMLFormControlElement
 // unless there is a special reason.
-class HTMLFormControlElement : public LabelableElement, public FormAssociatedElement {
+class HTMLFormControlElement : public LabelableElement, public FormListedElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLFormControlElement);
     friend class DelayedUpdateValidityScope;
 public:
     virtual ~HTMLFormControlElement();
 
-    HTMLFormElement* form() const final { return FormAssociatedElement::form(); }
+    HTMLFormElement* form() const final { return FormListedElement::form(); }
 
     WEBCORE_EXPORT String formEnctype() const;
     WEBCORE_EXPORT void setFormEnctype(const AtomString&);
@@ -189,7 +189,7 @@ private:
     const HTMLFormControlElement& asHTMLElement() const final { return *this; }
 
     FormNamedItem* asFormNamedItem() final { return this; }
-    FormAssociatedElement* asFormAssociatedElement() final { return this; }
+    FormListedElement* asFormListedElement() final { return this; }
 
     bool needsMouseFocusableQuirk() const;
 
@@ -244,5 +244,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFormControlElement)
     static bool isType(const WebCore::Element& element) { return element.isFormControlElement(); }
     static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
-    static bool isType(const WebCore::FormAssociatedElement& element) { return element.isFormControlElement(); }
+    static bool isType(const WebCore::FormListedElement& element) { return element.isFormControlElement(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLFormControlElementWithState.h
+++ b/Source/WebCore/html/HTMLFormControlElementWithState.h
@@ -62,5 +62,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFormControlElementWithState)
     static bool isType(const WebCore::Element& element) { return element.isFormControlElementWithState(); }
     static bool isType(const WebCore::Node& node) { return is<WebCore::Element>(node) && isType(downcast<WebCore::Element>(node)); }
-    static bool isType(const WebCore::FormAssociatedElement& element) { return element.isFormControlElementWithState(); }
+    static bool isType(const WebCore::FormListedElement& element) { return element.isFormControlElementWithState(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLFormControlsCollection.h
+++ b/Source/WebCore/html/HTMLFormControlsCollection.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-class FormAssociatedElement;
+class FormListedElement;
 class HTMLImageElement;
 
 // This class is just a big hack to find form elements even in malformed HTML elements.

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class DOMFormData;
 class Event;
-class FormAssociatedElement;
+class FormListedElement;
 class HTMLFormControlElement;
 class HTMLFormControlsCollection;
 class HTMLImageElement;
@@ -68,15 +68,14 @@ public:
     WEBCORE_EXPORT bool shouldAutocorrect() const final;
 #endif
 
-    // FIXME: Should rename these two functions to say "form control" or "form-associated element" instead of "form element".
-    void registerFormElement(FormAssociatedElement*);
-    void removeFormElement(FormAssociatedElement*);
+    void registerFormListedElement(FormListedElement&);
+    void unregisterFormListedElement(FormListedElement&);
 
-    void registerInvalidAssociatedFormControl(const HTMLFormControlElement&);
-    void removeInvalidAssociatedFormControlIfNeeded(const HTMLFormControlElement&);
+    void addInvalidFormControl(const HTMLFormControlElement&);
+    void removeInvalidFormControlIfNeeded(const HTMLFormControlElement&);
 
-    void registerImgElement(HTMLImageElement*);
-    void removeImgElement(HTMLImageElement*);
+    void registerImgElement(HTMLImageElement&);
+    void unregisterImgElement(HTMLImageElement&);
 
     void submitIfPossible(Event*, HTMLFormControlElement* = nullptr, FormSubmissionTrigger = NotSubmittedByJavaScript);
     WEBCORE_EXPORT void submit();
@@ -119,8 +118,8 @@ public:
 
     RadioButtonGroups& radioButtonGroups() { return m_radioButtonGroups; }
 
-    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& unsafeAssociatedElements() const;
-    Vector<Ref<FormAssociatedElement>> copyAssociatedElementsVector() const;
+    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& unsafeListedElements() const;
+    Vector<Ref<FormListedElement>> copyListedElementsVector() const;
     const Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>>& imageElements() const { return m_imageElements; }
 
     StringPairVector textFieldValues() const;
@@ -151,7 +150,7 @@ private:
     void submitDialog(Ref<FormSubmission>&&);
 
     unsigned formElementIndexWithFormAttribute(Element*, unsigned rangeStart, unsigned rangeEnd);
-    unsigned formElementIndex(FormAssociatedElement*);
+    unsigned formElementIndex(FormListedElement&);
 
     bool validateInteractively();
 
@@ -161,16 +160,16 @@ private:
     bool checkInvalidControlsAndCollectUnhandled(Vector<RefPtr<HTMLFormControlElement>>&);
 
     RefPtr<HTMLElement> elementFromPastNamesMap(const AtomString&) const;
-    void addToPastNamesMap(FormNamedItem*, const AtomString& pastName);
+    void addToPastNamesMap(FormNamedItem&, const AtomString& pastName);
 #if ASSERT_ENABLED
-    void assertItemCanBeInPastNamesMap(FormNamedItem*) const;
+    void assertItemCanBeInPastNamesMap(FormNamedItem&) const;
 #endif
-    void removeFromPastNamesMap(FormNamedItem*);
+    void removeFromPastNamesMap(FormNamedItem&);
 
     bool matchesValidPseudoClass() const final;
     bool matchesInvalidPseudoClass() const final;
 
-    void resetAssociatedFormControlElements();
+    void resetListedFormControlElements();
 
     RefPtr<HTMLFormControlElement> findSubmitButton(HTMLFormControlElement* submitter, bool needButtonActivation);
 
@@ -180,13 +179,14 @@ private:
     RadioButtonGroups m_radioButtonGroups;
     mutable WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_defaultButton;
 
-    unsigned m_associatedElementsBeforeIndex { 0 };
-    unsigned m_associatedElementsAfterIndex { 0 };
-    Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> m_associatedElements;
+    Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>> m_listedElements;
     Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>> m_imageElements;
-    WeakHashSet<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invalidAssociatedFormControls;
+    WeakHashSet<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invalidFormControls;
     WeakPtr<FormSubmission> m_plannedFormSubmission;
     std::unique_ptr<DOMTokenList> m_relList;
+
+    unsigned m_listedElementsBeforeIndex { 0 };
+    unsigned m_listedElementsAfterIndex { 0 };
 
     bool m_wasUserSubmitted { false };
     bool m_isSubmittingOrPreparingForSubmission { false };

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -115,10 +115,10 @@ void HTMLImageElement::setForm(HTMLFormElement* newForm)
     if (m_form == newForm)
         return;
     if (m_form)
-        m_form->removeImgElement(this);
+        m_form->unregisterImgElement(*this);
     m_form = newForm;
     if (newForm)
-        newForm->registerImgElement(this);
+        newForm->registerImgElement(*this);
 }
 
 void HTMLImageElement::formOwnerRemovedFromTree(const Node& formRoot)

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -56,6 +56,9 @@ public:
 
     virtual ~HTMLImageElement();
 
+    using HTMLElement::ref;
+    using HTMLElement::deref;
+
     void formOwnerRemovedFromTree(const Node& formRoot);
 
     WEBCORE_EXPORT unsigned width(bool ignorePendingStylesheets = false);
@@ -169,6 +172,8 @@ protected:
 private:
     HTMLFormElement* form() const final;
     void setForm(HTMLFormElement*);
+    void refFormAssociatedElement() final { HTMLElement::ref(); }
+    void derefFormAssociatedElement() final { HTMLElement::deref(); }
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void parseAttribute(const QualifiedName&, const AtomString&) override;
@@ -200,7 +205,7 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
 
-    bool isFormAssociatedElement() const final { return false; }
+    bool isFormListedElement() const final { return false; }
     FormNamedItem* asFormNamedItem() final { return this; }
     HTMLImageElement& asHTMLElement() final { return *this; }
     const HTMLImageElement& asHTMLElement() const final { return *this; }

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -29,7 +29,7 @@
 #include "ElementIterator.h"
 #include "Event.h"
 #include "EventNames.h"
-#include "FormAssociatedElement.h"
+#include "FormListedElement.h"
 #include "HTMLFormControlElement.h"
 #include "HTMLNames.h"
 #include "SelectionRestorationMode.h"

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -65,7 +65,7 @@ using namespace HTMLNames;
 
 inline HTMLObjectElement::HTMLObjectElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
     : HTMLPlugInImageElement(tagName, document)
-    , FormAssociatedElement(form)
+    , FormListedElement(form)
 {
     ASSERT(hasTagName(objectTag));
 }
@@ -295,7 +295,7 @@ void HTMLObjectElement::updateWidget(CreatePlugins createPlugins)
 Node::InsertedIntoAncestorResult HTMLObjectElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     HTMLPlugInImageElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    FormAssociatedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    FormListedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 
@@ -307,7 +307,7 @@ void HTMLObjectElement::didFinishInsertingNode()
 void HTMLObjectElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLPlugInImageElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    FormAssociatedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    FormListedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 }
 
 void HTMLObjectElement::childrenChanged(const ChildChange& change)
@@ -461,7 +461,7 @@ void HTMLObjectElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
 
 void HTMLObjectElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
-    FormAssociatedElement::didMoveToNewDocument(oldDocument);
+    FormListedElement::didMoveToNewDocument(oldDocument);
     HTMLPlugInImageElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -22,14 +22,14 @@
 
 #pragma once
 
-#include "FormAssociatedElement.h"
+#include "FormListedElement.h"
 #include "HTMLPlugInImageElement.h"
 
 namespace WebCore {
 
 class HTMLFormElement;
 
-class HTMLObjectElement final : public HTMLPlugInImageElement, public FormAssociatedElement {
+class HTMLObjectElement final : public HTMLPlugInImageElement, public FormListedElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLObjectElement);
 public:
     static Ref<HTMLObjectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
@@ -54,7 +54,7 @@ public:
     using HTMLPlugInImageElement::ref;
     using HTMLPlugInImageElement::deref;
 
-    HTMLFormElement* form() const final { return FormAssociatedElement::form(); }
+    HTMLFormElement* form() const final { return FormListedElement::form(); }
 
 private:
     HTMLObjectElement(const QualifiedName&, Document&, HTMLFormElement*);
@@ -92,7 +92,7 @@ private:
     void derefFormAssociatedElement() final { deref(); }
 
     FormNamedItem* asFormNamedItem() final { return this; }
-    FormAssociatedElement* asFormAssociatedElement() final { return this; }
+    FormListedElement* asFormListedElement() final { return this; }
 
     // These functions can be called concurrently for ValidityState.
     HTMLObjectElement& asHTMLElement() final { return *this; }

--- a/Source/WebCore/html/ValidityState.h
+++ b/Source/WebCore/html/ValidityState.h
@@ -22,25 +22,25 @@
 
 #pragma once
 
-#include "FormAssociatedElement.h"
+#include "FormListedElement.h"
 #include "HTMLElement.h"
 
 namespace WebCore {
 
-// ValidityState is not a separate object, but rather an interface of FormAssociatedElement that
-// is published as part of the DOM. We could implement this as a base class of FormAssociatedElement,
+// ValidityState is not a separate object, but rather an interface of FormListedElement that
+// is published as part of the DOM. We could implement this as a base class of FormListedElement,
 // but that would have a small runtime cost, and no significant benefit. We'd prefer to implement this
-// as a typedef of FormAssociatedElement, but that would require changes to bindings generation.
-class ValidityState : public FormAssociatedElement {
+// as a typedef of FormListedElement, but that would require changes to bindings generation.
+class ValidityState : public FormListedElement {
 public:
     Element* element() { return &asHTMLElement(); }
     Node* opaqueRootConcurrently() { return &asHTMLElement(); }
 };
 
-inline ValidityState* FormAssociatedElement::validity()
+inline ValidityState* FormListedElement::validity()
 {
-    // Because ValidityState adds nothing to FormAssociatedElement, we rely on it being safe
-    // to cast a FormAssociatedElement like this, even though it's not actually a ValidityState.
+    // Because ValidityState adds nothing to FormListedElement, we rely on it being safe
+    // to cast a FormListedElement like this, even though it's not actually a ValidityState.
     return static_cast<ValidityState*>(this);
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -290,9 +290,9 @@ static HTMLFormElement* formElementFromDOMElement(DOMElement *element)
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     AtomString targetName = name;
-    for (auto& weakElement : formElement->unsafeAssociatedElements()) {
+    for (auto& weakElement : formElement->unsafeListedElements()) {
         RefPtr element { weakElement.get() };
-        if (element && element->asFormAssociatedElement()->name() == targetName)
+        if (element && element->asFormListedElement()->name() == targetName)
             return kit(element.get());
     }
     return nil;
@@ -337,9 +337,9 @@ static HTMLInputElement* inputElementFromDOMElement(DOMElement* element)
         return nil;
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    auto result = createNSArray(formElement->unsafeAssociatedElements(), [] (auto& weakElement) -> DOMElement * {
+    auto result = createNSArray(formElement->unsafeListedElements(), [] (auto& weakElement) -> DOMElement * {
         RefPtr coreElement { weakElement.get() };
-        if (!coreElement || !coreElement->asFormAssociatedElement()->isEnumeratable()) // Skip option elements, other duds
+        if (!coreElement || !coreElement->asFormListedElement()->isEnumeratable()) // Skip option elements, other duds
             return nil;
         return kit(coreElement.get());
     });

--- a/Source/WebKitLegacy/win/WebFrame.cpp
+++ b/Source/WebKitLegacy/win/WebFrame.cpp
@@ -1128,10 +1128,10 @@ HRESULT WebFrame::elementWithName(BSTR name, IDOMElement* form, IDOMElement** el
     HTMLFormElement* formElement = formElementFromDOMElement(form);
     if (formElement) {
         AtomString targetName((UChar*)name, SysStringLen(name));
-        for (auto& associatedElement : formElement->copyAssociatedElementsVector()) {
-            if (!is<HTMLFormControlElement>(associatedElement))
+        for (auto& listedElement : formElement->copyListedElementsVector()) {
+            if (!is<HTMLFormControlElement>(listedElement))
                 continue;
-            auto& elt = downcast<HTMLFormControlElement>(associatedElement.get());
+            auto& elt = downcast<HTMLFormControlElement>(listedElement.get());
             // Skip option elements, other duds.
             if (elt.name() == targetName) {
                 *element = DOMElement::createInstance(&elt);
@@ -1232,7 +1232,7 @@ HRESULT WebFrame::controlsInForm(IDOMElement* form, IDOMElement** controls, int*
     if (!formElement)
         return E_FAIL;
 
-    auto elements = formElement->copyAssociatedElementsVector();
+    auto elements = formElement->copyListedElementsVector();
     int inCount = *cControls;
     int count = (int) elements.size();
     *cControls = count;


### PR DESCRIPTION
#### 8f06b8caf972d5cdf4d4f506acd91aae57bab856
<pre>
Rename FormAssociatedElement to FormListedElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=247877">https://bugs.webkit.org/show_bug.cgi?id=247877</a>

Reviewed by Chris Dumez.

Renamed FormAssociatedElement to FormListedElement, and updated relevant code since it maps to the concept
of the same name in HTML5 specification: <a href="https://html.spec.whatwg.org/multipage/forms.html#category-listed">https://html.spec.whatwg.org/multipage/forms.html#category-listed</a>

This patch also moves refFormAssociatedElement / derefFormAssociatedElement from FormAssociatedElement
to FormNamedItem, which will be renamed to FormAssociatedElement in a follow up patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ContainerNodeAlgorithms.h:

* Source/WebCore/dom/TreeScopeOrderedMap.cpp:
(WebCore::TreeScopeOrderedMap::get const):

* Source/WebCore/html/FormController.cpp:
(WebCore::formSignature):
(WebCore::FormController::restoreControlStateIn):

* Source/WebCore/html/FormListedElement.cpp: Renamed from Source/WebCore/html/FormAssociatedElement.cpp.
(WebCore::FormListedElement::FormListedElement):
(WebCore::FormListedElement::~FormListedElement):
(WebCore::FormListedElement::didMoveToNewDocument):
(WebCore::FormListedElement::insertedIntoAncestor):
(WebCore::FormListedElement::removedFromAncestor):
(WebCore::FormListedElement::findAssociatedForm):
(WebCore::FormListedElement::form const):
(WebCore::FormListedElement::formOwnerRemovedFromTree):
(WebCore::FormListedElement::setForm):
(WebCore::FormListedElement::willChangeForm):
(WebCore::FormListedElement::didChangeForm):
(WebCore::FormListedElement::formWillBeDestroyed):
(WebCore::FormListedElement::resetFormOwner):
(WebCore::FormListedElement::formAttributeChanged):
(WebCore::FormListedElement::customError const):
(WebCore::FormListedElement::hasBadInput const):
(WebCore::FormListedElement::patternMismatch const):
(WebCore::FormListedElement::rangeOverflow const):
(WebCore::FormListedElement::rangeUnderflow const):
(WebCore::FormListedElement::stepMismatch const):
(WebCore::FormListedElement::tooShort const):
(WebCore::FormListedElement::tooLong const):
(WebCore::FormListedElement::typeMismatch const):
(WebCore::FormListedElement::computeValidity const):
(WebCore::FormListedElement::valueMissing const):
(WebCore::FormListedElement::customValidationMessage const):
(WebCore::FormListedElement::validationMessage const):
(WebCore::FormListedElement::setCustomValidity):
(WebCore::FormListedElement::resetFormAttributeTargetObserver):
(WebCore::FormListedElement::formAttributeTargetChanged):
(WebCore::FormListedElement::name const):
(WebCore::FormListedElement::isFormControlElementWithState const):
(WebCore::FormAttributeTargetObserver::FormAttributeTargetObserver):
(WebCore::FormAttributeTargetObserver::idTargetChanged):

* Source/WebCore/html/FormListedElement.h: Renamed from Source/WebCore/html/FormAssociatedElement.h.
(WebCore::FormListedElement::appendFormData):
(WebCore::FormListedElement::badInput const):
(WebCore::FormListedElement::clearForm):

* Source/WebCore/html/FormNamedItem.h:
(WebCore::FormNamedItem::ref): Moved from FormAssociatedElement.
(WebCore::FormNamedItem::deref): Ditto.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::asFormListedElement): Renamed from asFormAssociatedElement.
* Source/WebCore/html/HTMLElement.h:

* Source/WebCore/html/HTMLFieldSetElement.h:

* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::HTMLFormControlElement):
(WebCore::HTMLFormControlElement::didMoveToNewDocument):
(WebCore::HTMLFormControlElement::insertedIntoAncestor):
(WebCore::HTMLFormControlElement::removedFromAncestor):
(WebCore::HTMLFormControlElement::updateWillValidateAndValidity):
(WebCore::HTMLFormControlElement::willChangeForm):
(WebCore::HTMLFormControlElement::didChangeForm):
(WebCore::HTMLFormControlElement::updateValidity):
(WebCore::HTMLFormControlElement::setCustomValidity):

* Source/WebCore/html/HTMLFormControlElement.h:
(isType):

* Source/WebCore/html/HTMLFormControlElementWithState.h:
(isType):

* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::findFormListedElement): Renamed from findFormAssociatedElement.
(WebCore::HTMLFormControlsCollection::customElementAfter const):
(WebCore::HTMLFormControlsCollection::updateNamedElementCache const): Use HashSet&lt;AtomString&gt; instead
of HashSet&lt;AtomStringImpl*&gt;.

* Source/WebCore/html/HTMLFormControlsCollection.h:

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::~HTMLFormElement):
(WebCore::HTMLFormElement::removedFromAncestor):
(WebCore::HTMLFormElement::length const):
(WebCore::HTMLFormElement::submitImplicitly):
(WebCore::HTMLFormElement::validateInteractively):
(WebCore::HTMLFormElement::textFieldValues const):
(WebCore::HTMLFormElement::findSubmitButton):
(WebCore::HTMLFormElement::submit):
(WebCore::HTMLFormElement::reset):
(WebCore::HTMLFormElement::resetListedFormControlElements): Renamed from
resetAssociatedFormControlElements.
(WebCore::HTMLFormElement::formElementIndexWithFormAttribute):
(WebCore::HTMLFormElement::formElementIndex):
(WebCore::HTMLFormElement::registerFormListedElement): Renamed from registerFormElement.
(WebCore::HTMLFormElement::unregisterFormListedElement): Ditto from removeFormElement.
(WebCore::HTMLFormElement::addInvalidFormControl): Renamed from registerInvalidAssociatedFormControl.
(WebCore::HTMLFormElement::removeInvalidFormControlIfNeeded): Renamed from
removeInvalidAssociatedFormControlIfNeeded.
(WebCore::HTMLFormElement::registerImgElement):
(WebCore::HTMLFormElement::unregisterImgElement): Renamed from removeImgElement for consistency.
(WebCore::HTMLFormElement::defaultButton const):
(WebCore::HTMLFormElement::checkInvalidControlsAndCollectUnhandled):
(WebCore::HTMLFormElement::assertItemCanBeInPastNamesMap const): Now takes a reference to FormNamedItem.
(WebCore::HTMLFormElement::elementFromPastNamesMap const):
(WebCore::HTMLFormElement::addToPastNamesMap): Ditto.
(WebCore::HTMLFormElement::removeFromPastNamesMap): Ditto.
(WebCore::HTMLFormElement::matchesValidPseudoClass const):
(WebCore::HTMLFormElement::namedElements):
(WebCore::HTMLFormElement::resumeFromDocumentSuspension):
(WebCore::HTMLFormElement::unsafeListedElements const): Renamed from unsafeAssociatedElements.
(WebCore::HTMLFormElement::copyListedElementsVector const): Renamed from copyAssociatedElementsVector.
(WebCore::HTMLFormElement::constructEntryList):

* Source/WebCore/html/HTMLFormElement.h:

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setForm):

* Source/WebCore/html/HTMLImageElement.h:
(WebCore::HTMLImageElement::refFormAssociatedElement): Added.
(WebCore::HTMLImageElement::derefFormAssociatedElement): Added.

* Source/WebCore/html/HTMLLabelElement.cpp:

* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::HTMLObjectElement):
(WebCore::HTMLObjectElement::insertedIntoAncestor):
(WebCore::HTMLObjectElement::removedFromAncestor):
(WebCore::HTMLObjectElement::didMoveToNewDocument):

* Source/WebCore/html/HTMLObjectElement.h:

* Source/WebCore/html/ValidityState.h:
(WebCore::FormListedElement::validity):
(WebCore::FormAssociatedElement::validity): Deleted.

* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(-[WebHTMLRepresentation elementWithName:inForm:]):
(-[WebHTMLRepresentation controlsInForm:]):

* Source/WebKitLegacy/win/WebFrame.cpp:
(WebFrame::elementWithName):
(WebFrame::controlsInForm):

Canonical link: <a href="https://commits.webkit.org/256659@main">https://commits.webkit.org/256659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dbc475ef47198b876834dddff8b1754611b9dee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105956 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166305 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5840 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34414 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102682 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4350 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83015 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31333 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74226 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40143 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19574 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37817 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20962 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/3527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43531 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2206 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40231 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->