### PR TITLE
Keyboard smooth scrolling with spacebar doesn't rubber band at edges like iPad

### DIFF
--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-frame.html
@@ -41,7 +41,10 @@
 
             // Click inside scroller
             await UIHelper.activateAt(30,30);
-            await UIHelper.keyDown("downArrow");
+
+            // The down arrow needs to be pressed twice to "escape" the rubber-banding
+            await UIHelper.rawKeyDown("downArrow");
+            await UIHelper.rawKeyDown("downArrow");
         }
     </script>
 </head>

--- a/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html
+++ b/LayoutTests/fast/scrolling/mac/smooth-scroll-recursive-overflow-to-overflow.html
@@ -46,7 +46,9 @@
             // Click inside innerScroller
             await UIHelper.activateAt(30,30);
 
-            await UIHelper.keyDown("downArrow");
+            // The down arrow needs to be pressed twice to "escape" the rubber-banding
+            await UIHelper.rawKeyDown("downArrow");
+            await UIHelper.rawKeyDown("downArrow");
         }
     </script>
 </head>

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -61,9 +61,9 @@ public:
     WEBCORE_EXPORT void stopScrollingImmediately();
 
 private:
-    RectEdges<bool> scrollableDirectionsFromPosition(FloatPoint) const;
     std::optional<KeyboardScroll> makeKeyboardScroll(ScrollDirection, ScrollGranularity) const;
     float scrollDistance(ScrollDirection, ScrollGranularity) const;
+    RectEdges<bool> rubberbandableDirections() const;
 
     ScrollableArea& m_scrollableArea;
     bool m_scrollTriggeringKeyIsPressed { false };

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.cpp
@@ -49,22 +49,6 @@ static FloatSize perpendicularAbsoluteUnitVector(ScrollDirection direction)
     return { };
 }
 
-static BoxSide boxSideForDirection(ScrollDirection direction)
-{
-    switch (direction) {
-    case ScrollDirection::ScrollUp:
-        return BoxSide::Top;
-    case ScrollDirection::ScrollDown:
-        return BoxSide::Bottom;
-    case ScrollDirection::ScrollLeft:
-        return BoxSide::Left;
-    case ScrollDirection::ScrollRight:
-        return BoxSide::Right;
-    }
-    ASSERT_NOT_REACHED();
-    return BoxSide::Top;
-}
-
 static FloatPoint farthestPointInDirection(FloatPoint a, FloatPoint b, ScrollDirection direction)
 {
     switch (direction) {

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.h
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.h
@@ -45,6 +45,8 @@ public:
 
     void stopKeyboardScrollAnimation();
 
+    ScrollClamping clamping() const override { return ScrollClamping::Unclamped; }
+
 private:
     void serviceAnimation(MonotonicTime) final;
     bool retargetActiveAnimation(const FloatPoint&) final;

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -27,6 +27,7 @@
 
 #include "FloatPoint.h"
 #include "FloatSize.h"
+#include "RectEdges.h"
 #include <wtf/EnumTraits.h>
 
 namespace WTF {
@@ -228,11 +229,28 @@ inline FloatPoint setValueForAxis(FloatPoint point, ScrollEventAxis axis, float 
     case ScrollEventAxis::Horizontal:
         point.setX(value);
         return point;
-    case ScrollEventAxis::Vertical: point.setY(value);
+    case ScrollEventAxis::Vertical: 
+        point.setY(value);
         return point;
     }
     ASSERT_NOT_REACHED();
     return point;
+}
+
+inline BoxSide boxSideForDirection(ScrollDirection direction)
+{
+    switch (direction) {
+    case ScrollDirection::ScrollUp:
+        return BoxSide::Top;
+    case ScrollDirection::ScrollDown:
+        return BoxSide::Bottom;
+    case ScrollDirection::ScrollLeft:
+        return BoxSide::Left;
+    case ScrollDirection::ScrollRight:
+        return BoxSide::Right;
+    }
+    ASSERT_NOT_REACHED();
+    return BoxSide::Top;
 }
 
 enum ScrollbarControlStateMask {


### PR DESCRIPTION
#### 5e563a763a1e67bb52d100790d874b2b9c74469e
<pre>
Keyboard smooth scrolling with spacebar doesn&apos;t rubber band at edges like iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=247915">https://bugs.webkit.org/show_bug.cgi?id=247915</a>
rdar://102012167

Reviewed by Simon Fraser.

Currently, there are two issues which was preventing keyboard smooth scrolling
on macOS from having rubber-banding behavior.

The first issue was that `ScrollAnimation::clamping` was not being overriden
in `ScrollAnimationKeyboard`, and so the clamping behavior was trivially
`Clamped` instead of `Unclamped`, which was preventing the scrolling from
going past the start / end of the page.

With the scroll animation now being `Unclamped`, keyboard scrolling now has
rubber-banding behavior, however continously holding down the arrow key or
space bar caused the page to get stuck in the overflow scroll state. This
was because with every relevant key, `KeyboardScrollingAnimator::beginKeyboardScrollGesture`
is called, and when the offset is overflowing, then
`!scrollableDirections.at(boxSideForDirection(direction))` is `true`, which
caused `KeyboardScrollingAnimator::stopScrollingImmediately` to be called,
which then prevented the scroll from properly rubber-banding back to the start
or end of the page as it should.

This PR fixes these issues by setting the clamping behavior to `Unclamped`,
and by removing the call to `stopScrollingImmediately`, as it was never
actually necessary.

Also refactors some common functions to remove code duplication.

* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::KeyboardScrollingAnimator::beginKeyboardScrollGesture):
(WebCore::KeyboardScrollingAnimator::scrollableDirectionsFromPosition const): Deleted.
(WebCore::boxSideForDirection): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.h:
* Source/WebCore/platform/ScrollAnimationKeyboard.cpp:
(WebCore::ScrollAnimationKeyboard::animateScroll):
(WebCore::boxSideForDirection): Deleted.
(WebCore::ScrollAnimationKeyboard::scrollableDirectionsFromPosition): Deleted.
* Source/WebCore/platform/ScrollAnimationKeyboard.h:
* Source/WebCore/platform/ScrollTypes.h:
(WebCore::setValueForAxis):
(WebCore::scrollableDirectionsFromPosition):
(WebCore::boxSideForDirection):
* Source/WebCore/platform/ScrollableArea.cpp:
* Source/WebCore/platform/ScrollingEffectsController.cpp:

Canonical link: <a href="https://commits.webkit.org/257220@main">https://commits.webkit.org/257220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8faa943dbab94a7959a0c88d5f170d9cf804e601

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107094 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167356 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7199 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35608 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103754 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5387 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84228 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32400 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/847 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20513 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/833 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4975 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44456 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41381 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->