### PR TITLE
Sort layout tests result page "image results" column numerically by percentage

### DIFF
--- a/LayoutTests/fast/harness/results.html
+++ b/LayoutTests/fast/harness/results.html
@@ -1765,24 +1765,30 @@ class TableSorter
 
         let rows = Utils.toArray(testsTable.querySelectorAll('tbody'));
 
+        const LT = reversed ? 1 : -1;
+        const GT = reversed ? -1 : 1;
+
         rows.sort(function(a, b) {
             // Only need to support lexicographic sort for now.
             let aText = TableSorter._textContent(a, sortColumn);
             let bText = TableSorter._textContent(b, sortColumn);
         
-            // Forward sort equal values by test name.
-            if (sortColumn && aText == bText) {
-                let aTestName = TableSorter._textContent(a, 0);
-                let bTestName = TableSorter._textContent(b, 0);
-                if (aTestName == bTestName)
-                    return 0;
-                return aTestName < bTestName ? -1 : 1;
-            }
+            // First, sort numerically by percentage (for the "image results" column).
+            let aPercentage = (/([0-9.]+)%/.exec(aText) || [, 0])[1];
+            let bPercentage = (/([0-9.]+)%/.exec(bText) || [, 0])[1];
+            if (aPercentage != bPercentage)
+                return +aPercentage < +bPercentage ? LT : GT;
 
-            if (reversed)
-                return aText < bText ? 1 : -1;
-            else
-                return aText < bText ? -1 : 1;
+            // Second, sort by the column text.
+            if (aText != bText)
+                return aText < bText ? LT : GT;
+
+            // Finally, forward sort by the test name.
+            let aTestName = TableSorter._textContent(a, 0);
+            let bTestName = TableSorter._textContent(b, 0);
+            if (aTestName != bTestName)
+                return aTestName < bTestName ? -1 : 1;
+            return 0;
         });
 
         for (let row of rows)


### PR DESCRIPTION
#### d5220e254917f82a86e5d6235224f82a03d25acb
<pre>
Sort layout tests result page &quot;image results&quot; column numerically by percentage
<a href="https://bugs.webkit.org/show_bug.cgi?id=247956">https://bugs.webkit.org/show_bug.cgi?id=247956</a>
rdar://problem/102384072

Reviewed by Simon Fraser.

* LayoutTests/fast/harness/results.html:

Canonical link: <a href="https://commits.webkit.org/256709@main">https://commits.webkit.org/256709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d069d0c7f9ce29fdb9c9446e7a158494e0fc0b33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106146 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6078 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34616 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/88999 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102299 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83225 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40347 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38010 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2229 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40424 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->