### PR TITLE
[macOS] Disable RunningBoard Management in info.plist for Open Source

### DIFF
--- a/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
+++ b/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
@@ -1,4 +1,4 @@
-if [[ "${WK_PLATFORM_NAME}" == macosx ]] && (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
+if [[ "${USE_INTERNAL_SDK}" == "YES"  &&  "${WK_PLATFORM_NAME}" == macosx ]] && (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
 then
     /usr/libexec/PlistBuddy -c "Add :LSDoNotSetTaskPolicyAutomatically bool YES" "${SCRIPT_INPUT_FILE_0}"
     /usr/libexec/PlistBuddy -c "Add :XPCService:_AdditionalProperties:RunningBoard:Managed bool YES" "${SCRIPT_INPUT_FILE_0}"


### PR DESCRIPTION
#### 60d2086f9b7043ac24841f29e39f8e5ac4e13283
<pre>
[macOS] Disable RunningBoard Management in info.plist for Open Source
<a href="https://bugs.webkit.org/show_bug.cgi?id=247963">https://bugs.webkit.org/show_bug.cgi?id=247963</a>
rdar://problem/102393706

Reviewed by Chris Dumez.

Open Source builds have RunningBoard process management disabled due
to entitlement issues. We need to also disable RunningBoard management
in each process&apos;s info.plist or else processes may become suspended
indefinitely. This is blocking our Open Source macOS 13 bots.

* Source/WebKit/Scripts/update-info-plist-for-runningboard.sh:

Canonical link: <a href="https://commits.webkit.org/256719@main">https://commits.webkit.org/256719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a8ea2a3246959ac05a471ad686c7fa09a80a0e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106180 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6114 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34649 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102891 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102333 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83260 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31532 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100249 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40381 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21185 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4662 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4312 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40466 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->