### PR TITLE
Remove Quirks shouldDisableResolutionMediaQuery()

### DIFF
--- a/Source/WebCore/css/LegacyMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/LegacyMediaQueryEvaluator.cpp
@@ -398,7 +398,7 @@ static bool devicePixelRatioEvaluate(CSSValue* value, const CSSToLengthConversio
 
 static bool resolutionEvaluate(CSSValue* value, const CSSToLengthConversionData&, Frame& frame, MediaFeaturePrefix op)
 {
-    if (!frame.settings().resolutionMediaFeatureEnabled() || frame.document()->quirks().shouldDisableResolutionMediaQuery())
+    if (!frame.settings().resolutionMediaFeatureEnabled())
         return false;
 
     return (!value || (is<CSSPrimitiveValue>(*value) && downcast<CSSPrimitiveValue>(*value).isResolution())) && evaluateResolution(value, frame, op);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -225,59 +225,6 @@ bool Quirks::shouldHideSearchFieldResultsButton() const
     return false;
 }
 
-bool Quirks::shouldDisableResolutionMediaQuery() const
-{
-    if (!needsQuirks())
-        return false;
-    auto host = m_document->url().host();
-
-    if (equalLettersIgnoringASCIICase(host, "www.carrentals.com"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.cheaptickets.com"_s))
-        return true;
-
-#if ENABLE(PUBLIC_SUFFIX_LIST)
-    if (topPrivatelyControlledDomain(host.toString()).startsWith("ebookers."_s))
-        return true;
-
-    if (topPrivatelyControlledDomain(host.toString()).startsWith("expedia."_s))
-        return true;
-#endif
-
-    if (host.endsWithIgnoringASCIICase(".hoteis.com"_s))
-        return true;
-
-    if (host.endsWithIgnoringASCIICase(".hoteles.com"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.hotels.cn"_s))
-        return true;
-
-    if (host.endsWithIgnoringASCIICase(".hotels.com"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.mrjet.se"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.orbitz.com"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.travelocity.ca"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.travelocity.com"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.wotif.com"_s))
-        return true;
-
-    if (equalLettersIgnoringASCIICase(host, "www.wotif.co.nz"_s))
-        return true;
-
-    return false;
-}
-
 bool Quirks::needsMillisecondResolutionForHighResTimeStamp() const
 {
     if (!needsQuirks())

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -82,7 +82,6 @@ public:
     bool shouldDisableContentChangeObserverTouchEventAdjustment() const;
     bool shouldTooltipPreventFromProceedingWithClick(const Element&) const;
     bool shouldHideSearchFieldResultsButton() const;
-    bool shouldDisableResolutionMediaQuery() const;
     bool shouldExposeShowModalDialog() const;
 
     bool needsMillisecondResolutionForHighResTimeStamp() const;


### PR DESCRIPTION
#### 02f0132355840d713d3465a2b963b2a126018ee3
<pre>
Remove Quirks shouldDisableResolutionMediaQuery()
<a href="https://bugs.webkit.org/show_bug.cgi?id=247940">https://bugs.webkit.org/show_bug.cgi?id=247940</a>
rdar://102355671

Reviewed by Tim Nguyen.

This PR removes the quirks which previously disabled the
resolution media feature on Expedia Group sites. When
disabling Site Specific Hacks, the site behaves correctly.
They probably have changed their widget. The patch was tested
for different window widths, and the issue didn&apos;t reproduce.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableResolutionMediaQuery const): Deleted.
* Source/WebCore/css/LegacyMediaQueryEvaluator.cpp:
(WebCore::resolutionEvaluate):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/256714@main">https://commits.webkit.org/256714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65239a4f79f29718cda497f3c183e8833e014fa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106078 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166420 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/5993 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34545 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102794 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4466 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83153 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31436 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74340 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40278 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37942 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21082 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4657 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43633 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40355 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->