### PR TITLE
Build a SHARED WebCore on WinCairo

### DIFF
--- a/Source/WebCore/platform/graphics/win/ImageWin.cpp
+++ b/Source/WebCore/platform/graphics/win/ImageWin.cpp
@@ -25,12 +25,20 @@
 
 #include "config.h"
 #include "Image.h"
-#include "BitmapImage.h"
 
+#include "BitmapImage.h"
 #include "SharedBuffer.h"
 
+#if !PLATFORM(WIN_CAIRO)
 // This function loads resources from WebKit
 RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char*);
+#else
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=188175
+RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char*)
+{
+    return nullptr;
+}
+#endif
 
 namespace WebCore {
 

--- a/Source/WebKit/WebProcess/win/WebProcessWin.cpp
+++ b/Source/WebKit/WebProcess/win/WebProcessWin.cpp
@@ -28,11 +28,6 @@
 
 #include <WebCore/SharedBuffer.h>
 
-RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char* name)
-{
-    return nullptr;
-}
-
 namespace WebKit {
 
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters&)

--- a/Source/WebKitLegacy/CMakeLists.txt
+++ b/Source/WebKitLegacy/CMakeLists.txt
@@ -32,11 +32,15 @@ set(WebKitLegacy_PRIVATE_INCLUDE_DIRECTORIES
     "${WebKitLegacy_DERIVED_SOURCES_DIR}"
 )
 
-set(WebKitLegacy_PRIVATE_LIBRARIES
-    WebKit::JavaScriptCore
-    WebKit::PAL
-    WebKit::WebCore
+set(WebKitLegacy_FRAMEWORKS
+    JavaScriptCore
+    PAL
+    WTF
+    WebCore
 )
+if (NOT USE_SYSTEM_MALLOC)
+    list(APPEND WebKit_FRAMEWORKS bmalloc)
+endif ()
 
 WEBKIT_FRAMEWORK_DECLARE(WebKitLegacy)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()

--- a/Source/WebKitLegacy/PlatformWin.cmake
+++ b/Source/WebKitLegacy/PlatformWin.cmake
@@ -7,9 +7,6 @@ if (${WTF_PLATFORM_WIN_CAIRO})
         win/WebDownloadCURL.cpp
         win/WebURLAuthenticationChallengeSenderCURL.cpp
     )
-    list(APPEND WebKitLegacy_PRIVATE_LIBRARIES
-        $<TARGET_OBJECTS:WebCore>
-    )
 else ()
     list(APPEND WebKitLegacy_SOURCES_Classes
         win/WebDownloadCFNet.cpp
@@ -486,9 +483,4 @@ endif ()
 
 set(WebKitLegacy_OUTPUT_NAME
     WebKit${DEBUG_SUFFIX}
-)
-
-list(APPEND WebKitLegacy_PRIVATE_DEFINITIONS
-    STATICALLY_LINKED_WITH_PAL
-    STATICALLY_LINKED_WITH_WebCore
 )

--- a/Source/WebKitLegacy/win/WebKitDLL.cpp
+++ b/Source/WebKitLegacy/win/WebKitDLL.cpp
@@ -169,6 +169,7 @@ void shutDownWebKit()
     WebKit::WebStorageNamespaceProvider::closeLocalStorage();
 }
 
+#if !PLATFORM(WIN_CAIRO)
 //FIXME: We should consider moving this to a new file for cross-project functionality
 WEBKIT_API RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char* name);
 RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char* name)
@@ -239,6 +240,7 @@ RefPtr<WebCore::FragmentedSharedBuffer> loadResourceIntoBuffer(const char* name)
 
     return WebCore::SharedBuffer::create(reinterpret_cast<const char*>(resource), size);
 }
+#endif // !PLATFORM(WIN_CAIRO)
 
 // Force symbols to be included so we can export them for legacy clients.
 // DEPRECATED! People should get these symbols from JavaScriptCore.dll, not WebKit.dll!

--- a/Source/cmake/OptionsWinCairo.cmake
+++ b/Source/cmake/OptionsWinCairo.cmake
@@ -86,5 +86,6 @@ add_definitions(-DWTF_PLATFORM_WIN_CAIRO=1)
 add_definitions(-DNOCRYPT)
 
 # Override library types
-set(WebCore_LIBRARY_TYPE OBJECT)
+set(PAL_LIBRARY_TYPE OBJECT)
+set(WebCore_LIBRARY_TYPE SHARED)
 set(WebCoreTestSupport_LIBRARY_TYPE OBJECT)


### PR DESCRIPTION
#### e912e7b00570fe6700dd49d366acc773616d0577
<pre>
Build a SHARED WebCore on WinCairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=247944">https://bugs.webkit.org/show_bug.cgi?id=247944</a>

Reviewed by Fujii Hironori.

Make WebCore a `SHARED` library. Build PAL into it as well. Build
WebKitLegacy as a framework now that there isn&apos;t a conflict with where
WebCore is built.

Stub out `loadResourceIntoBuffer` which loads icons. It will be
addressed in a future bug.

* Source/WebCore/platform/graphics/win/ImageWin.cpp:
* Source/WebKit/WebProcess/win/WebProcessWin.cpp:
* Source/WebKitLegacy/CMakeLists.txt:
* Source/WebKitLegacy/PlatformWin.cmake:
* Source/WebKitLegacy/win/WebKitDLL.cpp:
* Source/cmake/OptionsWinCairo.cmake:

Canonical link: <a href="https://commits.webkit.org/257608@main">https://commits.webkit.org/257608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ffb00e943755d153daf37d39b09c676d696e675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108800 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169037 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85924 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106722 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105173 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/90481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33910 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/88757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21828 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90098 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2470 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23345 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85956 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28900 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5232 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42820 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88823 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4257 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19868 "Passed tests") | 
<!--EWS-Status-Bubble-End-->