### PR TITLE
[css-transitions] setting transition-property to "none" does not disassociate CSS Transition from owning element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-replacement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-replacement-expected.txt
@@ -27,7 +27,7 @@ PASS Removes an animation after updating its effect to one with a different targ
 PASS Does NOT remove a CSS animation tied to markup
 PASS Removes a CSS animation no longer tied to markup
 PASS Does NOT remove a CSS transition tied to markup
-FAIL Removes a CSS transition no longer tied to markup assert_equals: expected "removed" but got "active"
+PASS Removes a CSS transition no longer tied to markup
 PASS Dispatches an event when removing
 PASS Does NOT dispatch a remove event twice
 PASS Does NOT remove an animation after making a redundant change to another animation's current time

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -548,7 +548,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
         // 3. If the element has a running transition or completed transition for the property, and there is not a matching transition-property
         //    value, then implementations must cancel the running transition or remove the completed transition from the set of completed transitions.
         if (hasRunningTransition)
-            styleable.ensureRunningTransitionsByProperty().take(property)->cancel();
+            styleable.ensureRunningTransitionsByProperty().take(property)->cancelFromStyle();
         else
             styleable.ensureCompletedTransitionsByProperty().remove(property);
     }


### PR DESCRIPTION
#### 7821448df0f4202c66c24715c1edad7b1cdb0c34
<pre>
[css-transitions] setting transition-property to &quot;none&quot; does not disassociate CSS Transition from owning element
<a href="https://bugs.webkit.org/show_bug.cgi?id=247884">https://bugs.webkit.org/show_bug.cgi?id=247884</a>

Reviewed by Antti Koivisto.

We would fail a subtest in web-animations/timing-model/timelines/update-and-send-events-replacement.html where a CSS Transition
was canceled by setting the transition-property CSS property to &quot;none&quot;. We would correctly cancel the transition in this situation,
but we would fail to disassociate it from its owning element, the element that was the transition&apos;s target when it was created.

That association is critical when determining whether an animation, including transitions, can be replaced, per
<a href="https://drafts.csswg.org/web-animations/#removing-replaced-animations.">https://drafts.csswg.org/web-animations/#removing-replaced-animations.</a>

We now correctly call DeclarativeAnimation::cancelFromStyle() instead of WebAnimation::cancel() when an element&apos;s style moves
from having a transition defined for a given property to no longer having one in the new style.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-replacement-expected.txt:
* Source/WebCore/style/Styleable.cpp:
(WebCore::updateCSSTransitionsForStyleableAndProperty):

Canonical link: <a href="https://commits.webkit.org/256666@main">https://commits.webkit.org/256666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74720f1fcff40d23ec3cd60c092f357a9c50a790

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105954 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166303 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5838 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34412 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102680 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4352 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83013 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31330 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74223 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40141 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19576 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20964 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/3258 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43533 "Found 1 new test failure: imported/w3c/web-platform-tests/webxr/xrWebGLLayer_viewports.https.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2210 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40233 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->