### PR TITLE
HTMLImageElement and FormAssociatedElement should share more code

### DIFF
--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -267,7 +267,7 @@ public:
     Element* parentOrShadowHostElement() const;
     void setParentNode(ContainerNode*);
     Node& rootNode() const;
-    Node& traverseToRootNode() const;
+    WEBCORE_EXPORT Node& traverseToRootNode() const;
     Node& shadowIncludingRoot() const;
 
     struct GetRootNodeOptions {

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -46,7 +46,6 @@ public:
     virtual ~FormListedElement();
 
     static HTMLFormElement* findAssociatedForm(const HTMLElement*, HTMLFormElement*);
-    WEBCORE_EXPORT HTMLFormElement* form() const;
     ValidityState* validity();
 
     virtual bool isFormControlElement() const = 0;
@@ -62,9 +61,9 @@ public:
     // Return true for a successful control (see HTML4-17.13.2).
     virtual bool appendFormData(DOMFormData&) { return false; }
 
-    void formWillBeDestroyed();
+    void formWillBeDestroyed() final;
 
-    void resetFormOwner();
+    void resetFormOwner() final;
 
     void formOwnerRemovedFromTree(const Node&);
 
@@ -91,12 +90,11 @@ public:
 protected:
     FormListedElement(HTMLFormElement*);
 
-    void insertedIntoAncestor(Node::InsertionType, ContainerNode&);
-    void removedFromAncestor(Node::RemovalType, ContainerNode&);
+    void elementInsertedIntoAncestor(Element&, Node::InsertionType) final;
+    void elementRemovedFromAncestor(Element&, Node::RemovalType);
     void didMoveToNewDocument(Document& oldDocument);
 
     void clearForm() { setForm(nullptr); }
-    void setForm(HTMLFormElement*);
     void formAttributeChanged();
 
     // If you add an override of willChangeForm() or didChangeForm() to a class
@@ -108,6 +106,7 @@ protected:
     String customValidationMessage() const;
 
 private:
+    void setFormInternal(HTMLFormElement*) final;
     // "willValidate" means "is a candidate for constraint validation".
     virtual bool willValidate() const = 0;
 
@@ -116,8 +115,6 @@ private:
     bool isFormListedElement() const final { return true; }
 
     std::unique_ptr<FormAttributeTargetObserver> m_formAttributeTargetObserver;
-    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_form;
-    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_formSetByParser;
     String m_customValidationMessage;
 };
 

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -255,7 +255,7 @@ Node::InsertedIntoAncestorResult HTMLFormControlElement::insertedIntoAncestor(In
     if (document().hasDisabledFieldsetElement())
         setAncestorDisabled(computeIsDisabledByFieldsetAncestor());
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    FormListedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    FormListedElement::elementInsertedIntoAncestor(*this, insertionType);
 
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
@@ -280,7 +280,7 @@ void HTMLFormControlElement::removedFromAncestor(RemovalType removalType, Contai
     }
 
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    FormListedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    FormListedElement::elementRemovedFromAncestor(*this, removalType);
 
     if (wasMatchingInvalidPseudoClass)
         removeInvalidElementToAncestorFromInsertionPoint(*this, &oldParentOfRemovedTree);

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -122,7 +122,7 @@ HTMLFormElement::~HTMLFormElement()
         listedElement->formWillBeDestroyed();
     }
     for (auto& imageElement : m_imageElements)
-        imageElement->m_form = nullptr;
+        imageElement->formWillBeDestroyed();
 }
 
 bool HTMLFormElement::formWouldHaveSecureSubmission(const String& url)

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -48,7 +48,6 @@ enum class RelevantMutation : bool;
 
 class HTMLImageElement : public HTMLElement, public FormAssociatedElement, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLImageElement);
-    friend class HTMLFormElement;
 public:
     static Ref<HTMLImageElement> create(Document&);
     static Ref<HTMLImageElement> create(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
@@ -170,10 +169,11 @@ protected:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 
 private:
-    HTMLFormElement* form() const final;
-    void setForm(HTMLFormElement*);
+    HTMLFormElement* form() const final { return FormAssociatedElement::form(); }
+    void resetFormOwner() final;
     void refFormAssociatedElement() final { HTMLElement::ref(); }
     void derefFormAssociatedElement() final { HTMLElement::deref(); }
+    void setFormInternal(HTMLFormElement*) final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void parseAttribute(const QualifiedName&, const AtomString&) override;
@@ -228,8 +228,6 @@ private:
     void setSourceElement(HTMLSourceElement*);
 
     std::unique_ptr<HTMLImageLoader> m_imageLoader;
-    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_form;
-    WeakPtr<HTMLFormElement, WeakPtrImplWithEventTargetData> m_formSetByParser;
 
     CompositeOperator m_compositeOperator;
     AtomString m_bestFitImageURL;

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -295,7 +295,7 @@ void HTMLObjectElement::updateWidget(CreatePlugins createPlugins)
 Node::InsertedIntoAncestorResult HTMLObjectElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     HTMLPlugInImageElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    FormListedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    FormListedElement::elementInsertedIntoAncestor(*this, insertionType);
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 
@@ -307,7 +307,7 @@ void HTMLObjectElement::didFinishInsertingNode()
 void HTMLObjectElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLPlugInImageElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    FormListedElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+    FormListedElement::elementRemovedFromAncestor(*this, removalType);
 }
 
 void HTMLObjectElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/loader/FormState.cpp
+++ b/Source/WebCore/loader/FormState.cpp
@@ -45,6 +45,8 @@ inline FormState::FormState(HTMLFormElement& form, StringPairVector&& textFieldV
     RELEASE_ASSERT(sourceDocument.frame());
 }
 
+FormState::~FormState() = default;
+
 Ref<FormState> FormState::create(HTMLFormElement& form, StringPairVector&& textFieldValues, Document& sourceDocument, FormSubmissionTrigger formSubmissionTrigger)
 {
     return adoptRef(*new FormState(form, WTFMove(textFieldValues), sourceDocument, formSubmissionTrigger));

--- a/Source/WebCore/loader/FormState.h
+++ b/Source/WebCore/loader/FormState.h
@@ -44,6 +44,7 @@ using StringPairVector = Vector<std::pair<String, String>>;
 class FormState : public RefCounted<FormState>, public CanMakeWeakPtr<FormState>, public FrameDestructionObserver {
 public:
     static Ref<FormState> create(HTMLFormElement&, StringPairVector&& textFieldValues, Document&, FormSubmissionTrigger);
+    ~FormState();
 
     HTMLFormElement& form() const { return m_form; }
     const StringPairVector& textFieldValues() const { return m_textFieldValues; }


### PR DESCRIPTION
#### 5780eeea65cd07eaeb33633e80b07c8c2765d2f7
<pre>
HTMLImageElement and FormAssociatedElement should share more code
<a href="https://bugs.webkit.org/show_bug.cgi?id=247936">https://bugs.webkit.org/show_bug.cgi?id=247936</a>

Reviewed by Aditya Keerthi.

This patch makes HTMLImageElement and FormListedElement share more code in FormAssociatedElement.
m_form and m_formSetByParser are moved from those two classes to FormAssociatedElement along with
some logic to update the associated form.

* Source/WebCore/dom/Node.h:
* Source/WebCore/html/FormAssociatedElement.h:
(WebCore::FormAssociatedElement::~FormAssociatedElement): Moved the release assertion from
FormListedElement::~FormListedElement.
(WebCore::FormAssociatedElement::formWillBeDestroyed): Added.
(WebCore::FormAssociatedElement::form const): Added.
(WebCore::FormAssociatedElement::FormAssociatedElement): Added.
(WebCore::FormAssociatedElement::setForm): Added.
(WebCore::FormAssociatedElement::setFormInternal): Added.
(WebCore::FormAssociatedElement::elementInsertedIntoAncestor): Added.
(WebCore::FormAssociatedElement::elementRemovedFromAncestor): Added.

* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormListedElement::FormListedElement):
(WebCore::FormListedElement::~FormListedElement): Deleted.
(WebCore::FormListedElement::elementInsertedIntoAncestor): Renamed from insertedIntoAncestor.
Also takes the element and InsertionType as arguments.
(WebCore::FormListedElement::elementRemovedFromAncestor): Ditto from removedFromAncestor.
(WebCore::FormListedElement::form const): Deleted.
(WebCore::FormListedElement::formOwnerRemovedFromTree):
(WebCore::FormListedElement::setFormInternal): Extracted from the old setForm, which has been
moved to FormAssociatedElement.
(WebCore::FormListedElement::formWillBeDestroyed):
(WebCore::FormListedElement::resetFormOwner):
(WebCore::FormListedElement::formAttributeChanged):
(WebCore::FormListedElement::setForm): Deleted.

* Source/WebCore/html/FormListedElement.h:
(WebCore::FormListedElement::clearForm):

* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::insertedIntoAncestor):
(WebCore::HTMLFormControlElement::removedFromAncestor):

* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::~HTMLFormElement): Call formWillBeDestroyed instead of directly
updating HTMLImageElement&apos;s private member variable.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::HTMLImageElement):
(WebCore::HTMLImageElement::form const): Deleted.
(WebCore::HTMLImageElement::resetFormOwner): Added.
(WebCore::HTMLImageElement::setFormInternal): Renamed from setForm.
(WebCore::HTMLImageElement::insertedIntoAncestor):
(WebCore::HTMLImageElement::removedFromAncestor):

* Source/WebCore/html/HTMLImageElement.h:

* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::insertedIntoAncestor):
(WebCore::HTMLObjectElement::removedFromAncestor):

* Source/WebCore/loader/FormState.cpp:

* Source/WebCore/loader/FormState.h:

Canonical link: <a href="https://commits.webkit.org/256697@main">https://commits.webkit.org/256697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f33f2bf2f693a37b1a4fbc1e9556ea75eb3d9f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106059 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166405 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5970 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34523 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102775 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4453 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83132 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31417 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88182 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40257 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37922 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21069 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43620 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2223 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40342 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->