### PR TITLE
Safari reuses Authorization header on second call to 301 redirects even if the header value changed when replaying the request

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-authorization-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-authorization-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Permanent redirections should not reuse a previous Authorization header - request without authorization header
+PASS Permanent redirections should not allow reusing Authorization header - request with authorization header
+

--- a/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-authorization.html
+++ b/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-authorization.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Tests that the Authorization header is present on same-origin redirect requests coming from cache</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#request">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+promise_test(async () => {
+    let response = await fetch("/WebKit/fetch/resources/redirect301.py?request=1&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-authorization-header.py"), {
+        headers: {
+            Authorization: "Foo Bar1",
+        },
+    });
+    assert_equals(await response.text(), "Foo Bar1");
+
+   response = await fetch("/WebKit/fetch/resources/redirect301.py?request=1&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-authorization-header.py"));
+    assert_equals(await response.text(), "none");
+}, "Permanent redirections should not reuse a previous Authorization header - request without authorization header");
+
+promise_test(async () => {
+    let response = await fetch("/WebKit/fetch/resources/redirect301.py?request=2&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-authorization-header.py"), {
+        headers: {
+            Authorization: "Foo Bar1",
+        },
+    });
+    assert_equals(await response.text(), "Foo Bar1");
+
+   response = await fetch("/WebKit/fetch/resources/redirect301.py?request=2&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-authorization-header.py"), {
+        headers: {
+            Authorization: "Foo Bar2",
+        },
+    });
+    assert_equals(await response.text(), "Foo Bar2");
+}, "Permanent redirections should not allow reusing Authorization header - request with authorization header");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/fetch/resources/dump-authorization-header.py
+++ b/LayoutTests/http/wpt/fetch/resources/dump-authorization-header.py
@@ -1,0 +1,6 @@
+def main(request, response):
+    headers = [(b"Content-Type", "text/html"),
+               (b"Cache-Control", b"no-cache")]
+    if b"authorization" in request.headers:
+        return 200, headers, request.headers.get(b"Authorization")
+    return 200, headers, "none"

--- a/LayoutTests/http/wpt/fetch/resources/redirect301.py
+++ b/LayoutTests/http/wpt/fetch/resources/redirect301.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    headers = [(b"Location", request.GET[b'url']),
+               (b"Cache-Control", b"public, max-age=86400")]
+    return 301, headers, ""

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1167,6 +1167,14 @@ void NetworkResourceLoader::willSendRedirectedRequestInternal(ResourceRequest&& 
         return;
     }
 
+    if (auto authorization = request.httpHeaderField(WebCore::HTTPHeaderName::Authorization); !authorization.isNull()
+#if PLATFORM(COCOA)
+        && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AuthorizationHeaderOnSameOriginRedirects)
+#endif
+        && protocolHostAndPortAreEqual(request.url(), redirectRequest.url())) {
+        redirectRequest.setHTTPHeaderField(WebCore::HTTPHeaderName::Authorization, authorization);
+    }
+
     if (m_networkLoadChecker) {
         if (privateClickMeasurementAttributionTriggerData)
             m_networkLoadChecker->enableContentExtensionsCheck();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -459,7 +459,9 @@ std::unique_ptr<Entry> Cache::makeEntry(const WebCore::ResourceRequest& request,
 
 std::unique_ptr<Entry> Cache::makeRedirectEntry(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& redirectRequest)
 {
-    return makeUnique<Entry>(makeCacheKey(request), response, redirectRequest, WebCore::collectVaryingRequestHeaders(networkProcess().storageSession(m_sessionID), request, response));
+    auto cachedRedirectRequest = redirectRequest;
+    cachedRedirectRequest.clearHTTPAuthorization();
+    return makeUnique<Entry>(makeCacheKey(request), response, WTFMove(cachedRedirectRequest), WebCore::collectVaryingRequestHeaders(networkProcess().storageSession(m_sessionID), request, response));
 }
 
 std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& responseData, Function<void(MappedBody&)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -579,11 +579,6 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
     m_lastHTTPMethod = request.httpMethod();
     request.removeCredentials();
 
-    if (auto authorization = m_firstRequest.httpHeaderField(WebCore::HTTPHeaderName::Authorization); !authorization.isNull()
-        && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AuthorizationHeaderOnSameOriginRedirects)
-        && protocolHostAndPortAreEqual(m_firstRequest.url(), request.url()))
-        request.setHTTPHeaderField(WebCore::HTTPHeaderName::Authorization, authorization);
-
     if (!protocolHostAndPortAreEqual(request.url(), redirectResponse.url())) {
         // The network layer might carry over some headers from the original request that
         // we want to strip here because the redirect is cross-origin.


### PR DESCRIPTION
#### 63145fa91bb8fb40c7103b9971d7292b6a3e0517
<pre>
Safari reuses Authorization header on second call to 301 redirects even if the header value changed when replaying the request
<a href="https://bugs.webkit.org/show_bug.cgi?id=247418">https://bugs.webkit.org/show_bug.cgi?id=247418</a>
rdar://problem/101935060

Reviewed by Chris Dumez.

In case of serving a redirection from HTTP cache, we cannot reuse the Authorization header of the past redirect request.
Instead, we should reuse the latest request Authorization header.

To do this, we remove Authorization header from stored redirected requests in network cache.
This handles the case of a cached redirection stored with authorization and reused without authorization.

We also move the NetworkDataTaskCocoa code used to reuse the original request Authorization header to NetworkResourceLoader,
so that it handles both the cache code path as well as the regular network code path.

* LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-authorization-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-authorization.html: Added.
* LayoutTests/http/wpt/fetch/resources/dump-authorization-header.py: Added.
(main):
* LayoutTests/http/wpt/fetch/resources/redirect301.py: Added.
(main):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::makeRedirectEntry):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):

Canonical link: <a href="https://commits.webkit.org/256726@main">https://commits.webkit.org/256726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1445a6fcc879d57f466e97f3b5fabfd7dd9feb17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106127 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166461 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6053 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34595 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102838 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4516 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83204 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31492 "Found 1 new test failure: media/video-seek-to-current-time.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40326 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21133 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4668 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43673 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40409 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->