### PR TITLE
Evaluate right-hand-side of assignment before TDZ check

### DIFF
--- a/JSTests/stress/assignment-side-effects-before-tdz-check.js
+++ b/JSTests/stress/assignment-side-effects-before-tdz-check.js
@@ -1,0 +1,15 @@
+try {
+    for (let x in x = new 0) { }
+} catch (e) {
+    if (!(e instanceof TypeError))
+        throw "Expected 'TypeError: 0 is not a constructor', got '" + e + "'";
+}
+
+try {
+    class x {
+        [x = new 0];
+    }
+} catch (e) {
+    if (!(e instanceof TypeError))
+        throw "Expected 'TypeError: 0 is not a constructor', got '" + e + "'";
+}


### PR DESCRIPTION
#### 876accfa73f6d4613d489f23a88b20e827cfbc73
<pre>
Evaluate right-hand-side of assignment before TDZ check
<a href="https://bugs.webkit.org/show_bug.cgi?id=247787">https://bugs.webkit.org/show_bug.cgi?id=247787</a>
rdar://102324888

Reviewed by Yusuke Suzuki.

When we assign to a variable in its TDZ, we currently always do a TDZ check
before evaluating anything else. However, per the spec, we should actually
be evaluating the right-hand-side value before putting it into the destination -
potentially resulting in observable side-effects like throwing an exception. This
patch makes it so we add a TDZ check only after evaluating the right-hand-side
expression in assignment expressions. We shouldn&apos;t need this for any
read-modify-assignment expressions (i.e. +=, &amp;&amp;=) since those are supposed to
read the TDZ-checked value before evaluating the right.

* JSTests/stress/assignment-side-effects-before-tdz-check.js: Added.
(catch):
(try.x):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::AssignResolveNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/256743@main">https://commits.webkit.org/256743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dee920f9c9b5139f9b84f39c5e5a292dcc386b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106165 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166493 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6096 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34633 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102875 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4551 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83244 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88272 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74433 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87593 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40365 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83026 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38027 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21169 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4684 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85706 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40447 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19324 "Passed tests") | 
<!--EWS-Status-Bubble-End-->