### PR TITLE
Add numeric identifier to generated getter name

### DIFF
--- a/JSTests/stress/numeric-getter-has-correct-name.js
+++ b/JSTests/stress/numeric-getter-has-correct-name.js
@@ -1,0 +1,8 @@
+class x {
+    get 0 () { }
+}
+
+let propertyName = Object.getOwnPropertyDescriptor(x.prototype, "0").get.name;
+if (propertyName !== 'get 0')
+    throw `Expected getter name 'get 0', got '${propertyName}'`;
+

--- a/LayoutTests/js/script-tests/function-toString-vs-name.js
+++ b/LayoutTests/js/script-tests/function-toString-vs-name.js
@@ -735,8 +735,8 @@ section = "get/set function";
 
     let o2 = { get 100() {}, set 100(x){} };
     let desc2 = Object.getOwnPropertyDescriptor(o2, 100);
-    test(desc2.get, "get ", "function() {}");
-    test(desc2.set, "set ", "function(x) {}");
+    test(desc2.get, "get 100", "function() {}");
+    test(desc2.set, "set 100", "function(x) {}");
 
     let o3 = { get [100]() {}, set [100](x){} };
     let desc3 = Object.getOwnPropertyDescriptor(o3, 100);
@@ -759,9 +759,9 @@ section = "get/set function";
         test(bound2, "bound set bar", "function set bar() { [native code] }");
 
         bound1 = desc2.get.bind(o);
-        test(bound1, "bound get ", "function get () { [native code] }");
+        test(bound1, "bound get 100", "function get 100() { [native code] }");
         bound2 = desc2.set.bind(o);
-        test(bound2, "bound set ", "function set () { [native code] }");
+        test(bound2, "bound set 100", "function set 100() { [native code] }");
 
         bound1 = desc3.get.bind(o);
         test(bound1, "bound get 100", "function get 100() { [native code] }");

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -516,6 +516,7 @@ public:
     {
         functionInfo.body->setLoc(functionInfo.startLine, functionInfo.endLine, location.startOffset, location.lineStartOffset);
         const Identifier& ident = parserArena.identifierArena().makeNumericIdentifier(vm, name);
+        functionInfo.body->setEcmaName(ident);
         SourceCode source = m_sourceCode->subExpression(functionInfo.startOffset, functionInfo.endOffset, functionInfo.startLine, functionInfo.parametersStartColumn);
         MethodDefinitionNode* methodDef = new (m_parserArena) MethodDefinitionNode(location, vm.propertyNames->nullIdentifier, functionInfo.body, source);
         return new (m_parserArena) PropertyNode(ident, methodDef, type, SuperBinding::Needed, tag);


### PR DESCRIPTION
#### ad1302fe8297f628d73984d072f423c1f629fbfa
<pre>
Add numeric identifier to generated getter name
<a href="https://bugs.webkit.org/show_bug.cgi?id=247424">https://bugs.webkit.org/show_bug.cgi?id=247424</a>
rdar://101940115

Reviewed by Justin Michaud.

Adds a call to set the ECMA property name for a generated getter/setter
when the property name is a numeric identifier. With this change, we
include the property name in the name of the new getter/setter, i.e.
&apos;get 0&apos; instead of &apos;get &apos;.

* JSTests/stress/numeric-getter-has-correct-name.js: Added.
(x.prototype.get 0):
(x):
* LayoutTests/js/script-tests/function-toString-vs-name.js:
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createGetterOrSetterProperty):

Canonical link: <a href="https://commits.webkit.org/256740@main">https://commits.webkit.org/256740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c474e1064bc132a589cb2433900b9ac97e089f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106129 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166463 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6055 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34597 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102840 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4515 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83206 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31486 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74398 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87557 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40328 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82984 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21137 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28340 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4682 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43672 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85664 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1073 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40413 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19316 "Passed tests") | 
<!--EWS-Status-Bubble-End-->