### PR TITLE
Fix font-variant shorthand serialization

### DIFF
--- a/LayoutTests/fast/css/font-property-priority-expected.txt
+++ b/LayoutTests/fast/css/font-property-priority-expected.txt
@@ -2,10 +2,10 @@ Test for rdar://problem/6065547 REGRESSION (r34879): "Subject" in unread emails 
 
 Property 'font-weight' has priority 'important'.
 Property 'font-variant-ligatures' has priority 'important'.
-Property 'font-variant-numeric' has priority 'important'.
 Property 'font-variant-caps' has priority 'important'.
 Property 'font-variant-alternates' has priority 'important'.
-Property 'font-variant-position' has priority 'important'.
+Property 'font-variant-numeric' has priority 'important'.
 Property 'font-variant-east-asian' has priority 'important'.
+Property 'font-variant-position' has priority 'important'.
 Property 'font-style' has priority 'important'.
 

--- a/LayoutTests/fast/text/font-variant-shorthand-expected.txt
+++ b/LayoutTests/fast/text/font-variant-shorthand-expected.txt
@@ -33,7 +33,7 @@ PASS window.getComputedStyle(document.getElementById('t12')).getPropertyValue('f
 PASS window.getComputedStyle(document.getElementById('t13')).getPropertyValue('font-variant') is "normal"
 PASS window.getComputedStyle(document.getElementById('t14')).getPropertyValue('font-variant') is "normal"
 PASS window.getComputedStyle(document.getElementById('t15')).getPropertyValue('font-variant') is "normal"
-PASS window.getComputedStyle(document.getElementById('t16')).getPropertyValue('font-variant') is "common-ligatures super small-caps lining-nums historical-forms simplified"
+PASS window.getComputedStyle(document.getElementById('t16')).getPropertyValue('font-variant') is "common-ligatures small-caps historical-forms lining-nums simplified super"
 PASS window.getComputedStyle(document.getElementById('t17')).getPropertyValue('font-variant') is "normal"
 PASS window.getComputedStyle(document.getElementById('t18')).getPropertyValue('font-variant') is "none"
 PASS window.getComputedStyle(document.getElementById('t19')).getPropertyValue('font-variant') is "normal"

--- a/LayoutTests/fast/text/font-variant-shorthand.html
+++ b/LayoutTests/fast/text/font-variant-shorthand.html
@@ -171,7 +171,7 @@ shouldBeEqualToString("window.getComputedStyle(document.getElementById('t13')).g
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('t14')).getPropertyValue('font-variant')", "normal");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('t15')).getPropertyValue('font-variant')", "normal");
 
-shouldBeEqualToString("window.getComputedStyle(document.getElementById('t16')).getPropertyValue('font-variant')", "common-ligatures super small-caps lining-nums historical-forms simplified");
+shouldBeEqualToString("window.getComputedStyle(document.getElementById('t16')).getPropertyValue('font-variant')", "common-ligatures small-caps historical-forms lining-nums simplified super");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('t17')).getPropertyValue('font-variant')", "normal");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('t18')).getPropertyValue('font-variant')", "none");
 shouldBeEqualToString("window.getComputedStyle(document.getElementById('t19')).getPropertyValue('font-variant')", "normal");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-variant-shorthand-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-variant-shorthand-serialization-expected.txt
@@ -1,0 +1,9 @@
+
+PASS font-variant: normal serialization
+PASS font-variant: none serialization
+PASS font-variant-ligatures: none serialization with non-default value for another longhand
+PASS font-variant: normal with non-default longhands
+PASS CSS-wide keyword in one longhand
+PASS CSS-wide keyword in shorthand
+PASS font: menu serialization
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-variant-shorthand-serialization.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-variant-shorthand-serialization.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Serialization of font-variant shorthand</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-1/#serialize-a-css-declaration-block">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<div id="target"></div>
+<script>
+    const cssWideKeywords = ["initial", "inherit", "unset", "revert", "revert-layer"];
+    function test_serialization_set(expected) {
+        for (const [property, value] of Object.entries(expected)) {
+            if (!CSS.supports(`${property}: initial`))
+                continue;
+            assert_equals(target.style[property], value, `${property} was set`);
+        }
+    }
+    function setWithValue(value) {
+        return {
+            "font-variant-ligatures": value,
+            "font-variant-caps": value,
+            "font-variant-alternates": value,
+            "font-variant-numeric": value,
+            "font-variant-east-asian": value,
+            "font-variant-position": value,
+            "font-variant-emoji": value,
+            "font-variant": value
+        };
+    }
+    const emptySet = setWithValue("");
+    const normalSet = setWithValue("normal");
+    const nonDefaultValues = {
+        "font-variant-ligatures": "common-ligatures discretionary-ligatures",
+        "font-variant-caps": "small-caps",
+        "font-variant-alternates": "historical-forms",
+        "font-variant-numeric": "oldstyle-nums stacked-fractions",
+        "font-variant-east-asian": "ruby",
+        "font-variant-position": "sub",
+        "font-variant-emoji": "emoji",
+    };
+    test(function(t) {
+        target.style.fontVariant = "normal";
+        t.add_cleanup(() => target.removeAttribute("style"));
+
+        test_serialization_set(normalSet);
+    }, "font-variant: normal serialization");
+
+    test(function(t) {
+        target.style.fontVariant = "normal";
+        target.style.fontVariantLigatures = "none";
+        t.add_cleanup(() => target.removeAttribute("style"));
+
+        const expected = Object.assign({}, normalSet);
+        expected["font-variant-ligatures"] = "none";
+        expected["font-variant"] = "none";
+
+        test_serialization_set(expected);
+    }, "font-variant: none serialization");
+
+    test(function(t) {
+        t.add_cleanup(() => target.removeAttribute("style"));
+        for (const [property, value] of Object.entries(nonDefaultValues)) {
+            if (property == "font-variant-ligatures" || !CSS.supports(`${property}: initial`))
+                continue;
+            target.style.fontVariant = "normal";
+            target.style.fontVariantLigatures = "none";
+            target.style[property] = value;
+
+            const expected = Object.assign({}, normalSet);
+            expected["font-variant-ligatures"] = "none";
+            expected["font-variant"] = "";
+            expected[property] = value;
+
+            test_serialization_set(expected);
+            target.removeAttribute("style");
+        }
+    }, "font-variant-ligatures: none serialization with non-default value for another longhand");
+
+    test(function(t) {
+        t.add_cleanup(() => target.removeAttribute("style"));
+
+        for (const [property, value] of Object.entries(nonDefaultValues)) {
+            if (!CSS.supports(`${property}: initial`))
+                continue;
+            target.style.fontVariant = "normal";
+            target.style[property] = value;
+
+            const expected = Object.assign({}, normalSet);
+            expected[property] = value;
+            expected["font-variant"] = value;
+            test_serialization_set(expected);
+
+            target.removeAttribute("style");
+        }
+    }, "font-variant: normal with non-default longhands");
+
+    test(function(t) {
+        t.add_cleanup(() => target.removeAttribute("style"));
+        for (const keyword of cssWideKeywords) {
+            target.style.fontVariant = "normal";
+            target.style.fontVariantLigatures = keyword;
+
+            const expected = Object.assign({}, normalSet);
+            expected["font-variant-ligatures"] = keyword;
+            expected["font-variant"] = "";
+            test_serialization_set(expected);
+            target.removeAttribute("style");
+        }
+    }, "CSS-wide keyword in one longhand");
+
+    test(function(t) {
+        t.add_cleanup(() => target.removeAttribute("style"));
+
+        for (const keyword of cssWideKeywords) {
+            target.style.fontVariant = keyword;
+            test_serialization_set(setWithValue(keyword));
+            target.removeAttribute("style");
+        }
+    }, "CSS-wide keyword in shorthand");
+
+    test(function(t) {
+        target.style.fontVariant = "normal";
+        target.style.font = "menu";
+        t.add_cleanup(() => target.removeAttribute("style"));
+
+        test_serialization_set(emptySet);
+    }, "font: menu serialization");
+</script>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -750,13 +750,13 @@
             "inherited": true,
             "codegen-properties": {
                 "longhands": [
-                              "font-variant-ligatures",
-                              "font-variant-position",
-                              "font-variant-caps",
-                              "font-variant-numeric",
-                              "font-variant-alternates",
-                              "font-variant-east-asian"
-                              ]
+                    "font-variant-ligatures",
+                    "font-variant-caps",
+                    "font-variant-alternates",
+                    "font-variant-numeric",
+                    "font-variant-east-asian",
+                    "font-variant-position"
+                ]
             },
             "specification": {
                 "category": "css-fonts",

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -169,7 +169,6 @@ private:
     String fontSynthesisValue() const;
     String textDecorationSkipValue() const;
     String offsetValue() const;
-    void appendFontLonghandValueIfExplicit(CSSPropertyID, StringBuilder& result, String& value) const;
     bool shorthandHasVariableReference(CSSPropertyID, String&) const;
     StringBuilder asTextInternal() const;
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -5416,9 +5416,9 @@ bool CSSPropertyParser::consumeFontVariantShorthand(bool important)
 {
     if (identMatches<CSSValueNormal, CSSValueNone>(m_range.peek().id())) {
         addProperty(CSSPropertyFontVariantLigatures, CSSPropertyFontVariant, consumeIdent(m_range).releaseNonNull(), important);
-        addProperty(CSSPropertyFontVariantNumeric, CSSPropertyFontVariant, CSSValuePool::singleton().createIdentifierValue(CSSValueNormal), important, true);
         addProperty(CSSPropertyFontVariantCaps, CSSPropertyFontVariant, CSSValuePool::singleton().createIdentifierValue(CSSValueNormal), important, true);
         addProperty(CSSPropertyFontVariantAlternates, CSSPropertyFontVariant, CSSValuePool::singleton().createIdentifierValue(CSSValueNormal), important, true);
+        addProperty(CSSPropertyFontVariantNumeric, CSSPropertyFontVariant, CSSValuePool::singleton().createIdentifierValue(CSSValueNormal), important, true);
         addProperty(CSSPropertyFontVariantEastAsian, CSSPropertyFontVariant, CSSValuePool::singleton().createIdentifierValue(CSSValueNormal), important, true);
         addProperty(CSSPropertyFontVariantPosition, CSSPropertyFontVariant, CSSValuePool::singleton().createIdentifierValue(CSSValueNormal), important, true);
         return m_range.atEnd();
@@ -5478,14 +5478,13 @@ bool CSSPropertyParser::consumeFontVariantShorthand(bool important)
 
     } while (!m_range.atEnd());
 
-    addProperty(CSSPropertyFontVariantLigatures, CSSPropertyFontVariant, ligaturesParser.finalizeValue().releaseNonNull(), important, implicitLigatures);
-    addProperty(CSSPropertyFontVariantNumeric, CSSPropertyFontVariant, numericParser.finalizeValue().releaseNonNull(), important, implicitNumeric);
-
     auto& valuePool = CSSValuePool::singleton();
+    addProperty(CSSPropertyFontVariantLigatures, CSSPropertyFontVariant, ligaturesParser.finalizeValue().releaseNonNull(), important, implicitLigatures);
     addPropertyWithImplicitDefault(CSSPropertyFontVariantCaps, CSSPropertyFontVariant, capsValue, valuePool.createIdentifierValue(CSSValueNormal), important);
     addPropertyWithImplicitDefault(CSSPropertyFontVariantAlternates, CSSPropertyFontVariant, WTFMove(alternatesValue), valuePool.createIdentifierValue(CSSValueNormal), important);
-    addPropertyWithImplicitDefault(CSSPropertyFontVariantPosition, CSSPropertyFontVariant, positionValue, valuePool.createIdentifierValue(CSSValueNormal), important);
+    addProperty(CSSPropertyFontVariantNumeric, CSSPropertyFontVariant, numericParser.finalizeValue().releaseNonNull(), important, implicitNumeric);
     addPropertyWithImplicitDefault(CSSPropertyFontVariantEastAsian, CSSPropertyFontVariant, WTFMove(eastAsianValue), valuePool.createIdentifierValue(CSSValueNormal), important);
+    addPropertyWithImplicitDefault(CSSPropertyFontVariantPosition, CSSPropertyFontVariant, positionValue, valuePool.createIdentifierValue(CSSValueNormal), important);
 
     return true;
 }


### PR DESCRIPTION
#### cee0d60d4af3a42f1dfecc60aeb3928df9d7d2c1
<pre>
Fix font-variant shorthand serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=247919">https://bugs.webkit.org/show_bug.cgi?id=247919</a>
rdar://102339716

Reviewed by Darin Adler.

- Fixed bug where font-variant-ligatures: none + another non-default longhand would serialize even if it not possible
- Clean up fontValue()/fontVariantValue() to not consider implicit/explicit anymore used to represent default/system values
- Refactor to remove appendFontLonghandValueIfExplicit()

* LayoutTests/fast/text/font-variant-shorthand-expected.txt:
* LayoutTests/fast/text/font-variant-shorthand.html:
* LayoutTests/fast/css/font-property-priority-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-shorthand-serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-variant-shorthand-serialization-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-variant-shorthand-serialization.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-shorthand-serialization-expected.txt:
* Source/WebCore/css/CSSProperties.json:
Updated ordering to match order from the spec (which matters for serialization).

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::fontValue const):
Inlined parts of appendFontLonghandValueIfExplicit, simplified font-stretch handling.

(WebCore::StyleProperties::fontVariantValue const):
Rewrite to stop using appendFontLonghandValueIfExplicit, fix various serialization issues when collapsing longhands.

(WebCore::canUseShorthandForLonghand):
Add notes on why collapsing is not possible.

(WebCore::StyleProperties::appendFontLonghandValueIfExplicit const): Deleted.

* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeFontVariantShorthand):

Canonical link: <a href="https://commits.webkit.org/256681@main">https://commits.webkit.org/256681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac000242265a4977b7233ba0a74988829b085750

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106044 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5951 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34510 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88886 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102186 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83116 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31406 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40241 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37909 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4634 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4176 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40327 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->