### PR TITLE
[build.webkit.org] Remove WebKitGTK and WPE packaging bots for Ubuntu 18.04 from CI

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -515,12 +515,6 @@
                       "workernames": ["gtk-linux-bot-21"]
                     },
                     {
-                      "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
-                      "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
-                      "additionalArguments": ["--no-bubblewrap-sandbox"],
-                      "workernames": ["gtk-linux-bot-16"]
-                    },
-                    {
                       "name": "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
                       "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                       "additionalArguments": ["--no-bubblewrap-sandbox"],
@@ -630,12 +624,6 @@
                       "name": "WPE-Linux-64-bit-Debug-JS-Tests", "factory": "TestJSFactory",
                       "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
                       "workernames": ["wpe-linux-bot-6"]
-                    },
-                    {
-                      "name": "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
-                      "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
-                      "additionalArguments": ["--no-bubblewrap-sandbox", "--cmakeargs=-DENABLE_WPE_QT_API=OFF"],
-                      "workernames": ["wpe-linux-bot-7"]
                     },
                     {
                       "name": "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004", "factory": "BuildAndGenerateMiniBrowserBundleFactory",
@@ -886,8 +874,8 @@
                     },
                     { "type": "Nightly", "name": "NightlyScheduler", "change_filter": "main_filter",
                       "branch": "main", "hour": 22, "minute": 0,
-                      "builderNames": ["GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804", "GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004",
-                                       "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804", "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004"]
+                      "builderNames": ["GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004",
+                                       "WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004"]
                     }
                   ]
 }

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1423,19 +1423,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
-        'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'generate-minibrowser-bundle'
-        ],
         'GTK-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
             'configure-build',
             'configuration',
@@ -1760,19 +1747,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'jscore-test',
             'test262-test'
-        ],
-        'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu1804': [
-            'configure-build',
-            'configuration',
-            'clean-and-update-working-directory',
-            'checkout-specific-revision',
-            'show-identifier',
-            'kill-old-processes',
-            'delete-WebKitBuild-directory',
-            'delete-stale-build-files',
-            'jhbuild',
-            'compile-webkit',
-            'generate-minibrowser-bundle'
         ],
         'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
             'configure-build',


### PR DESCRIPTION
#### b55a0fa5e42e6d810a6795f38e4a26fdfccce380
<pre>
[build.webkit.org] Remove WebKitGTK and WPE packaging bots for Ubuntu 18.04 from CI
<a href="https://bugs.webkit.org/show_bug.cgi?id=247974">https://bugs.webkit.org/show_bug.cgi?id=247974</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:

Canonical link: <a href="https://commits.webkit.org/256772@main">https://commits.webkit.org/256772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a9cbec7485ed8af19e9077e661b8e484e404c5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106210 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166529 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6152 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34681 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102920 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4602 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83290 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31558 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74480 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40408 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/95640 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38069 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43747 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40493 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->