### PR TITLE
Only require a "transient" user activation for Web Audio rendering

### DIFF
--- a/LayoutTests/webaudio/require-transient-activation-expected.txt
+++ b/LayoutTests/webaudio/require-transient-activation-expected.txt
@@ -1,0 +1,16 @@
+Tests that starting Web Audio rendering requires a transient user activation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS context.state is "suspended"
+node.connect(context.destination)
+PASS context.state is "suspended"
+PASS navigator.userActivation.isActive is true
+PASS resume() promise was resolved
+PASS context.state is "running"
+PASS navigator.userActivation.isActive is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/require-transient-activation.html
+++ b/LayoutTests/webaudio/require-transient-activation.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script type="text/javascript" src="resources/audio-testing.js"></script>
+</head>
+<body>
+<script>
+description("Tests that starting Web Audio rendering requires a transient user activation.");
+jsTestIsAsync = true;
+
+onload = () => {
+    context = new AudioContext();
+
+    if (window.internals)
+        internals.setAudioContextRestrictions(context, 'RequireUserGestureForAudioStart');
+
+    shouldBeEqualToString('context.state', 'suspended');
+
+    node = context.createBufferSource();
+    evalAndLog('node.connect(context.destination)');
+
+    shouldBeEqualToString('context.state', 'suspended');
+
+    runWithKeyDown(function() {
+        setTimeout(() => {
+            // We should have transient activation.
+            shouldBeTrue("navigator.userActivation.isActive");
+            context.resume().then(() => {
+                testPassed("resume() promise was resolved");
+                shouldBeEqualToString('context.state', 'running');
+                // Transient activation should not have been consumed.
+                shouldBeTrue("navigator.userActivation.isActive");
+                finishJSTest();
+            }, () => {
+                testFailed("resume() promise was rejected");
+                finishJSTest();
+            });
+        }, 10);
+    });
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -77,9 +77,12 @@ static std::optional<float>& defaultSampleRateForTesting()
 
 static bool shouldDocumentAllowWebAudioToAutoPlay(const Document& document)
 {
-    if (document.processingUserGestureForMedia() || document.isCapturing())
+    if (document.isCapturing())
         return true;
-    return document.quirks().shouldAutoplayWebAudioForArbitraryUserGesture() && document.topDocument().hasHadUserInteraction();
+    if (document.quirks().shouldAutoplayWebAudioForArbitraryUserGesture() && document.topDocument().hasHadUserInteraction())
+        return true;
+    auto* window = document.domWindow();
+    return window && window->hasTransientActivation();
 }
 
 void AudioContext::setDefaultSampleRateForTesting(std::optional<float> sampleRate)


### PR DESCRIPTION
#### 7cc4b4216132642cf20a83a674947c4c578e86a7
<pre>
Only require a &quot;transient&quot; user activation for Web Audio rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=247614">https://bugs.webkit.org/show_bug.cgi?id=247614</a>
rdar://102364692

Reviewed by Jer Noble.

Only require a &quot;transient&quot; user activation for Web Audio rendering instead of
having a strict synchronous user gesture requirement. Our behavior was so
strict it was confusing Web developers. It was also causing a lot of demo sites
to fail in Safari and work in other browsers.

For example:
- <a href="https://googlechromelabs.github.io/web-audio-samples/audio-worklet/basic/hello-audio-worklet/">https://googlechromelabs.github.io/web-audio-samples/audio-worklet/basic/hello-audio-worklet/</a>

Such demos require you to click a button but then they use an async function
and use `await` before actually starting the audio rendering.

* LayoutTests/webaudio/require-transient-activation-expected.txt: Added.
* LayoutTests/webaudio/require-transient-activation.html: Added.
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::shouldDocumentAllowWebAudioToAutoPlay):

Canonical link: <a href="https://commits.webkit.org/256721@main">https://commits.webkit.org/256721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37cf19a5f5229799c0c93310437a14aef49a7acf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106171 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6102 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34638 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102880 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102323 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83249 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31522 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74439 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40370 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4664 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40449 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->