### PR TITLE
Hook up the WebProcess objects for Web Extensions and propogate some info over.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -321,6 +321,8 @@ def serialized_identifiers():
         'WebKit::UserContentControllerIdentifier',
         'WebKit::VideoDecoderIdentifier',
         'WebKit::VideoEncoderIdentifier',
+        'WebKit::WebExtensionContextIdentifier',
+        'WebKit::WebExtensionControllerIdentifier',
         'WebKit::WebGPUIdentifier',
         'WebKit::WebPageProxyIdentifier',
         'WebKit::WebURLSchemeHandlerIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -65,6 +65,8 @@
 #include "UserContentControllerIdentifier.h"
 #include "VideoDecoderIdentifier.h"
 #include "VideoEncoderIdentifier.h"
+#include "WebExtensionContextIdentifier.h"
+#include "WebExtensionControllerIdentifier.h"
 #include "WebGPUIdentifier.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebURLSchemeHandlerIdentifier.h"
@@ -439,6 +441,8 @@ Vector<ASCIILiteral> serializedIdentifiers()
     static_assert(sizeof(uint64_t) == sizeof(WebKit::UserContentControllerIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::VideoDecoderIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::VideoEncoderIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionContextIdentifier));
+    static_assert(sizeof(uint64_t) == sizeof(WebKit::WebExtensionControllerIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebGPUIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebPageProxyIdentifier));
     static_assert(sizeof(uint64_t) == sizeof(WebKit::WebURLSchemeHandlerIdentifier));
@@ -512,6 +516,8 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebKit::UserContentControllerIdentifier"_s,
         "WebKit::VideoDecoderIdentifier"_s,
         "WebKit::VideoEncoderIdentifier"_s,
+        "WebKit::WebExtensionContextIdentifier"_s,
+        "WebKit::WebExtensionControllerIdentifier"_s,
         "WebKit::WebGPUIdentifier"_s,
         "WebKit::WebPageProxyIdentifier"_s,
         "WebKit::WebURLSchemeHandlerIdentifier"_s,

--- a/Source/WebKit/Shared/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.h
@@ -27,12 +27,24 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+OBJC_CLASS NSDictionary;
+
 #include "WebExtensionContextIdentifier.h"
+#include <wtf/RetainPtr.h>
+#include <wtf/URL.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 struct WebExtensionContextParameters {
     WebExtensionContextIdentifier identifier;
+
+#if PLATFORM(COCOA)
+    URL baseURL;
+    String uniqueIdentifier;
+    RetainPtr<NSDictionary> manifest;
+    double manifestVersion;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
@@ -21,7 +21,18 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+
+file_extension: mm
+
 struct WebKit::WebExtensionContextParameters {
     WebKit::WebExtensionContextIdentifier identifier;
+
+#if PLATFORM(COCOA)
+    URL baseURL;
+    String uniqueIdentifier;
+    RetainPtr<NSDictionary> manifest;
+    double manifestVersion;
+#endif
 }
+
 #endif

--- a/Source/WebKit/Shared/WebExtensionControllerParameters.h
+++ b/Source/WebKit/Shared/WebExtensionControllerParameters.h
@@ -27,12 +27,17 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "WebExtensionContextParameters.h"
 #include "WebExtensionControllerIdentifier.h"
 
 namespace WebKit {
 
 struct WebExtensionControllerParameters {
     WebExtensionControllerIdentifier identifier;
+
+#if PLATFORM(COCOA)
+    Vector<WebExtensionContextParameters> contextParameters;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebExtensionControllerParameters.serialization.in
+++ b/Source/WebKit/Shared/WebExtensionControllerParameters.serialization.in
@@ -21,7 +21,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(WK_WEB_EXTENSIONS)
+
 struct WebKit::WebExtensionControllerParameters {
     WebKit::WebExtensionControllerIdentifier identifier;
+
+#if PLATFORM(COCOA)
+    Vector<WebKit::WebExtensionContextParameters> contextParameters;
+#endif
 }
+
 #endif

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -153,6 +153,9 @@ public:
     void ref() final { ThreadSafeRefCounted::ref(); }
     void deref() final { ThreadSafeRefCounted::deref(); }
 
+    bool operator==(const AuxiliaryProcessProxy& other) const { return (this == &other); }
+    bool operator!=(const AuxiliaryProcessProxy& other) const { return !(this == &other); }
+
     std::optional<SandboxExtension::Handle> createMobileGestaltSandboxExtensionIfNeeded() const;
 
 protected:

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -183,6 +183,7 @@ bool WebExtensionContext::load(WebExtensionController& controller, NSError **out
     }
 
     m_extensionController = controller;
+    m_contentScriptWorld = API::ContentWorld::sharedWorldWithName(makeString("WebExtension-", m_uniqueIdentifier));
 
     loadBackgroundWebViewDuringLoad();
 
@@ -203,6 +204,7 @@ bool WebExtensionContext::unload(NSError **outError)
     }
 
     m_extensionController = nil;
+    m_contentScriptWorld = nullptr;
 
     unloadBackgroundWebView();
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -141,7 +141,7 @@ public:
     static const PermissionsSet& supportedPermissions();
 
     bool operator==(const WebExtension& other) const { return (this == &other); }
-    bool operator!=(const WebExtension& other) const { return !(*this == other); }
+    bool operator!=(const WebExtension& other) const { return !(this == &other); }
 
     bool manifestParsedSuccessfully();
     NSDictionary *manifest();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -66,6 +66,13 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
 
     parameters.identifier = identifier();
 
+#if PLATFORM(COCOA)
+    parameters.baseURL = baseURL();
+    parameters.uniqueIdentifier = uniqueIdentifier();
+    parameters.manifest = extension().manifest();
+    parameters.manifestVersion = extension().manifestVersion();
+#endif
+
     return parameters;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "APIContentWorld.h"
 #include "APIObject.h"
 #include "MessageReceiver.h"
 #include "WebExtension.h"
@@ -113,6 +114,9 @@ public:
     WebExtensionContextIdentifier identifier() const { return m_identifier; }
     WebExtensionContextParameters parameters() const;
 
+    bool operator==(const WebExtensionContext& other) const { return (this == &other); }
+    bool operator!=(const WebExtensionContext& other) const { return !(this == &other); }
+
 #if PLATFORM(COCOA)
     NSError *createError(Error, NSString *customLocalizedDescription = nil, NSError *underlyingError = nil);
 
@@ -124,7 +128,7 @@ public:
     WebExtension& extension() const { return *m_extension; }
     WebExtensionController* extensionController() const { return m_extensionController.get(); }
 
-    URL baseURL() const { return m_baseURL; }
+    const URL& baseURL() const { return m_baseURL; }
     void setBaseURL(URL&&);
 
     bool isURLForThisExtension(const URL&);
@@ -226,6 +230,8 @@ private:
 
     URL m_baseURL;
     String m_uniqueIdentifier = UUID::createVersion4().toString();
+
+    RefPtr<API::ContentWorld> m_contentScriptWorld;
 
     PermissionsMap m_grantedPermissions;
     PermissionsMap m_deniedPermissions;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -66,6 +66,16 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
 
     parameters.identifier = identifier();
 
+#if PLATFORM(COCOA)
+    Vector<WebExtensionContextParameters> contextParameters;
+    contextParameters.reserveInitialCapacity(extensionContexts().size());
+
+    for (auto& context : extensionContexts())
+        contextParameters.append(context->parameters());
+
+    parameters.contextParameters = contextParameters;
+#endif
+
     return parameters;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -47,6 +47,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 class WebPageProxy;
+class WebProcessProxy;
 struct WebExtensionControllerParameters;
 
 class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
@@ -65,6 +66,9 @@ public:
 
     WebExtensionControllerIdentifier identifier() const { return m_identifier; }
     WebExtensionControllerParameters parameters() const;
+
+    bool operator==(const WebExtensionController& other) const { return (this == &other); }
+    bool operator!=(const WebExtensionController& other) const { return !(this == &other); }
 
 #if PLATFORM(COCOA)
     bool load(WebExtensionContext&, NSError ** = nullptr);
@@ -92,6 +96,7 @@ private:
     WebExtensionContextSet m_extensionContexts;
     WebExtensionContextBaseURLMap m_extensionContextBaseURLMap;
     WeakHashSet<WebPageProxy> m_pages;
+    WeakHashSet<WebProcessProxy> m_processes;
     HashMap<String, Ref<WebExtensionURLSchemeHandler>> m_registeredSchemeHandlers;
 #endif
 };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -81,7 +81,7 @@ public:
     static const URLSchemeSet& supportedSchemes();
 
     bool operator==(const WebExtensionMatchPattern&) const;
-    bool operator!=(const WebExtensionMatchPattern& other) const { return !(*this == other); }
+    bool operator!=(const WebExtensionMatchPattern& other) const { return !(this == &other); }
 
     bool isValid() const { return m_valid; }
     bool isSupported() const;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 		1C3BEB7B2888A00B00E66E38 /* WebExtensionControllerParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */; };
 		1C3BEB7C2888A01000E66E38 /* WebExtensionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CC23B1C288732A800D0A65A /* WebExtensionController.h */; };
 		1C3BEB7D2888A01600E66E38 /* WebExtensionControllerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CC23B20288732F600D0A65A /* WebExtensionControllerProxy.h */; };
+		1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C3D0AC0291AE6200093F67E /* WebExtensionControllerProxyCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C56557F2745C5A1006300AF /* UnifiedSource101.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557C2745C5A0006300AF /* UnifiedSource101.cpp */; };
 		1C5655802745C5A1006300AF /* UnifiedSource102.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557D2745C5A1006300AF /* UnifiedSource102.cpp */; };
 		1C5655812745C5A1006300AF /* UnifiedSource103.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C56557E2745C5A1006300AF /* UnifiedSource103.cpp */; };
@@ -3576,6 +3577,7 @@
 		1C3BEB6D288883E200E66E38 /* _WKWebExtensionInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionInternal.h; sourceTree = "<group>"; };
 		1C3BEB6E288883E200E66E38 /* _WKWebExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtension.mm; sourceTree = "<group>"; };
 		1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionPrivate.h; sourceTree = "<group>"; };
+		1C3D0AC0291AE6200093F67E /* WebExtensionControllerProxyCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionControllerProxyCocoa.mm; sourceTree = "<group>"; };
 		1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionControllerParameters.serialization.in; sourceTree = "<group>"; };
 		1C55A572275457C300EB7E95 /* RemoteQuerySetMessagesReplies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteQuerySetMessagesReplies.h; sourceTree = "<group>"; };
 		1C55A573275457C400EB7E95 /* RemoteTextureMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteTextureMessages.h; sourceTree = "<group>"; };
@@ -8808,6 +8810,14 @@
 			path = Automation;
 			sourceTree = "<group>";
 		};
+		1C3D0ABF291AE6200093F67E /* Cocoa */ = {
+			isa = PBXGroup;
+			children = (
+				1C3D0AC0291AE6200093F67E /* WebExtensionControllerProxyCocoa.mm */,
+			);
+			path = Cocoa;
+			sourceTree = "<group>";
+		};
 		1C5DC44D29087E7F0061EC62 /* API */ = {
 			isa = PBXGroup;
 			children = (
@@ -9233,6 +9243,7 @@
 			children = (
 				1C5DC44D29087E7F0061EC62 /* API */,
 				1C5DC45629099F010061EC62 /* Bindings */,
+				1C3D0ABF291AE6200093F67E /* Cocoa */,
 				1C9DD98F28FA19A30093BDB0 /* Interfaces */,
 				1C0234C428A00E9E00AC1E5B /* WebExtensionContextProxy.cpp */,
 				1C0234C628A00E9F00AC1E5B /* WebExtensionContextProxy.h */,
@@ -18173,6 +18184,7 @@
 				1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */,
 				1CBEE27028F4DDA1006D1A02 /* WebExtensionControllerCocoa.mm in Sources */,
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
+				1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,
 				1CAB9B8628F743DB00E6C77E /* WebExtensionURLSchemeHandlerCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -34,16 +34,20 @@
 
 namespace WebKit {
 
-bool WebExtensionAPIExtension::isPropertyAllowed(String, WebPage*)
+bool WebExtensionAPIExtension::isPropertyAllowed(String name, WebPage*)
 {
-    // FIXME: Implement.
+    // This method was removed in manifest version 3.
+    if (name == "getURL"_s)
+        return !extensionContext().usesManifestVersion(3);
+
+    ASSERT_NOT_REACHED();
     return false;
 }
 
 NSURL *WebExtensionAPIExtension::getURL(NSString *resourcePath, NSString **errorString)
 {
-    // FIXME: Implement.
-    return nil;
+    URL baseURL = extensionContext().baseURL();
+    return resourcePath.length ? URL { baseURL, resourcePath } : baseURL;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -37,14 +37,14 @@ namespace WebKit {
 WebExtensionAPIExtension& WebExtensionAPINamespace::extension()
 {
     if (!m_extension)
-        m_extension = WebExtensionAPIExtension::create(forMainWorld(), runtime());
+        m_extension = WebExtensionAPIExtension::create(forMainWorld(), runtime(), extensionContext());
     return *m_extension;
 }
 
 WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime()
 {
     if (!m_runtime)
-        m_runtime = WebExtensionAPIRuntime::create(forMainWorld());
+        m_runtime = WebExtensionAPIRuntime::create(forMainWorld(), extensionContext());
     return *m_runtime;
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -58,20 +58,18 @@ void WebExtensionAPIRuntimeBase::reportErrorForCallbackHandler(WebExtensionCallb
 
 NSURL *WebExtensionAPIRuntime::getURL(NSString *resourcePath, NSString **errorString)
 {
-    // FIXME: Implement.
-    return nil;
+    URL baseURL = extensionContext().baseURL();
+    return resourcePath.length ? URL { baseURL, resourcePath } : baseURL;
 }
 
-NSString *WebExtensionAPIRuntime::getManifest()
+NSDictionary *WebExtensionAPIRuntime::getManifest()
 {
-    // FIXME: Implement.
-    return nil;
+    return extensionContext().manifest();
 }
 
 NSString *WebExtensionAPIRuntime::runtimeIdentifier()
 {
-    // FIXME: Implement.
-    return nil;
+    return extensionContext().uniqueIdentifier();
 }
 
 void WebExtensionAPIRuntime::getPlatformInfo(Ref<WebExtensionCallbackHandler>&& callback)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -29,6 +29,7 @@
 
 #include "JSWebExtensionWrappable.h"
 #include "JSWebExtensionWrapper.h"
+#include "WebExtensionContextProxy.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 
@@ -40,14 +41,16 @@ class WebExtensionAPIObject {
 public:
     enum class ForMainWorld : bool { No, Yes };
 
-    WebExtensionAPIObject(ForMainWorld forMainWorld)
+    WebExtensionAPIObject(ForMainWorld forMainWorld, WebExtensionContextProxy& context)
         : m_forMainWorld(forMainWorld)
+        , m_extensionContext(&context)
     {
     }
 
-    WebExtensionAPIObject(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime)
+    WebExtensionAPIObject(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context)
         : m_forMainWorld(forMainWorld)
         , m_runtime(&runtime)
+        , m_extensionContext(&context)
     {
     }
 
@@ -57,10 +60,12 @@ public:
     bool isForMainWorld() const { return m_forMainWorld == ForMainWorld::Yes; }
 
     virtual WebExtensionAPIRuntimeBase& runtime() { return *m_runtime; }
+    WebExtensionContextProxy& extensionContext() { return *m_extensionContext; }
 
 private:
     ForMainWorld m_forMainWorld = ForMainWorld::Yes;
     RefPtr<WebExtensionAPIRuntimeBase> m_runtime;
+    RefPtr<WebExtensionContextProxy> m_extensionContext;
 };
 
 } // namespace WebKit
@@ -78,13 +83,13 @@ public: \
     virtual ~ImplClass() = default; \
 \
 private: \
-    explicit ImplClass(ForMainWorld forMainWorld) \
-        : WebExtensionAPIObject(forMainWorld) \
+    explicit ImplClass(ForMainWorld forMainWorld, WebExtensionContextProxy& context) \
+        : WebExtensionAPIObject(forMainWorld, context) \
     { \
     } \
 \
-    explicit ImplClass(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime) \
-        : WebExtensionAPIObject(forMainWorld, runtime) \
+    explicit ImplClass(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context) \
+        : WebExtensionAPIObject(forMainWorld, runtime, context) \
     { \
     } \
 \

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -30,6 +30,7 @@
 #include "JSWebExtensionAPIRuntime.h"
 #include "WebExtensionAPIObject.h"
 
+OBJC_CLASS NSDictionary;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
 
@@ -60,7 +61,7 @@ public:
 #if PLATFORM(COCOA)
     NSURL *getURL(NSString *resourcePath, NSString **errorString);
 
-    NSString *getManifest();
+    NSDictionary *getManifest();
 
     NSString *runtimeIdentifier();
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -79,8 +79,8 @@ private:
     WebExtensionCallbackHandler(JSContextRef, JSObjectRef callbackFunction, WebExtensionAPIRuntimeBase&);
     WebExtensionCallbackHandler(JSContextRef, WebExtensionAPIRuntimeBase&);
 
-    JSObjectRef m_callbackFunction;
-    JSObjectRef m_rejectFunction;
+    JSObjectRef m_callbackFunction = nullptr;
+    JSObjectRef m_rejectFunction = nullptr;
     JSRetainPtr<JSGlobalContextRef> m_globalContext;
     RefPtr<WebExtensionAPIRuntimeBase> m_runtime;
 #endif
@@ -150,7 +150,7 @@ inline JSValueRef toJSValue(JSContextRef context, id object)
     ASSERT(context);
 
     if (!object)
-        return nullptr;
+        return JSValueMakeUndefined(context);
 
     if (JSValue *value = dynamic_objc_cast<JSValue>(object))
         return value.JSValueRef;

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -162,6 +162,8 @@ sub _generateHeaderFile
     push(@contents, $self->_licenseBlock());
     push(@contents, "\n\n");
 
+    push(@contents, "#pragma once\n\n");
+
     my $idlType = $interface->type;
     my $className = _className($idlType);
     my $implementationClassName = _implementationClassName($idlType);
@@ -175,10 +177,10 @@ sub _generateHeaderFile
 EOF
 
     push(@contents, <<EOF);
-#import "${parentClassName}.h"
+#include "${parentClassName}.h"
 EOF
 
-    push(@contents, "#import \"${className}Custom.h\"\n") if $interface->extendedAttributes->{"CustomHeader"};
+    push(@contents, "#include \"${className}Custom.h\"\n") if $interface->extendedAttributes->{"CustomHeader"};
     push(@contents, <<EOF);
 
 namespace WebKit {
@@ -311,7 +313,7 @@ EOF
     $contentsIncludes{"\"${implementationClassName}.h\""} = 1;
 
     push(@contents, <<EOF);
-#import <wtf/GetPtr.h>
+#include <wtf/GetPtr.h>
 
 namespace WebKit {
 
@@ -851,7 +853,7 @@ EOF
 #endif // ${conditionalString}
 EOF
 
-    unshift(@contents, map { "#import $_\n" } sort keys(%contentsIncludes));
+    unshift(@contents, map { "#include $_\n" } sort keys(%contentsIncludes));
     unshift(@contents, @contentsPrefix);
 
     return { name => $filename, contents => \@contents };

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#include "config.h"
+#include "WebExtensionControllerProxy.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "JSWebExtensionAPINamespace.h"
+#include "JSWebExtensionWrapper.h"
+#include "WebExtensionAPINamespace.h"
+#include "WebExtensionContextProxy.h"
+#include "WebFrame.h"
+#include "WebPage.h"
+
+namespace WebKit {
+
+using namespace WebCore;
+
+void WebExtensionControllerProxy::globalObjectIsAvailableForFrame(WebPage& page, WebFrame& frame, DOMWrapperWorld& world)
+{
+    auto extension = extensionContext(frame, world);
+    bool isMainWorld = world.isNormal();
+
+    if (!extension && isMainWorld) {
+        // FIXME: <https://webkit.org/b/246491> Add bindings for externally connectable.
+        return;
+    }
+
+    if (!extension)
+        return;
+
+    auto context = frame.jsContextForWorld(world);
+    auto globalObject = JSContextGetGlobalObject(context);
+
+    auto namespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+    if (namespaceObject && JSValueIsObject(context, namespaceObject))
+        return;
+
+    if (!isMainWorld)
+        extension->setContentScriptWorld(&world);
+
+    auto forMainWorld = isMainWorld ? WebExtensionAPINamespace::ForMainWorld::Yes : WebExtensionAPINamespace::ForMainWorld::No;
+    // FIXME: <https://webkit.org/b/246485> Handle inspector pages by setting forMainWorld to No.
+
+    namespaceObject = toJS(context, WebExtensionAPINamespace::create(forMainWorld, *extension).ptr());
+
+    JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+}
+
+void WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame(WebPage& page, WebFrame& frame, DOMWrapperWorld& world)
+{
+    RELEASE_ASSERT(world.isNormal());
+
+    auto extension = extensionContext(frame, world);
+    if (!extension)
+        return;
+
+    auto context = frame.jsContextForServiceWorkerWorld(world);
+    auto globalObject = JSContextGetGlobalObject(context);
+
+    auto namespaceObject = JSObjectGetProperty(context, globalObject, toJSString("browser").get(), nullptr);
+    if (namespaceObject && JSValueIsObject(context, namespaceObject))
+        return;
+
+    namespaceObject = toJS(context, WebExtensionAPINamespace::create(WebExtensionAPINamespace::ForMainWorld::Yes, *extension).ptr());
+
+    JSObjectSetProperty(context, globalObject, toJSString("browser").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+    JSObjectSetProperty(context, globalObject, toJSString("chrome").get(), namespaceObject, kJSPropertyAttributeNone, nullptr);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -28,29 +28,55 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "MessageReceiver.h"
-#include "WebExtensionContextIdentifier.h"
+#include "WebExtensionContextParameters.h"
+#include <WebCore/DOMWrapperWorld.h>
 #include <wtf/Forward.h>
 
 namespace WebKit {
 
-class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, private IPC::MessageReceiver {
+class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProxy>, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WebExtensionContextProxy);
 
 public:
-    static Ref<WebExtensionContextProxy> getOrCreate(WebExtensionContextIdentifier);
+    static RefPtr<WebExtensionContextProxy> get(WebExtensionContextIdentifier);
+    static Ref<WebExtensionContextProxy> getOrCreate(WebExtensionContextParameters);
 
     ~WebExtensionContextProxy();
 
     WebExtensionContextIdentifier identifier() { return m_identifier; }
 
+    bool operator==(const WebExtensionContextProxy& other) const { return (this == &other); }
+    bool operator!=(const WebExtensionContextProxy& other) const { return !(this == &other); }
+
+#if PLATFORM(COCOA)
+    const URL& baseURL() { return m_baseURL; }
+    const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
+
+    NSDictionary *manifest() { return m_manifest.get(); }
+
+    double manifestVersion() { return m_manifestVersion; }
+    bool usesManifestVersion(double version) { return manifestVersion() >= version; }
+
+    WebCore::DOMWrapperWorld* contentScriptWorld() { return m_contentScriptWorld.get(); }
+    void setContentScriptWorld(WebCore::DOMWrapperWorld* world) { m_contentScriptWorld = world; }
+#endif
+
 private:
-    explicit WebExtensionContextProxy(WebExtensionContextIdentifier);
+    explicit WebExtensionContextProxy(WebExtensionContextParameters);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     WebExtensionContextIdentifier m_identifier;
+
+#if PLATFORM(COCOA)
+    URL m_baseURL;
+    String m_uniqueIdentifier;
+    RetainPtr<NSDictionary> m_manifest;
+    double m_manifestVersion;
+    RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -28,29 +28,66 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "MessageReceiver.h"
-#include "WebExtensionControllerIdentifier.h"
+#include "WebExtensionControllerParameters.h"
 #include <wtf/Forward.h>
+#include <wtf/URLHash.h>
+
+namespace WebCore {
+class DOMWrapperWorld;
+}
 
 namespace WebKit {
 
-class WebExtensionControllerProxy final : public RefCounted<WebExtensionControllerProxy>, private IPC::MessageReceiver {
+class WebExtensionContextProxy;
+class WebFrame;
+class WebPage;
+
+class WebExtensionControllerProxy final : public RefCounted<WebExtensionControllerProxy>, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WebExtensionControllerProxy);
 
 public:
-    static Ref<WebExtensionControllerProxy> getOrCreate(WebExtensionControllerIdentifier);
+    static RefPtr<WebExtensionControllerProxy> get(WebExtensionControllerIdentifier);
+    static Ref<WebExtensionControllerProxy> getOrCreate(WebExtensionControllerParameters);
 
     ~WebExtensionControllerProxy();
 
+    using WebExtensionContextProxySet = HashSet<Ref<WebExtensionContextProxy>>;
+    using WebExtensionContextProxyBaseURLMap = HashMap<URL, Ref<WebExtensionContextProxy>>;
+
     WebExtensionControllerIdentifier identifier() { return m_identifier; }
 
+    bool operator==(const WebExtensionControllerProxy& other) const { return (this == &other); }
+    bool operator!=(const WebExtensionControllerProxy& other) const { return !(this == &other); }
+
+#if PLATFORM(COCOA)
+    void globalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
+    void serviceWorkerGlobalObjectIsAvailableForFrame(WebPage&, WebFrame&, WebCore::DOMWrapperWorld&);
+#endif
+
 private:
-    explicit WebExtensionControllerProxy(WebExtensionControllerIdentifier);
+    explicit WebExtensionControllerProxy(WebExtensionControllerParameters);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
+#if PLATFORM(COCOA)
+    void load(const WebExtensionContextParameters&);
+    void unload(WebExtensionContextIdentifier);
+
+    RefPtr<WebExtensionContextProxy> extensionContext(const URL&) const;
+    RefPtr<WebExtensionContextProxy> extensionContext(const String& uniqueIdentifier) const;
+    RefPtr<WebExtensionContextProxy> extensionContext(WebFrame&, WebCore::DOMWrapperWorld&) const;
+
+    const WebExtensionContextProxySet& extensionContexts() const { return m_extensionContexts; }
+#endif
+
     WebExtensionControllerIdentifier m_identifier;
+
+#if PLATFORM(COCOA)
+    WebExtensionContextProxySet m_extensionContexts;
+    WebExtensionContextProxyBaseURLMap m_extensionContextBaseURLMap;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
@@ -26,7 +26,8 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionControllerProxy {
-
+    Load(struct WebKit::WebExtensionContextParameters contextParameters)
+    Unload(WebKit::WebExtensionContextIdentifier contextIdentifier)
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1744,8 +1744,13 @@ void WebFrameLoaderClient::dispatchGlobalObjectAvailable(DOMWrapperWorld& world)
     WebPage* webPage = m_frame->page();
     if (!webPage)
         return;
-    
+
     webPage->injectedBundleLoaderClient().globalObjectIsAvailableForFrame(*webPage, m_frame, world);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+        extensionControllerProxy->globalObjectIsAvailableForFrame(*webPage, m_frame, world);
+#endif
 }
 
 void WebFrameLoaderClient::dispatchServiceWorkerGlobalObjectAvailable(DOMWrapperWorld& world)
@@ -1755,6 +1760,11 @@ void WebFrameLoaderClient::dispatchServiceWorkerGlobalObjectAvailable(DOMWrapper
         return;
 
     webPage->injectedBundleLoaderClient().serviceWorkerGlobalObjectIsAvailableForFrame(*webPage, m_frame, world);
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    if (auto* extensionControllerProxy = webPage->webExtensionControllerProxy())
+        extensionControllerProxy->serviceWorkerGlobalObjectIsAvailableForFrame(*webPage, m_frame, world);
+#endif
 }
 
 void WebFrameLoaderClient::willInjectUserScript(DOMWrapperWorld& world)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -564,27 +564,37 @@ JSGlobalContextRef WebFrame::jsContext()
     return toGlobalRef(localFrame->script().globalObject(mainThreadNormalWorld()));
 }
 
-JSGlobalContextRef WebFrame::jsContextForWorld(InjectedBundleScriptWorld* world)
+JSGlobalContextRef WebFrame::jsContextForWorld(DOMWrapperWorld& world)
 {
     auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame)
         return nullptr;
 
-    return toGlobalRef(localFrame->script().globalObject(world->coreWorld()));
+    return toGlobalRef(localFrame->script().globalObject(world));
 }
 
-JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(InjectedBundleScriptWorld* world)
+JSGlobalContextRef WebFrame::jsContextForWorld(InjectedBundleScriptWorld* world)
+{
+    return jsContextForWorld(world->coreWorld());
+}
+
+JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(DOMWrapperWorld& world)
 {
 #if ENABLE(SERVICE_WORKER)
     auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame || !localFrame->page())
         return nullptr;
 
-    return toGlobalRef(localFrame->page()->serviceWorkerGlobalObject(world->coreWorld()));
+    return toGlobalRef(localFrame->page()->serviceWorkerGlobalObject(world));
 #else
     UNUSED_PARAM(world);
     return nullptr;
 #endif
+}
+
+JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(InjectedBundleScriptWorld* world)
+{
+    return jsContextForServiceWorkerWorld(world->coreWorld());
 }
 
 void WebFrame::setAccessibleName(const AtomString& accessibleName)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -119,7 +119,9 @@ public:
     WebFrame* parentFrame() const;
     Ref<API::Array> childFrames();
     JSGlobalContextRef jsContext();
+    JSGlobalContextRef jsContextForWorld(WebCore::DOMWrapperWorld&);
     JSGlobalContextRef jsContextForWorld(InjectedBundleScriptWorld*);
+    JSGlobalContextRef jsContextForServiceWorkerWorld(WebCore::DOMWrapperWorld&);
     JSGlobalContextRef jsContextForServiceWorkerWorld(InjectedBundleScriptWorld*);
     WebCore::IntRect contentBounds() const;
     WebCore::IntRect visibleContentBounds() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -681,7 +681,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
 #if ENABLE(WK_WEB_EXTENSIONS)
     if (parameters.webExtensionControllerParameters)
-        m_webExtensionController = WebExtensionControllerProxy::getOrCreate(parameters.webExtensionControllerParameters.value().identifier);
+        m_webExtensionController = WebExtensionControllerProxy::getOrCreate(parameters.webExtensionControllerParameters.value());
 #endif
 
     m_corsDisablingPatterns = WTFMove(parameters.corsDisablingPatterns);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1372,6 +1372,10 @@ public:
 
     UserContentControllerIdentifier userContentControllerIdentifier() const { return m_userContentController->identifier(); }
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+    WebExtensionControllerProxy* webExtensionControllerProxy() const { return m_webExtensionController.get(); }
+#endif
+
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() const { return m_userInterfaceLayoutDirection; }
 
     bool isSuspended() const { return m_isSuspended; }


### PR DESCRIPTION
#### 0080cc8363bfda7701fe208f44a51c01385d4f44
<pre>
Hook up the WebProcess objects for Web Extensions and propogate some info over.
Inject the browser and chrome namespace objects into Web Extension JS contexts.
Implement the simple methods on browser.runtime and browser.extension that had FIXMEs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247964">https://bugs.webkit.org/show_bug.cgi?id=247964</a>

Reviewed by Brian Weinstein.

* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/WebExtensionContextParameters.h:
* Source/WebKit/Shared/WebExtensionContextParameters.serialization.in:
* Source/WebKit/Shared/WebExtensionControllerParameters.h:
* Source/WebKit/Shared/WebExtensionControllerParameters.serialization.in:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::operator== const): Added for easy equality checks.
(WebKit::AuxiliaryProcessProxy::operator!= const): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::addPage):
(WebKit::WebExtensionController::removePage):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
(WebKit::WebExtension::operator!= const): Changed style to match others.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::operator== const): Added for easy equality checks.
(WebKit::WebExtensionContext::operator!= const): Ditto.
(WebKit::WebExtensionContext::baseURL const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::operator== const): Added for easy equality checks.
(WebKit::WebExtensionController::operator!= const): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
(WebKit::WebExtensionMatchPattern::operator!= const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::get):
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::WebExtensionControllerProxy::get):
(WebKit::WebExtensionControllerProxy::getOrCreate):
(WebKit::WebExtensionControllerProxy::WebExtensionControllerProxy):
(WebKit::WebExtensionControllerProxy::load): Added.
(WebKit::WebExtensionControllerProxy::unload): Added.
(WebKit::WebExtensionControllerProxy::extensionContext const):
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load): Create the content script world.
(WebKit::WebExtensionContext::unload): Clear the content script world.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::extension):
(WebKit::WebExtensionAPINamespace::runtime):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::WebExtensionAPIObject):
(WebKit::WebExtensionAPIObject::extensionContext):
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::WebExtensionCallbackHandler): Initialize m_callbackFunction and m_rejectFunction to nullptr.
(WebKit::toJSValue): Return JSValueMakeUndefined instead of nullptr for clarity.
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateHeaderFile): Added &quot;#pragma once&quot;.
(_generateImplementationFile): Use #include instead of #import.
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm: Added.
(WebKit::WebExtensionControllerProxy::globalObjectIsAvailableForFrame): Do the injection for pages.
(WebKit::WebExtensionControllerProxy::serviceWorkerGlobalObjectIsAvailableForFrame): Do the inejction for service workers.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::WebExtensionControllerProxy::extensionContext const): Added various lookup methods.
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchGlobalObjectAvailable): Call webExtensionControllerProxy if it exists.
(WebKit::WebFrameLoaderClient::dispatchServiceWorkerGlobalObjectAvailable): Ditto.
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::jsContextForWorld): Added DOMWrapperWorld version.
(WebKit::WebFrame::jsContextForServiceWorkerWorld): Ditto.
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::webExtensionControllerProxy const): Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed): Block getURL in v3 extensions.
(WebKit::WebExtensionAPIExtension::getURL): Added implementation.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getURL): Added implementation.
(WebKit::WebExtensionAPIRuntime::getManifest): Ditto.
(WebKit::WebExtensionAPIRuntime::runtimeIdentifier): Ditto.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h: Fix return type for getManifest().

Canonical link: <a href="https://commits.webkit.org/256747@main">https://commits.webkit.org/256747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/262e72a4c4a308e46ab5eeca70ae9c5973b55a47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96723 "Failed to checkout and rebase branch from PR 6535") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106251 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6202 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/34724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89107 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/102961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102398 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83335 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/5/builds/100317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/27 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/24 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/4808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2244 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/1249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->