### PR TITLE
[WK2] Introduce IPC::Message to better support move semantics of message arguments

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -42,9 +42,9 @@ public:
 
     template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
     {
-        static_assert(!T::isSync, "Message is sync!");
+        static_assert(!MessageTraits<T>::isSync, "Message is sync!");
 
-        auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID);
+        auto encoder = makeUniqueRef<Encoder>(MessageTraits<T>::name(), destinationID);
         encoder.get() << message.arguments();
         return sendMessage(WTFMove(encoder), sendOptions);
     }
@@ -60,7 +60,7 @@ public:
     template<typename T>
     SendSyncResult<T> sendSync(T&& message, Timeout timeout = Timeout::infinity(), OptionSet<SendSyncOption> sendSyncOptions = { })
     {
-        static_assert(T::isSync, "Message is not sync!");
+        static_assert(MessageTraits<T>::isSync, "Message is not sync!");
 
         return sendSync(std::forward<T>(message), messageSenderDestinationID(), timeout, sendSyncOptions);
     }
@@ -91,9 +91,9 @@ public:
     template<typename T, typename C>
     AsyncReplyID sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> sendOptions = { })
     {
-        static_assert(!T::isSync, "Async message expected");
+        static_assert(!MessageTraits<T>::isSync, "Async message expected");
 
-        auto encoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
+        auto encoder = makeUniqueRef<IPC::Encoder>(MessageTraits<T>::name(), destinationID);
         encoder.get() << WTFMove(message).arguments();
         auto asyncHandler = Connection::makeAsyncReplyHandler<T>(WTFMove(completionHandler));
         auto replyID = asyncHandler.replyID;

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -148,7 +148,7 @@ bool StreamServerConnection::send(T&& message, ObjectIdentifier<U> destinationID
 template<typename T, typename... Arguments>
 void StreamServerConnection::sendSyncReply(Connection::SyncRequestID syncRequestID, Arguments&&... arguments)
 {
-    if constexpr(T::isReplyStreamEncodable) {
+    if constexpr(MessageTraits<T>::isReplyStreamEncodable) {
         if (m_isDispatchingStreamMessage) {
             auto span = acquireAll();
             {

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -176,8 +176,8 @@ def message_to_struct_declaration(receiver, message):
                 sys.stderr.write("Error: %s::%s has a reply but is marked as batched. Messages with replies are intended to be sent without latency.\n" % (receiver.name, message.name))
                 sys.exit(1)
         result.append('    static constexpr bool isStreamBatched = %s;\n' % ('false', 'true')[message.has_attribute(STREAM_BATCHED_ATTRIBUTE)])
-
     result.append('\n')
+
     if message.reply_parameters != None:
         if not message.has_attribute(SYNCHRONOUS_ATTRIBUTE):
             result.append('    static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::%s_%sReply; }\n' % (receiver.name, message.name))
@@ -186,12 +186,12 @@ def message_to_struct_declaration(receiver, message):
         else:
             result.append('    static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;\n')
         result.append('    using ReplyArguments = std::tuple<%s>;\n' % ', '.join([parameter.type for parameter in message.reply_parameters]))
+        result.append('\n')
 
-    if len(function_parameters):
-        result.append('    %s%s(%s)' % (len(function_parameters) == 1 and 'explicit ' or '', message.name, ', '.join([' '.join(x) for x in function_parameters])))
-        result.append('\n        : m_arguments(%s)\n' % ', '.join([x[1] for x in function_parameters]))
-        result.append('    {\n')
-        result.append('    }\n\n')
+    result.append('    explicit %s(%s)\n' % (message.name, ', '.join([' '.join(x) for x in function_parameters])))
+    result.append('        : m_arguments(%s)\n' % ', '.join([x[1] for x in function_parameters]))
+    result.append('    { }\n')
+    result.append('\n')
     result.append('    const auto& arguments() const\n')
     result.append('    {\n')
     result.append('        return m_arguments;\n')

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -53,8 +53,7 @@ public:
 
     explicit SendCVPixelBuffer(const RetainPtr<CVPixelBufferRef>& s0)
         : m_arguments(s0)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -77,6 +76,11 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
+
+    explicit ReceiveCVPixelBuffer()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h
@@ -50,8 +50,7 @@ public:
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -71,10 +70,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
     static constexpr bool isSync = false;
 
-    LoadURL(const String& url, int64_t value)
+    explicit LoadURL(const String& url, int64_t value)
         : m_arguments(url, value)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -50,8 +50,7 @@ public:
 
     explicit SendImageData(const RefPtr<WebCore::ImageData>& s0)
         : m_arguments(s0)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -72,6 +71,11 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RefPtr<WebCore::ImageData>>;
+
+    explicit ReceiveImageData()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -71,8 +71,7 @@ public:
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -93,8 +92,7 @@ public:
 
     explicit LoadSomething(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -116,8 +114,7 @@ public:
 
     explicit TouchEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -139,8 +136,7 @@ public:
 
     explicit AddEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -162,8 +158,7 @@ public:
 
     explicit LoadSomethingElse(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -182,10 +177,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision; }
     static constexpr bool isSync = false;
 
-    DidReceivePolicyDecision(uint64_t frameID, uint64_t listenerID, uint32_t policyAction)
+    explicit DidReceivePolicyDecision(uint64_t frameID, uint64_t listenerID, uint32_t policyAction)
         : m_arguments(frameID, listenerID, policyAction)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -202,6 +196,10 @@ public:
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_Close; }
     static constexpr bool isSync = false;
+
+    explicit Close()
+        : m_arguments()
+    { }
 
     const auto& arguments() const
     {
@@ -221,8 +219,7 @@ public:
 
     explicit PreferencesDidChange(const WebKit::WebPreferencesStore& store)
         : m_arguments(store)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -240,10 +237,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendDoubleAndFloat; }
     static constexpr bool isSync = false;
 
-    SendDoubleAndFloat(double d, float f)
+    explicit SendDoubleAndFloat(double d, float f)
         : m_arguments(d, f)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -261,10 +257,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_SendInts; }
     static constexpr bool isSync = false;
 
-    SendInts(const Vector<uint64_t>& ints, const Vector<Vector<uint64_t>>& intVectors)
+    explicit SendInts(const Vector<uint64_t>& ints, const Vector<Vector<uint64_t>>& intVectors)
         : m_arguments(ints, intVectors)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -285,10 +280,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
-    CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
+
+    explicit CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
         : m_arguments(pluginInstanceID, parameters)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -309,10 +304,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    RunJavaScriptAlert(uint64_t frameID, const String& message)
+
+    explicit RunJavaScriptAlert(uint64_t frameID, const String& message)
         : m_arguments(frameID, message)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -333,10 +328,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
+
     explicit GetPlugins(bool refresh)
         : m_arguments(refresh)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -356,10 +351,10 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Connection::Handle>;
+
     explicit GetPluginProcessConnection(const String& pluginPath)
         : m_arguments(pluginPath)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -379,6 +374,11 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+
+    explicit TestMultipleAttributes()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;
@@ -395,10 +395,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_TestParameterAttributes; }
     static constexpr bool isSync = false;
 
-    TestParameterAttributes(uint64_t foo, double bar, double baz)
+    explicit TestParameterAttributes(uint64_t foo, double bar, double baz)
         : m_arguments(foo, bar, baz)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -418,8 +417,7 @@ public:
 
     explicit TemplateTest(const HashMap<String, std::pair<String, uint64_t>>& a)
         : m_arguments(a)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -439,8 +437,7 @@ public:
 
     explicit SetVideoLayerID(const WebCore::GraphicsLayer::PlatformLayerID& videoLayerID)
         : m_arguments(videoLayerID)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -459,10 +456,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection; }
     static constexpr bool isSync = false;
 
-    DidCreateWebProcessConnection(const MachSendRight& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
+    explicit DidCreateWebProcessConnection(const MachSendRight& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
         : m_arguments(connectionIdentifier, flags)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -485,10 +481,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithLegacyReceiver_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
+
     explicit InterpretKeyEvent(uint32_t type)
         : m_arguments(type)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -510,8 +506,7 @@ public:
 
     explicit DeprecatedOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -533,8 +528,7 @@ public:
 
     explicit ExperimentalOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -49,8 +49,7 @@ public:
 
     explicit SendSemaphore(const IPC::Semaphore& s0)
         : m_arguments(s0)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -71,6 +70,11 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Semaphore>;
+
+    explicit ReceiveSemaphore()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -51,8 +51,7 @@ public:
 
     explicit SendString(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
@@ -51,8 +51,7 @@ public:
 
     explicit SendStreamBuffer(const IPC::StreamConnectionBuffer& stream)
         : m_arguments(stream)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -52,8 +52,7 @@ public:
 
     explicit SendString(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -77,10 +76,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_SendStringAsyncReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<int64_t>;
+
     explicit SendStringAsync(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -103,10 +102,10 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<int64_t>;
+
     explicit SendStringSync(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -129,8 +128,7 @@ public:
 
     explicit SendMachSendRight(const MachSendRight& a1)
         : m_arguments(a1)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -155,6 +153,11 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<MachSendRight>;
+
+    explicit ReceiveMachSendRight()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;
@@ -178,10 +181,10 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<MachSendRight>;
+
     explicit SendAndReceiveMachSendRight(const MachSendRight& a1)
         : m_arguments(a1)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -54,8 +54,7 @@ public:
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -77,10 +76,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::MainThread;
     using ReplyArguments = std::tuple<uint64_t>;
+
     explicit TestAsyncMessage(WebKit::TestTwoStateEnum twoStateEnum)
         : m_arguments(twoStateEnum)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -103,6 +102,11 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+
+    explicit TestAsyncMessageWithNoArguments()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;
@@ -124,6 +128,11 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool, uint64_t>;
+
+    explicit TestAsyncMessageWithMultipleArguments()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;
@@ -145,10 +154,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithConnectionReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
+
     explicit TestAsyncMessageWithConnection(const int& value)
         : m_arguments(value)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -169,10 +178,10 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<uint8_t>;
+
     explicit TestSyncMessage(uint32_t param)
         : m_arguments(param)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -192,10 +201,10 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<std::optional<WebKit::TestClassName>>;
+
     explicit TestSynchronousMessage(bool value)
         : m_arguments(value)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -71,8 +71,7 @@ public:
 
     explicit LoadURL(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -93,8 +92,7 @@ public:
 
     explicit LoadSomething(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -116,8 +114,7 @@ public:
 
     explicit TouchEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -139,8 +136,7 @@ public:
 
     explicit AddEvent(const WebKit::WebTouchEvent& event)
         : m_arguments(event)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -162,8 +158,7 @@ public:
 
     explicit LoadSomethingElse(const String& url)
         : m_arguments(url)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -182,10 +177,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidReceivePolicyDecision; }
     static constexpr bool isSync = false;
 
-    DidReceivePolicyDecision(uint64_t frameID, uint64_t listenerID, uint32_t policyAction)
+    explicit DidReceivePolicyDecision(uint64_t frameID, uint64_t listenerID, uint32_t policyAction)
         : m_arguments(frameID, listenerID, policyAction)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -202,6 +196,10 @@ public:
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_Close; }
     static constexpr bool isSync = false;
+
+    explicit Close()
+        : m_arguments()
+    { }
 
     const auto& arguments() const
     {
@@ -221,8 +219,7 @@ public:
 
     explicit PreferencesDidChange(const WebKit::WebPreferencesStore& store)
         : m_arguments(store)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -240,10 +237,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendDoubleAndFloat; }
     static constexpr bool isSync = false;
 
-    SendDoubleAndFloat(double d, float f)
+    explicit SendDoubleAndFloat(double d, float f)
         : m_arguments(d, f)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -261,10 +257,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_SendInts; }
     static constexpr bool isSync = false;
 
-    SendInts(const Vector<uint64_t>& ints, const Vector<Vector<uint64_t>>& intVectors)
+    explicit SendInts(const Vector<uint64_t>& ints, const Vector<Vector<uint64_t>>& intVectors)
         : m_arguments(ints, intVectors)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -285,10 +280,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_CreatePluginReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool>;
-    CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
+
+    explicit CreatePlugin(uint64_t pluginInstanceID, const WebKit::Plugin::Parameters& parameters)
         : m_arguments(pluginInstanceID, parameters)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -309,10 +304,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_RunJavaScriptAlertReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    RunJavaScriptAlert(uint64_t frameID, const String& message)
+
+    explicit RunJavaScriptAlert(uint64_t frameID, const String& message)
         : m_arguments(frameID, message)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -333,10 +328,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_GetPluginsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::PluginInfo>>;
+
     explicit GetPlugins(bool refresh)
         : m_arguments(refresh)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -356,10 +351,10 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Connection::Handle>;
+
     explicit GetPluginProcessConnection(const String& pluginPath)
         : m_arguments(pluginPath)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -379,6 +374,11 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
+
+    explicit TestMultipleAttributes()
+        : m_arguments()
+    { }
+
     const auto& arguments() const
     {
         return m_arguments;
@@ -395,10 +395,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_TestParameterAttributes; }
     static constexpr bool isSync = false;
 
-    TestParameterAttributes(uint64_t foo, double bar, double baz)
+    explicit TestParameterAttributes(uint64_t foo, double bar, double baz)
         : m_arguments(foo, bar, baz)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -418,8 +417,7 @@ public:
 
     explicit TemplateTest(const HashMap<String, std::pair<String, uint64_t>>& a)
         : m_arguments(a)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -439,8 +437,7 @@ public:
 
     explicit SetVideoLayerID(const WebCore::GraphicsLayer::PlatformLayerID& videoLayerID)
         : m_arguments(videoLayerID)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -459,10 +456,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_DidCreateWebProcessConnection; }
     static constexpr bool isSync = false;
 
-    DidCreateWebProcessConnection(const MachSendRight& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
+    explicit DidCreateWebProcessConnection(const MachSendRight& connectionIdentifier, const OptionSet<WebKit::SelectionFlags>& flags)
         : m_arguments(connectionIdentifier, flags)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -485,10 +481,10 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithoutAttributes_InterpretKeyEventReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<Vector<WebCore::KeypressCommand>>;
+
     explicit InterpretKeyEvent(uint32_t type)
         : m_arguments(type)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -510,8 +506,7 @@ public:
 
     explicit DeprecatedOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {
@@ -533,8 +528,7 @@ public:
 
     explicit ExperimentalOperation(const IPC::DummyType& dummy)
         : m_arguments(dummy)
-    {
-    }
+    { }
 
     const auto& arguments() const
     {

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -219,9 +219,9 @@ private:
 template<typename T>
 bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions)
 {
-    static_assert(!T::isSync, "Async message expected");
+    static_assert(!IPC::MessageTraits<T>::isSync, "Async message expected");
 
-    auto encoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
+    auto encoder = makeUniqueRef<IPC::Encoder>(IPC::MessageTraits<T>::name(), destinationID);
     encoder.get() << message.arguments();
 
     return sendMessage(WTFMove(encoder), sendOptions);
@@ -230,7 +230,7 @@ bool AuxiliaryProcessProxy::send(T&& message, uint64_t destinationID, OptionSet<
 template<typename T>
 AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& message, uint64_t destinationID, IPC::Timeout timeout, OptionSet<IPC::SendSyncOption> sendSyncOptions)
 {
-    static_assert(T::isSync, "Sync message expected");
+    static_assert(IPC::MessageTraits<T>::isSync, "Sync message expected");
 
     if (!m_connection)
         return { };
@@ -243,9 +243,9 @@ AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& mes
 template<typename T, typename C>
 AuxiliaryProcessProxy::AsyncReplyID AuxiliaryProcessProxy::sendWithAsyncReply(T&& message, C&& completionHandler, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
 {
-    static_assert(!T::isSync, "Async message expected");
+    static_assert(!IPC::MessageTraits<T>::isSync, "Async message expected");
 
-    auto encoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
+    auto encoder = makeUniqueRef<IPC::Encoder>(IPC::MessageTraits<T>::name(), destinationID);
     encoder.get() << message.arguments();
     auto handler = IPC::Connection::makeAsyncReplyHandler<T>(WTFMove(completionHandler));
     auto replyID = handler.replyID;

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -125,7 +125,7 @@ RefPtr<GPUProcessConnection> GPUProcessConnection::create(IPC::Connection& paren
     if (!connectionIdentifiers)
         return nullptr;
 
-    parentConnection.send(Messages::WebProcessProxy::CreateGPUProcessConnection(connectionIdentifiers->client, getGPUProcessConnectionParameters()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    parentConnection.send(IPC::createMessage<Messages::WebProcessProxy::CreateGPUProcessConnection>(WTFMove(connectionIdentifiers->client), getGPUProcessConnectionParameters()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 
     auto instance = adoptRef(*new GPUProcessConnection(WTFMove(connectionIdentifiers->server)));
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -978,9 +978,9 @@ void MediaPlayerPrivateRemote::setPresentationSize(const IntSize& size)
 }
 
 #if PLATFORM(COCOA)
-void MediaPlayerPrivateRemote::setVideoInlineSizeFenced(const FloatSize& size, const WTF::MachSendRight& machSendRight)
+void MediaPlayerPrivateRemote::setVideoInlineSizeFenced(const FloatSize& size, WTF::MachSendRight&& machSendRight)
 {
-    connection().send(Messages::RemoteMediaPlayerProxy::SetVideoInlineSizeFenced(size, machSendRight), m_id);
+    connection().send(IPC::createMessage<Messages::RemoteMediaPlayerProxy::SetVideoInlineSizeFenced>(size, WTFMove(machSendRight)), m_id);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -116,7 +116,7 @@ public:
     void renderingModeChanged();
 #if PLATFORM(COCOA)
     void layerHostingContextIdChanged(std::optional<WebKit::LayerHostingContextID>&&, const WebCore::IntSize&);
-    void setVideoInlineSizeFenced(const WebCore::FloatSize&, const WTF::MachSendRight&);
+    void setVideoInlineSizeFenced(const WebCore::FloatSize&, WTF::MachSendRight&&);
 #endif
 
     void currentTimeChanged(const MediaTime&, const MonotonicTime&, bool);

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
@@ -185,10 +185,8 @@ static const Seconds PostAnimationDelay { 100_ms };
 
     if (!CGRectEqualToRect(self.videoLayerFrame, self.bounds)) {
         self.videoLayerFrame = self.bounds;
-        if (auto* mediaPlayerPrivateRemote = self.mediaPlayerPrivateRemote) {
-            MachSendRight fenceSendRight = MachSendRight::adopt([_context createFencePort]);
-            mediaPlayerPrivateRemote->setVideoInlineSizeFenced(WebCore::FloatSize(self.videoLayerFrame.size), fenceSendRight);
-        }
+        if (auto* mediaPlayerPrivateRemote = self.mediaPlayerPrivateRemote)
+            mediaPlayerPrivateRemote->setVideoInlineSizeFenced(WebCore::FloatSize(self.videoLayerFrame.size), MachSendRight::adopt([_context createFencePort]));
     }
 
     auto* videoSublayer = [sublayers objectAtIndex:0];

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -104,7 +104,7 @@ void WebInspectorUI::updateConnection()
     m_backendConnection = IPC::Connection::createServerConnection(connectionIdentifiers->server);
     m_backendConnection->open(*this);
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetFrontendConnection(connectionIdentifiers->client), m_inspectedPageIdentifier);
+    WebProcess::singleton().parentProcessConnection()->send(IPC::createMessage<Messages::WebInspectorUIProxy::SetFrontendConnection>(WTFMove(connectionIdentifiers->client)), m_inspectedPageIdentifier);
 }
 
 void WebInspectorUI::windowObjectCleared()

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -40,7 +40,8 @@ struct MessageInfo {
 struct MockTestMessage1 {
     static constexpr bool isSync = false;
     static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
-    std::tuple<> arguments() { return { }; }
+    using Arguments = std::tuple<>;
+    Arguments arguments() { return { }; }
 };
 
 struct MockTestMessageWithAsyncReply1 {
@@ -49,7 +50,8 @@ struct MockTestMessageWithAsyncReply1 {
     // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
-    std::tuple<> arguments() { return { }; }
+    using Arguments = std::tuple<>;
+    Arguments arguments() { return { }; }
     using ReplyArguments = std::tuple<uint64_t>;
 };
 

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -53,7 +53,8 @@ struct MockStreamTestMessage1 {
     static constexpr bool isStreamEncodable = true;
     static constexpr bool isStreamBatched = false;
     static constexpr IPC::MessageName name()  { return static_cast<IPC::MessageName>(123); }
-    std::tuple<> arguments() { return { }; }
+    using Arguments = std::tuple<>;
+    Arguments arguments() { return { }; }
 };
 
 struct MockStreamTestMessageWithAsyncReply1 {
@@ -64,7 +65,8 @@ struct MockStreamTestMessageWithAsyncReply1 {
     // Just using WebPage_GetBytecodeProfileReply as something that is async message name.
     // If WebPage_GetBytecodeProfileReply is removed, just use another one.
     static constexpr IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::WebPage_GetBytecodeProfileReply; }
-    std::tuple<uint64_t> arguments() { return { contents }; }
+    using Arguments = std::tuple<uint64_t>;
+    Arguments arguments() { return { contents }; }
     using ReplyArguments = std::tuple<uint64_t>;
     MockStreamTestMessageWithAsyncReply1(uint64_t contents)
         : contents(contents)


### PR DESCRIPTION
#### 3352bd070797e65869919a26aaf4e0b4540c6727
<pre>
[WK2] Introduce IPC::Message to better support move semantics of message arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=247914">https://bugs.webkit.org/show_bug.cgi?id=247914</a>

Reviewed by NOBODY (OOPS!).

Introduce IPC::Message to allow for better control of how the arguments
should be passed into the encoder.

Currently, each IPC message is implemented as a standalone struct,
providing various constants like sync flags and types like the argument
or reply-argument tuples. When these structs are constructed, they
store the arguments into a tuple of trivial types or lvalue references
to more complex objects. Different send-methods in the Connection class
then take that tuple and encode it into the encoder object.

The hard-coded lvalue-reference usage for non-trivial types hinders
occasions where the actual value could be passed to the encoder more
efficiently through move semantics. To address that, the generic
IPC::Message struct is introduced, allowing to construct the desired
message-arguments container that allows to pass objects into the encoder
via rvalue references.

The current per-IPC-message structs remain in place, only changes there
are making every constructor explicit and some styling tweaks.
In parallel, IPC::Message can be used to construct the desired IPC
message, with the existing message struct acting as the baseline that
still provides all the message metadata like its sync nature as well as
the arguments and possible reply-arguments tuples.

IPC::createMessage() template function has to be used for construction
of IPC::Message, with the message type listed as the template parameter.
Every passed-in message argument is stored in a tuple in IPC::Message
through an lvalue or rvalue reference, depending on the caller&apos;s
intention. Compile-time validation is done to ensure the argument types
passed into IPC::createMessage() correspond to the argument types listed
in the message definition.

In IPC::Connection and other relevant classes, templated MessageTraits
helper is used to accommodate using metadata on the message definition
structs either directly or through IPC::Message.

A few places where IPC::Connection::Handle was passed through to the
encoder by lvalue reference are changed to adopt IPC::createMessage()
and pass the handle value by rvalue reference.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Message::Message):
(IPC::Message::arguments const):
(IPC::createMessage):
(IPC::Connection::SendSyncResult::reply):
(IPC::Connection::SendSyncResult::takeReply):
(IPC::Connection::SendSyncResult::takeReplyOr):
(IPC::Connection::send):
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::callReply):
(IPC::Connection::cancelReply):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessage):
(IPC::handleMessageWantsConnection):
(IPC::handleMessageSynchronous):
(IPC::handleMessageSynchronousWantsConnection):
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWantsConnection):
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::trySendStream):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::sendSyncReply):
* Source/WebKit/Scripts/webkit/messages.py:
(message_to_struct_declaration):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
(Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::SendCVPixelBuffer):
(Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::ReceiveCVPixelBuffer):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h:
(Messages::TestWithIfMessage::LoadURL::LoadURL):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
(Messages::TestWithImageData::SendImageData::SendImageData):
(Messages::TestWithImageData::ReceiveImageData::ReceiveImageData):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
(Messages::TestWithLegacyReceiver::LoadURL::LoadURL):
(Messages::TestWithLegacyReceiver::LoadSomething::LoadSomething):
(Messages::TestWithLegacyReceiver::TouchEvent::TouchEvent):
(Messages::TestWithLegacyReceiver::AddEvent::AddEvent):
(Messages::TestWithLegacyReceiver::LoadSomethingElse::LoadSomethingElse):
(Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::DidReceivePolicyDecision):
(Messages::TestWithLegacyReceiver::Close::Close):
(Messages::TestWithLegacyReceiver::PreferencesDidChange::PreferencesDidChange):
(Messages::TestWithLegacyReceiver::SendDoubleAndFloat::SendDoubleAndFloat):
(Messages::TestWithLegacyReceiver::SendInts::SendInts):
(Messages::TestWithLegacyReceiver::CreatePlugin::CreatePlugin):
(Messages::TestWithLegacyReceiver::RunJavaScriptAlert::RunJavaScriptAlert):
(Messages::TestWithLegacyReceiver::GetPlugins::GetPlugins):
(Messages::TestWithLegacyReceiver::GetPluginProcessConnection::GetPluginProcessConnection):
(Messages::TestWithLegacyReceiver::TestMultipleAttributes::TestMultipleAttributes):
(Messages::TestWithLegacyReceiver::TestParameterAttributes::TestParameterAttributes):
(Messages::TestWithLegacyReceiver::TemplateTest::TemplateTest):
(Messages::TestWithLegacyReceiver::SetVideoLayerID::SetVideoLayerID):
(Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::DidCreateWebProcessConnection):
(Messages::TestWithLegacyReceiver::InterpretKeyEvent::InterpretKeyEvent):
(Messages::TestWithLegacyReceiver::DeprecatedOperation::DeprecatedOperation):
(Messages::TestWithLegacyReceiver::ExperimentalOperation::ExperimentalOperation):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
(Messages::TestWithSemaphore::SendSemaphore::SendSemaphore):
(Messages::TestWithSemaphore::ReceiveSemaphore::ReceiveSemaphore):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h:
(Messages::TestWithStreamBatched::SendString::SendString):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h:
(Messages::TestWithStreamBuffer::SendStreamBuffer::SendStreamBuffer):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
(Messages::TestWithStream::SendString::SendString):
(Messages::TestWithStream::SendStringAsync::SendStringAsync):
(Messages::TestWithStream::SendStringSync::SendStringSync):
(Messages::TestWithStream::SendMachSendRight::SendMachSendRight):
(Messages::TestWithStream::ReceiveMachSendRight::ReceiveMachSendRight):
(Messages::TestWithStream::SendAndReceiveMachSendRight::SendAndReceiveMachSendRight):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
(Messages::TestWithSuperclass::LoadURL::LoadURL):
(Messages::TestWithSuperclass::TestAsyncMessage::TestAsyncMessage):
(Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::TestAsyncMessageWithNoArguments):
(Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::TestAsyncMessageWithMultipleArguments):
(Messages::TestWithSuperclass::TestAsyncMessageWithConnection::TestAsyncMessageWithConnection):
(Messages::TestWithSuperclass::TestSyncMessage::TestSyncMessage):
(Messages::TestWithSuperclass::TestSynchronousMessage::TestSynchronousMessage):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
(Messages::TestWithoutAttributes::LoadURL::LoadURL):
(Messages::TestWithoutAttributes::LoadSomething::LoadSomething):
(Messages::TestWithoutAttributes::TouchEvent::TouchEvent):
(Messages::TestWithoutAttributes::AddEvent::AddEvent):
(Messages::TestWithoutAttributes::LoadSomethingElse::LoadSomethingElse):
(Messages::TestWithoutAttributes::DidReceivePolicyDecision::DidReceivePolicyDecision):
(Messages::TestWithoutAttributes::Close::Close):
(Messages::TestWithoutAttributes::PreferencesDidChange::PreferencesDidChange):
(Messages::TestWithoutAttributes::SendDoubleAndFloat::SendDoubleAndFloat):
(Messages::TestWithoutAttributes::SendInts::SendInts):
(Messages::TestWithoutAttributes::CreatePlugin::CreatePlugin):
(Messages::TestWithoutAttributes::RunJavaScriptAlert::RunJavaScriptAlert):
(Messages::TestWithoutAttributes::GetPlugins::GetPlugins):
(Messages::TestWithoutAttributes::GetPluginProcessConnection::GetPluginProcessConnection):
(Messages::TestWithoutAttributes::TestMultipleAttributes::TestMultipleAttributes):
(Messages::TestWithoutAttributes::TestParameterAttributes::TestParameterAttributes):
(Messages::TestWithoutAttributes::TemplateTest::TemplateTest):
(Messages::TestWithoutAttributes::SetVideoLayerID::SetVideoLayerID):
(Messages::TestWithoutAttributes::DidCreateWebProcessConnection::DidCreateWebProcessConnection):
(Messages::TestWithoutAttributes::InterpretKeyEvent::InterpretKeyEvent):
(Messages::TestWithoutAttributes::DeprecatedOperation::DeprecatedOperation):
(Messages::TestWithoutAttributes::ExperimentalOperation::ExperimentalOperation):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::send):
(WebKit::AuxiliaryProcessProxy::sendSync):
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReply):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::create):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setVideoInlineSizeFenced):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm:
(-[WKVideoLayerRemote resolveBounds]):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::updateConnection):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
(TestWebKitAPI::MockTestMessage1::arguments):
(TestWebKitAPI::MockTestMessageWithAsyncReply1::arguments):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3352bd070797e65869919a26aaf4e0b4540c6727

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110823 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171062 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1587 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108621 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35392 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/105049 "webkitpy-tests (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25029 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1484 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44517 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6114 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->