### PR TITLE
[Wasm-GC] Fix refcounts for compound type definitions

### DIFF
--- a/JSTests/wasm/gc/bug247874.js
+++ b/JSTests/wasm/gc/bug247874.js
@@ -1,0 +1,42 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--collectContinuously=true")
+
+import { compile, instantiate } from "./wast-wrapper.js";
+
+// Test that with compound type definitions like recursion and subtypes that
+// type definitions don't get de-allocated too soon.
+//
+// Even with continuous collection enabled, the test is somewhat non-deterministic
+// so we loop several times to ensure it triggers.
+for (let i = 0; i < 10; i++) {
+  instantiate(`(module (type (func)))`);
+  let m1 = instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct (field i32))))
+      (global (export "g") (ref null 1) (ref.null 1))
+    )
+  `);
+  instantiate(`
+    (module
+      (type (struct))
+      (type (sub 0 (struct (field i32))))
+      (global (import "m" "g") (ref null 1))
+    )
+  `, { m: { g: m1.exports.g } });
+}
+
+for (let i = 0; i < 10; i++) {
+  instantiate(`(module (type (func)))`);
+  let m1 = instantiate(`
+    (module
+      (rec (type (struct)) (type (func)))
+      (global (export "g") (ref null 1) (ref.null 1))
+    )
+  `);
+  instantiate(`
+    (module
+      (rec (type (struct)) (type (func)))
+      (global (import "m" "g") (ref null 1))
+    )
+  `, { m: { g: m1.exports.g } });
+}

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -273,6 +273,8 @@ public:
     {
     }
 
+    void cleanup();
+
     RecursionGroupCount typeCount() const { return m_typeCount; }
     TypeIndex type(RecursionGroupCount i) const { return const_cast<RecursionGroup*>(this)->getType(i); }
 
@@ -306,6 +308,8 @@ public:
         : m_payload(payload)
     {
     }
+
+    void cleanup();
 
     TypeIndex recursionGroup() const { return const_cast<Projection*>(this)->getRecursionGroup(); }
     ProjectionIndex index() const { return const_cast<Projection*>(this)->getIndex(); }
@@ -342,6 +346,8 @@ public:
         , m_displaySize(displaySize)
     {
     }
+
+    void cleanup();
 
     TypeIndex superType() const { return const_cast<Subtype*>(this)->getSuperType(); }
     TypeIndex underlyingType() const { return const_cast<Subtype*>(this)->getUnderlyingType(); }
@@ -438,6 +444,12 @@ public:
     const TypeDefinition& unroll() const;
     const TypeDefinition& expand() const;
     bool hasRecursiveReference() const;
+
+    // Type definitions that are compound and contain references to other definitions
+    // via a type index should ref() the other definition when new unique instances are
+    // constructed, and need to be cleaned up and have deref() called through this cleanup()
+    // method when the containing module is destroyed.
+    void cleanup();
 
     // Type definitions are uniqued and, for call_indirect, validated at runtime. Tables can create invalid TypeIndex values which cause call_indirect to fail. We use 0 as the invalidIndex so that the codegen can easily test for it and trap, and we add a token invalid entry in TypeInformation.
     static const constexpr TypeIndex invalidIndex = 0;


### PR DESCRIPTION
#### febd6818b5b7c349cdf7dcd04c387eedbba87fde
<pre>
[Wasm-GC] Fix refcounts for compound type definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=247874">https://bugs.webkit.org/show_bug.cgi?id=247874</a>

Reviewed by Yusuke Suzuki.

Compound type definitions that use type indices to refer to other types
need to ref/deref the referred type definitions in order to keep them
live (since the module&apos;s type signature list will not necessarily hold
these types). Type definitions that only hold value types such as
functions or arrays are fine as-is.

* JSTests/wasm/gc/bug247874.js: Added.
(i.instantiate.module.type.struct.type.sub.0.struct.field.i32.global.import.string_appeared_here.string_appeared_here):
(i.instantiate.module.rec.type.struct.type.func.global.import.string_appeared_here.string_appeared_here):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::Subtype::cleanup):
(JSC::Wasm::Projection::cleanup):
(JSC::Wasm::RecursionGroup::cleanup):
(JSC::Wasm::TypeDefinition::cleanup):
(JSC::Wasm::RecursionGroupParameterTypes::translate):
(JSC::Wasm::ProjectionParameterTypes::translate):
(JSC::Wasm::SubtypeParameterTypes::translate):
(JSC::Wasm::TypeInformation::tryCleanup):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:

Canonical link: <a href="https://commits.webkit.org/256800@main">https://commits.webkit.org/256800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13c577c2aef8ecbd03acdea1c225f4eb9f434368

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106148 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166480 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6080 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34618 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102860 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4540 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83227 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31506 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74421 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40349 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19745 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83008 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38012 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21151 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28343 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43691 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85688 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2276 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40427 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19319 "Passed tests") | 
<!--EWS-Status-Bubble-End-->