### PR TITLE
[GTK] Documentation of WebKitSettings:hardware-acceleration-policy mentions old default value

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -1474,15 +1474,15 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
      * WebKitSettings:hardware-acceleration-policy:
      *
      * The #WebKitHardwareAccelerationPolicy to decide how to enable and disable
-     * hardware acceleration. The default value %WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND
-     * enables the hardware acceleration when the web contents request it.
+     * hardware acceleration. The value %WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND
+     * enables hardware acceleration only when the web content requests it.
      * It's possible to enforce hardware acceleration to be always enabled
-     * by using %WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS. And it's also possible to disable it
+     * by using %WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS, or to disable it
      * completely using %WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER. Note that disabling hardware
      * acceleration might cause some websites to not render correctly or consume more CPU.
      *
      * Note that changing this setting might not be possible if hardware acceleration is not
-     * supported by the hardware or the system. In that case you can get the value to know the
+     * supported by the hardware or the system. In that case, you can get the value to know the
      * actual policy being used, but changing the setting will not have any effect.
      *
      * Since: 2.16
@@ -1510,7 +1510,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             _("Whether horizontal swipe gesture will trigger back-forward navigation"),
             FALSE,
             readWriteConstructParamFlags);
-#endif // PLATFOTM(GTK)
+#endif // PLATFORM(GTK)
 
     /**
      * WebKitSettings:enable-javascript-markup:


### PR DESCRIPTION
#### 94d6cf2aa8cd2d2d1fb1f07acab0172e338d3c23
<pre>
[GTK] Documentation of WebKitSettings:hardware-acceleration-policy mentions old default value
<a href="https://bugs.webkit.org/show_bug.cgi?id=247957">https://bugs.webkit.org/show_bug.cgi?id=247957</a>

Reviewed by Carlos Garcia Campos.

This fixes the documentation to not refer to any particular default
value. I considered referencing that the default value changed in
2.36.4, but this is difficult to do without referencing
WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND, which is about to
disappear in the new API version, so it seemed less awkward to just omit
it. It&apos;s expected that settings will change default values over time,
after all.

I&apos;ve also made a few drive-by tweaks.

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_class_init):

Canonical link: <a href="https://commits.webkit.org/256734@main">https://commits.webkit.org/256734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66da8a6c1c7459312b1d2ab877b555d8764c25d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106147 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6079 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34617 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102859 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4535 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83226 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31504 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74418 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40348 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4678 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43689 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40426 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->