### PR TITLE
[Flatpak SDK] Support using the SDK on 64-bit ARM hosts

### DIFF
--- a/Tools/buildstream/elements/filtered.bst
+++ b/Tools/buildstream/elements/filtered.bst
@@ -4,3 +4,8 @@ kind: stack
 - arch == "x86_64":
     depends:
     - sdk/rr.bst
+    - sdk/clangd.bst
+
+- arch == "aarch64":
+    depends:
+    - sdk/clangd-arduino.bst

--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -5,7 +5,6 @@ depends:
 - qt5.bst
 - test-infra.bst
 - filtered.bst
-- filtered-openh264.bst
 
 # replaced (patched) elements:
 - sdk/abseil-cpp.bst
@@ -15,7 +14,6 @@ depends:
 - sdk/capnp.bst
 - sdk/cargo-c.bst
 - sdk/ccls.bst
-- sdk/clangd.bst
 - sdk/eigen.bst
 - sdk/enchant-2.bst
 - sdk/ffmpeg.bst

--- a/Tools/buildstream/elements/sdk/clangd-arduino.bst
+++ b/Tools/buildstream/elements/sdk/clangd-arduino.bst
@@ -1,0 +1,20 @@
+kind: manual
+sources:
+- kind: tar
+  url: github_files:arduino/clang-static-binaries/releases/download/15.0.0/clangd_15.0.0_Linux_ARM64.tar.bz2
+  ref: 176b60b321135114c4f063be82ec0f325bc3a9f8b5b411050ceda1675d971cfe
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+
+config:
+  install-commands:
+  - |
+    install -D -m a+rx -t "%{install-root}/%{bindir}" ./clangd
+
+variables:
+  strip-binaries: "true"
+public:
+  bst:
+    integration-commands:
+    - |
+      clangd --version

--- a/Tools/buildstream/elements/sdk/clangd.bst
+++ b/Tools/buildstream/elements/sdk/clangd.bst
@@ -1,8 +1,8 @@
 kind: manual
 sources:
 - kind: zip
-  url: github_files:clangd/clangd/releases/download/14.0.3/clangd-linux-14.0.3.zip
-  ref: 6c6eabfcc5ce91dea2ebce039cf0dea612a191ebbbffe366d973f0a102325bce
+  url: github_files:clangd/clangd/releases/download/15.0.3/clangd-linux-15.0.3.zip
+  ref: c1ebe5b37372553273703f16b7d00c7bc6cf42f4997a07110d18c2105932b9d6
 depends:
 - freedesktop-sdk.bst:bootstrap-import.bst
 

--- a/Tools/buildstream/elements/sdk/gst-plugins-bad.bst
+++ b/Tools/buildstream/elements/sdk/gst-plugins-bad.bst
@@ -14,9 +14,9 @@ depends:
 - freedesktop-sdk.bst:components/openjpeg.bst
 - freedesktop-sdk.bst:components/libdrm.bst
 - sdk/libkate.bst
+- sdk/libopenh264.bst
 - sdk/libusrsctp.bst
 - freedesktop-sdk.bst:components/libusb.bst
-- filtered-openh264.bst
 - freedesktop-sdk.bst:components/aom.bst
 - freedesktop-sdk.bst:components/librsvg.bst
 - freedesktop-sdk.bst:components/frei0r.bst


### PR DESCRIPTION
#### 0c600e832115f15dbe465bcca82b21e01dc7b0e5
<pre>
[Flatpak SDK] Support using the SDK on 64-bit ARM hosts
<a href="https://bugs.webkit.org/show_bug.cgi?id=242759">https://bugs.webkit.org/show_bug.cgi?id=242759</a>

Reviewed by Žan Doberšek.

The SDK already had support for aarch64, only a few additional changes were needed:
- move official clangd recipe to x86_64, they don&apos;t provide aarch64 binaries
- add a clang-arduino recipe providing aarch64 clangd binary
- enable openh264 on aarch64

Driving by, I also bumped clangd to version 15.0.3.

* Tools/buildstream/elements/filtered.bst:
* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/clangd-arduino.bst: Added.
* Tools/buildstream/elements/sdk/clangd.bst:
* Tools/buildstream/elements/sdk/gst-plugins-bad.bst:

Canonical link: <a href="https://commits.webkit.org/256777@main">https://commits.webkit.org/256777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82040552134a8836bd30b8473bd8a61990a9495c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106211 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166530 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6153 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34682 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102921 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4605 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83291 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31560 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74482 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/66/builds/40409 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/67/builds/38070 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21213 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43748 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2262 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40495 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->