### PR TITLE
Use the display colorspace for IOSurfaces with macOS UI-side compositing

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -198,8 +198,13 @@ bool RemoteLayerBackingStore::usesDeepColorBackingStore() const
 
 DestinationColorSpace RemoteLayerBackingStore::colorSpace() const
 {
+#if PLATFORM(MAC)
+    if (auto* context = m_layer->context())
+        return context->displayColorSpace().value_or(DestinationColorSpace::SRGB());
+#else
     if (usesDeepColorBackingStore())
         return DestinationColorSpace { extendedSRGBColorSpaceRef() };
+#endif
     return DestinationColorSpace::SRGB();
 }
 

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -75,7 +75,7 @@ public:
     virtual WebCore::DelegatedScrollingMode delegatedScrollingMode() const;
 
     virtual void deviceScaleFactorDidChange() = 0;
-    
+    virtual void colorSpaceDidChange() { }
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond> /* nominalFramesPerSecond */) { }
 
     // FIXME: These should be pure virtual.
@@ -92,7 +92,6 @@ public:
     virtual void targetRefreshRateDidChange(unsigned) { }
 #endif
 
-    virtual void colorSpaceDidChange() { }
     virtual void minimumSizeForAutoLayoutDidChange() { }
     virtual void sizeToContentAutoSizeMaximumSizeDidChange() { }
     virtual void windowKindDidChange() { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -56,6 +56,7 @@ private:
     void pauseDisplayRefreshCallbacks() override;
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond) override;
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
+    void colorSpaceDidChange() override;
 
     void didChangeViewExposedRect() override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "DrawingAreaMessages.h"
 #import "RemoteScrollingCoordinatorProxyMac.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
@@ -211,6 +212,11 @@ void RemoteLayerTreeDrawingAreaProxyMac::didChangeViewExposedRect()
 {
     RemoteLayerTreeDrawingAreaProxy::didChangeViewExposedRect();
     updateDebugIndicatorPosition();
+}
+
+void RemoteLayerTreeDrawingAreaProxyMac::colorSpaceDidChange()
+{
+    send(Messages::DrawingArea::SetColorSpace(m_webPageProxy.colorSpace()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1205,6 +1205,8 @@ public:
 #if PLATFORM(MAC)
     void setUseSystemAppearance(bool);
     bool useSystemAppearance() const { return m_useSystemAppearance; }
+
+    WebCore::DestinationColorSpace colorSpace();
 #endif
 
     void effectiveAppearanceDidChange();
@@ -1224,8 +1226,6 @@ public:
     RefPtr<WebCore::SharedBuffer> dataSelectionForPasteboard(const String& pasteboardType);
     void makeFirstResponder();
     void assistiveTechnologyMakeFirstResponder();
-
-    WebCore::DestinationColorSpace colorSpace();
 #endif
 
     void pageScaleFactorDidChange(double);

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -318,10 +318,12 @@ void WebPageProxy::assistiveTechnologyMakeFirstResponder()
     pageClient().assistiveTechnologyMakeFirstResponder();
 }
 
+#if PLATFORM(MAC)
 WebCore::DestinationColorSpace WebPageProxy::colorSpace()
 {
     return pageClient().colorSpace();
 }
+#endif
 
 void WebPageProxy::registerUIProcessAccessibilityTokens(const IPC::DataReference& elementToken, const IPC::DataReference& windowToken)
 {

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -133,6 +133,8 @@ public:
 
     virtual void setShouldScaleViewToFitDocument(bool) { }
 
+    virtual std::optional<WebCore::DestinationColorSpace> displayColorSpace() const { return { }; }
+
     virtual bool addMilestonesToDispatch(OptionSet<WebCore::LayoutMilestone>) { return false; }
 
 #if PLATFORM(COCOA)
@@ -187,7 +189,6 @@ private:
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;
 
 #if PLATFORM(COCOA)
-    // Used by TiledCoreAnimationDrawingArea.
     virtual void setDeviceScaleFactor(float) { }
     virtual void setColorSpace(std::optional<WebCore::DestinationColorSpace>) { }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -57,6 +57,8 @@ public:
     float deviceScaleFactor() const;
 
     LayerHostingMode layerHostingMode() const;
+    
+    std::optional<WebCore::DestinationColorSpace> displayColorSpace() const;
 
     void buildTransaction(RemoteLayerTreeTransaction&, WebCore::PlatformCALayer& rootLayer);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -29,6 +29,7 @@
 #import "GenericCallback.h"
 #import "GraphicsLayerCARemote.h"
 #import "PlatformCALayerRemote.h"
+#import "RemoteLayerTreeDrawingArea.h"
 #import "RemoteLayerTreeTransaction.h"
 #import "RemoteLayerWithRemoteRenderingBackingStoreCollection.h"
 #import "WebPage.h"
@@ -79,6 +80,14 @@ float RemoteLayerTreeContext::deviceScaleFactor() const
 LayerHostingMode RemoteLayerTreeContext::layerHostingMode() const
 {
     return m_webPage.layerHostingMode();
+}
+
+std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeContext::displayColorSpace() const
+{
+    if (auto* drawingArea = m_webPage.drawingArea())
+        return drawingArea->displayColorSpace();
+    
+    return { };
 }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h
@@ -38,6 +38,11 @@ public:
 
 private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
+
+    void setColorSpace(std::optional<WebCore::DestinationColorSpace>) override;
+    std::optional<WebCore::DestinationColorSpace> displayColorSpace() const override;
+
+    std::optional<WebCore::DestinationColorSpace> m_displayColorSpace;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC)
 
+#import "WebPageCreationParameters.h"
 #import <WebCore/ScrollView.h>
 
 namespace WebKit {
@@ -36,6 +37,7 @@ using namespace WebCore;
 RemoteLayerTreeDrawingAreaMac::RemoteLayerTreeDrawingAreaMac(WebPage& webPage, const WebPageCreationParameters& parameters)
     : RemoteLayerTreeDrawingArea(webPage, parameters)
 {
+    setColorSpace(parameters.colorSpace);
 }
 
 RemoteLayerTreeDrawingAreaMac::~RemoteLayerTreeDrawingAreaMac() = default;
@@ -44,6 +46,17 @@ DelegatedScrollingMode RemoteLayerTreeDrawingAreaMac::delegatedScrollingMode() c
 {
     return DelegatedScrollingMode::DelegatedToWebKit;
 }
+
+void RemoteLayerTreeDrawingAreaMac::setColorSpace(std::optional<WebCore::DestinationColorSpace> colorSpace)
+{
+    m_displayColorSpace = colorSpace;
+}
+
+std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeDrawingAreaMac::displayColorSpace() const
+{
+    return m_displayColorSpace;
+}
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -102,6 +102,7 @@ private:
     void resumePainting();
     void setLayerHostingMode(LayerHostingMode) override;
     void setColorSpace(std::optional<WebCore::DestinationColorSpace>) override;
+    std::optional<WebCore::DestinationColorSpace> displayColorSpace() const override;
     void addFence(const WTF::MachSendRight&) override;
 
     void addTransactionCallbackID(CallbackID) override;

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -645,6 +645,11 @@ void TiledCoreAnimationDrawingArea::setColorSpace(std::optional<WebCore::Destina
     m_layerHostingContext->setColorSpace(colorSpace ? colorSpace->platformColorSpace() : nullptr);
 }
 
+std::optional<WebCore::DestinationColorSpace> TiledCoreAnimationDrawingArea::displayColorSpace() const
+{
+    return DestinationColorSpace { m_layerHostingContext->colorSpace() };
+}
+
 RefPtr<WebCore::DisplayRefreshMonitor> TiledCoreAnimationDrawingArea::createDisplayRefreshMonitor(PlatformDisplayID displayID)
 {
     return DisplayRefreshMonitorMac::create(displayID);


### PR DESCRIPTION
#### c32ad2723bd94f699194b280ebb253a8ee302c06
<pre>
Use the display colorspace for IOSurfaces with macOS UI-side compositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247929">https://bugs.webkit.org/show_bug.cgi?id=247929</a>
&lt;rdar://problem/102346748&gt;

Reviewed by Tim Horton.

Hook up `RemoteLayerTreeDrawingAreaMac::setColorSpace()`, and add a `displayColorSpace()`
getter on DrawingArea, implementing on TiledCoreAnimationDrawingArea and RemoteLayerTreeDrawingAreaMac.
TiledCoreAnimationDrawingArea stores the colorspace on the LayerHostingContext, and
RemoteLayerTreeDrawingAreaMac stores it directly.

Then add some code for macOS in `RemoteLayerBackingStore::colorSpace()` to fetch the
colorspace via the RemoteLayerTreeContext, which consults the DrawingArea.

Also hook up `RemoteLayerTreeDrawingAreaProxyMac::colorSpaceDidChange()`, which
is used to push in the colorspace on initial window creation.

Updating the colorspace on all IOSurfaces when moving a window between displays is not yet supported.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::colorSpace const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::colorSpaceDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::colorSpaceDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::displayColorSpace const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::displayColorSpace const):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.h:
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::RemoteLayerTreeDrawingAreaMac):
(WebKit::RemoteLayerTreeDrawingAreaMac::setColorSpace):
(WebKit::RemoteLayerTreeDrawingAreaMac::displayColorSpace const):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::displayColorSpace const):

Canonical link: <a href="https://commits.webkit.org/256715@main">https://commits.webkit.org/256715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5779b1c302922c1a16c7e6d38d41bf318208c987

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106043 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5950 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34509 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102767 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4440 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83115 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31404 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40240 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19660 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4658 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43611 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40323 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->