### PR TITLE
Fix new-target Syntax Error

### DIFF
--- a/JSTests/stress/class-static-block.js
+++ b/JSTests/stress/class-static-block.js
@@ -76,6 +76,18 @@ function shouldThrow(func, errorMessage) {
     }
 }
 
+shouldThrow(() => {
+    eval(`
+        class x {
+            static {
+                function nested() {
+                    if (0?.[{ [Symbol.toPrimitive]: x => super[new.target()] }] ** 0);
+                }
+            }
+        }
+    `);
+}, `SyntaxError: super is not valid in this context.`);
+
 //  ---------- access to private fields ---------- 
 {
     let getDPrivateField;
@@ -516,6 +528,115 @@ shouldThrow(() => {
         }
     }
 }
+
+// ---------- new.target ----------
+
+{
+    class x {
+        static #f = false;
+        static {
+            if (new.target) {
+                this.#f = false;
+            } else {
+                this.#f = true;
+            }
+        }
+        static {
+            assert(this.#f === true);
+        }
+    }
+}
+
+{
+    class x {
+        static #f = false;
+        static {
+            (() => {
+                if (new.target) {
+                    this.#f = false;
+                } else {
+                    this.#f = true;
+                }
+            })();
+        }
+        static {
+            assert(this.#f === true);
+        }
+    }
+}
+
+{
+    class x {
+        static #f = false;
+        static {
+            function nested() {
+                (() => {
+                    if (new.target) {
+                        x.#f = false;
+                    } else {
+                        x.#f = true;
+                    }
+                })();
+            }
+    
+            nested();
+        }
+        static {
+            assert(this.#f === true);
+        }
+    }
+}
+
+{
+    class x {
+        static y = new.target;
+        static {
+            assert(new.target === undefined);
+        }
+    }
+
+    assert(x.y === undefined);
+}
+
+shouldThrow(() => {
+    eval(`
+        class x {
+            static {
+                if (0?.[{ [Symbol.toPrimitive]: x => super[new.target()] }] ** 0);
+            }
+        }
+    `);
+}, `TypeError: new.target is not a function. (In 'new.target()', 'new.target' is undefined)`);
+
+shouldThrow(() => {
+    eval(`
+        class x {
+            static {
+                {
+                    if (0?.[{ [Symbol.toPrimitive]: x => super[new.target()] }] ** 0);
+                }
+            }
+        }
+    `);
+}, `TypeError: new.target is not a function. (In 'new.target()', 'new.target' is undefined)`);
+
+shouldThrow(() => {
+    eval(`
+        class x {
+            static {
+                function nested() {
+                    class y {
+                        static {
+                            if (0?.[{ [Symbol.toPrimitive]: x => super[new.target()] }] ** 0);
+                        }
+                    }
+                }
+
+                nested();
+            }
+        }
+    `);
+}, `TypeError: new.target is not a function. (In 'new.target()', 'new.target' is undefined)`);
 
 // ---------- others ----------
 {

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -1932,7 +1932,8 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseBlockStatemen
             newScope->preventVarDeclarations();
             break;
         case BlockType::StaticBlock:
-            newScope->setIsStaticBlock();
+            newScope->setSourceParseMode(SourceParseMode::ClassStaticBlockMode);
+            newScope->setExpectedSuperBinding(SuperBinding::Needed);
             break;
         case BlockType::Normal:
             newScope->preventVarDeclarations();
@@ -3203,7 +3204,6 @@ parseMethod:
             matchOrFail(OPENBRACE, "Expected block statement for class static block");
             size_t usedVariablesSize = currentScope()->currentUsedVariablesSize();
             currentScope()->pushUsedVariableSet();
-            SetForScope parsingWithClassStaticBlockMode(m_parseMode, parseMode);
             DepthManager statementDepth(&m_statementDepth);
             m_statementDepth = 1;
             failIfFalse(parseBlockStatement(context, BlockType::StaticBlock), "Cannot parse class static block");


### PR DESCRIPTION
#### 9a3c9a17863e2d04c262b559b1249f98857a7c16
<pre>
Fix new-target Syntax Error
<a href="https://bugs.webkit.org/show_bug.cgi?id=247789">https://bugs.webkit.org/show_bug.cgi?id=247789</a>
rdar://102324348

Reviewed by Yusuke Suzuki.

Running JavaScript program
```
class x {
    static {
        if (0?.[{ [Symbol.toPrimitive]: x =&gt; super[new.target()] }] ** 0);
    }
}
```
should throw a TypeError.

V8
```
if (0?.[{ [Symbol.toPrimitive]: x =&gt; super[new.target()] }] ** 0);
                                                ^
TypeError: .new.target is not a function
```

GraalJS
```
TypeError: &lt;new.target&gt; is not a function
```

From class static block spec, a ClassStaticBlockDefinition Record contains a
[[BodyFunction]] with value function object.
<a href="https://tc39.es/proposal-class-static-block/#sec-ecmascript-specification-types">https://tc39.es/proposal-class-static-block/#sec-ecmascript-specification-types</a>

And according to Built-in Function Objects (section 10.3), &quot;The behaviour
specified for each built-in function via algorithm steps or other means is
the specification of the function body behaviour for both [[Call]] and
[[Construct]] invocations of the function. However, [[Construct]] invocation
is not supported by all built-in functions. For each built-in function, when
invoked with [[Call]], the [[Call]] thisArgument provides the this value,
the [[Call]] argumentsList provides the named parameters, and the NewTarget
value is undefined.&quot;
<a href="https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-built-in-function-objects">https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-built-in-function-objects</a>

In MDN, &quot;In normal function calls (as opposed to constructor function calls),
new.target is undefined. This lets you detect whether a function was called
with new as a constructor.&quot;
<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_function_calls">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_function_calls</a>

&quot;In class constructors, new.target refers to the constructor that was directly
invoked by new. This is also the case if the constructor is in a parent class
and was delegated from a child constructor. new.target points to the class
definition of class which is initialized. For example, when b was initialized
using new B(), the name of B was printed; and similarly, in case of a, the
name of class A was printed.&quot;
<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors</a>

To fix this issue, we should treat class static block as function block
with super binding.

* JSTests/stress/class-static-block.js:
(await.x):
(await):
(assert.x):
(assert):
(assert.x.nested):
(shouldThrow.eval.x):
(shouldThrow):
(await.doSomethingWith): Deleted.
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseBlockStatement):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
* Source/JavaScriptCore/parser/Parser.h:

Canonical link: <a href="https://commits.webkit.org/256700@main">https://commits.webkit.org/256700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846d7433a310fa30cfb30d69b9746a664914c5ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106114 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6038 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34582 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88961 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102825 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102263 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83191 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31472 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74379 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87542 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40313 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/82969 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21120 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28337 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4650 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85649 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40396 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19313 "Passed tests") | 
<!--EWS-Status-Bubble-End-->