### PR TITLE
Update libwebrtc up to 08b882d762edadb9797334859d915c5c1e34896b

### DIFF
--- a/LayoutTests/webrtc/datachannel/mdns-ice-candidates.html
+++ b/LayoutTests/webrtc/datachannel/mdns-ice-candidates.html
@@ -53,15 +53,21 @@ function sendMessages(channel)
 
 let connection;
 promise_test(async (test) => {
+    let localConnectionCandidates = [], remoteConnectionCandidates = [];
     await new Promise((resolve, reject) => {
         createConnections((localConnection) => {
             connection = localConnection;
             localConnection.createDataChannel('sendDataChannel');
         }, () => {
         }, {
-            filterOutICECandidate: (candidate) => {
-                if (candidate && candidate.candidate.toLowerCase().indexOf("host") !== -1)
+            filterOutICECandidate: (candidate, candidateConnection) => {
+                if (candidate && candidate.candidate.toLowerCase().indexOf("host") !== -1) {
                     assert_true(candidate.candidate.indexOf(".local") !== -1);
+                    if (candidateConnection == connection)
+                       localConnectionCandidates.push(candidate.foundation);
+                    else
+                        remoteConnectionCandidates.push(candidate.foundation);
+                }
                 if (!candidate)
                     resolve();
                 return false;
@@ -69,6 +75,12 @@ promise_test(async (test) => {
         });
         setTimeout(() => { reject("Test timed out"); }, 5000);
     });
+
+    for (const foundation of localConnectionCandidates)
+        assert_false(remoteConnectionCandidates.includes(foundation), "local connection foundation");
+
+    for (const foundation of remoteConnectionCandidates)
+        assert_false(localConnectionCandidates.includes(foundation), "remote connection foundation");
 
     assert_true(connection.localDescription.sdp.includes(".local "));
     closeConnections();

--- a/LayoutTests/webrtc/routines.js
+++ b/LayoutTests/webrtc/routines.js
@@ -5,9 +5,9 @@ var remoteConnection;
 function createConnections(setupLocalConnection, setupRemoteConnection, options = { }) {
     localConnection = new RTCPeerConnection();
     remoteConnection = new RTCPeerConnection();
-    remoteConnection.onicecandidate = (event) => { iceCallback2(event, options.filterOutICECandidate) };
+    remoteConnection.onicecandidate = (event) => { iceCallback2(event, options.filterOutICECandidate, remoteConnection) };
 
-    localConnection.onicecandidate = (event) => { iceCallback1(event, options.filterOutICECandidate) };
+    localConnection.onicecandidate = (event) => { iceCallback1(event, options.filterOutICECandidate, localConnection) };
 
     Promise.resolve(setupLocalConnection(localConnection)).then(() => {
         return Promise.resolve(setupRemoteConnection(remoteConnection));
@@ -52,17 +52,17 @@ function gotDescription2(desc, options)
     localConnection.setRemoteDescription(desc);
 }
 
-function iceCallback1(event, filterOutICECandidate)
+function iceCallback1(event, filterOutICECandidate, connection)
 {
-    if (filterOutICECandidate && filterOutICECandidate(event.candidate))
+    if (filterOutICECandidate && filterOutICECandidate(event.candidate, connection))
         return;
 
     remoteConnection.addIceCandidate(event.candidate).then(onAddIceCandidateSuccess, onAddIceCandidateError);
 }
 
-function iceCallback2(event, filterOutICECandidate)
+function iceCallback2(event, filterOutICECandidate, connection)
 {
-    if (filterOutICECandidate && filterOutICECandidate(event.candidate))
+    if (filterOutICECandidate && filterOutICECandidate(event.candidate, connection))
         return;
 
     localConnection.addIceCandidate(event.candidate).then(onAddIceCandidateSuccess, onAddIceCandidateError);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/connection.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/connection.cc
@@ -1563,7 +1563,7 @@ void Connection::MaybeUpdateLocalCandidate(StunRequest* request,
   // Set the related address and foundation attributes before changing the
   // address.
   local_candidate_.set_related_address(local_candidate_.address());
-  local_candidate_.set_foundation(Port::ComputeFoundation(
+  local_candidate_.set_foundation(port()->ComputeFoundation(
       PRFLX_PORT_TYPE, local_candidate_.protocol(),
       local_candidate_.relay_protocol(), local_candidate_.address()));
   local_candidate_.set_priority(priority);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/p2p_transport_channel.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/p2p_transport_channel.cc
@@ -874,6 +874,7 @@ int P2PTransportChannel::check_receiving_interval() const {
 
 void P2PTransportChannel::MaybeStartGathering() {
   RTC_DCHECK_RUN_ON(network_thread_);
+  // TODO(bugs.webrtc.org/14605): ensure tie_breaker_ is set.
   if (ice_parameters_.ufrag.empty() || ice_parameters_.pwd.empty()) {
     RTC_LOG(LS_ERROR)
         << "Cannot gather candidates because ICE parameters are empty"
@@ -918,6 +919,7 @@ void P2PTransportChannel::MaybeStartGathering() {
                                       ice_parameters_.ufrag,
                                       ice_parameters_.pwd);
     if (pooled_session) {
+      pooled_session->set_ice_tiebreaker(tiebreaker_);
       AddAllocatorSession(std::move(pooled_session));
       PortAllocatorSession* raw_pooled_session =
           allocator_sessions_.back().get();
@@ -934,6 +936,7 @@ void P2PTransportChannel::MaybeStartGathering() {
       AddAllocatorSession(allocator_->CreateSession(
           transport_name(), component(), ice_parameters_.ufrag,
           ice_parameters_.pwd));
+      allocator_sessions_.back()->set_ice_tiebreaker(tiebreaker_);
       allocator_sessions_.back()->StartGettingPorts();
     }
   }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port.cc
@@ -100,8 +100,10 @@ std::string Port::ComputeFoundation(absl::string_view type,
                                     absl::string_view protocol,
                                     absl::string_view relay_protocol,
                                     const rtc::SocketAddress& base_address) {
+  // TODO(bugs.webrtc.org/14605): ensure IceTiebreaker() is set.
   rtc::StringBuilder sb;
-  sb << type << base_address.ipaddr().ToString() << protocol << relay_protocol;
+  sb << type << base_address.ipaddr().ToString() << protocol << relay_protocol
+     << rtc::ToString(IceTiebreaker());
   return rtc::ToString(rtc::ComputeCrc32(sb.Release()));
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port.h
@@ -390,10 +390,10 @@ class Port : public PortInterface,
   //   then the foundation will be different.  Two candidate pairs with
   //   the same foundation pairs are likely to have similar network
   //   characteristics. Foundations are used in the frozen algorithm.
-  static std::string ComputeFoundation(absl::string_view type,
-                                       absl::string_view protocol,
-                                       absl::string_view relay_protocol,
-                                       const rtc::SocketAddress& base_address);
+  std::string ComputeFoundation(absl::string_view type,
+                                absl::string_view protocol,
+                                absl::string_view relay_protocol,
+                                const rtc::SocketAddress& base_address);
 
  protected:
   enum { MSG_DESTROY_IF_DEAD = 0, MSG_FIRST_AVAILABLE };

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port_allocator.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port_allocator.h
@@ -206,6 +206,10 @@ class RTC_EXPORT PortAllocatorSession : public sigslot::has_slots<> {
   const std::string& ice_pwd() const { return ice_pwd_; }
   bool pooled() const { return pooled_; }
 
+  // TODO(bugs.webrtc.org/14605): move this to the constructor
+  void set_ice_tiebreaker(uint64_t tiebreaker) { tiebreaker_ = tiebreaker; }
+  uint64_t ice_tiebreaker() const { return tiebreaker_; }
+
   // Setting this filter should affect not only candidates gathered in the
   // future, but candidates already gathered and ports already "ready",
   // which would be returned by ReadyCandidates() and ReadyPorts().
@@ -322,6 +326,9 @@ class RTC_EXPORT PortAllocatorSession : public sigslot::has_slots<> {
 
   bool pooled_ = false;
 
+  // TODO(bugs.webrtc.org/14605): move this to the constructor
+  uint64_t tiebreaker_;
+
   // SetIceParameters is an implementation detail which only PortAllocator
   // should be able to call.
   friend class PortAllocator;
@@ -373,6 +380,9 @@ class RTC_EXPORT PortAllocator : public sigslot::has_slots<> {
                         webrtc::TurnCustomizer* turn_customizer = nullptr,
                         const absl::optional<int>&
                             stun_candidate_keepalive_interval = absl::nullopt);
+
+  void SetIceTiebreaker(uint64_t tiebreaker);
+  uint64_t IceTiebreaker() const { return tiebreaker_; }
 
   const ServerAddresses& stun_servers() const {
     CheckRunOnValidThreadIfInitialized();
@@ -665,6 +675,9 @@ class RTC_EXPORT PortAllocator : public sigslot::has_slots<> {
   // if ice_credentials is nullptr.
   std::vector<std::unique_ptr<PortAllocatorSession>>::const_iterator
   FindPooledSession(const IceParameters* ice_credentials = nullptr) const;
+
+  // ICE tie breaker.
+  uint64_t tiebreaker_;
 };
 
 }  // namespace cricket

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/client/basic_port_allocator.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/client/basic_port_allocator.cc
@@ -1496,6 +1496,7 @@ void AllocationSequence::CreateUDPPorts() {
   }
 
   if (port) {
+    port->SetIceTiebreaker(session_->ice_tiebreaker());
     // If shared socket is enabled, STUN candidate will be allocated by the
     // UDPPort.
     if (IsFlagSet(PORTALLOCATOR_ENABLE_SHARED_SOCKET)) {
@@ -1531,6 +1532,7 @@ void AllocationSequence::CreateTCPPorts() {
       session_->allocator()->allow_tcp_listen(),
       session_->allocator()->field_trials());
   if (port) {
+    port->SetIceTiebreaker(session_->ice_tiebreaker());
     session_->AddAllocatedPort(port.release(), this);
     // Since TCPPort is not created using shared socket, `port` will not be
     // added to the dequeue.
@@ -1560,6 +1562,7 @@ void AllocationSequence::CreateStunPorts() {
       session_->allocator()->stun_candidate_keepalive_interval(),
       session_->allocator()->field_trials());
   if (port) {
+    port->SetIceTiebreaker(session_->ice_tiebreaker());
     session_->AddAllocatedPort(port.release(), this);
     // Since StunPort is not created using shared socket, `port` will not be
     // added to the dequeue.
@@ -1656,6 +1659,7 @@ void AllocationSequence::CreateTurnPort(const RelayServerConfig& config) {
       }
     }
     RTC_DCHECK(port != NULL);
+    port->SetIceTiebreaker(session_->ice_tiebreaker());
     session_->AddAllocatedPort(port.release(), this);
   }
 }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc
@@ -63,6 +63,9 @@ JsepTransportController::JsepTransportController(
   RTC_DCHECK(config_.ice_transport_factory);
   RTC_DCHECK(config_.on_dtls_handshake_error_);
   RTC_DCHECK(config_.field_trials);
+  if (port_allocator_) {
+    port_allocator_->SetIceTiebreaker(ice_tiebreaker_);
+  }
 }
 
 JsepTransportController::~JsepTransportController() {


### PR DESCRIPTION
#### 4af71c6a875d741376e233eef08e2c6ce5de42f7
<pre>
Update libwebrtc up to 08b882d762edadb9797334859d915c5c1e34896b
<a href="https://bugs.webkit.org/show_bug.cgi?id=247946">https://bugs.webkit.org/show_bug.cgi?id=247946</a>
rdar://problem/102366905

Reviewed by Eric Carlson.

Update libwebrtc and update mdns-ice-candidates checks.

* LayoutTests/webrtc/datachannel/mdns-ice-candidates.html:
* LayoutTests/webrtc/routines.js:
(createConnections):
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/connection.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/p2p_transport_channel.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port_allocator.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/port_allocator.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/client/basic_port_allocator.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport_controller.cc:

Canonical link: <a href="https://commits.webkit.org/256778@main">https://commits.webkit.org/256778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4008f2f1f08efe96c907ea442f57e005f809178c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106207 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166527 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6148 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34678 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89063 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102917 "Hash 4008f2f1 for PR 6546 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4606 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83287 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31559 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40405 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21210 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4705 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43744 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40492 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->