### PR TITLE
Fix for pixel-moving CSS filters with clipping

### DIFF
--- a/LayoutTests/css3/filters/effect-drop-shadow-clip-abspos-expected.html
+++ b/LayoutTests/css3/filters/effect-drop-shadow-clip-abspos-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+.container {
+    filter: drop-shadow(5px 5px 5px black);
+}
+.circle-mask {
+    border-radius: 80px;
+    overflow: hidden;
+    width: 100px;
+    height: 100px;
+    filter: blur(20px);
+}
+.green-box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+</style>
+<div class="container">
+    <div class="circle-mask">
+    <div class="green-box"></div>
+</div>
+</div>

--- a/LayoutTests/css3/filters/effect-drop-shadow-clip-abspos.html
+++ b/LayoutTests/css3/filters/effect-drop-shadow-clip-abspos.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+.container {
+    filter: drop-shadow(5px 5px 5px black);
+}
+.circle-mask {
+    border-radius: 80px;
+    overflow: hidden;
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    filter: blur(20px);
+}
+.green-box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+</style>
+<div class="container">
+    <div class="circle-mask">
+    <div class="green-box"></div>
+</div>
+</div>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3269,7 +3269,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         // Now walk the sorted list of children with negative z-indices.
         if ((isPaintingScrollingContent && isPaintingOverflowContents) || (!isPaintingScrollingContent && isPaintingCompositedBackground))
-            paintList(negativeZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);
+            paintList(negativeZOrderLayers(), currentContext, paintingInfo, localPaintFlags);
         
         if (isPaintingCompositedForeground) {
             if (shouldPaintContent) {
@@ -3286,7 +3286,7 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
 
         if (isPaintingCompositedForeground) {
             // Paint any child layers that have overflow.
-            paintList(normalFlowLayers(), currentContext, localPaintingInfo, localPaintFlags);
+            paintList(normalFlowLayers(), currentContext, paintingInfo, localPaintFlags);
         
             // Now walk the sorted list of children with positive z-indices.
             paintList(positiveZOrderLayers(), currentContext, localPaintingInfo, localPaintFlags);


### PR DESCRIPTION
#### 3894c75f5f9ffe16ec91de57edc2d93b2e2051c2
<pre>
Fix for pixel-moving CSS filters with clipping

Fix for pixel-moving CSS filters with clipping
<a href="https://bugs.webkit.org/show_bug.cgi?id=247961">https://bugs.webkit.org/show_bug.cgi?id=247961</a>

Reviewed by Simon Fraser.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=180361

When using a &quot;pixel-moving&quot; filter (ie., drop-shadow or blur), we
disable the normal clip operation, since we want to want to render
the full results of the element pre-clip for filtering. Clipping is
then applied just before drawing the filtered result.

However, we shouldn&apos;t disable *all* clipping recursively, since we
want children which clip themselves to still continue to be clipped.
The fix is to pass the original (unmodified) paintingInfo to
paintChildren().

NOTE - The test case has been slightly modified to apply blur to reflect the issue.

* Source/WebCore/rendering/RenderLayer.cpp:
(RenderLayer::paintLayerContents): Update to take &quot;original&quot; paintingInfo
* LayoutTests/css3/filters/effect-drop-shadow-clip-abpos.html: Added Test Case
* LayoutTests/css3/filters/effect-drop-shadow-clip-abpos-expected.html: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256825@main">https://commits.webkit.org/256825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46dc2d72c87abd5ff92d139351bf655cb77e13be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106301 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166590 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6251 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34770 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103005 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4695 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83386 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31640 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/74 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/19872 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/67 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21290 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4728 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43820 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40575 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->