### PR TITLE
[Curl] Use CURLOPT_SSL_EC_CURVES to set key exchange curves

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -342,9 +342,10 @@ void CurlHandle::enableSSLForHost(const String& host)
         setSslVerifyHost(CurlHandle::VerifyHost::StrictNameCheck);
     }
 
-    const auto& cipherList = sslHandle.getCipherList();
-    if (!cipherList.isEmpty())
-        setSslCipherList(cipherList.utf8().data());
+    setSslCipherList(sslHandle.cipherList().data());
+
+    if (const auto& ecCurves = sslHandle.ecCurves(); !ecCurves.isNull())
+        setSslECCurves(ecCurves.data());
 
     setSslCtxCallbackFunction(willSetupSslCtxCallback, this);
 
@@ -592,6 +593,11 @@ void CurlHandle::setSslKeyPassword(const char* password)
 void CurlHandle::setSslCipherList(const char* cipherList)
 {
     curl_easy_setopt(m_handle, CURLOPT_SSL_CIPHER_LIST, cipherList);
+}
+
+void CurlHandle::setSslECCurves(const char* ecCurves)
+{
+    curl_easy_setopt(m_handle, CURLOPT_SSL_EC_CURVES, ecCurves);
 }
 
 void CurlHandle::enableProxyIfExists()

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -278,6 +278,7 @@ public:
     void setSslCertType(const char*);
     void setSslKeyPassword(const char*);
     void setSslCipherList(const char*);
+    void setSslECCurves(const char*);
 
     void enableProxyIfExists();
 

--- a/Source/WebCore/platform/network/curl/CurlSSLHandle.h
+++ b/Source/WebCore/platform/network/curl/CurlSSLHandle.h
@@ -53,13 +53,13 @@ public:
 
     CurlSSLHandle();
 
-    const String& getCipherList() const { return m_cipherList; }
-    const String& getSignatureAlgorithmsList() const { return m_signatureAlgorithmsList; }
-    const String& getCurvesList() const { return m_curvesList; }
+    const CString& cipherList() const { return m_cipherList; }
+    const CString& signatureAlgorithmsList() const { return m_signatureAlgorithmsList; }
+    const CString& ecCurves() const { return m_ecCurves; }
 
-    WEBCORE_EXPORT void setCipherList(String&& data) { m_cipherList = WTFMove(data); }
-    WEBCORE_EXPORT void setSignatureAlgorithmsList(String&& data) { m_signatureAlgorithmsList = WTFMove(data); }
-    WEBCORE_EXPORT void setCurvesList(String&& data) { m_curvesList = WTFMove(data); }
+    void setCipherList(CString&& data) { m_cipherList = WTFMove(data); }
+    void setSignatureAlgorithmsList(CString&& data) { m_signatureAlgorithmsList = WTFMove(data); }
+    void setECCurves(CString&& data) { m_ecCurves = WTFMove(data); }
 
     bool shouldIgnoreSSLErrors() const { return m_ignoreSSLErrors; }
     WEBCORE_EXPORT void setIgnoreSSLErrors(bool flag) { m_ignoreSSLErrors = flag; }
@@ -105,9 +105,9 @@ private:
 
     void platformInitialize();
 
-    String m_cipherList;
-    String m_signatureAlgorithmsList;
-    String m_curvesList;
+    CString m_cipherList;
+    CString m_signatureAlgorithmsList;
+    CString m_ecCurves;
     CACertInfo m_caCertInfo;
 
     bool m_ignoreSSLErrors { false };

--- a/Source/WebCore/platform/network/curl/CurlSSLVerifier.cpp
+++ b/Source/WebCore/platform/network/curl/CurlSSLVerifier.cpp
@@ -49,14 +49,9 @@ CurlSSLVerifier::CurlSSLVerifier(void* sslCtx)
 #endif
 
 #if (!defined(LIBRESSL_VERSION_NUMBER))
-    const auto& signatureAlgorithmsList = sslHandle.getSignatureAlgorithmsList();
-    if (!signatureAlgorithmsList.isEmpty())
-        SSL_CTX_set1_sigalgs_list(ctx, signatureAlgorithmsList.utf8().data());
+    if (const auto& signatureAlgorithmsList = sslHandle.signatureAlgorithmsList(); !signatureAlgorithmsList.isNull())
+        SSL_CTX_set1_sigalgs_list(ctx, signatureAlgorithmsList.data());
 #endif
-
-    const auto& curvesList = sslHandle.getCurvesList();
-    if (!curvesList.isEmpty())
-        SSL_CTX_set1_curves_list(ctx, curvesList.utf8().data());
 
 #if ENABLE(TLS_DEBUG)
     SSL_CTX_set_info_callback(ctx, infoCallback);

--- a/Source/WebCore/platform/network/playstation/CurlSSLHandlePlayStation.cpp
+++ b/Source/WebCore/platform/network/playstation/CurlSSLHandlePlayStation.cpp
@@ -40,8 +40,8 @@ void CurlSSLHandle::platformInitialize()
     if (certificateData->size())
         setCACertData(WTFMove(caCertData));
 
-    setCipherList(String::fromUTF8(CertificateStore::cipherSuites()));
-    setCurvesList(String::fromUTF8(CertificateStore::supportedGroups()));
+    setCipherList(CertificateStore::cipherSuites());
+    setECCurves(CertificateStore::supportedGroups());
 
     setIgnoreSSLErrors(CertificateStore::shouldIgnoreTLSErrors());
 }


### PR DESCRIPTION
#### b262535120dd95bc9d8425b14eb523fa16fe44c5
<pre>
[Curl] Use CURLOPT_SSL_EC_CURVES to set key exchange curves
<a href="https://bugs.webkit.org/show_bug.cgi?id=247933">https://bugs.webkit.org/show_bug.cgi?id=247933</a>

Reviewed by Fujii Hironori.

CURLOPT_SSL_EC_CURVES option to set key exchange curves was
added in 7.73.0. So, we use this option instead of using OpenSSL API.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::enableSSLForHost):
(WebCore::CurlHandle::setSslECCurves):
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlSSLHandle.h:
(WebCore::CurlSSLHandle::cipherList const):
(WebCore::CurlSSLHandle::signatureAlgorithmsList const):
(WebCore::CurlSSLHandle::ecCurves const):
(WebCore::CurlSSLHandle::setCipherList):
(WebCore::CurlSSLHandle::setSignatureAlgorithmsList):
(WebCore::CurlSSLHandle::setECCurves):
(WebCore::CurlSSLHandle::getCipherList const): Deleted.
(WebCore::CurlSSLHandle::getSignatureAlgorithmsList const): Deleted.
(WebCore::CurlSSLHandle::getCurvesList const): Deleted.
(WebCore::CurlSSLHandle::setCurvesList): Deleted.
* Source/WebCore/platform/network/curl/CurlSSLVerifier.cpp:
(WebCore::CurlSSLVerifier::CurlSSLVerifier):
* Source/WebCore/platform/network/playstation/CurlSSLHandlePlayStation.cpp:
(WebCore::CurlSSLHandle::platformInitialize):

Canonical link: <a href="https://commits.webkit.org/256692@main">https://commits.webkit.org/256692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec826dac328ce540a01ebb497b33deba12a2ed45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106072 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166414 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5986 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34538 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102788 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4461 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83146 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31429 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-css.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74334 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40271 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37935 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4203 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40352 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->