### PR TITLE
Re-import inert and <dialog> WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-expected.txt
@@ -22,8 +22,8 @@ PASS show: Autofocus after, yes delegatesFocus
 PASS showModal: Autofocus after, yes delegatesFocus
 PASS show: Autofocus on shadow host, yes delegatesFocus, no siblings
 PASS showModal: Autofocus on shadow host, yes delegatesFocus, no siblings
-FAIL show: Autofocus on shadow host, yes delegatesFocus, sibling before assert_equals: expected Element node <div autofocus=""></div> but got Element node <button tabindex="-1">Focusable</button>
-FAIL showModal: Autofocus on shadow host, yes delegatesFocus, sibling before assert_equals: expected Element node <div autofocus=""></div> but got Element node <button tabindex="-1">Focusable</button>
+FAIL show: Autofocus on shadow host, yes delegatesFocus, sibling before assert_equals: expected Element node <div autofocus="true"></div> but got Element node <button tabindex="-1">Focusable</button>
+FAIL showModal: Autofocus on shadow host, yes delegatesFocus, sibling before assert_equals: expected Element node <div autofocus="true"></div> but got Element node <button tabindex="-1">Focusable</button>
 PASS show: Autofocus on shadow host, yes delegatesFocus, sibling after
 PASS showModal: Autofocus on shadow host, yes delegatesFocus, sibling after
 PASS show: Autofocus on shadow host, no delegatesFocus, no siblings
@@ -36,12 +36,18 @@ PASS show: Autofocus inside shadow tree, yes delegatesFocus, no siblings
 PASS showModal: Autofocus inside shadow tree, yes delegatesFocus, no siblings
 PASS show: Autofocus inside shadow tree, yes delegatesFocus, sibling before
 PASS showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling before
-FAIL show: Autofocus inside shadow tree, yes delegatesFocus, sibling after assert_equals: expected Element node <button tabindex="-1" class="focus-me">Focusable</button> but got Element node <div></div>
-FAIL showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling after assert_equals: expected Element node <button tabindex="-1" class="focus-me">Focusable</button> but got Element node <div></div>
+PASS show: Autofocus inside shadow tree, yes delegatesFocus, sibling after
+PASS showModal: Autofocus inside shadow tree, yes delegatesFocus, sibling after
 PASS show: Autofocus inside shadow tree, no delegatesFocus, no siblings
 PASS showModal: Autofocus inside shadow tree, no delegatesFocus, no siblings
 PASS show: Autofocus inside shadow tree, no delegatesFocus, sibling before
 PASS showModal: Autofocus inside shadow tree, no delegatesFocus, sibling before
 PASS show: Autofocus inside shadow tree, no delegatesFocus, sibling after
 PASS showModal: Autofocus inside shadow tree, no delegatesFocus, sibling after
+PASS show: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does
+PASS showModal: Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does
+PASS show: No autofocus, no delegatesFocus, slotted target
+PASS showModal: No autofocus, no delegatesFocus, slotted target
+PASS show: Shadowroot on child, no autofocus, no delegatesFocus
+PASS showModal: Shadowroot on child, no autofocus, no delegatesFocus
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html
@@ -171,10 +171,10 @@
 <dialog data-description="Autofocus inside shadow tree, yes delegatesFocus, sibling after">
   <template class="turn-into-shadow-tree delegates-focus">
     <button tabindex="-1">Focusable</button>
-    <button tabindex="-1" autofocus>Focusable</button>
+    <button tabindex="-1" autofocus class="focus-me">Focusable</button>
     <button disabled>Non-focusable</button>
   </template>
-  <button tabindex="-1" class="focus-me">Focusable</button>
+  <button tabindex="-1">Focusable</button>
 </dialog>
 
 <dialog data-description="Autofocus inside shadow tree, no delegatesFocus, no siblings">
@@ -203,11 +203,43 @@
   <button tabindex="-1" class="focus-me">Focusable</button>
 </dialog>
 
+<dialog data-description="Two shadow trees, both delegatesFocus, first tree doesn't have autofocus element, second does">
+  <template class="turn-into-shadow-tree delegates-focus">
+    <button disabled>Non-focusable</button>
+    <button tabindex="-1" class="focus-me">Focusable</button>
+    <button disabled>Non-focusable</button>
+  </template>
+  <template class="turn-into-shadow-tree delegates-focus">
+    <button tabindex="-1" autofocus>Focusable</button>
+  </template>
+</dialog>
+
+<dialog data-description="No autofocus, no delegatesFocus, slotted target">
+  <template class="turn-into-shadow-tree">
+    <button tabindex="-1">Focusable</button>
+    <slot></slot>
+    <button tabindex="-1">Focusable</button>
+  </template>
+  <button tabindex="-1" class="focus-me">Focusable</button>
+</dialog>
+
+<dialog data-description="Shadowroot on child, no autofocus, no delegatesFocus">
+  <div>
+    <template class="turn-into-shadow-tree">
+      <button tabindex="-1">Focusable</button>
+    </template>
+  </div>
+  <button tabindex="-1" class="focus-me">Focusable</button>
+</dialog>
+
 <script>
 for (const template of document.querySelectorAll(".turn-into-shadow-tree")) {
   const div = document.createElement("div");
   div.attachShadow({ mode: "open", delegatesFocus: template.classList.contains("delegates-focus")  });
-  div.autofocus = template.classList.contains("autofocus");
+
+  if (template.classList.contains("autofocus")) {
+    div.setAttribute("autofocus", true);
+  }
   div.shadowRoot.append(template.content);
   template.replaceWith(div);
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Hit-testing doesn't reach contents of an inert SVG
-PASS Hit-testing can reach contents of a no longer inert SVG
+FAIL Hit-testing can reach contents of a no longer inert SVG assert_true: target is active expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html
@@ -38,11 +38,11 @@ promise_test(async function() {
         reachedTarget = true;
     }, { once: true });
 
+    let wrapperRect = wrapper.getBoundingClientRect();
     await new test_driver.Actions()
-        .pointerMove(0, 0, { origin: wrapper })
+        .pointerMove(wrapperRect.x + 1, wrapperRect.y + 1, { origin: "viewport" })
         .pointerDown()
         .send();
-    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_false(target.matches(":active"), "target is not active");
     assert_false(target.matches(":hover"), "target is not hovered");
@@ -61,7 +61,6 @@ promise_test(async function() {
         .pointerMove(0, 0, { origin: wrapper })
         .pointerDown()
         .send();
-    this.add_cleanup(() => test_driver.click(document.body));
 
     assert_true(target.matches(":active"), "target is active");
     assert_true(reachedTarget, "target got event");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-blocks-mouse-events.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-blocks-mouse-events.html
@@ -47,7 +47,9 @@ promise_test(async () => {
   async function clickOn(element) {
     const rect = element.getBoundingClientRect();
     const actions = new test_driver.Actions()
-      .pointerMove(rect.left + rect.width / 2, rect.top + rect.height / 2)
+      .pointerMove(
+        Math.floor(rect.left + rect.width / 2),
+        Math.floor(rect.top + rect.height / 2))
       .pointerDown()
       .pointerUp()
       .pointerMove(0, 0);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html
@@ -28,14 +28,32 @@ dialog {
 
 <script>
 test(() => {
+  function documentHeight() {
+    // clientHeight is an integer, but we want the correct floating point
+    // value.  Start a binary search at clientHeight-1 and clientHeight+1.
+    let min = document.documentElement.clientHeight;
+    let max = min + 1;
+    --min;
+
+    // binary search with media queries to find the correct height
+    for (let iter = 0; iter < 10; ++iter) {
+      let test = (min + max) / 2;
+      if (window.matchMedia(`(min-height: ${test}px)`).matches)
+        min = test;
+      else
+        max = test;
+    }
+    return min;
+  }
   function expectedTop(dialog) {
-    return Math.floor((document.documentElement.clientHeight - dialog.offsetHeight) / 2);
+    let height = documentHeight();
+    return (height - dialog.getBoundingClientRect().height) / 2;
   }
 
   function showAndTest(id) {
     dialog = document.getElementById(id);
     dialog.showModal();
-    assert_equals(dialog.offsetTop, expectedTop(dialog), id);
+    assert_approx_equals(dialog.getBoundingClientRect().top, expectedTop(dialog), 0.05, id);
   }
 
   showAndTest('top-dialog');

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-computed-style-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL inert isn't hit-testable, but that isn't expose in the computed style assert_equals: inert node doesn't change pointer-events computed value expected (string) "auto" but got (undefined) undefined
+FAIL inert isn't hit-testable, but that isn't expose in the computed style assert_equals: inert node doesn't change user-select computed value expected (string) "auto" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-computed-style.html
@@ -43,7 +43,7 @@
     assert_equals(
       getComputedStyle(inert).userSelect,
       "auto",
-      "inert node doesn't change pointer-events computed value",
+      "inert node doesn't change user-select computed value",
     );
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001-expected.txt
@@ -2,5 +2,5 @@
 PASS Modal dialog only marks outside nodes as inert
 PASS Inner nodes with 'inert' attribute become inert anyways
 PASS If the modal dialog has the 'inert' attribute, everything becomes inert
-FAIL If an ancestor of the dialog has the 'inert' attribute, everything becomes inert assert_equals: expected "" but got "dialog child"
+PASS If an ancestor of the dialog has the 'inert' attribute, the dialog escapes inertness
 wrapper

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001.html
@@ -3,7 +3,7 @@
 <title>Interaction of 'inert' attribute with modal dialog</title>
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#inert">
-<meta name="assert" content="Checks that being part of a modal dialog does not protect a node from being marked inert by an 'inert' attribute.">
+<meta name="assert" content="Checks that a modal dialog escapes inertness from ancestors.">
 <div id="log"></div>
 <div id="wrapper">
   wrapper
@@ -51,6 +51,6 @@ test(function() {
 test(function() {
   wrapper.inert = true;
   this.add_cleanup(() => { wrapper.inert = false; });
-  checkSelection("");
-}, "If an ancestor of the dialog has the 'inert' attribute, everything becomes inert");
+  checkSelection("dialog child");
+}, "If an ancestor of the dialog has the 'inert' attribute, the dialog escapes inertness");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/inert/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/inert/w3c-import.log
@@ -29,6 +29,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/inert/inert-node-is-unselectable.html
 /LayoutTests/imported/w3c/web-platform-tests/inert/inert-on-non-html.html
 /LayoutTests/imported/w3c/web-platform-tests/inert/inert-on-slots.html
+/LayoutTests/imported/w3c/web-platform-tests/inert/inert-pseudo-element-hittest.html
 /LayoutTests/imported/w3c/web-platform-tests/inert/inert-svg-hittest.html
 /LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001.html
 /LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-002.html

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt
@@ -1,4 +1,0 @@
-
-PASS Hit-testing doesn't reach contents of an inert SVG
-FAIL Hit-testing can reach contents of a no longer inert SVG assert_true: target is active expected true got false
-


### PR DESCRIPTION
#### 6c4737c7286fbf347866862d30dd605e76da0c4d
<pre>
Re-import inert and &lt;dialog&gt; WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=247880">https://bugs.webkit.org/show_bug.cgi?id=247880</a>

Reviewed by Youenn Fablet.

Upstream revision: <a href="https://github.com/web-platform-tests/wpt/commit/fecf3732104da8aa2181b822e74554fd0941a54b">https://github.com/web-platform-tests/wpt/commit/fecf3732104da8aa2181b822e74554fd0941a54b</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-blocks-mouse-events.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/multiple-centered-dialogs.html:
* LayoutTests/imported/w3c/web-platform-tests/inert/inert-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/inert/inert-computed-style.html:
* LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/inert/inert-with-modal-dialog-001.html:
* LayoutTests/imported/w3c/web-platform-tests/inert/w3c-import.log:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-svg-hittest-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/256640@main">https://commits.webkit.org/256640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d8776b55128c78f9116769a84bab7a7e94a4ba3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105946 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5828 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34403 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102672 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4338 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83005 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31322 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88072 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40133 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20952 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4609 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/3188 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40221 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->