### PR TITLE
Rename FormNamedItem to FormAssociatedElement

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -891,8 +891,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/DataListSuggestionInformation.h
     html/EnterKeyHint.h
     html/FeaturePolicy.h
+    html/FormAssociatedElement.h
     html/FormListedElement.h
-    html/FormNamedItem.h
     html/HTMLAnchorElement.h
     html/HTMLAnchorElementInlines.h
     html/HTMLAreaElement.h

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -24,13 +24,13 @@ namespace WebCore {
 
 class HTMLElement;
 
-// FIXME: Rename this to FormAssociatedElement
-class FormNamedItem {
+// https://html.spec.whatwg.org/multipage/forms.html#form-associated-element
+class FormAssociatedElement {
 public:
     void ref() { refFormAssociatedElement(); }
     void deref() { derefFormAssociatedElement(); }
 
-    virtual ~FormNamedItem() = default;
+    virtual ~FormAssociatedElement() = default;
     virtual HTMLElement& asHTMLElement() = 0;
     virtual const HTMLElement& asHTMLElement() const = 0;
     virtual bool isFormListedElement() const = 0;

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "FormNamedItem.h"
+#include "FormAssociatedElement.h"
 #include "Node.h"
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
@@ -39,7 +39,7 @@ class HTMLFormElement;
 class ValidityState;
 
 // https://html.spec.whatwg.org/multipage/forms.html#category-listed
-class FormListedElement : public FormNamedItem {
+class FormListedElement : public FormAssociatedElement {
     WTF_MAKE_NONCOPYABLE(FormListedElement);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -762,7 +762,7 @@ HTMLFormElement* HTMLElement::form() const
     return HTMLFormElement::findClosestFormAncestor(*this);
 }
 
-FormNamedItem* HTMLElement::asFormNamedItem()
+FormAssociatedElement* HTMLElement::asFormAssociatedElement()
 {
     return nullptr;
 }

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class ElementInternals;
 class FormListedElement;
-class FormNamedItem;
+class FormAssociatedElement;
 class HTMLFormElement;
 class VisibleSelection;
 struct SimpleRange;
@@ -100,7 +100,7 @@ public:
     bool willRespondToMouseClickEventsWithEditability(Editability) const override;
 
     virtual bool isLabelable() const { return false; }
-    virtual FormNamedItem* asFormNamedItem();
+    virtual FormAssociatedElement* asFormAssociatedElement();
     virtual FormListedElement* asFormListedElement();
 
     virtual bool isInteractiveContent() const { return false; }

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -188,7 +188,7 @@ private:
     HTMLElement& asHTMLElement() final { return *this; }
     const HTMLFormControlElement& asHTMLElement() const final { return *this; }
 
-    FormNamedItem* asFormNamedItem() final { return this; }
+    FormAssociatedElement* asFormAssociatedElement() final { return this; }
     FormListedElement* asFormListedElement() final { return this; }
 
     bool needsMouseFocusableQuirk() const;

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -878,7 +878,7 @@ bool HTMLFormElement::reportValidity()
 }
 
 #if ASSERT_ENABLED
-void HTMLFormElement::assertItemCanBeInPastNamesMap(FormNamedItem& item) const
+void HTMLFormElement::assertItemCanBeInPastNamesMap(FormAssociatedElement& item) const
 {
     HTMLElement& element = item.asHTMLElement();
     ASSERT(element.form() == this);
@@ -902,12 +902,12 @@ RefPtr<HTMLElement> HTMLFormElement::elementFromPastNamesMap(const AtomString& p
         return nullptr;
     RefPtr element { weakElement.get() };
 #if ASSERT_ENABLED
-    assertItemCanBeInPastNamesMap(*element->asFormNamedItem());
+    assertItemCanBeInPastNamesMap(*element->asFormAssociatedElement());
 #endif
     return element;
 }
 
-void HTMLFormElement::addToPastNamesMap(FormNamedItem& item, const AtomString& pastName)
+void HTMLFormElement::addToPastNamesMap(FormAssociatedElement& item, const AtomString& pastName)
 {
 #if ASSERT_ENABLED
     assertItemCanBeInPastNamesMap(item);
@@ -917,7 +917,7 @@ void HTMLFormElement::addToPastNamesMap(FormNamedItem& item, const AtomString& p
     m_pastNamesMap.set(pastName.impl(), item.asHTMLElement());
 }
 
-void HTMLFormElement::removeFromPastNamesMap(FormNamedItem& item)
+void HTMLFormElement::removeFromPastNamesMap(FormAssociatedElement& item)
 {
     if (m_pastNamesMap.isEmpty())
         return;
@@ -948,7 +948,7 @@ Vector<Ref<Element>> HTMLFormElement::namedElements(const AtomString& name)
 
     auto elementFromPast = elementFromPastNamesMap(name);
     if (namedItems.size() == 1 && namedItems.first().ptr() != elementFromPast)
-        addToPastNamesMap(*downcast<HTMLElement>(namedItems.first().get()).asFormNamedItem(), name);
+        addToPastNamesMap(*downcast<HTMLElement>(namedItems.first().get()).asFormAssociatedElement(), name);
     else if (elementFromPast && namedItems.isEmpty())
         namedItems.append(*elementFromPast);
 

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -160,11 +160,11 @@ private:
     bool checkInvalidControlsAndCollectUnhandled(Vector<RefPtr<HTMLFormControlElement>>&);
 
     RefPtr<HTMLElement> elementFromPastNamesMap(const AtomString&) const;
-    void addToPastNamesMap(FormNamedItem&, const AtomString& pastName);
+    void addToPastNamesMap(FormAssociatedElement&, const AtomString& pastName);
 #if ASSERT_ENABLED
-    void assertItemCanBeInPastNamesMap(FormNamedItem&) const;
+    void assertItemCanBeInPastNamesMap(FormAssociatedElement&) const;
 #endif
-    void removeFromPastNamesMap(FormNamedItem&);
+    void removeFromPastNamesMap(FormAssociatedElement&);
 
     bool matchesValidPseudoClass() const final;
     bool matchesInvalidPseudoClass() const final;

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -25,7 +25,7 @@
 
 #include "ActiveDOMObject.h"
 #include "DecodingOptions.h"
-#include "FormNamedItem.h"
+#include "FormAssociatedElement.h"
 #include "GraphicsLayer.h"
 #include "GraphicsTypes.h"
 #include "HTMLElement.h"
@@ -46,7 +46,7 @@ struct ImageCandidate;
 enum class ReferrerPolicy : uint8_t;
 enum class RelevantMutation : bool;
 
-class HTMLImageElement : public HTMLElement, public FormNamedItem, public ActiveDOMObject {
+class HTMLImageElement : public HTMLElement, public FormAssociatedElement, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLImageElement);
     friend class HTMLFormElement;
 public:
@@ -206,7 +206,7 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) override;
 
     bool isFormListedElement() const final { return false; }
-    FormNamedItem* asFormNamedItem() final { return this; }
+    FormAssociatedElement* asFormAssociatedElement() final { return this; }
     HTMLImageElement& asHTMLElement() final { return *this; }
     const HTMLImageElement& asHTMLElement() const final { return *this; }
 

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -91,7 +91,7 @@ private:
     void refFormAssociatedElement() final { ref(); }
     void derefFormAssociatedElement() final { deref(); }
 
-    FormNamedItem* asFormNamedItem() final { return this; }
+    FormAssociatedElement* asFormAssociatedElement() final { return this; }
     FormListedElement* asFormListedElement() final { return this; }
 
     // These functions can be called concurrently for ValidityState.


### PR DESCRIPTION
#### b8989c738ff49825b179917831a0e8607ef039b4
<pre>
Rename FormNamedItem to FormAssociatedElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=247912">https://bugs.webkit.org/show_bug.cgi?id=247912</a>

Reviewed by Chris Dumez.

Renamed FormNamedItem to FormAssociatedElement since it maps to the concept of the same name
in the HTML5 specification: <a href="https://html.spec.whatwg.org/multipage/forms.html#form-associated-element">https://html.spec.whatwg.org/multipage/forms.html#form-associated-element</a>

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/FormAssociatedElement.h: Renamed from Source/WebCore/html/FormNamedItem.h.
(WebCore::FormAssociatedElement::ref):
(WebCore::FormAssociatedElement::deref):
* Source/WebCore/html/FormListedElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::asFormAssociatedElement):
(WebCore::HTMLElement::asFormNamedItem): Deleted.
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::assertItemCanBeInPastNamesMap const):
(WebCore::HTMLFormElement::elementFromPastNamesMap const):
(WebCore::HTMLFormElement::addToPastNamesMap):
(WebCore::HTMLFormElement::removeFromPastNamesMap):
(WebCore::HTMLFormElement::namedElements):
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLObjectElement.h:

Canonical link: <a href="https://commits.webkit.org/256678@main">https://commits.webkit.org/256678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88ae5826e8d2445174e54e0dc8e1e7a618fd54cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106011 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166362 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5905 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34469 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102734 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4404 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83073 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31382 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74284 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40200 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37872 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21018 "Found 1 new test failure: gamepad/gamepad-polling-access.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2217 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40288 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->