### PR TITLE
Removing reportingScope observers in destructor to fix nullptr

### DIFF
--- a/LayoutTests/http/tests/workers/reportingObserverNonNull-expected.txt
+++ b/LayoutTests/http/tests/workers/reportingObserverNonNull-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/http/tests/workers/reportingObserverNonNull.html
+++ b/LayoutTests/http/tests/workers/reportingObserverNonNull.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it doesn't crash.</p>
+<script>
+ if (window.testRunner) {
+     testRunner.waitUntilDone();
+     testRunner.dumpAsText();
+ }
+ new Image().src = 'data:';
+ w = new Worker(`data:text/javascript,new ReportingObserver(() => {}).observe(); postMessage('DONE');`);
+ w.onmessage = (e) => {
+    if (window.testRunner)
+        testRunner.notifyDone();
+  };
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -176,6 +176,7 @@ void WorkerGlobalScope::removeAllEventListeners()
     WorkerOrWorkletGlobalScope::removeAllEventListeners();
     m_performance->removeAllEventListeners();
     m_performance->removeAllObservers();
+    m_reportingScope->removeAllObservers();
 }
 
 bool WorkerGlobalScope::isSecureContext() const


### PR DESCRIPTION
#### 24db74d224090552034da32f80359ebc6c12617c
<pre>
Removing reportingScope observers in destructor to fix nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=247677#c0">https://bugs.webkit.org/show_bug.cgi?id=247677#c0</a>
rdar://102142833

The issue is that when doing in ReportingObserver::disconnect, there are pointers that are already null since the WorkerGlobalScope object is being deleted in the process so any reference to its ReportingObserver objects
might not be valid. That is why when destroying it, it is also necessary to remove the corresponding ReportingObserver objects.

Reviewed by Youenn Fablet.

* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::removeAllEventListeners):

Canonical link: <a href="https://commits.webkit.org/256932@main">https://commits.webkit.org/256932@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e67ab1938fd31f7673e80fe39cf9d945fbae2db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106686 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166958 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6709 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35169 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103376 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5040 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83794 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32021 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74925 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/457 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20195 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/441 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44142 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1681 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40959 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->