### PR TITLE
Evaluate what happens to application specific HTTP headers in case of 301 cached redirections

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-custom-header-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-custom-header-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Permanent redirections should not reuse a previous custom header - request without custom header
+PASS Permanent redirections should not allow reusing custom header - request with custom header
+

--- a/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-custom-header.html
+++ b/LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-custom-header.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Tests that the Authorization header is present on same-origin redirect requests coming from cache</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#request">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+promise_test(async () => {
+    let response = await fetch("/WebKit/fetch/resources/redirect301.py?request=1&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-custom-header.py"), {
+        headers: {
+            "custom-authorization": "Foo Bar1",
+        },
+    });
+    assert_equals(await response.text(), "Foo Bar1");
+
+   response = await fetch("/WebKit/fetch/resources/redirect301.py?request=1&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-custom-header.py"));
+    assert_equals(await response.text(), "none");
+}, "Permanent redirections should not reuse a previous custom header - request without custom header");
+
+promise_test(async () => {
+    let response = await fetch("/WebKit/fetch/resources/redirect301.py?request=2&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-custom-header.py"), {
+        headers: {
+            "custom-authorization": "Foo Bar1",
+        },
+    });
+    assert_equals(await response.text(), "Foo Bar1");
+
+   response = await fetch("/WebKit/fetch/resources/redirect301.py?request=2&url=" + encodeURIComponent("/WebKit/fetch/resources/dump-custom-header.py"), {
+        headers: {
+            "custom-authorization": "Foo Bar2",
+        },
+    });
+    assert_equals(await response.text(), "Foo Bar2");
+}, "Permanent redirections should not allow reusing custom header - request with custom header");
+    </script>
+  </body>
+</html>

--- a/LayoutTests/http/wpt/fetch/resources/dump-custom-header.py
+++ b/LayoutTests/http/wpt/fetch/resources/dump-custom-header.py
@@ -1,0 +1,6 @@
+def main(request, response):
+    headers = [(b"Content-Type", "text/html"),
+               (b"Cache-Control", b"no-cache")]
+    if b"custom-authorization" in request.headers:
+        return 200, headers, request.headers.get(b"custom-authorization")
+    return 200, headers, "none"

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -62,6 +62,7 @@ using ResponseCompletionHandler = CompletionHandler<void(WebCore::PolicyAction)>
 class NetworkDataTaskClient {
 public:
     virtual void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&) = 0;
+    virtual void setRequestAuthorizationHeader(const String&) { };
     virtual void didReceiveChallenge(WebCore::AuthenticationChallenge&&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&) = 0;
     virtual void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&) = 0;
     virtual void didReceiveData(const WebCore::SharedBuffer&) = 0;

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -105,6 +105,11 @@ static inline void updateRequest(ResourceRequest& currentRequest, const Resource
 #endif
 }
 
+void NetworkLoad::setRequestAuthorizationHeader(const String& value)
+{
+    m_currentRequest.setHTTPHeaderField(HTTPHeaderName::Authorization, value);
+}
+
 void NetworkLoad::updateRequestAfterRedirection(WebCore::ResourceRequest& newRequest) const
 {
     ResourceRequest updatedRequest = m_currentRequest;

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -56,6 +56,7 @@ public:
     bool isAllowedToAskUserForCredentials() const;
 
     const WebCore::ResourceRequest& currentRequest() const { return m_currentRequest; }
+    void setRequestAuthorizationHeader(const String&) final;
     void updateRequestAfterRedirection(WebCore::ResourceRequest&) const;
     void reprioritizeRequest(WebCore::ResourceLoadPriority);
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -459,9 +459,7 @@ std::unique_ptr<Entry> Cache::makeEntry(const WebCore::ResourceRequest& request,
 
 std::unique_ptr<Entry> Cache::makeRedirectEntry(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& redirectRequest)
 {
-    auto cachedRedirectRequest = redirectRequest;
-    cachedRedirectRequest.clearHTTPAuthorization();
-    return makeUnique<Entry>(makeCacheKey(request), response, WTFMove(cachedRedirectRequest), WebCore::collectVaryingRequestHeaders(networkProcess().storageSession(m_sessionID), request, response));
+    return makeUnique<Entry>(makeCacheKey(request), response, redirectRequest, WebCore::collectVaryingRequestHeaders(networkProcess().storageSession(m_sessionID), request, response));
 }
 
 std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& responseData, Function<void(MappedBody&)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -108,6 +108,9 @@ private:
     bool needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const;
 #endif
     bool isAlwaysOnLoggingAllowed() const;
+#if USE(CREDENTIAL_STORAGE_WITH_NETWORK_SESSION)
+    void applyBasicAuthorizationHeader(WebCore::ResourceRequest&, const WebCore::Credential&);
+#endif
 
     WeakPtr<SessionWrapper> m_sessionWrapper;
     RefPtr<SandboxExtension> m_sandboxExtension;


### PR DESCRIPTION
#### d6715c2d16877c94b36f129cab924a3e029561f7
<pre>
Evaluate what happens to application specific HTTP headers in case of 301 cached redirections
<a href="https://bugs.webkit.org/show_bug.cgi?id=247942">https://bugs.webkit.org/show_bug.cgi?id=247942</a>

Reviewed by NOBODY (OOPS!).

Make sure to reuse the application specific HTTP headers in case of redirections.
Make it sure by creating the redirected request from the past request and the redirection response, like specified in fetch.

* LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-custom-header-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-permanent-redirect-same-origin-custom-header.html: Added.
* LayoutTests/http/wpt/fetch/resources/dump-custom-header.py: Added.
(main):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::redirectedRequest const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
(WebKit::NetworkResourceLoader::dispatchWillSendRequestForCacheEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::makeRedirectEntry):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6715c2d16877c94b36f129cab924a3e029561f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106480 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166763 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6442 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34950 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89344 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103177 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4841 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83567 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31855 "Found 9 new test failures: http/wpt/resource-timing/rt-cors.html, http/wpt/resource-timing/rt-cors.worker.html, imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_server.html, imported/w3c/web-platform-tests/navigation-timing/unload-event-same-origin-check.html, imported/w3c/web-platform-tests/resource-timing/redirects.html, imported/w3c/web-platform-tests/resource-timing/resource-timing-level1.sub.html, imported/w3c/web-platform-tests/resource-timing/resource_TAO_cross_origin_redirect_chain.html, imported/w3c/web-platform-tests/resource-timing/resource_timing_TAO_cross_origin_redirect.html, imported/w3c/web-platform-tests/resource-timing/resource_timing_same_origin_redirect.html (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86686 "Found 2 new API test failures: TestWebKitAPI.HSTS.CrossOriginRedirect, TestWebKitAPI.HSTS.Basic (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88556 "Found 1 new API test failure: TestWebKitAPI.WebKit.DecidePolicyForNavigationActionForPOSTFormSubmissionThatRedirectsToGET (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74749 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-persistence (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/254 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/240 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21461 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43972 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1469 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40762 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->