### PR TITLE
[WPE] Do not skip generic touch event handling for axis event gesturing

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -234,18 +234,7 @@ void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& touchEvent, b
             event->modifiers &= ~wpe_input_pointer_modifier_button1;
             page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor()));
         },
-        [&](TouchGestureController::AxisEvent& axisEvent)
-        {
-#if WPE_CHECK_VERSION(1, 5, 0)
-            auto* event = &axisEvent.event.base;
-#else
-            auto* event = &axisEvent.event;
-#endif
-            if (event->type != wpe_input_axis_event_type_null) {
-                page.handleNativeWheelEvent(WebKit::NativeWebWheelEvent(event, page.deviceScaleFactor(),
-                    axisEvent.phase, WebWheelEvent::Phase::PhaseNone));
-            }
-        });
+        [](TouchGestureController::AxisEvent&) { });
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -261,12 +261,6 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
                             handledThroughGestureController = true;
                         }
                     });
-
-                // In case of the axis event gesturing, the generic touch event handling should be skipped.
-                // Exception to this are touch-up events that should still be handled just like the corresponding
-                // touch-down events were.
-                if (handledThroughGestureController && event->type != wpe_input_touch_event_type_up)
-                    return;
             }
 
             page.handleTouchEvent(touchEvent);


### PR DESCRIPTION
#### 0c5bceacedb58b229e64b06600223b053b754efa
<pre>
[WPE] Do not skip generic touch event handling for axis event gesturing
<a href="https://bugs.webkit.org/show_bug.cgi?id=247975">https://bugs.webkit.org/show_bug.cgi?id=247975</a>

Reviewed by Michael Catanzaro.

touchmove events are not sent anymore if the TouchGestureController
is activated. This is wrong. Drop the short cut to make them work again.

* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithTouchEvent): Drop special wheel event
handling.
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
(WKWPE::m_backend): Do not skip touch event handling on axis event
gesturing.

Canonical link: <a href="https://commits.webkit.org/262970@main">https://commits.webkit.org/262970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1bca0485bec6fcea02a73edafff7bfdf3c7c0e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3518 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2749 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4380 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2652 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2605 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4129 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2983 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2581 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3227 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2814 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/789 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/776 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2813 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3310 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3079 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/911 "Passed tests") | 
<!--EWS-Status-Bubble-End-->