### PR TITLE
Revert (255705@main): Remove WebArchiveDebugMode

### DIFF
--- a/LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
+++ b/LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
@@ -6,11 +6,11 @@ frame "<!--frame1-->" - didStartProvisionalLoadForFrame
 resources/subresource-null-mimetype.webarchive - willSendRequest <NSURLRequest URL resources/subresource-null-mimetype.webarchive, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
 resources/subresource-null-mimetype.webarchive - didReceiveResponse <NSURLResponse resources/subresource-null-mimetype.webarchive, http status code 0>
 frame "<!--frame1-->" - didCommitLoadForFrame
-webarchive+file:///test.png - willSendRequest <NSURLRequest URL webarchive+file:///test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
+test.png - willSendRequest <NSURLRequest URL test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 resources/subresource-null-mimetype.webarchive - didFinishLoading
-webarchive+file:///test.png - didReceiveResponse <NSURLResponse webarchive+file:///test.png, http status code 0>
-webarchive+file:///test.png - didFinishLoading
+test.png - didReceiveResponse <NSURLResponse test.png, http status code 0>
+test.png - didFinishLoading
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame

--- a/LayoutTests/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
+++ b/LayoutTests/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt
@@ -6,11 +6,11 @@ main frame - didFinishDocumentLoadForFrame
 test-loading-archive-subresource-null-mimetype.html - didFinishLoading
 resources/subresource-null-mimetype.webarchive - didReceiveResponse <NSURLResponse resources/subresource-null-mimetype.webarchive, http status code 0>
 frame "<!--frame1-->" - didCommitLoadForFrame
-webarchive+file:///test.png - willSendRequest <NSURLRequest URL webarchive+file:///test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
+test.png - willSendRequest <NSURLRequest URL test.png, main document URL test-loading-archive-subresource-null-mimetype.html, http method GET> redirectResponse (null)
 frame "<!--frame1-->" - didFinishDocumentLoadForFrame
 resources/subresource-null-mimetype.webarchive - didFinishLoading
-webarchive+file:///test.png - didReceiveResponse <NSURLResponse webarchive+file:///test.png, http status code 0>
-webarchive+file:///test.png - didFinishLoading
+test.png - didReceiveResponse <NSURLResponse test.png, http status code 0>
+test.png - didFinishLoading
 frame "<!--frame1-->" - didHandleOnloadEventsForFrame
 main frame - didHandleOnloadEventsForFrame
 frame "<!--frame1-->" - didFinishLoadForFrame

--- a/Source/WTF/Scripts/Preferences/WebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferences.yaml
@@ -2516,17 +2516,6 @@ WebArchiveDebugModeEnabled:
     WebCore:
       default: false
 
-WebArchiveTestingModeEnabled:
-  type: bool
-  condition: ENABLE(WEB_ARCHIVE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 WebAudioEnabled:
   type: bool
   condition: ENABLE(WEB_AUDIO)

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -429,7 +429,7 @@ struct MarkupAndArchive {
 
 static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buffer, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
 {
-    auto archive = LegacyWebArchive::create(buffer);
+    auto archive = LegacyWebArchive::create(URL(), buffer);
     if (!archive)
         return std::nullopt;
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1229,21 +1229,6 @@ static inline bool shouldUseActiveServiceWorkerFromParent(const Document& docume
 }
 #endif
 
-#if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
-bool DocumentLoader::isLoadingRemoteArchive() const
-{
-#if ENABLE(MHTML)
-    return m_archive && m_archive->shouldOverrideBaseURL();
-#else
-    bool isQuickLookPreview = false;
-#if USE(QUICK_LOOK)
-    isQuickLookPreview = isQuickLookPreviewURL(m_response.url());
-#endif // QUICK_LOOK
-    return m_archive && !m_frame->settings().webArchiveTestingModeEnabled() && !isQuickLookPreview;
-#endif // !MHTML
-}
-#endif // WEBARCHIVE || MHTML
-
 void DocumentLoader::commitData(const SharedBuffer& data)
 {
     if (!m_gotFirstByte) {
@@ -1271,21 +1256,9 @@ void DocumentLoader::commitData(const SharedBuffer& data)
             return;
 
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
-        if (isLoadingRemoteArchive()) {
-            auto& url { m_archive->mainResource()->url() };
-            if (m_archive->shouldOverrideBaseURL())
-                document.setBaseURLOverride(url);
-#if ENABLE(WEB_ARCHIVE)
-            constexpr auto webArchivePrefix { "webarchive+"_s };
-            if (url.protocol().startsWith(webArchivePrefix)) {
-                auto unprefixedScheme { url.protocol().substring(webArchivePrefix.length()) };
-                if (LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(unprefixedScheme.toStringWithoutCopying()))
-                    document.securityOrigin().grantLoadLocalResources();
-            }
-#endif // WEB_ARCHIVE
-        }
-#endif // WEB_ARCHIVE || MHTML
-
+        if (m_archive && m_archive->shouldOverrideBaseURL())
+            document.setBaseURLOverride(m_archive->mainResource()->url());
+#endif
 #if ENABLE(SERVICE_WORKER)
         if (m_canUseServiceWorkers) {
             if (!document.securityOrigin().isOpaque()) {
@@ -1840,7 +1813,12 @@ bool DocumentLoader::scheduleArchiveLoad(ResourceLoader& loader, const ResourceR
     if (!m_archive)
         return false;
 
-    DOCUMENTLOADER_RELEASE_LOG("scheduleArchiveLoad: Failed to unarchive subresource");
+#if ENABLE(WEB_ARCHIVE)
+    // The idea of WebArchiveDebugMode is that we should fail instead of trying to fetch from the network.
+    // Returning true ensures the caller will not try to fetch from the network.
+    if (m_frame->settings().webArchiveDebugModeEnabled() && responseMIMEType() == "application/x-webarchive"_s)
+        return true;
+#endif
 
     // If we want to load from the archive only, then we should always return true so that the caller
     // does not try to fetch from the network.

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -512,10 +512,6 @@ private:
     void clearArchiveResources();
 #endif
 
-#if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
-    bool isLoadingRemoteArchive() const;
-#endif
-
     void willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     void finishedLoading();
     void mainReceivedError(const ResourceError&);

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -222,16 +222,6 @@ void ResourceLoader::start()
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
     if (m_documentLoader && m_documentLoader->scheduleArchiveLoad(*this, m_request))
         return;
-
-#if ENABLE(WEB_ARCHIVE)
-    constexpr auto webArchivePrefix { "webarchive+"_s };
-    if (m_request.url().protocol().startsWith(webArchivePrefix)) {
-        auto url { m_request.url() };
-        const auto unprefixedScheme { url.protocol().substring(webArchivePrefix.length()) };
-        url.setProtocol(unprefixedScheme);
-        m_request.setURL(url);
-    }
-#endif
 #endif
 
     if (m_documentLoader && m_documentLoader->applicationCacheHost().maybeLoadResource(*this, m_request, m_request.url()))

--- a/Source/WebCore/loader/archive/ArchiveResourceCollection.h
+++ b/Source/WebCore/loader/archive/ArchiveResourceCollection.h
@@ -48,7 +48,7 @@ public:
     void addResource(Ref<ArchiveResource>&&);
     void addAllResources(Archive&);
     
-    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(URL);
+    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(const URL&);
     RefPtr<Archive> popSubframeArchive(const String& frameName, const URL&);
     
 private:    

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -52,8 +52,6 @@ public:
     WEBCORE_EXPORT RetainPtr<CFDataRef> rawDataRepresentation();
 
 private:
-    enum class UsePrefixedScheme : bool { No, Yes };
-
     LegacyWebArchive() = default;
 
     bool shouldLoadFromArchiveOnly() const final { return false; }
@@ -63,16 +61,15 @@ private:
 
     enum MainResourceStatus { Subresource, MainResource };
 
-    static RefPtr<LegacyWebArchive> create(const URL&, FragmentedSharedBuffer&, const UsePrefixedScheme);
     static RefPtr<LegacyWebArchive> create(const String& markupString, Frame&, const Vector<Node*>& nodes, Function<bool(Frame&)>&& frameFilter);
-    static RefPtr<ArchiveResource> createResource(CFDictionaryRef, const UsePrefixedScheme);
+    static RefPtr<ArchiveResource> createResource(CFDictionaryRef);
     static ResourceResponse createResourceResponseFromMacArchivedData(CFDataRef);
     static ResourceResponse createResourceResponseFromPropertyListData(CFDataRef, CFStringRef responseDataType);
     static RetainPtr<CFDataRef> createPropertyListRepresentation(const ResourceResponse&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(Archive&);
     static RetainPtr<CFDictionaryRef> createPropertyListRepresentation(ArchiveResource*, MainResourceStatus);
 
-    bool extract(CFDictionaryRef, const UsePrefixedScheme);
+    bool extract(CFDictionaryRef);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -119,11 +119,6 @@ static bool shouldTreatAsOpaqueOrigin(const URL& url)
         || url.protocolIs("x-apple-ql-id2"_s)
         || url.protocolIs("x-apple-ql-magic"_s)
 #endif
-#if ENABLE(WEB_ARCHIVE) && USE(CF)
-        || url.protocolIs("webarchive+http"_s)
-        || url.protocolIs("webarchive+https"_s)
-        || url.protocolIs("webarchive+ftp"_s)
-#endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
         || url.protocolIs("resource"_s)
 #endif

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -567,14 +567,14 @@ bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferencesRef)
     return toImpl(preferencesRef)->domTimersThrottlingEnabled();
 }
 
-void WKPreferencesSetWebArchiveTestingModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
+void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
 {
-    toImpl(preferencesRef)->setWebArchiveTestingModeEnabled(enabled);
+    toImpl(preferencesRef)->setWebArchiveDebugModeEnabled(enabled);
 }
 
-bool WKPreferencesGetWebArchiveTestingModeEnabled(WKPreferencesRef preferencesRef)
+bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
-    return toImpl(preferencesRef)->webArchiveTestingModeEnabled();
+    return toImpl(preferencesRef)->webArchiveDebugModeEnabled();
 }
 
 void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferencesRef, bool enabled)
@@ -2151,15 +2151,6 @@ void WKPreferencesSetXSSAuditorEnabled(WKPreferencesRef, bool)
 }
 
 bool WKPreferencesGetXSSAuditorEnabled(WKPreferencesRef)
-{
-    return false;
-}
-
-void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef, bool enabled)
-{
-}
-
-bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferencesRef)
 {
     return false;
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -122,8 +122,8 @@ WK_EXPORT void WKPreferencesSetDOMTimersThrottlingEnabled(WKPreferencesRef prefe
 WK_EXPORT bool WKPreferencesGetDOMTimersThrottlingEnabled(WKPreferencesRef preferences);
 
 // Defaults to false.
-WK_EXPORT void WKPreferencesSetWebArchiveTestingModeEnabled(WKPreferencesRef preferences, bool enabled);
-WK_EXPORT bool WKPreferencesGetWebArchiveTestingModeEnabled(WKPreferencesRef preferences);
+WK_EXPORT void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferences, bool enabled);
+WK_EXPORT bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferences);
 
 // Defaults to false.
 WK_EXPORT void WKPreferencesSetLocalFileContentSniffingEnabled(WKPreferencesRef preferences, bool enabled);
@@ -561,11 +561,8 @@ WK_EXPORT void WKPreferencesSetResourceTimingEnabled(WKPreferencesRef, bool) WK_
 WK_EXPORT bool WKPreferencesGetResourceTimingEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetSubpixelCSSOMElementMetricsEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
-WK_EXPORT void WKPreferencesSetWebArchiveDebugModeEnabled(WKPreferencesRef preferences, bool enabled) WK_C_API_DEPRECATED;
-WK_EXPORT bool WKPreferencesGetWebArchiveDebugModeEnabled(WKPreferencesRef preferences) WK_C_API_DEPRECATED;
 WK_EXPORT void WKPreferencesSetSubpixelAntialiasedLayerTextEnabled(WKPreferencesRef, bool) WK_C_API_DEPRECATED;
 WK_EXPORT bool WKPreferencesGetSubpixelAntialiasedLayerTextEnabled(WKPreferencesRef) WK_C_API_DEPRECATED;
-
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -982,14 +982,14 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->domTimersThrottlingEnabled();
 }
 
-- (void)_setWebArchiveTestingModeEnabled:(BOOL)enabled
+- (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
 {
-    _preferences->setWebArchiveTestingModeEnabled(enabled);
+    _preferences->setWebArchiveDebugModeEnabled(enabled);
 }
 
-- (BOOL)_webArchiveTestingModeEnabled
+- (BOOL)_webArchiveDebugModeEnabled
 {
-    return _preferences->webArchiveTestingModeEnabled();
+    return _preferences->webArchiveDebugModeEnabled();
 }
 
 - (void)_setLocalFileContentSniffingEnabled:(BOOL)enabled
@@ -1665,15 +1665,6 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 }
 
 - (BOOL)_subpixelCSSOMElementMetricsEnabled
-{
-    return NO;
-}
-
-- (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
-{
-}
-
-- (BOOL)_webArchiveDebugModeEnabled
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -189,7 +189,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setDefaultTextEncodingName:) NSString *_defaultTextEncodingName WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setAuthorAndUserStylesEnabled:) BOOL _authorAndUserStylesEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setDOMTimersThrottlingEnabled:) BOOL _domTimersThrottlingEnabled WK_API_AVAILABLE(macos(10.13.4));
-@property (nonatomic, setter=_setWebArchiveTestingModeEnabled:) BOOL _webArchiveTestingModeEnabled WK_API_AVAILABLE(macos(13.0));
+@property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setLocalFileContentSniffingEnabled:) BOOL _localFileContentSniffingEnabled WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setUsesPageCache:) BOOL _usesPageCache WK_API_AVAILABLE(macos(10.13.4));
 @property (nonatomic, setter=_setPageCacheSupportsPlugins:) BOOL _pageCacheSupportsPlugins WK_API_AVAILABLE(macos(10.13.4));
@@ -235,6 +235,6 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setSubpixelAntialiasedLayerTextEnabled:) BOOL _subpixelAntialiasedLayerTextEnabled WK_API_DEPRECATED("Subpixel antialiased text is no longer supported", macos(10.12, WK_MAC_TBA), ios(10.0, WK_IOS_TBA));
 #if !TARGET_OS_IPHONE
 @property (nonatomic, setter=_setSubpixelCSSOMElementMetricsEnabled:) BOOL _subpixelCSSOMElementMetricsEnabled WK_API_DEPRECATED("Subpixel CSSOM element metrics are no longer supported", macos(10.13.4, 10.15));
-@property (nonatomic, setter=_setWebArchiveDebugModeEnabled:) BOOL _webArchiveDebugModeEnabled WK_API_DEPRECATED("WebArchive Debug Mode is no longer supported", macos(10.13.4, 13.0));
 #endif
+
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3273,13 +3273,6 @@ IGNORE_WARNINGS_END
     if ([scheme _webkit_isCaseInsensitiveEqualToString:@"blob"])
         return YES;
 
-    NSString* webArchivePrefix = @"webarchive+";
-    if ([scheme _webkit_hasCaseInsensitivePrefix:webArchivePrefix]) {
-        auto url = [request URL];
-        NSString* modifiedURL = [[url absoluteString] substringFromIndex:[webArchivePrefix length]];
-        return [self _canHandleRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:modifiedURL]] forMainFrame:forMainFrame];
-    }
-
     return NO;
 }
 

--- a/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm
@@ -32,7 +32,6 @@
 #import "TestWKWebView.h"
 #import <WebKit/WKDragDestinationAction.h>
 #import <WebKit/WKNavigationPrivate.h>
-#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -206,9 +205,9 @@ TEST(LoadWebArchive, DragNavigationReload)
     EXPECT_WK_STREQ(finalURL, "");
 }
 
-static NSData* constructArchive(const char *script)
+static NSData* constructArchive()
 {
-    auto *js = [NSString stringWithUTF8String:script];
+    NSString *js = @"alert('loaded http subresource successfully')";
     auto response = adoptNS([[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://download/script.js"] MIMEType:@"application/javascript" expectedContentLength:js.length textEncodingName:@"utf-8"]);
     auto responseArchiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
     [responseArchiver encodeObject:response.get() forKey:@"WebResourceResponse"];
@@ -233,7 +232,7 @@ static NSData* constructArchive(const char *script)
 
 TEST(LoadWebArchive, HTTPSUpgrade)
 {
-    NSData *data = constructArchive("alert('loaded http subresource successfully')");
+    NSData *data = constructArchive();
 
     auto webView = adoptNS([WKWebView new]);
     [webView loadData:data MIMEType:@"application/x-webarchive" characterEncodingName:@"utf-8" baseURL:[NSURL URLWithString:@"http://download/"]];
@@ -242,7 +241,7 @@ TEST(LoadWebArchive, HTTPSUpgrade)
 
 TEST(LoadWebArchive, DisallowedNetworkHosts)
 {
-    NSData *data = constructArchive("alert('loaded http subresource successfully')");
+    NSData *data = constructArchive();
 
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get()._allowedNetworkHosts = [NSSet set];
@@ -253,7 +252,3 @@ TEST(LoadWebArchive, DisallowedNetworkHosts)
 }
 
 } // namespace TestWebKitAPI
-
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/LoadWebArchiveAdditions.mm>
-#endif


### PR DESCRIPTION
#### 18c8e990f9b6144f63de52b51564879bb48c37a6
<pre>
Revert (255705@main): Remove WebArchiveDebugMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=247896">https://bugs.webkit.org/show_bug.cgi?id=247896</a>
rdar://102319526

Reviewed by Wenson Hsieh.

Reverting API removal due to discovered breakage.

* LayoutTests/platform/wk2/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt:
* LayoutTests/webarchive/loading/test-loading-archive-subresource-null-mimetype-expected.txt:
* Source/WTF/Scripts/Preferences/WebPreferences.yaml:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::extractMarkupAndArchive):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::scheduleArchiveLoad):
(WebCore::DocumentLoader::isLoadingRemoteArchive const): Deleted.
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::start):
* Source/WebCore/loader/archive/ArchiveResourceCollection.cpp:
(WebCore::ArchiveResourceCollection::addResource):
(WebCore::ArchiveResourceCollection::archiveResourceForURL):
(): Deleted.
* Source/WebCore/loader/archive/ArchiveResourceCollection.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createResource):
(WebCore::LegacyWebArchive::create):
(WebCore::LegacyWebArchive::extract):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::shouldTreatAsOpaqueOrigin):
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetWebArchiveDebugModeEnabled):
(WKPreferencesGetWebArchiveDebugModeEnabled):
(WKPreferencesSetWebArchiveTestingModeEnabled): Deleted.
(WKPreferencesGetWebArchiveTestingModeEnabled): Deleted.
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setWebArchiveDebugModeEnabled:]):
(-[WKPreferences _webArchiveDebugModeEnabled]):
(-[WKPreferences _setWebArchiveTestingModeEnabled:]): Deleted.
(-[WKPreferences _webArchiveTestingModeEnabled]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView _canHandleRequest:forMainFrame:]):
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::constructArchive):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/256696@main">https://commits.webkit.org/256696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53cd1cef2ef576ebc9b45499712bd59270e97578

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/105993 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166344 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5883 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34450 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102718 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4386 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83053 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31365 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74263 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87434 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40180 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19608 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82831 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/20999 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28302 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4647 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43561 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85509 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40269 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19274 "Passed tests") | 
<!--EWS-Status-Bubble-End-->