### PR TITLE
Change ReplaceSelectionCommand::moveNodeOutOfAncestor() to avoid hitting assertion while trying replace selection

### DIFF
--- a/LayoutTests/editing/inserting/replace-in-heading-001-expected.txt
+++ b/LayoutTests/editing/inserting/replace-in-heading-001-expected.txt
@@ -1,0 +1,5 @@
+PASS $("destination").textContent is "source"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/inserting/replace-in-heading-001.html
+++ b/LayoutTests/editing/inserting/replace-in-heading-001.html
@@ -1,0 +1,31 @@
+<head>
+<script>
+    function $(id) { return document.getElementById(id); }
+    
+    function testIt()
+    {
+        description('Replace in heading by heading');
+    
+        var selection = window.getSelection();
+        var range = document.createRange();
+        range.selectNodeContents($('destination'));
+        selection.addRange(range);
+        document.execCommand('insertHTML', false, '<h2>source</h2>');
+        shouldBeEqualToString('$("destination").textContent', 'source');
+    
+        if (window.testRunner)
+            $('content').outerHTML = '';
+    }
+    </script>
+</head>
+<body>
+<div id="content">
+<p id="description"></p>
+<h1 contenteditable="true" id="destination">destination</h1>
+</div>
+<div id="console"></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+    testIt();
+</script>
+</body>

--- a/LayoutTests/editing/inserting/replace-in-paragraph-001-expected.txt
+++ b/LayoutTests/editing/inserting/replace-in-paragraph-001-expected.txt
@@ -1,0 +1,5 @@
+PASS $("destination").textContent is "source"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/inserting/replace-in-paragraph-001.html
+++ b/LayoutTests/editing/inserting/replace-in-paragraph-001.html
@@ -1,0 +1,31 @@
+<head>
+<script>
+    function $(id) { return document.getElementById(id); }
+    
+    function testIt()
+    {
+        description('Replace in pargraph by paragraph');
+    
+        var selection = window.getSelection();
+        var range = document.createRange();
+        range.selectNodeContents($('destination'));
+        selection.addRange(range);
+        document.execCommand('insertHTML', false, '<p>source</p>');
+        shouldBeEqualToString('$("destination").textContent', 'source');
+    
+        if (window.testRunner)
+            $('content').outerHTML = '';
+    }
+</script>
+</head>
+<body>
+<div id="content">
+    <p id="description"></p>
+    <p contenteditable="true" id="destination">destination</p>
+</div>
+<div id="console"></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+    testIt();
+</script>
+</body>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005-2017 Apple Inc. All rights reserved.
- * Copyright (C) 2009, 2010, 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -832,6 +832,9 @@ void ReplaceSelectionCommand::moveNodeOutOfAncestor(Node& node, Node& ancestor, 
 {
     Ref<Node> protectedNode = node;
     Ref<Node> protectedAncestor = ancestor;
+
+    if (!protectedAncestor->parentNode()->hasEditableStyle())
+        return;
 
     VisiblePosition positionAtEndOfNode = lastPositionInOrAfterNode(&node);
     VisiblePosition lastPositionInParagraph = lastPositionInNode(&ancestor);


### PR DESCRIPTION
#### 531d3679e268acaf10750ee50bdce95007891bdb
<pre>
Change ReplaceSelectionCommand::moveNodeOutOfAncestor() to avoid hitting assertion while trying replace selection

Change ReplaceSelectionCommand::moveNodeOutOfAncestor() to avoid hitting assertion while trying replace selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=247918">https://bugs.webkit.org/show_bug.cgi?id=247918</a>

Reviewed by Ryosuke Niwa.

Merge - <a href="https://src.chromium.org/viewvc/blink?revision=153031&amp">https://src.chromium.org/viewvc/blink?revision=153031&amp</a>;view=revision

Before this patch, replacing selection in heading/paragraph with heading/paragraph gets assertion at InsertNodeBeforeCommand constructor, or crash when assertion disabled. It tries to move replaced heading/paragraph out of ancestor, ReplaceSelectionCommand::moveNodeOutOfAncestor().

This patch changes ReplaceSelectionCommand::moveNodeOutOfAncestor() to avoid the assertion.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(ReplaceSelectionCommand::moveNodeOutOfAncestor): Add logic to avoid crash
* LayoutTests/editing/inserting/replace-in-paragraph-001.html: Added Test Case
* LayoutTests/editing/inserting/replace-in-paragraph-001-expected.txt: Added Test Case Expectations
* LayoutTests/editing/inserting/replace-in-heading-001.html: Added Test Case
* LayoutTests/editing/inserting/replace-in-heading-001-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256682@main">https://commits.webkit.org/256682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64adbdaadd2022e3028f6787e049075ee3b4aef7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106025 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166376 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5922 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34484 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102747 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4417 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83088 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31389 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74293 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40215 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21029 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4154 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2219 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40299 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->