### PR TITLE
Prevent WebCodecs encoder and decoder from being GCed in case they are flushing

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/webcodecs-gc-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/webcodecs-gc-expected.txt
@@ -1,0 +1,5 @@
+
+PASS VP8 codec GC
+PASS VP9 codec GC
+PASS H.264 codec GC
+

--- a/LayoutTests/http/wpt/webcodecs/webcodecs-gc.html
+++ b/LayoutTests/http/wpt/webcodecs/webcodecs-gc.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src="../resources/gc.js"></script>
+</header>
+<body>
+<script>
+
+function makeOffscreenCanvas(width, height) {
+  let canvas = new OffscreenCanvas(width, height);
+  let ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+  ctx.fillRect(0, 0, width, height);
+  return new VideoFrame(canvas, { timestamp: 1 });
+}
+
+let chunks = [];
+let config;
+
+async function createChunks(encoderConfig) {
+  chunks = [];
+  const encoderInit = {
+    output(chunk, metadata) {
+      if (metadata.decoderConfig) {
+        config = metadata.decoderConfig;
+      }
+      chunks.push(chunk);
+    },
+    error(e) {
+      reject(e.message);
+    }
+  };
+
+  const encoder = new VideoEncoder(encoderInit);
+  encoder.configure(encoderConfig);
+
+  const w = encoderConfig.width;
+  const h = encoderConfig.height;
+  const frame = makeOffscreenCanvas(w, h);
+  encoder.encode(frame, { keyFrame: true });
+
+  const timer = setInterval(() => gc(), 100); 
+  await encoder.flush();
+  clearInterval(timer);
+}
+
+async function doEncodeDecode(encoderConfig)
+{
+  await createChunks(encoderConfig);
+
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  const decoder = new VideoDecoder({
+    output(frame) {
+      resolve(frame);
+    },
+    error(e) {
+      reject(e.message);
+    }
+  });
+
+  decoder.configure(config);
+
+  for (let chunk of chunks)
+    decoder.decode(chunk);
+
+  const timer = setInterval(() => gc(), 100); 
+  await decoder.flush();
+  clearInterval(timer);
+
+  return promise;
+}
+
+function doTest(codec, title)
+{
+  const config = { codec };
+  config.width = 320;
+  config.height = 200;
+  config.bitrate = 1000000;
+  config.framerate = 30;
+
+  promise_test(async t => {
+    const frame = await doEncodeDecode(config);
+    t.add_cleanup(() => frame.close());
+ 
+    assert_not_equals(frame.colorSpace.primaries, null, "primaries");
+  }, title);
+}
+
+doTest('vp8', "VP8 codec GC");
+doTest('vp09.00.10.08', "VP9 codec GC");
+doTest('avc1.42001E', "H.264 codec GC");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h
@@ -107,6 +107,7 @@ private:
     bool m_isKeyChunkRequired { false };
     Deque<Function<void()>> m_controlMessageQueue;
     bool m_isMessageQueueBlocked { false };
+    bool m_isFlushing { false };
 };
 
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h
@@ -112,6 +112,7 @@ private:
     WebCodecsVideoEncoderConfig m_baseConfiguration;
     VideoEncoder::ActiveConfiguration m_activeConfiguration;
     bool m_hasNewActiveConfiguration { false };
+    bool m_isFlushing { false };
 };
 
 }


### PR DESCRIPTION
#### 688c513969e45393eab4da4d912b2e9eda4fdd94
<pre>
Prevent WebCodecs encoder and decoder from being GCed in case they are flushing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247941">https://bugs.webkit.org/show_bug.cgi?id=247941</a>
rdar://problem/102360806

Reviewed by Eric Carlson.

Add a m_isFlushing boolean to encoder and decoder.
Forbidd GC when m_isFlushing is true.
Set m_isFlushing to true when flush is called and corresponding promise is not resolved.

* LayoutTests/http/wpt/webcodecs/webcodecs-gc-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/webcodecs-gc.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::~WebCodecsVideoDecoder):
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
(WebCore::WebCodecsVideoDecoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::flush):
(WebCore::WebCodecsVideoEncoder::virtualHasPendingActivity const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.h:

Canonical link: <a href="https://commits.webkit.org/256739@main">https://commits.webkit.org/256739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887a89296b1447cd0c31aec2340b38bcb10eaac5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106095 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166433 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6015 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34563 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102808 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4482 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83171 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31456 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74358 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40295 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19697 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/37958 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4681 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43645 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40377 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->