### PR TITLE
[Safari 16 regression] service worker download does not work in case of preloads

### DIFF
--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt
@@ -1,0 +1,5 @@
+Download started.
+Downloading URL with suggested filename "fetch-service-worker-preload-script.py.vcf"
+Download size: 7.
+Download completed.
+

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+<script src="/common/utils.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.setShouldLogDownloadSize(true);
+  testRunner.waitUntilDownloadFinished();
+  testRunner.setShouldDownloadUndisplayableMIMETypes(true);
+}
+
+var activeWorker;
+var uuid = token();
+var url = "/WebKit/service-workers/resources/fetch-service-worker-preload-script.py?download=yes&token=" + uuid;
+var frame;
+const channel = new MessageChannel();
+
+function waitUntilActivating()
+{
+    return new Promise(resolve => {
+        channel.port2.onmessage = (event) => {
+            if (event.data === "activating")
+                resolve();
+        };
+    });
+}
+
+function triggerActivation()
+{
+    activeWorker.postMessage("activate");
+}
+
+async function doTest() {
+    if (window.testRunner) {
+        testRunner.setUseSeparateServiceWorkerProcess(true);
+        await fetch("").then(() => { }, () => { });
+    }
+
+    const registration = await navigator.serviceWorker.register("/WebKit/service-workers/fetch-service-worker-preload-worker.js", { scope : url });
+    if (!registration.installing) {
+        registration.unregister();
+        registration = await navigator.serviceWorker.register("/WebKit/service-workers/fetch-service-worker-preload-worker.js", { scope : url });
+    }
+
+    activeWorker = registration.installing;
+    activeWorker.postMessage({ port: channel.port1 }, [channel.port1]);
+
+    await waitUntilActivating();
+    triggerActivation();
+    await registration.navigationPreload.enable();
+
+    // Download size should be size of "use-preload".
+    const promise = withIframe(url + "&promise=getCloneResponseFromNavigationPreload");
+}
+doTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt
@@ -1,0 +1,5 @@
+Download started.
+Downloading URL with suggested filename "fetch-service-worker-preload-script.py.vcf"
+Download size: 7.
+Download completed.
+

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+<script src="/common/utils.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.setShouldLogDownloadCallbacks(true);
+  testRunner.setShouldLogDownloadSize(true);
+  testRunner.waitUntilDownloadFinished();
+  testRunner.setShouldDownloadUndisplayableMIMETypes(true);
+}
+
+var activeWorker;
+var uuid = token();
+var url = "/WebKit/service-workers/resources/fetch-service-worker-preload-script.py?download=yes&token=" + uuid;
+var frame;
+const channel = new MessageChannel();
+
+function waitUntilActivating()
+{
+    return new Promise(resolve => {
+        channel.port2.onmessage = (event) => {
+            if (event.data === "activating")
+                resolve();
+        };
+    });
+}
+
+function triggerActivation()
+{
+    activeWorker.postMessage("activate");
+}
+
+async function doTest() {
+    if (window.testRunner) {
+        testRunner.setUseSeparateServiceWorkerProcess(true);
+        await fetch("").then(() => { }, () => { });
+    }
+
+    const registration = await navigator.serviceWorker.register("/WebKit/service-workers/fetch-service-worker-preload-worker.js", { scope : url });
+    if (!registration.installing) {
+        registration.unregister();
+        registration = await navigator.serviceWorker.register("/WebKit/service-workers/fetch-service-worker-preload-worker.js", { scope : url });
+    }
+
+    activeWorker = registration.installing;
+    activeWorker.postMessage({ port: channel.port1 }, [channel.port1]);
+
+    await waitUntilActivating();
+    triggerActivation();
+    await registration.navigationPreload.enable();
+
+    // Download size should be size of "use-preload".
+    const promise = withIframe(url + "&promise=getResponseFromNavigationPreload");
+}
+doTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-worker.js
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-worker.js
@@ -22,7 +22,7 @@ onactivate = (event) => {
     self.port.postMessage("activating");
 }
 
-self.addEventListener('fetch', (event) => {
+self.addEventListener('fetch', async (event) => {
     if (event.request.url.includes("no-fetch-event-handling"))
         return;
 
@@ -30,5 +30,27 @@ self.addEventListener('fetch', (event) => {
         event.respondWith(event.preloadResponse);
         return;
     }
+
+    if (event.request.url.includes("getResponseFromNavigationPreload") && event.preloadResponse) {
+        event.respondWith((async () => {
+            const response = await event.preloadResponse;
+            if (response)
+                 return response;
+            return fetch(event.request);
+        })());
+        return;
+    }
+
+
+    if (event.request.url.includes("getCloneResponseFromNavigationPreload") && event.preloadResponse) {
+        event.respondWith((async () => {
+            const response = await event.preloadResponse;
+            if (response)
+                 return response.clone();
+            return fetch(event.request);
+        })());
+        return;
+    }
+
     event.respondWith(fetch(event.request));
 });

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1183,6 +1183,9 @@ webkit.org/b/177940 workers/wasm-hashset.html [ Skip ]
 webkit.org/b/201981 http/wpt/service-workers/server-trust-evaluation.https.html [ Failure ]
 webkit.org/b/201981 imported/w3c/web-platform-tests/service-workers/service-worker/fetch-canvas-tainting-image-cache.https.html [ Failure Pass ]
 
+http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https.html [ Failure ]
+http/wpt/service-workers/fetch-service-worker-preload-use-download.https.html [ Failure ]
+
 webkit.org/b/238738 http/wpt/service-workers/navigate-iframes-window-client.https.html [ Failure ]
 webkit.org/b/238738238738 imported/w3c/web-platform-tests/service-workers/service-worker/windowclient-navigate.https.html [ Failure ]
 

--- a/LayoutTests/platform/ios-wk2/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt
@@ -1,0 +1,5 @@
+Download started.
+Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
+Download size: 7.
+Download completed.
+

--- a/LayoutTests/platform/ios-wk2/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt
+++ b/LayoutTests/platform/ios-wk2/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt
@@ -1,0 +1,5 @@
+Download started.
+Downloading URL with suggested filename "fetch-service-worker-preload-script.py"
+Download size: 7.
+Download completed.
+

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -483,7 +483,7 @@ NetworkSession* ServiceWorkerFetchTask::session()
 
 bool ServiceWorkerFetchTask::convertToDownload(DownloadManager& manager, DownloadID downloadID, const ResourceRequest& request, const ResourceResponse& response)
 {
-    if (m_preloader  && !m_preloader->isServiceWorkerNavigationPreloadEnabled())
+    if (m_preloader)
         return m_preloader->convertToDownload(manager, downloadID, request, response);
 
     auto* session = this->session();


### PR DESCRIPTION
#### daf8b0ba46a83dd93ba488b73557960e01e02c7a
<pre>
[Safari 16 regression] service worker download does not work in case of preloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=247885">https://bugs.webkit.org/show_bug.cgi?id=247885</a>
rdar://problem/102312723

Reviewed by Alex Christensen and Geoffrey Garen.

When a fetch is converted to download and is served from a service worker that uses a preload, we should use that preload.

* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https.html: Added.
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https.html: Added.
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-worker.js:
(event.event.request.url.includes): Deleted.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios-wk2/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https-expected.txt: Added.
* LayoutTests/platform/ios-wk2/http/wpt/service-workers/fetch-service-worker-preload-use-download.https-expected.txt: Added.
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::convertToDownload):

Canonical link: <a href="https://commits.webkit.org/256731@main">https://commits.webkit.org/256731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02141c6d5e722eaba775469971802e2c7d152cef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106084 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166424 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6000 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34552 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102799 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4474 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83160 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31444 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74348 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40284 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19690 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37948 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21091 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4672 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43638 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40366 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->