### PR TITLE
html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-expected.txt
@@ -22,8 +22,8 @@ PASS show: Autofocus after, yes delegatesFocus
 PASS showModal: Autofocus after, yes delegatesFocus
 PASS show: Autofocus on shadow host, yes delegatesFocus, no siblings
 PASS showModal: Autofocus on shadow host, yes delegatesFocus, no siblings
-FAIL show: Autofocus on shadow host, yes delegatesFocus, sibling before assert_equals: expected Element node <div autofocus="true"></div> but got Element node <button tabindex="-1">Focusable</button>
-FAIL showModal: Autofocus on shadow host, yes delegatesFocus, sibling before assert_equals: expected Element node <div autofocus="true"></div> but got Element node <button tabindex="-1">Focusable</button>
+PASS show: Autofocus on shadow host, yes delegatesFocus, sibling before
+PASS showModal: Autofocus on shadow host, yes delegatesFocus, sibling before
 PASS show: Autofocus on shadow host, yes delegatesFocus, sibling after
 PASS showModal: Autofocus on shadow host, yes delegatesFocus, sibling after
 PASS show: Autofocus on shadow host, no delegatesFocus, no siblings

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3225,6 +3225,8 @@ static bool isProgramaticallyFocusable(Element& element)
     return element.supportsFocus();
 }
 
+static RefPtr<Element> findFocusDelegateInternal(ContainerNode& target);
+
 // https://html.spec.whatwg.org/multipage/interaction.html#autofocus-delegate
 static RefPtr<Element> autoFocusDelegate(ContainerNode& target)
 {
@@ -3232,7 +3234,7 @@ static RefPtr<Element> autoFocusDelegate(ContainerNode& target)
         if (!element.hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
             continue;
         if (auto root = shadowRootWithDelegatesFocus(element)) {
-            if (auto target = autoFocusDelegate(*root))
+            if (auto target = findFocusDelegateInternal(*root))
                 return target;
         }
         if (isProgramaticallyFocusable(element))


### PR DESCRIPTION
#### 2fe8f95f2038133a86a66f58504f2c7dff5de6f9
<pre>
html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=247910">https://bugs.webkit.org/show_bug.cgi?id=247910</a>

Reviewed by Tim Nguyen.

The test cases were failing because &quot;autofocus delegate&quot; was invoking &quot;autofocus delegate&quot; in step 1.2. instead of
&quot;getting the focusable area&quot;, which then invokes &quot;focus delegate&quot; when the target is a shadow host with focus delegates.

Relevant spec concepts:
<a href="https://html.spec.whatwg.org/multipage/interaction.html#autofocus-delegate">https://html.spec.whatwg.org/multipage/interaction.html#autofocus-delegate</a>
<a href="https://html.spec.whatwg.org/multipage/interaction.html#focus-delegate">https://html.spec.whatwg.org/multipage/interaction.html#focus-delegate</a>
<a href="https://html.spec.whatwg.org/multipage/interaction.html#get-the-focusable-area">https://html.spec.whatwg.org/multipage/interaction.html#get-the-focusable-area</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-shadow-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::autoFocusDelegate):

Canonical link: <a href="https://commits.webkit.org/256672@main">https://commits.webkit.org/256672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad883085365a5ab6a9e6291902f9baa145d29776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106008 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166360 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5901 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34466 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102732 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102140 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83069 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31377 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74279 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40196 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37869 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21014 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4140 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2214 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40284 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->