### PR TITLE
[JSC] Wasm test regressions on 32-bit ARM after 256472@main

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -480,14 +480,13 @@ inline void Type::dump(PrintStream& out) const
 {
     TypeKind kindToPrint = kind;
     if (index != TypeDefinition::invalidIndex) {
-        auto signedIndex = static_cast<std::make_signed<TypeIndex>::type>(index);
-        if (signedIndex < 0) {
+        if (typeIndexIsType(index)) {
             // If the index is negative, we assume we're using it to represent a TypeKind.
             // FIXME: Reusing index to store a typekind is kind of messy? We should consider
             // refactoring Type to handle this case more explicitly, since it's used in
             // funcrefType() and externrefType().
             // https://bugs.webkit.org/show_bug.cgi?id=247454
-            kindToPrint = static_cast<TypeKind>(signedIndex);
+            kindToPrint = static_cast<TypeKind>(index);
         } else {
             // Assume the index is a pointer to a TypeDefinition.
             out.print(*reinterpret_cast<TypeDefinition*>(index));

--- a/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
+++ b/Source/JavaScriptCore/wasm/generateWasmOpsHeader.py
@@ -70,6 +70,7 @@ type_definitions_except_funcref_externref = ["#define FOR_EACH_WASM_TYPE_EXCEPT_
 type_definitions_except_funcref_externref.extend([t for t in typeMacroizerFiltered(lambda x: x == "funcref" or x == "externref")])
 type_definitions_except_funcref_externref = "".join(type_definitions_except_funcref_externref)
 
+min_type_value = min(wasm.types.items(), key=lambda pair: pair[1]['value'])[1]['value']
 
 def opcodeMacroizer(filter, opcodeField="value", modifier=None):
     inc = 0
@@ -219,6 +220,7 @@ static constexpr unsigned expectedVersionNumber = """ + wasm.expectedVersionNumb
 
 static constexpr unsigned numTypes = """ + str(len(types)) + """;
 
+static constexpr int minTypeValue = """ + str(min_type_value) + """;
 """ + type_definitions + "\n" + """
 """ + type_definitions_except_funcref_externref + """
 #define CREATE_ENUM_VALUE(name, id, ...) name = id,
@@ -228,6 +230,12 @@ enum class TypeKind : int8_t {
 #undef CREATE_ENUM_VALUE
 
 using TypeIndex = uintptr_t;
+
+inline bool typeIndexIsType(TypeIndex index)
+{
+    auto signedIndex = static_cast<std::make_signed<TypeIndex>::type>(index);
+    return (signedIndex < 0) && (signedIndex > minTypeValue);
+}
 
 struct Type {
     TypeKind kind;


### PR DESCRIPTION
#### 24455f01485116bf93e8b750e86691c44d70230d
<pre>
[JSC] Wasm test regressions on 32-bit ARM after 256472@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=247886">https://bugs.webkit.org/show_bug.cgi?id=247886</a>

Reviewed by Yusuke Suzuki.

Testing if the index is &lt; 0 is not appropriate on 32-bit ARM.
Define and use minTypeValue instead.

Implementing <a href="https://bugs.webkit.org/show_bug.cgi?id=247454">https://bugs.webkit.org/show_bug.cgi?id=247454</a> would be a
better medium-term fix.

* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::Type::dump const):
* Source/JavaScriptCore/wasm/generateWasmOpsHeader.py:

Canonical link: <a href="https://commits.webkit.org/257116@main">https://commits.webkit.org/257116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7766d0bc915a5473af81f9e1e671f2534b613ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107433 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167706 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7648 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35957 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90450 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84572 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88838 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1163 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84544 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1145 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28585 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4892 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87380 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41699 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19604 "Passed tests") | 
<!--EWS-Status-Bubble-End-->