### PR TITLE
Web audio rendering becomes garbled with switching from speakers to headphones (and vice-versa)

### DIFF
--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -28,6 +28,7 @@
 #if USE(AUDIO_SESSION) && PLATFORM(MAC)
 
 #include "AudioSession.h"
+#include <pal/spi/cf/CoreAudioSPI.h>
 
 typedef UInt32 AudioObjectID;
 typedef struct AudioObjectPropertyAddress AudioObjectPropertyAddress;
@@ -42,11 +43,25 @@ public:
 private:
     void addSampleRateObserverIfNeeded() const;
     void addBufferSizeObserverIfNeeded() const;
+    void addDefaultDeviceObserverIfNeeded() const;
+    void addMuteChangeObserverIfNeeded() const;
+    void removeMuteChangeObserverIfNeeded() const;
+
+    float sampleRateWithoutCaching() const;
+    std::optional<size_t> bufferSizeWithoutCaching() const;
+    void removePropertyListenersForDefaultDevice() const;
 
     static OSStatus handleSampleRateChange(AudioObjectID, UInt32, const AudioObjectPropertyAddress*, void* inClientData);
     void handleSampleRateChange() const;
     static OSStatus handleBufferSizeChange(AudioObjectID, UInt32, const AudioObjectPropertyAddress*, void* inClientData);
     void handleBufferSizeChange() const;
+    static OSStatus handleDefaultDeviceChange(AudioObjectID, UInt32, const AudioObjectPropertyAddress*, void* inClientData);
+
+    AudioDeviceID defaultDevice() const;
+    static const AudioObjectPropertyAddress& defaultOutputDeviceAddress();
+    static const AudioObjectPropertyAddress& nominalSampleRateAddress();
+    static const AudioObjectPropertyAddress& bufferSizeAddress();
+    static const AudioObjectPropertyAddress& muteAddress();
 
     // AudioSession
     CategoryType category() const final { return m_category; }
@@ -79,8 +94,11 @@ private:
 #endif
     mutable bool m_hasSampleRateObserver { false };
     mutable bool m_hasBufferSizeObserver { false };
+    mutable bool m_hasDefaultDeviceObserver { false };
+    mutable bool m_hasMuteChangeObserver { false };
     mutable std::optional<double> m_sampleRate;
     mutable std::optional<size_t> m_bufferSize;
+    mutable std::optional<AudioDeviceID> m_defaultDevice;
 };
 
 }


### PR DESCRIPTION
#### 91ac45e95dc389df2d0ee9c5b3da6ac4f84d8d88
<pre>
Web audio rendering becomes garbled with switching from speakers to headphones (and vice-versa)
<a href="https://bugs.webkit.org/show_bug.cgi?id=241223">https://bugs.webkit.org/show_bug.cgi?id=241223</a>
rdar://94721398

Reviewed by Jer Noble.

Web Audio requires a rendering quantum of 128. As a result,
MediaSessionManagerCocoa::updateSessionState() always requests a buffer size of
128 if WebAudio is in use, by calling AudioSession::setPreferredBufferSize().

When plugging in the headphones, I noticed that the rendering quantum became
480 instead of 128, which was the cause of the garbled Web Audio rendering.
updateSessionState() was however called when plugging in the headphones and
did try to set the buffer size of 128. However,
AudioSessionMac::setPreferredBufferSize() would return early because
m_bufferSize was already 128. The issue was that m_bufferSize was stale
and causing the call to setPreferredBufferSize(128) to be incorrectly ignored.

Normally, when we initialize m_bufferSize, we set a property listener so that
we can update our cached m_bufferSize whenever the corresponding property on
the audio device changes. However, our listener was set on a particular audio
device. When plugging in the headphone, the default audio device would change
and our listener would still listen for changes on the old device. As a result,
m_bufferSize would not get updated even though the audio device (and thus the
buffer size) would change.

To address the issue, I now register a default audio device listener so that
we get notified whenever the default audio device changes. When it changes,
we do the following:
1. Unregister the property listeners we had on the previous audio device
2. Register the property listeners (the one we had) on the new device
3. If we have cached property values, call the change handler for these
   properties so that our cached values get updated.

Even though the bug was caused by the buffer size not being updated, the
same issue applied to the sample rate and the muted state. I fixed all
3.

* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::defaultDeviceWithoutCaching):
(WebCore::defaultDeviceTransportIsBluetooth):
(WebCore::AudioSessionMac::removePropertyListenersForDefaultDevice const):
(WebCore::AudioSessionMac::handleDefaultDeviceChange):
(WebCore::AudioSessionMac::defaultOutputDeviceAddress):
(WebCore::AudioSessionMac::addDefaultDeviceObserverIfNeeded const):
(WebCore::AudioSessionMac::nominalSampleRateAddress):
(WebCore::AudioSessionMac::addSampleRateObserverIfNeeded const):
(WebCore::AudioSessionMac::handleSampleRateChange):
(WebCore::AudioSessionMac::handleSampleRateChange const):
(WebCore::AudioSessionMac::bufferSizeAddress):
(WebCore::AudioSessionMac::addBufferSizeObserverIfNeeded const):
(WebCore::AudioSessionMac::handleBufferSizeChange):
(WebCore::AudioSessionMac::handleBufferSizeChange const):
(WebCore::AudioSessionMac::sampleRate const):
(WebCore::AudioSessionMac::sampleRateWithoutCaching const):
(WebCore::AudioSessionMac::bufferSize const):
(WebCore::AudioSessionMac::bufferSizeWithoutCaching const):
(WebCore::AudioSessionMac::defaultDevice const):
(WebCore::AudioSessionMac::setPreferredBufferSize):
(WebCore::AudioSessionMac::muteAddress):
(WebCore::AudioSessionMac::addConfigurationChangeObserver):
(WebCore::AudioSessionMac::removeConfigurationChangeObserver):
(WebCore::AudioSessionMac::addMuteChangeObserverIfNeeded const):
(WebCore::AudioSessionMac::removeMuteChangeObserverIfNeeded const):
(WebCore::defaultDevice): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::connection):

Canonical link: <a href="https://commits.webkit.org/256712@main">https://commits.webkit.org/256712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd63ac2bd428f911158bedf450e8c817f3de5d72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106140 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6067 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34608 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102851 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102290 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83217 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31494 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40339 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21145 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4659 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4271 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40422 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->