### PR TITLE
Web Inspector: Cookies for extensions show UUID instead of extension name in Storage tab

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/CookieStorageTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CookieStorageTreeElement.js
@@ -36,7 +36,7 @@ WI.CookieStorageTreeElement = class CookieStorageTreeElement extends WI.StorageT
 
     get name()
     {
-        return this.representedObject.host;
+        return WI.displayNameForHost(this.representedObject.host);
     }
 
     get categoryName()


### PR DESCRIPTION
#### 6cf49cf97d1f72b2a52b05827a552b179d125e90
<pre>
Web Inspector: Cookies for extensions show UUID instead of extension name in Storage tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=247903">https://bugs.webkit.org/show_bug.cgi?id=247903</a>
rdar://101966366

Reviewed by Timothy Hatcher.

`CookieStorageTreeElement` was the only subclass of `StorageTreeElement` not using `WI.displayNameForHost` to generate a
display name, which exists to convert extension UUIDs into a friendly name. Non-extension cookies will still just use
the host for its name.

* Source/WebInspectorUI/UserInterface/Views/CookieStorageTreeElement.js:
(WI.CookieStorageTreeElement.prototype.get name):

Canonical link: <a href="https://commits.webkit.org/256695@main">https://commits.webkit.org/256695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cfb78c0744f6ca01434ca3b2810774ab2396427

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106000 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166352 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5892 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34458 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102725 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4396 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83061 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31374 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88124 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74275 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40187 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19615 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21007 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43569 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40277 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->