### PR TITLE
[web-animations] changing writing-mode or direction on an element that has an animation targeting a logical property should ensure animation resolution is scheduled

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-replacement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-replacement-expected.txt
@@ -19,7 +19,7 @@ PASS Removes an animation when another animation uses a shorthand
 PASS Removes an animation that uses a shorthand
 PASS Removes an animation by another animation using logical properties
 PASS Removes an animation using logical properties
-FAIL Removes an animation by another animation using logical properties after updating the context assert_equals: expected "removed" but got "active"
+PASS Removes an animation by another animation using logical properties after updating the context
 PASS Removes an animation after updating another animation's effect's target
 PASS Removes an animation after updating its effect's target
 PASS Removes an animation after updating another animation's effect to one with a different target

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -936,6 +936,21 @@ bool KeyframeEffect::animatesProperty(CSSPropertyID property) const
     return false;
 }
 
+bool KeyframeEffect::animatesDirectionAwareProperty() const
+{
+    if (!m_blendingKeyframes.isEmpty())
+        return m_blendingKeyframes.containsDirectionAwareProperty();
+
+    for (auto& keyframe : m_parsedKeyframes) {
+        for (auto property : keyframe.styleStrings.keys()) {
+            if (CSSProperty::isDirectionAwareProperty(property))
+                return true;
+        }
+    }
+
+    return false;
+}
+
 bool KeyframeEffect::forceLayoutIfNeeded()
 {
     if (!m_needsForcedLayout || !m_target)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -163,6 +163,7 @@ public:
     const HashSet<AtomString>& animatedCustomProperties();
     const HashSet<CSSPropertyID>& inheritedProperties() const { return m_inheritedProperties; }
     bool animatesProperty(CSSPropertyID) const;
+    bool animatesDirectionAwareProperty() const;
 
     bool computeExtentOfTransformAnimation(LayoutRect&) const;
     bool computeTransformedExtentViaTransformList(const FloatRect&, const RenderStyle&, LayoutRect&) const;

--- a/Source/WebCore/rendering/style/KeyframeList.cpp
+++ b/Source/WebCore/rendering/style/KeyframeList.cpp
@@ -225,6 +225,15 @@ bool KeyframeList::containsAnimatableProperty() const
     return false;
 }
 
+bool KeyframeList::containsDirectionAwareProperty() const
+{
+    for (auto& keyframe : m_keyframes) {
+        if (keyframe.containsDirectionAwareProperty())
+            return true;
+    }
+    return false;
+}
+
 bool KeyframeList::usesContainerUnits() const
 {
     for (auto& keyframe : m_keyframes) {

--- a/Source/WebCore/rendering/style/KeyframeList.h
+++ b/Source/WebCore/rendering/style/KeyframeList.h
@@ -69,6 +69,9 @@ public:
     std::optional<CompositeOperation> compositeOperation() const { return m_compositeOperation; }
     void setCompositeOperation(std::optional<CompositeOperation> op) { m_compositeOperation = op; }
 
+    bool containsDirectionAwareProperty() const { return m_containsDirectionAwareProperty; }
+    void setContainsDirectionAwareProperty(bool containsDirectionAwareProperty) { m_containsDirectionAwareProperty = containsDirectionAwareProperty; }
+
 private:
     double m_key;
     HashSet<CSSPropertyID> m_properties; // The properties specified in this keyframe.
@@ -76,6 +79,7 @@ private:
     std::unique_ptr<RenderStyle> m_style;
     RefPtr<TimingFunction> m_timingFunction;
     std::optional<CompositeOperation> m_compositeOperation;
+    bool m_containsDirectionAwareProperty { false };
 };
 
 class KeyframeList {
@@ -97,6 +101,7 @@ public:
     bool containsProperty(CSSPropertyID prop) const { return m_properties.contains(prop); }
     const HashSet<CSSPropertyID>& properties() const { return m_properties; }
     bool containsAnimatableProperty() const;
+    bool containsDirectionAwareProperty() const;
 
     void addCustomProperty(const AtomString& customProperty) { m_customProperties.add(customProperty); }
     bool containsCustomProperty(const AtomString& customProperty) const { return m_customProperties.contains(customProperty); }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -281,13 +281,16 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(const Element& element, 
     bool hasRevert = false;
     for (unsigned i = 0; i < propertyCount; ++i) {
         auto propertyReference = keyframe.properties().propertyAt(i);
-        auto property = CSSProperty::resolveDirectionAwareProperty(propertyReference.id(), elementStyle.direction(), elementStyle.writingMode());
+        auto unresolvedProperty = propertyReference.id();
+        auto resolvedProperty = CSSProperty::resolveDirectionAwareProperty(unresolvedProperty, elementStyle.direction(), elementStyle.writingMode());
         // The animation-composition and animation-timing-function within keyframes are special
         // because they are not animated; they just describe the composite operation and timing
         // function between this keyframe and the next.
-        bool isAnimatableValue = property != CSSPropertyAnimationTimingFunction && property != CSSPropertyAnimationComposition;
+        bool isAnimatableValue = resolvedProperty != CSSPropertyAnimationTimingFunction && resolvedProperty != CSSPropertyAnimationComposition;
         if (isAnimatableValue)
-            keyframeValue.addProperty(property);
+            keyframeValue.addProperty(resolvedProperty);
+        if (CSSProperty::isDirectionAwareProperty(unresolvedProperty))
+            keyframeValue.setContainsDirectionAwareProperty(true);
         if (auto* value = propertyReference.value()) {
             if (isAnimatableValue && value->isCustomPropertyValue())
                 keyframeValue.addCustomProperty(downcast<CSSCustomPropertyValue>(*value).name());


### PR DESCRIPTION
#### 1b793da552f71613cc9d8b9b68ffe280890d2428
<pre>
[web-animations] changing writing-mode or direction on an element that has an animation targeting a logical property should ensure animation resolution is scheduled
<a href="https://bugs.webkit.org/show_bug.cgi?id=247895">https://bugs.webkit.org/show_bug.cgi?id=247895</a>

Reviewed by Antti Koivisto.

When an effect in an effect stack is finished and is entirely superseded by another animation targeting the same property,
it can be removed. The procedure to remove replaced animations [0] runs as part of the procedure to update animations and
send events, which in our code happens as a result of page rendering being updated.

In the case where an effect targets a logical property, the *resolved* property it targets can change if the &quot;writing-mode&quot;
or &quot;direction&quot; properties change. And if the resolved target property changes, then the replaced state of the associated
animation may change as well. As such, we must make sure to schedule an animation update when the resolved target property
changes.

To do this, we now track whether a KeyframeValue targets a property that was resolved from a logical property and set that
boolean flag in Style::Resolver::styleForKeyframe(), which populates the generated KeyframeList for both script-originated
animations and CSS Animations. CSS Transitions aren&apos;t a concern here since they cannot change resolved property in-flight,
instead being canceled altogether if &quot;writing-mode&quot; or &quot;direction&quot; changes.

Then in KeyframeEffectStack::applyKeyframeEffects() where we already track whether the &quot;writing-mode&quot; or &quot;direction&quot; property
changes, we ask each processed effect whether they also target a logical property allowing us to determine whether the
resolved animated property changed and ensuring we schedule an update in such a case.

[0] <a href="https://drafts.csswg.org/web-animations-1/#removing-replaced-animations">https://drafts.csswg.org/web-animations-1/#removing-replaced-animations</a>

* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-replacement-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::animatesDirectionAwareProperty const):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/rendering/style/KeyframeList.cpp:
(WebCore::KeyframeList::containsDirectionAwareProperty const):
* Source/WebCore/rendering/style/KeyframeList.h:
(WebCore::KeyframeValue::KeyframeValue):
(WebCore::KeyframeValue::containsDirectionAwareProperty const):
(WebCore::KeyframeValue::setContainsDirectionAwareProperty):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe):

Canonical link: <a href="https://commits.webkit.org/256667@main">https://commits.webkit.org/256667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b74254e6c450712fa28eb8e55fbd60100da7d82c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5729 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/29546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/106015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/100457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/5909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102148 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/76/builds/5909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/83077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/88853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/76/builds/5909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/29546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/88853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/66/builds/40204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/29546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/67/builds/37876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/29546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/4145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/83077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2212 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/29546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->