### PR TITLE
Bump test fuzziness for GPU process on macOS

### DIFF
--- a/LayoutTests/fast/box-shadow/inset-spread-box-shadow-split-inline.html
+++ b/LayoutTests/fast/box-shadow/inset-spread-box-shadow-split-inline.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-14" />
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-20" />
   <style>
     .container {
         width: 6ch;

--- a/LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html
+++ b/LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-13" />
 <title>This tests that paginated lines are painting properly when lines visually overflow.</title>
 <style>
 html {

--- a/LayoutTests/imported/blink/svg/text/obb-paintserver.html
+++ b/LayoutTests/imported/blink/svg/text/obb-paintserver.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-11800" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-12411" />
 <svg width="200" height="400">
   <linearGradient id="gradient" x1="0" x2="0" y1="0" y2="1">
     <stop offset="0" stop-color="green"/>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-background-properties-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-306">
 <style>
     div {
         position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-default.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-default.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-default-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-236">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic1.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-from-image-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-236">
 <style>
     body {
         overflow: hidden;}

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic2.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-none-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-123">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-from-image-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-236">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-dynamic1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-dynamic1.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-from-image-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-236">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-dynamic2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-dynamic2.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-none-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-123">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-from-image-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-236">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none-image-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none-image-document.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-none-image-document-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-236">
 <style>
     iframe {
         display: inline-block;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Stephen Chenney" href="mailto:schenney@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">
 <link rel="match" href="reference/image-orientation-none-ref.html">
-<meta name=fuzzy content="10;100">
+<meta name="fuzzy" content="maxDifference=0-100; totalPixels=0-123">
 <style>
     body {
         overflow: hidden;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-contentBox-1a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-contentBox-1a.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
     <meta name="assert" content="Test checks whether clip-path content-box works correctly or not. This test is for clip-path applied to an HTML element.">
-    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
     <style>
       div {
         background-color: blue;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-contentBox-1b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-contentBox-1b.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
     <meta name="assert" content="Test checks whether clip-path content-box works correctly or not. This test is for clip-path applied to an SVG element.">
-    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
   </head>
   <body>
     <svg width="200" height="200" style="position: absolute; left: 0px; top: 0px;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-marginBox-1a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-marginBox-1a.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
     <meta name="assert" content="Test checks whether clip-path margin-box works correctly or not. This test is for clip-path applied to an SVG element.">
-    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
   </head>
   <body>
     <svg width="200" height="200" style="position: absolute; left: 10px; top: 15px;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1a.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
     <meta name="assert" content="Test checks whether clip-path padding-box works correctly or not. This test is for clip-path applied to an HTML element.">
-    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
     <style>
       div {
         position: absolute;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1b.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
     <meta name="assert" content="Test checks whether clip-path padding-box works correctly or not. This test is for clip-path applied to an SVG element.">
-    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
   </head>
   <body>
     <svg width="200" height="200" style="position: absolute; left: 0px; top: 0px;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1a.html
@@ -8,7 +8,7 @@
     <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-clip-path">
     <link rel="match" href="clip-path-geometryBox-1-ref.html">
     <meta name="assert" content="Test checks whether clip-path view-box works correctly or not.">
-    <meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+    <meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
   </head>
   <body>
     <svg width="200" height="200" style="position: absolute; left: 10px; top: 10px;">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clip-path-circle-offset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clip-path-circle-offset.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.fxtf.org/css-masking/#the-clip-path">
 <link rel="match" href="svg-clip-path-circle-offset-ref.html">
 <!-- Allow antialised pixel differences along the edge of the circle -->
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+<meta name="fuzzy" content="maxDifference=0-62; totalPixels=0-420">
 <svg>
   <rect x="30" y="30" width="100" height="100" fill="green" style="clip-path: circle(50%)"/>
 </svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clip-path-ellipse-offset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clip-path-ellipse-offset.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.fxtf.org/css-masking/#the-clip-path">
 <link rel="match" href="svg-clip-path-ellipse-offset-ref.html">
 <!-- Allow antialised pixel differences along the edge of the ellipse -->
-<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-394">
+<meta name="fuzzy" content="maxDifference=0-69; totalPixels=0-394">
 <svg>
   <rect x="30" y="30" width="100" height="100" fill="green" style="clip-path: ellipse(40% 50%)"/>
 </svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-007.html
@@ -7,7 +7,7 @@
     <meta name="assert" content="This is identical to
     transform3d-preserve3d-006.html, except with rotatey() instead of
     rotatex().">
-    <meta name="fuzzy" content="maxDifference=0-54;totalPixels=0-200">
+    <meta name="fuzzy" content="maxDifference=0-55; totalPixels=0-200">
     <link rel="match" href="transform-lime-square-ref.html">
   </head>
   <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html
@@ -4,7 +4,7 @@
 <link rel="match" href="masked-ref.html">
 <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
 <link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
-<meta name="fuzzy" content="maxDifference=0-36; totalPixels=0-124">
+<meta name="fuzzy" content="maxDifference=0-37; totalPixels=0-124">
 <svg style="display: block">
     <foreignObject x="0" y="0" width="32" height="32" mask="url(#circle)">
         <div style="width: 32px; height: 32px; background: green"></div>

--- a/LayoutTests/svg/clip-path/svg-in-html.html
+++ b/LayoutTests/svg/clip-path/svg-in-html.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=1; totalPixels=0-164" />
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-548" />
 <style>
 body {
     border: 2em blue solid;

--- a/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden.html
+++ b/LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <!-- FIXME: Small AA differences, probably due to off-device-pixel-alignment issues -->
-<meta name="fuzzy" content="maxDifference=46-47; totalPixels=262-295" />
+<meta name="fuzzy" content="maxDifference=0-47; totalPixels=0-295" />
 <style>
     html, body {
         margin: 0;


### PR DESCRIPTION
#### 68c7e095336e350fb25defd9c5e2cb040a0764e2
<pre>
Bump test fuzziness for GPU process on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=247969">https://bugs.webkit.org/show_bug.cgi?id=247969</a>
rdar://problem/102399611

Unreviewed test gardening.

These are tests that are already fuzzy.

* LayoutTests/compositing/geometry/css-clip-oversize.html:
* LayoutTests/fast/box-shadow/inset-spread-box-shadow-split-inline.html:
* LayoutTests/fast/multicol/simple-line-layout-line-index-after-strut.html:
* LayoutTests/imported/blink/svg/text/obb-paintserver.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-default.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-dynamic1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-dynamic2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none-image-document.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-none.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-contentBox-1a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-contentBox-1b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-marginBox-1a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-paddingBox-1b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-viewBox-1a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clip-path-circle-offset.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/svg-clip-path-ellipse-offset.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-skewY.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html:
* LayoutTests/svg/clip-path/svg-in-html.html:
* LayoutTests/svg/compositing/outermost-svg-directly-composited-group-child-overflow-hidden.html:

Canonical link: <a href="https://commits.webkit.org/256914@main">https://commits.webkit.org/256914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72176761ebf96cd959b35387cf60ae2738d288f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106673 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166945 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6689 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35156 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103363 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5024 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83779 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32010 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88705 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74900 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/444 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21626 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5226 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44129 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2339 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40942 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->