### PR TITLE
Rebaseline properties-value-003 for font-size-adjust

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-003-expected.txt
@@ -25,10 +25,10 @@ FAIL background-size background-size(keyword) / values assert_not_equals: must n
 FAIL background-size background-size(keyword) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "background-size:2s" but got ""
 PASS box-shadow box-shadow(shadow) / values
 FAIL box-shadow box-shadow(shadow) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "box-shadow:2s" but got "-webkit-box-shadow:2s box-shadow:2s"
-FAIL font-size-adjust number(integer) / values assert_not_equals: initial and target values may not match got disallowed value ""
-FAIL font-size-adjust number(integer) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "font-size-adjust:2s" but got ""
-FAIL font-size-adjust number(decimal) / values assert_not_equals: initial and target values may not match got disallowed value ""
-FAIL font-size-adjust number(decimal) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "font-size-adjust:2s" but got ""
+PASS font-size-adjust number(integer) / values
+PASS font-size-adjust number(integer) / events
+PASS font-size-adjust number(decimal) / values
+PASS font-size-adjust number(decimal) / events
 PASS font-stretch font-stretch(keyword) / values
 PASS font-stretch font-stretch(keyword) / events
 FAIL marker-offset length(pt) / values assert_not_equals: initial and target values may not match got disallowed value ""


### PR DESCRIPTION
#### 64fbd5380f82bd9f2bc2968889def6b02bd6846e
<pre>
Rebaseline properties-value-003 for font-size-adjust
<a href="https://bugs.webkit.org/show_bug.cgi?id=247889">https://bugs.webkit.org/show_bug.cgi?id=247889</a>
rdar://problem/102316626

Test has new passing test cases due to font-size-adjust implementation.

Reviewed by Aakash Jain.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-003-expected.txt:

Canonical link: <a href="https://commits.webkit.org/256652@main">https://commits.webkit.org/256652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dde46b9e01b08eb1a43649a0759564ab0b6e450a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105966 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166315 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5854 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34424 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102692 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102094 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83026 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31341 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88095 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74235 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40153 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37827 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4616 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/3849 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/891 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40244 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->