### PR TITLE
Fix sandbox violation of diagnostics service

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/OSLogSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/OSLogSPI.h
@@ -31,11 +31,26 @@
 
 #include <os/log_private.h>
 
+#else
+
+typedef uint32_t os_trace_mode_t;
+
+OS_ENUM(_os_trace_commonmodes, os_trace_mode_t,
+    OS_TRACE_MODE_INFO                          = 0x01,
+    OS_TRACE_MODE_DEBUG                         = 0x02,
+    OS_TRACE_MODE_BACKTRACE                     = 0x04,
+    OS_TRACE_MODE_STREAM_LIVE                   = 0x08,
+    OS_TRACE_MODE_OFF                           = 0x0400,
+);
+
 #endif
 
 WTF_EXTERN_C_BEGIN
 
 OS_EXPORT OS_NOTHROW OS_NOT_TAIL_CALLED OS_NONNULL5
 void os_log_with_args(os_log_t oslog, os_log_type_t type, const char *format, va_list args, void *ret_addr);
+
+OS_EXPORT OS_NOTHROW
+void os_trace_set_mode(os_trace_mode_t mode);
 
 WTF_EXTERN_C_END


### PR DESCRIPTION
#### 3e0b1dd1b0ed0574ee4f4fea42bea235e5bc0ba9
<pre>
Fix sandbox violation of diagnostics service
<a href="https://bugs.webkit.org/show_bug.cgi?id=247898">https://bugs.webkit.org/show_bug.cgi?id=247898</a>
rdar://102321130

Reviewed by Chris Dumez.

In public builds, we block access to a diagnostics service in the WebContent process, which is causing many sandbox violations.
Fix this by adjusting the log mode in public builds.

* Source/WTF/wtf/spi/cocoa/OSLogSPI.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(isInternalBuild):
(WebKit::initializeLogd):
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::initializeXPCConnectionToLogd): Deleted.

Canonical link: <a href="https://commits.webkit.org/256668@main">https://commits.webkit.org/256668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b8a38d3c965f18694da0e55f653b42d06d2ff03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96445 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105988 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166345 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5878 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34446 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102713 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4380 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83048 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31359 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74258 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87430 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40175 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82826 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20993 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28301 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4624 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4124 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85504 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40263 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19273 "Passed tests") | 
<!--EWS-Status-Bubble-End-->