### PR TITLE
[GTK][WPE] Use KeyboardScrollingAnimator for keyboard scrolling

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml
@@ -302,6 +302,7 @@ EventHandlerDrivenSmoothKeyboardScrollingEnabled:
       default: false
     WebKit:
       "PLATFORM(MAC)": WebKit::defaultScrollAnimatorEnabled()
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       default: false

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -389,13 +389,14 @@ private:
     bool handleMousePressEventDoubleClick(const MouseEventWithHitTestResults&);
     bool handleMousePressEventTripleClick(const MouseEventWithHitTestResults&);
 
+    bool keyboardScroll(std::optional<ScrollDirection>, std::optional<ScrollGranularity>, Node*);
     bool beginKeyboardScrollGesture(KeyboardScrollingAnimator*, ScrollDirection, ScrollGranularity);
     void stopKeyboardScrolling();
     bool startKeyboardScrollAnimationOnDocument(ScrollDirection, ScrollGranularity);
     bool startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection, ScrollGranularity, RenderBox*);
     bool startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(ScrollDirection, ScrollGranularity, RenderBox*);
     bool startKeyboardScrollAnimationOnEnclosingScrollableContainer(ScrollDirection, ScrollGranularity, Node*);
-    bool focusedScrollableAreaUsesScrollSnap();
+    bool focusedScrollableAreaShouldUseSmoothKeyboardScrolling();
 
 #if ENABLE(DRAG_SUPPORT)
     bool handleMouseDraggedEvent(const MouseEventWithHitTestResults&, CheckDragHysteresis = ShouldCheckDragHysteresis);
@@ -495,6 +496,10 @@ private:
 
     bool platformCompletePlatformWidgetWheelEvent(const PlatformWheelEvent&, const Widget&, const WeakPtr<ScrollableArea>&);
 
+    bool defaultKeyboardScrollEventHandler(KeyboardEvent&, ScrollLogicalDirection, ScrollGranularity);
+
+    void defaultPageUpDownEventHandler(KeyboardEvent&);
+    void defaultHomeEndEventHandler(KeyboardEvent&);
     void defaultSpaceEventHandler(KeyboardEvent&);
     void defaultBackspaceEventHandler(KeyboardEvent&);
     void defaultTabEventHandler(KeyboardEvent&);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
@@ -190,6 +190,21 @@ FloatPoint ThreadedScrollingTreeScrollingNodeDelegate::adjustedScrollPosition(co
     return { roundf(position.x()), roundf(position.y()) };
 }
 
+void ThreadedScrollingTreeScrollingNodeDelegate::handleKeyboardScrollRequest(const RequestedKeyboardScrollData& scrollData)
+{
+    switch (scrollData.action) {
+    case KeyboardScrollAction::StartAnimation:
+        m_scrollController.startKeyboardScroll(*scrollData.keyboardScroll);
+        break;
+    case KeyboardScrollAction::StopWithAnimation:
+        m_scrollController.finishKeyboardScroll(false);
+        break;
+    case KeyboardScrollAction::StopImmediately:
+        m_scrollController.finishKeyboardScroll(true);
+        break;
+    }
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING) && ENABLE(SCROLLING_THREAD)

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h
@@ -83,6 +83,8 @@ protected:
 
     FloatPoint adjustedScrollPosition(const FloatPoint&) const override;
 
+    void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&) override;
+
     ScrollingEffectsController m_scrollController;
 };
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -51,8 +51,6 @@ public:
 
     bool handleWheelEvent(const PlatformWheelEvent&);
 
-    void handleKeyboardScrollRequest(const RequestedKeyboardScrollData&) override;
-
     void willDoProgrammaticScroll(const FloatPoint&);
     void currentScrollPositionChanged();
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -146,23 +146,6 @@ bool ScrollingTreeScrollingNodeDelegateMac::isRubberBandInProgress() const
     return m_scrollController.isRubberBandInProgress();
 }
 
-void ScrollingTreeScrollingNodeDelegateMac::handleKeyboardScrollRequest(const RequestedKeyboardScrollData& scrollData)
-{
-    switch (scrollData.action) {
-    case KeyboardScrollAction::StartAnimation:
-        m_scrollController.startKeyboardScroll(*scrollData.keyboardScroll);
-        return;
-
-    case KeyboardScrollAction::StopWithAnimation:
-        m_scrollController.finishKeyboardScroll(false);
-        return;
-
-    case KeyboardScrollAction::StopImmediately:
-        m_scrollController.finishKeyboardScroll(true);
-        return;
-    }
-}
-
 bool ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching(const PlatformWheelEvent& wheelEvent) const
 {
     switch (horizontalScrollElasticity()) {

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.cpp
@@ -83,6 +83,8 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
 
     static constexpr std::pair<PackedASCIILiteral<uint64_t>, KeyboardScrollingKey> mappings[] = {
         { "Down", KeyboardScrollingKey::DownArrow },
+        { "End", KeyboardScrollingKey::End },
+        { "Home", KeyboardScrollingKey::Home },
         { "Left", KeyboardScrollingKey::LeftArrow },
         { "PageDown", KeyboardScrollingKey::PageDown },
         { "PageUp", KeyboardScrollingKey::PageUp },
@@ -116,9 +118,11 @@ const std::optional<ScrollDirection> scrollDirectionForKeyboardEvent(const Keybo
             return ScrollDirection::ScrollRight;
         case KeyboardScrollingKey::UpArrow:
         case KeyboardScrollingKey::PageUp:
+        case KeyboardScrollingKey::Home:
             return ScrollDirection::ScrollUp;
         case KeyboardScrollingKey::DownArrow:
         case KeyboardScrollingKey::PageDown:
+        case KeyboardScrollingKey::End:
             return ScrollDirection::ScrollDown;
         case KeyboardScrollingKey::Space:
             return event.shiftKey() ? ScrollDirection::ScrollUp : ScrollDirection::ScrollDown;
@@ -152,6 +156,9 @@ const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const K
         case KeyboardScrollingKey::PageUp:
         case KeyboardScrollingKey::PageDown:
             return ScrollGranularity::Page;
+        case KeyboardScrollingKey::Home:
+        case KeyboardScrollingKey::End:
+            return ScrollGranularity::Document;
         };
         RELEASE_ASSERT_NOT_REACHED();
     }();

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -41,7 +41,9 @@ enum class KeyboardScrollingKey : uint8_t {
     DownArrow,
     Space,
     PageUp,
-    PageDown
+    PageDown,
+    Home,
+    End
 };
 
 const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(const KeyboardEvent&);

--- a/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp
@@ -783,9 +783,11 @@ String PlatformKeyboardEvent::keyIdentifierForGdkKeyCode(unsigned keyCode)
     case GDK_KEY_Clear:
         return "Clear"_s;
     case GDK_KEY_Down:
+    case GDK_KEY_KP_Down:
         return "Down"_s;
         // "End"
     case GDK_KEY_End:
+    case GDK_KEY_KP_End:
         return "End"_s;
         // "Enter"
     case GDK_KEY_ISO_Enter:
@@ -845,14 +847,18 @@ String PlatformKeyboardEvent::keyIdentifierForGdkKeyCode(unsigned keyCode)
     case GDK_KEY_Help:
         return "Help"_s;
     case GDK_KEY_Home:
+    case GDK_KEY_KP_Home:
         return "Home"_s;
     case GDK_KEY_Insert:
         return "Insert"_s;
     case GDK_KEY_Left:
+    case GDK_KEY_KP_Left:
         return "Left"_s;
     case GDK_KEY_Page_Down:
+    case GDK_KEY_KP_Page_Down:
         return "PageDown"_s;
     case GDK_KEY_Page_Up:
+    case GDK_KEY_KP_Page_Up:
         return "PageUp"_s;
     case GDK_KEY_Pause:
         return "Pause"_s;
@@ -860,10 +866,12 @@ String PlatformKeyboardEvent::keyIdentifierForGdkKeyCode(unsigned keyCode)
     case GDK_KEY_Print:
         return "PrintScreen"_s;
     case GDK_KEY_Right:
+    case GDK_KEY_KP_Right:
         return "Right"_s;
     case GDK_KEY_Select:
         return "Select"_s;
     case GDK_KEY_Up:
+    case GDK_KEY_KP_Up:
         return "Up"_s;
         // Standard says that DEL becomes U+007F.
     case GDK_KEY_Delete:

--- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
@@ -777,9 +777,11 @@ String PlatformKeyboardEvent::keyIdentifierForWPEKeyCode(unsigned keyCode)
     case WPE_KEY_Clear:
         return "Clear"_s;
     case WPE_KEY_Down:
+    case WPE_KEY_KP_Down:
         return "Down"_s;
         // "End"
     case WPE_KEY_End:
+    case WPE_KEY_KP_End:
         return "End"_s;
         // "Enter"
     case WPE_KEY_ISO_Enter:
@@ -839,14 +841,18 @@ String PlatformKeyboardEvent::keyIdentifierForWPEKeyCode(unsigned keyCode)
     case WPE_KEY_Help:
         return "Help"_s;
     case WPE_KEY_Home:
+    case WPE_KEY_KP_Home:
         return "Home"_s;
     case WPE_KEY_Insert:
         return "Insert"_s;
     case WPE_KEY_Left:
+    case WPE_KEY_KP_Left:
         return "Left"_s;
     case WPE_KEY_Page_Down:
+    case WPE_KEY_KP_Page_Down:
         return "PageDown"_s;
     case WPE_KEY_Page_Up:
+    case WPE_KEY_KP_Page_Up:
         return "PageUp"_s;
     case WPE_KEY_Pause:
         return "Pause"_s;
@@ -854,10 +860,12 @@ String PlatformKeyboardEvent::keyIdentifierForWPEKeyCode(unsigned keyCode)
     case WPE_KEY_Print:
         return "PrintScreen"_s;
     case WPE_KEY_Right:
+    case WPE_KEY_KP_Right:
         return "Right"_s;
     case WPE_KEY_Select:
         return "Select"_s;
     case WPE_KEY_Up:
+    case WPE_KEY_KP_Up:
         return "Up"_s;
         // Standard says that DEL becomes U+007F.
     case WPE_KEY_Delete:

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -253,6 +253,23 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool 
     if (wasEventHandled || event.type() != WebEvent::Type::KeyDown || !event.nativeEvent())
         return;
 
+    // Always consider arrow keys as handled, otherwise the GtkWindow key bindings will move the focus.
+    guint keyval;
+    gdk_event_get_keyval(event.nativeEvent(), &keyval);
+    switch (keyval) {
+    case GDK_KEY_Up:
+    case GDK_KEY_KP_Up:
+    case GDK_KEY_Down:
+    case GDK_KEY_KP_Down:
+    case GDK_KEY_Left:
+    case GDK_KEY_KP_Left:
+    case GDK_KEY_Right:
+    case GDK_KEY_KP_Right:
+        return;
+    default:
+        break;
+    }
+
     WebKitWebViewBase* webkitWebViewBase = WEBKIT_WEB_VIEW_BASE(m_viewWidget);
     webkitWebViewBaseForwardNextKeyEvent(webkitWebViewBase);
 #if USE(GTK4)

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
@@ -59,44 +59,9 @@ void WebPage::platformReinitialize()
 {
 }
 
-bool WebPage::performDefaultBehaviorForKeyEvent(const WebKeyboardEvent& keyboardEvent)
+bool WebPage::performDefaultBehaviorForKeyEvent(const WebKeyboardEvent&)
 {
-    if (keyboardEvent.type() != WebEvent::KeyDown && keyboardEvent.type() != WebEvent::RawKeyDown)
-        return false;
-
-    switch (keyboardEvent.windowsVirtualKeyCode()) {
-    case VK_SPACE:
-        scroll(m_page.get(), keyboardEvent.shiftKey() ? ScrollUp : ScrollDown, ScrollGranularity::Page);
-        break;
-    case VK_LEFT:
-        scroll(m_page.get(), ScrollLeft, ScrollGranularity::Line);
-        break;
-    case VK_RIGHT:
-        scroll(m_page.get(), ScrollRight, ScrollGranularity::Line);
-        break;
-    case VK_UP:
-        scroll(m_page.get(), ScrollUp, ScrollGranularity::Line);
-        break;
-    case VK_DOWN:
-        scroll(m_page.get(), ScrollDown, ScrollGranularity::Line);
-        break;
-    case VK_HOME:
-        scroll(m_page.get(), ScrollUp, ScrollGranularity::Document);
-        break;
-    case VK_END:
-        scroll(m_page.get(), ScrollDown, ScrollGranularity::Document);
-        break;
-    case VK_PRIOR:
-        scroll(m_page.get(), ScrollUp, ScrollGranularity::Page);
-        break;
-    case VK_NEXT:
-        scroll(m_page.get(), ScrollDown, ScrollGranularity::Page);
-        break;
-    default:
-        return false;
-    }
-
-    return true;
+    return false;
 }
 
 bool WebPage::platformCanHandleRequest(const ResourceRequest&)


### PR DESCRIPTION
#### 70b513d37784d67b87416b6745b34eba28258b0a
<pre>
[GTK][WPE] Use KeyboardScrollingAnimator for keyboard scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=247949">https://bugs.webkit.org/show_bug.cgi?id=247949</a>

Reviewed by Michael Catanzaro.

* Source/WTF/Scripts/Preferences/WebPreferencesInternal.yaml: Enable
EventHandlerDrivenSmoothKeyboardScrollingEnabled for GTK and WPE.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultKeyboardEventHandler): Handle PageUp/Down and Home/End keys.
(WebCore::EventHandler::defaultKeyboardScrollEventHandler): Helper to
start a keyboard scrolling for a default key event handler.
(WebCore::EventHandler::defaultPageUpDownEventHandler): Scroll by page.
(WebCore::EventHandler::defaultHomeEndEventHandler): Scroll by document.
(WebCore::EventHandler::defaultSpaceEventHandler): Do not scroll
recursively when doing smooth scrolling.
(WebCore::EventHandler::focusedScrollableAreaShouldUseSmoothKeyboardScrolling):
(WebCore::EventHandler::shouldUseSmoothKeyboardScrollingForFocusedScrollableArea):
(WebCore::EventHandler::keyboardScrollRecursively): Do not call
shouldUseSmoothKeyboardScrollingForFocusedScrollableArea() since it&apos;s
always checked by callers.
(WebCore::EventHandler::keyboardScroll): Added.
(WebCore::EventHandler::defaultArrowEventHandler): Use defaultKeyboardScrollEventHandler() to support the non smooth scrolling path.
(WebCore::EventHandler::focusedScrollableAreaUsesScrollSnap): Deleted.
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp:
(WebCore::ThreadedScrollingTreeScrollingNodeDelegate::handleKeyboardScrollRequest): Moved from mac.
* Source/WebCore/page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::handleKeyboardScrollRequest): Deleted.
* Source/WebCore/platform/KeyboardScrollingAnimator.cpp:
(WebCore::keyboardScrollingKeyForKeyboardEvent): Handler Home and End keys.
(WebCore::scrollDirectionForKeyboardEvent): Ditto.
(WebCore::scrollGranularityForKeyboardEvent): Ditto.
* Source/WebCore/platform/KeyboardScrollingAnimator.h: Add Home and End keys.
* Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp:
(WebCore::PlatformKeyboardEvent::keyIdentifierForGdkKeyCode): Handle keypad keys.
* Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp:
(WebCore::PlatformKeyboardEvent::keyIdentifierForWPEKeyCode): Ditto.
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithKeyEvent): Do not propagate arrow keys to parent widgets.
* Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp:
(WebKit::WebPage::performDefaultBehaviorForKeyEvent): Remove implementation, key events are not handled by EventHandler.

Canonical link: <a href="https://commits.webkit.org/256929@main">https://commits.webkit.org/256929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e676e15733bbf2ebd0bd02bfc0bd646872c441a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106209 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166528 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6151 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34680 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102919 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4603 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83289 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31561 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74483 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87634 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40407 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19798 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83071 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38068 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21212 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28359 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4779 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43746 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85750 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40494 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19336 "Passed tests") | 
<!--EWS-Status-Bubble-End-->