### PR TITLE
Allow painting of Apple Pay button in Mac GPUP

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -460,18 +460,11 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
         return false;
     
     ControlPart part = box.style().effectiveAppearance();
-    IntRect integralSnappedRect = snappedIntRect(rect);
 
-    // Temporarily move this call above the canPaint check to allow
-    // this to work in the GPU process
-#if ENABLE(ATTACHMENT_ELEMENT)
-    if (part == AttachmentPart || part == BorderlessAttachmentPart)
-        return paintAttachment(box, paintInfo, integralSnappedRect);
-#endif
-
-    if (UNLIKELY(!canPaint(paintInfo, box.settings())))
+    if (UNLIKELY(!canPaint(paintInfo, box.settings(), part)))
         return false;
 
+    IntRect integralSnappedRect = snappedIntRect(rect);
     float deviceScaleFactor = box.document().deviceScaleFactor();
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
 
@@ -558,6 +551,11 @@ bool RenderTheme::paint(const RenderBox& box, ControlStates& controlStates, cons
 #if ENABLE(DATALIST_ELEMENT)
     case ListButtonPart:
         return paintListButton(box, paintInfo, devicePixelSnappedRect);
+#endif
+#if ENABLE(ATTACHMENT_ELEMENT)
+    case AttachmentPart:
+    case BorderlessAttachmentPart:
+        return paintAttachment(box, paintInfo, integralSnappedRect);
 #endif
     default:
         break;

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -252,7 +252,7 @@ public:
 #endif
 
 protected:
-    virtual bool canPaint(const PaintInfo&, const Settings&) const { return true; }
+    virtual bool canPaint(const PaintInfo&, const Settings&, ControlPart) const { return true; }
 
     // The platform selection color.
     virtual Color platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const;

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -66,7 +66,7 @@ public:
     WEBCORE_EXPORT static IconAndSize iconForAttachment(const String& fileName, const String& attachmentType, const String& title);
 
 private:
-    bool canPaint(const PaintInfo&, const Settings&) const final;
+    bool canPaint(const PaintInfo&, const Settings&, ControlPart) const final;
 
     LengthBox popupInternalPaddingBox(const RenderStyle&, const Settings&) const override;
 

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -362,7 +362,7 @@ static void drawJoinedLines(CGContextRef context, const Vector<CGPoint>& points,
     CGContextStrokePath(context);
 }
 
-bool RenderThemeIOS::canPaint(const PaintInfo& paintInfo, const Settings& settings) const
+bool RenderThemeIOS::canPaint(const PaintInfo& paintInfo, const Settings& settings, ControlPart) const
 {
 #if ENABLE(IOS_FORM_CONTROL_REFRESH)
     if (settings.iOSFormControlRefreshEnabled())

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -101,7 +101,7 @@ public:
 private:
     RenderThemeMac();
 
-    bool canPaint(const PaintInfo&, const Settings&) const final;
+    bool canPaint(const PaintInfo&, const Settings&, ControlPart) const final;
 
     bool paintTextField(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     void adjustTextFieldStyle(RenderStyle&, const Element*) const final;

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -256,8 +256,21 @@ RenderTheme& RenderTheme::singleton()
     return theme;
 }
 
-bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&) const
+bool RenderThemeMac::canPaint(const PaintInfo& paintInfo, const Settings&, ControlPart part) const
 {
+    switch (part) {
+#if ENABLE(ATTACHMENT_ELEMENT)
+    case AttachmentPart:
+    case BorderlessAttachmentPart:
+        return true;
+#endif
+#if ENABLE(APPLE_PAY)
+    case ApplePayButtonPart:
+        return true;
+#endif
+    default:
+        break;
+    }
     return paintInfo.context().hasPlatformContext();
 }
 


### PR DESCRIPTION
#### 6b4a6f81a9aefaff2eb854ac7283c814a53a6c3b
<pre>
Allow painting of Apple Pay button in Mac GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=247916">https://bugs.webkit.org/show_bug.cgi?id=247916</a>
&lt;rdar://102277273&gt;

Reviewed by Simon Fraser.

Allow painting of apple pay button without platform context
as it is not used by paintApplePayButton.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::canPaintWithoutPlatformContext):
(WebCore::RenderTheme::paint):

Canonical link: <a href="https://commits.webkit.org/256713@main">https://commits.webkit.org/256713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a358e1564404a271cdd0bfc1fded29d4d7bf95fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106142 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6070 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34610 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102854 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102293 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83219 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31498 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88247 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40341 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21142 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4656 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4273 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40419 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->