### PR TITLE
Rebaseline some macOS tests with UI side compositing enabled

### DIFF
--- a/LayoutTests/platform/mac-gpup/TestExpectations
+++ b/LayoutTests/platform/mac-gpup/TestExpectations
@@ -1,1 +1,5 @@
 # Test expectations for macOS with --use-gpu-process --remote-layer-tree.
+
+# The direct image codepath is not used with the remote layer tree.
+compositing/images/direct-image-object-fit.html [ Skip ]
+compositing/reflections/direct-image-object-fit-reflected.html [ Skip ]

--- a/LayoutTests/platform/mac-gpup/compositing/backing/inline-block-no-backing-expected.txt
+++ b/LayoutTests/platform/mac-gpup/compositing/backing/inline-block-no-backing-expected.txt
@@ -1,0 +1,80 @@
+ 
+
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 18.00 18.00)
+          (bounds 160.00 320.00)
+          (drawsContent 1)
+          (children 2
+            (GraphicsLayer
+              (position 18.00 10.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 10.00 154.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 202.00 18.00)
+          (bounds 160.00 320.00)
+          (children 2
+            (GraphicsLayer
+              (position 10.00 10.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 10.00 154.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 386.00 18.00)
+          (bounds 160.00 320.00)
+          (children 2
+            (GraphicsLayer
+              (position 10.00 10.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 10.00 154.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 570.00 18.00)
+          (bounds 160.00 320.00)
+          (children 2
+            (GraphicsLayer
+              (position 10.00 10.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 10.00 154.00)
+              (bounds 120.00 120.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-gpup/compositing/backing/whitespace-nodes-no-backing-expected.txt
+++ b/LayoutTests/platform/mac-gpup/compositing/backing/whitespace-nodes-no-backing-expected.txt
@@ -1,0 +1,120 @@
+
+
+
+
+
+
+span
+inner span
+
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 9
+        (GraphicsLayer
+          (position 10.00 8.00)
+          (bounds 780.00 58.00)
+          (drawsContent 1)
+          (children 2
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 60.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 68.00)
+          (bounds 780.00 58.00)
+          (children 2
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 60.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 128.00)
+          (bounds 780.00 58.00)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 188.00)
+          (bounds 780.00 58.00)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 248.00)
+          (bounds 780.00 78.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 328.00)
+          (bounds 780.00 54.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 10.00 384.00)
+          (bounds 780.00 18.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 10.00 404.00)
+          (bounds 780.00 18.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 10.00 424.00)
+          (bounds 780.00 78.00)
+          (children 2
+            (GraphicsLayer
+              (position 2.00 2.00)
+              (bounds 50.00 50.00)
+              (drawsContent 1)
+            )
+            (GraphicsLayer
+              (position 0.00 58.00)
+              (bounds 20.00 20.00)
+              (contentsOpaque 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-gpup/compositing/fixed-image-loading-expected.txt
+++ b/LayoutTests/platform/mac-gpup/compositing/fixed-image-loading-expected.txt
@@ -1,0 +1,24 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 13.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 214.00 232.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-gpup/compositing/tiling/huge-layer-img-expected.txt
+++ b/LayoutTests/platform/mac-gpup/compositing/tiling/huge-layer-img-expected.txt
@@ -1,0 +1,20 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 20053.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 20053.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 500.00 20000.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-gpup/compositing/visibility/visibility-image-layers-dynamic-expected.txt
+++ b/LayoutTests/platform/mac-gpup/compositing/visibility/visibility-image-layers-dynamic-expected.txt
@@ -1,0 +1,169 @@
+
+
+
+Initial
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 626.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 626.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (anchor 0.50 0.50)
+          (bounds 749.00 144.00)
+          (children 1
+            (GraphicsLayer
+              (position 20.00 20.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+              (contentsVisible 0)
+            )
+          )
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-4 height=-4)
+          (position 14.00 160.00)
+          (anchor 0.50 0.50)
+          (bounds 757.00 152.00)
+          (contentsVisible 0)
+          (children 1
+            (GraphicsLayer
+              (position 24.00 24.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+              (contentsVisible 0)
+            )
+          )
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-4 height=-4)
+          (position 14.00 314.00)
+          (anchor 0.50 0.50)
+          (bounds 757.00 152.00)
+          (contentsVisible 0)
+          (children 1
+            (GraphicsLayer
+              (position 24.00 24.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+After step 1
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 1456.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 1456.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (anchor 0.50 0.50)
+          (bounds 749.00 144.00)
+          (children 1
+            (GraphicsLayer
+              (position 20.00 20.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-4 height=-4)
+          (position 14.00 160.00)
+          (anchor 0.50 0.50)
+          (bounds 757.00 152.00)
+          (contentsVisible 0)
+          (children 1
+            (GraphicsLayer
+              (position 24.00 24.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+              (contentsVisible 0)
+            )
+          )
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-4 height=-4)
+          (position 14.00 314.00)
+          (anchor 0.50 0.50)
+          (bounds 757.00 152.00)
+          (contentsVisible 0)
+          (children 1
+            (GraphicsLayer
+              (position 24.00 24.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+After step 2
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 785.00 2270.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 785.00 2270.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 18.00 10.00)
+          (anchor 0.50 0.50)
+          (bounds 749.00 144.00)
+          (children 1
+            (GraphicsLayer
+              (position 20.00 20.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-4 height=-4)
+          (position 14.00 160.00)
+          (anchor 0.50 0.50)
+          (bounds 757.00 152.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (position 24.00 24.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (offsetFromRenderer width=-4 height=-4)
+          (position 14.00 314.00)
+          (anchor 0.50 0.50)
+          (bounds 757.00 152.00)
+          (contentsVisible 0)
+          (children 1
+            (GraphicsLayer
+              (position 24.00 24.00)
+              (bounds 100.00 100.00)
+              (drawsContent 1)
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-non-cb-overflow-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-non-cb-overflow-expected.txt
@@ -1,0 +1,5 @@
+Outer scrolling content
+Inner scrolling content
+Fixed background
+
+

--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-overflow-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-overflow-expected.txt
@@ -1,0 +1,5 @@
+Outer scrolling content
+Inner scrolling content
+Fixed background
+
+

--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-overflow2-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-overflow2-expected.txt
@@ -1,0 +1,5 @@
+Outer scrolling content
+Inner scrolling content
+Fixed background
+
+

--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/latching/horizontal-overflow-in-vertical-overflow-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/latching/horizontal-overflow-in-vertical-overflow-expected.txt
@@ -1,0 +1,12 @@
+Scrolls vertically
+Scrolls horizontally
+Initial state
+PASS outerScroller.scrollTop is 0
+PASS innerScroller.scrollTop is 0
+After scrolll
+FAIL outerScroller.scrollTop should be 210. Was 0.
+PASS innerScroller.scrollTop is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/latching/zero-delta-began-should-not-latch-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/latching/zero-delta-began-should-not-latch-expected.txt
@@ -1,0 +1,10 @@
+FAIL: Timed out waiting for notifyDone to be called
+
+Tests a gesture with zero delta on the began event doesn't latch on the document
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS overflow.scrollTop is 0
+PASS window.pageYOffset is 0
+

--- a/LayoutTests/platform/mac-gpup/scrollingcoordinator/non-fast-scrollable-region-scaled-iframe-expected.txt
+++ b/LayoutTests/platform/mac-gpup/scrollingcoordinator/non-fast-scrollable-region-scaled-iframe-expected.txt
@@ -1,0 +1,12 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0
+layer at (50,50) size 324x224
+  RenderIFrame {IFRAME} at (50,50) size 324x224 [border: (2px inset #000000)]
+    layer at (0,0) size 1008x1016
+      RenderView at (0,0) size 285x185
+    layer at (0,0) size 285x1016
+      RenderBlock {HTML} at (0,0) size 285x1016
+        RenderBody {BODY} at (8,8) size 1000x1000


### PR DESCRIPTION
#### 4488a9d1dc6e0aaa0b04e246207c41b4f60e09d8
<pre>
Rebaseline some macOS tests with UI side compositing enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=247876">https://bugs.webkit.org/show_bug.cgi?id=247876</a>
&lt;rdar://problem/102303038&gt;

Unreviewed test gardening.

* LayoutTests/platform/mac-gpup/TestExpectations:

Skip tests that don&apos;t apply in this configuration.

* LayoutTests/platform/mac-gpup/compositing/backing/inline-block-no-backing-expected.txt:
* LayoutTests/platform/mac-gpup/compositing/backing/whitespace-nodes-no-backing-expected.txt:
* LayoutTests/platform/mac-gpup/compositing/fixed-image-loading-expected.txt:
* LayoutTests/platform/mac-gpup/compositing/tiling/huge-layer-img-expected.txt:

Layer tree dumps now include (drawsContent) and (usingTiledLayer).

* LayoutTests/platform/mac-gpup/compositing/visibility/visibility-image-layers-dynamic-expected.txt:

Same, except the layer bounds are also updated because the layer tree dump is in the content.

* LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-non-cb-overflow-expected.txt:
* LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-overflow-expected.txt:
* LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/fixed-backgrounds/fixed-background-in-nested-overflow2-expected.txt:
* LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/latching/horizontal-overflow-in-vertical-overflow-expected.txt:
* LayoutTests/platform/mac-gpup/scrollingcoordinator/mac/latching/zero-delta-began-should-not-latch-expected.txt:
* LayoutTests/platform/mac-gpup/scrollingcoordinator/non-fast-scrollable-region-scaled-iframe-expected.txt:

Scrolling tree does not exist in the Web process and so is no longer
included in the layer dump output.

Canonical link: <a href="https://commits.webkit.org/256634@main">https://commits.webkit.org/256634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/461f338f88a6d0e7ea372294abe523425777d710

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105944 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5826 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34401 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102670 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102072 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83003 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40131 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37805 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/20950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/3183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2200 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/722 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->