### PR TITLE
[web-animations] web-animations/timing-model/timelines/update-and-send-events.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Fires cancel event before requestAnimationFrame
 PASS Fires finish event before requestAnimationFrame
-FAIL Sorts finish events by composite order assert_array_equals: finish events for various animation type should be sorted by composite order expected property 0 to be "CSSTransition:finish" but got "ScriptAnimation:finish" (expected array ["CSSTransition:finish", "CSSAnimation:finish", "ScriptAnimation:finish"] got ["ScriptAnimation:finish", "CSSTransition:finish", "CSSAnimation:finish"])
-FAIL Sorts cancel events by composite order assert_array_equals: cancel events should be sorted by composite order expected property 0 to be "CSSTransition:cancel" but got "ScriptAnimation:cancel" (expected array ["CSSTransition:cancel", "CSSAnimation:cancel", "ScriptAnimation:cancel", "transitioncancel", "animationcancel"] got ["ScriptAnimation:cancel", "CSSAnimation:cancel", "animationcancel", "CSSTransition:cancel", "transitioncancel"])
+PASS Sorts finish events by composite order
+PASS Sorts cancel events by composite order
 PASS Queues a cancel event in transitionstart event callback
 PASS Sorts events for the same transition
 PASS Playback events with the same timeline retain the order in which they arequeued

--- a/Source/WebCore/animation/AnimationEventBase.cpp
+++ b/Source/WebCore/animation/AnimationEventBase.cpp
@@ -34,10 +34,9 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationEventBase);
 
-AnimationEventBase::AnimationEventBase(const AtomString& type, WebAnimation* animation, std::optional<Seconds> timelineTime)
+AnimationEventBase::AnimationEventBase(const AtomString& type, WebAnimation* animation)
     : Event(type, CanBubble::Yes, IsCancelable::No)
     , m_animation(animation)
-    , m_timelineTime(timelineTime)
 {
 }
 

--- a/Source/WebCore/animation/AnimationEventBase.h
+++ b/Source/WebCore/animation/AnimationEventBase.h
@@ -35,9 +35,9 @@ class WebAnimation;
 class AnimationEventBase : public Event {
     WTF_MAKE_ISO_ALLOCATED(AnimationEventBase);
 public:
-    static Ref<AnimationEventBase> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> timelineTime)
+    static Ref<AnimationEventBase> create(const AtomString& type, WebAnimation* animation)
     {
-        return adoptRef(*new AnimationEventBase(type, animation, timelineTime));
+        return adoptRef(*new AnimationEventBase(type, animation));
     }
 
     virtual ~AnimationEventBase();
@@ -46,15 +46,13 @@ public:
     virtual bool isAnimationEvent() const { return false; }
     virtual bool isTransitionEvent() const { return false; }
 
-    std::optional<Seconds> timelineTime() const { return m_timelineTime; }
     WebAnimation* animation() const { return m_animation.get(); }
 
 protected:
-    AnimationEventBase(const AtomString&, WebAnimation*, std::optional<Seconds>);
+    AnimationEventBase(const AtomString&, WebAnimation*);
     AnimationEventBase(const AtomString&, const EventInit&, IsTrusted);
 
     RefPtr<WebAnimation> m_animation;
-    Markable<Seconds, Seconds::MarkableTraits> m_timelineTime;
 };
 
 }

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -47,8 +47,10 @@ AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, const Ani
         m_timelineTime = std::nullopt;
 }
 
-AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, std::optional<Seconds> currentTime, std::optional<Seconds> timelineTime, WebAnimation* animation)
-    : AnimationEventBase(type, animation, timelineTime)
+AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> timelineTime, std::optional<Seconds> scheduledTime, std::optional<Seconds> currentTime)
+    : AnimationEventBase(type, animation)
+    , m_timelineTime(timelineTime)
+    , m_scheduledTime(scheduledTime)
     , m_currentTime(currentTime)
 {
 }
@@ -64,9 +66,9 @@ std::optional<double> AnimationPlaybackEvent::bindingsCurrentTime() const
 
 std::optional<double> AnimationPlaybackEvent::bindingsTimelineTime() const
 {
-    if (!timelineTime())
+    if (!m_timelineTime)
         return std::nullopt;
-    return secondsToWebAnimationsAPITime(timelineTime().value());
+    return secondsToWebAnimationsAPITime(m_timelineTime.value());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -34,9 +34,9 @@ namespace WebCore {
 class AnimationPlaybackEvent final : public AnimationEventBase {
     WTF_MAKE_ISO_ALLOCATED(AnimationPlaybackEvent);
 public:
-    static Ref<AnimationPlaybackEvent> create(const AtomString& type, std::optional<Seconds> currentTime, std::optional<Seconds> timelineTime, WebAnimation* animation)
+    static Ref<AnimationPlaybackEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> timelineTime, std::optional<Seconds> scheduledTime, std::optional<Seconds> currentTime)
     {
-        return adoptRef(*new AnimationPlaybackEvent(type, currentTime, timelineTime, animation));
+        return adoptRef(*new AnimationPlaybackEvent(type, animation, timelineTime, scheduledTime, currentTime));
     }
 
     static Ref<AnimationPlaybackEvent> create(const AtomString& type, const AnimationPlaybackEventInit& initializer, IsTrusted isTrusted = IsTrusted::No)
@@ -48,16 +48,22 @@ public:
 
     bool isAnimationPlaybackEvent() const final { return true; }
 
+    std::optional<Seconds> timelineTime() const { return m_timelineTime; }
+    std::optional<double> bindingsTimelineTime() const;
+
+    std::optional<Seconds> scheduledTime() const { return m_scheduledTime; }
+
     std::optional<double> bindingsCurrentTime() const;
     std::optional<Seconds> currentTime() const { return m_currentTime; }
-    std::optional<double> bindingsTimelineTime() const;
 
     EventInterface eventInterface() const override { return AnimationPlaybackEventInterfaceType; }
 
 private:
-    AnimationPlaybackEvent(const AtomString&, std::optional<Seconds>, std::optional<Seconds>, WebAnimation*);
+    AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<Seconds> timelineTime, std::optional<Seconds> scheduledTime, std::optional<Seconds> currentTime);
     AnimationPlaybackEvent(const AtomString&, const AnimationPlaybackEventInit&, IsTrusted);
 
+    Markable<Seconds, Seconds::MarkableTraits> m_timelineTime;
+    Markable<Seconds, Seconds::MarkableTraits> m_scheduledTime;
     Markable<Seconds, Seconds::MarkableTraits> m_currentTime;
 };
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -281,9 +281,9 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
         keyframeEffect.computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
 }
 
-Ref<AnimationEventBase> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId, std::optional<Seconds> timelineTime)
+Ref<AnimationEventBase> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
 {
-    return AnimationEvent::create(eventType, m_animationName, elapsedTime, pseudoId, timelineTime, this);
+    return AnimationEvent::create(eventType, this, elapsedTime, m_animationName, pseudoId);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -54,7 +54,7 @@ private:
     CSSAnimation(const Styleable&, const Animation&);
 
     void syncPropertiesWithBackingAnimation() final;
-    Ref<AnimationEventBase> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId, std::optional<Seconds> timelineTime) final;
+    Ref<AnimationEventBase> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId) final;
 
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -93,9 +93,9 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
     unsuspendEffectInvalidation();
 }
 
-Ref<AnimationEventBase> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId, std::optional<Seconds> timelineTime)
+Ref<AnimationEventBase> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
 {
-    return TransitionEvent::create(eventType, nameString(m_property), elapsedTime, pseudoId, timelineTime, this);
+    return TransitionEvent::create(eventType, this, elapsedTime, nameString(m_property), pseudoId);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -56,7 +56,7 @@ public:
 private:
     CSSTransition(const Styleable&, CSSPropertyID, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
-    Ref<AnimationEventBase> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId, std::optional<Seconds> timelineTime) final;
+    Ref<AnimationEventBase> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId) final;
     void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -339,8 +339,7 @@ void DeclarativeAnimation::enqueueDOMEvent(const AtomString& eventType, Seconds 
 
     auto time = secondsToWebAnimationsAPITime(elapsedTime) / 1000;
     auto pseudoId = pseudoIdAsString(m_owningPseudoId);
-    auto timelineTime = timeline() ? timeline()->currentTime() : std::nullopt;
-    auto event = createEvent(eventType, time, pseudoId, timelineTime);
+    auto event = createEvent(eventType, time, pseudoId);
     event->setTarget(RefPtr { m_owningElement.get() });
     enqueueAnimationEvent(WTFMove(event));
 }

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -77,7 +77,7 @@ protected:
     virtual void syncPropertiesWithBackingAnimation();
     // elapsedTime is the animation's current time at the time the event is added and is exposed through the DOM API, timelineTime is the animations'
     // timeline current time and is not exposed through the DOM API but used by the DocumentTimeline for sorting events before dispatch. 
-    virtual Ref<AnimationEventBase> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId, std::optional<Seconds> timelineTime) = 0;
+    virtual Ref<AnimationEventBase> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId) = 0;
     void invalidateDOMEvents(Seconds elapsedTime = 0_s);
 
 private:

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -79,6 +79,8 @@ public:
     WEBCORE_EXPORT Vector<std::pair<String, double>> acceleratedAnimationsForElement(Element&) const;    
     WEBCORE_EXPORT unsigned numberOfAnimationTimelineInvalidationsForTesting() const;
 
+    Seconds convertTimelineTimeToOriginRelativeTime(Seconds) const;
+
     std::optional<FramesPerSecond> maximumFrameRate() const;
 
 private:

--- a/Source/WebCore/animation/DocumentTimelinesController.cpp
+++ b/Source/WebCore/animation/DocumentTimelinesController.cpp
@@ -192,10 +192,7 @@ void DocumentTimelinesController::updateAnimationsAndSendEvents(ReducedResolutio
 
     // 6. Perform a stable sort of the animation events in events to dispatch as follows.
     std::stable_sort(events.begin(), events.end(), [] (const Ref<AnimationEventBase>& lhs, const Ref<AnimationEventBase>& rhs) {
-        // 1. Sort the events by their scheduled event time such that events that were scheduled to occur earlier, sort before events scheduled to occur later
-        // and events whose scheduled event time is unresolved sort before events with a resolved scheduled event time.
-        // 2. Within events with equal scheduled event times, sort by their composite order. FIXME: Need to do this.
-        return lhs->timelineTime() < rhs->timelineTime();
+        return compareAnimationEventsByCompositeOrder(lhs.get(), rhs.get());
     });
 
     // 7. Dispatch each of the events in events to dispatch at their corresponding target using the order established in the previous step.

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -144,12 +144,14 @@ public:
     bool isSuspended() const { return m_isSuspended; }
     bool isReplaceable() const;
     void remove();
-    void enqueueAnimationPlaybackEvent(const AtomString&, std::optional<Seconds>, std::optional<Seconds>);
+    void enqueueAnimationPlaybackEvent(const AtomString&, std::optional<Seconds> currentTime, std::optional<Seconds> scheduledTime);
 
     uint64_t globalPosition() const { return m_globalPosition; }
     void setGlobalPosition(uint64_t globalPosition) { m_globalPosition = globalPosition; }
 
     virtual bool canHaveGlobalPosition() { return true; }
+
+    std::optional<Seconds> convertAnimationTimeToTimelineTime(Seconds) const;
 
     // ContextDestructionObserver.
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 enum class PseudoId : uint16_t;
 
+class AnimationEventBase;
 class Element;
 class WebAnimation;
 
@@ -53,6 +54,7 @@ inline double secondsToWebAnimationsAPITime(const Seconds time)
 const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
+bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
 String pseudoIdAsString(PseudoId);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AnimationEvent.cpp
+++ b/Source/WebCore/dom/AnimationEvent.cpp
@@ -40,8 +40,8 @@ AnimationEvent::AnimationEvent(const AtomString& type, const Init& initializer, 
 {
 }
 
-AnimationEvent::AnimationEvent(const AtomString& type, const String& animationName, double elapsedTime, const String& pseudoElement, std::optional<Seconds> timelineTime, WebAnimation* animation)
-    : AnimationEventBase(type, animation, timelineTime)
+AnimationEvent::AnimationEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& animationName, const String& pseudoElement)
+    : AnimationEventBase(type, animation)
     , m_animationName(animationName)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)

--- a/Source/WebCore/dom/AnimationEvent.h
+++ b/Source/WebCore/dom/AnimationEvent.h
@@ -32,9 +32,9 @@ namespace WebCore {
 class AnimationEvent final : public AnimationEventBase {
     WTF_MAKE_ISO_ALLOCATED(AnimationEvent);
 public:
-    static Ref<AnimationEvent> create(const AtomString& type, const String& animationName, double elapsedTime, const String& pseudoElement, std::optional<Seconds> timelineTime, WebAnimation* animation)
+    static Ref<AnimationEvent> create(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& animationName, const String& pseudoElement)
     {
-        return adoptRef(*new AnimationEvent(type, animationName, elapsedTime, pseudoElement, timelineTime, animation));
+        return adoptRef(*new AnimationEvent(type, animation, elapsedTime, animationName, pseudoElement));
     }
 
     struct Init : EventInit {
@@ -59,7 +59,7 @@ public:
     EventInterface eventInterface() const override;
 
 private:
-    AnimationEvent(const AtomString& type, const String& animationName, double elapsedTime, const String& pseudoElement, std::optional<Seconds> timelineTime, WebAnimation*);
+    AnimationEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& animationName, const String& pseudoElement);
     AnimationEvent(const AtomString&, const Init&, IsTrusted);
 
     String m_animationName;

--- a/Source/WebCore/dom/TransitionEvent.cpp
+++ b/Source/WebCore/dom/TransitionEvent.cpp
@@ -33,8 +33,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(TransitionEvent);
 
-TransitionEvent::TransitionEvent(const AtomString& type, const String& propertyName, double elapsedTime, const String& pseudoElement, std::optional<Seconds> timelineTime, WebAnimation* animation)
-    : AnimationEventBase(type, animation, timelineTime)
+TransitionEvent::TransitionEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& propertyName, const String& pseudoElement)
+    : AnimationEventBase(type, animation)
     , m_propertyName(propertyName)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)

--- a/Source/WebCore/dom/TransitionEvent.h
+++ b/Source/WebCore/dom/TransitionEvent.h
@@ -33,9 +33,9 @@ namespace WebCore {
 class TransitionEvent final : public AnimationEventBase {
     WTF_MAKE_ISO_ALLOCATED(TransitionEvent);
 public:
-    static Ref<TransitionEvent> create(const AtomString& type, const String& propertyName, double elapsedTime, const String& pseudoElement, std::optional<Seconds> timelineTime, WebAnimation* animation)
+    static Ref<TransitionEvent> create(const AtomString& type, WebAnimation* animation,  double elapsedTime, const String& propertyName, const String& pseudoElement)
     {
-        return adoptRef(*new TransitionEvent(type, propertyName, elapsedTime, pseudoElement, timelineTime, animation));
+        return adoptRef(*new TransitionEvent(type, animation, elapsedTime, propertyName, pseudoElement));
     }
 
     struct Init : EventInit {
@@ -60,7 +60,7 @@ public:
     EventInterface eventInterface() const override;
 
 private:
-    TransitionEvent(const AtomString& type, const String& propertyName, double elapsedTime, const String& pseudoElement, std::optional<Seconds> timelineTime, WebAnimation*);
+    TransitionEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& propertyName, const String& pseudoElement);
     TransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
     String m_propertyName;


### PR DESCRIPTION
#### 4623d94c854c0884e3d10484b0bcf580e6d07096
<pre>
[web-animations] web-animations/timing-model/timelines/update-and-send-events.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=191187">https://bugs.webkit.org/show_bug.cgi?id=191187</a>

Reviewed by Dean Jackson.

We implement the animation sorting behavior specified by the Web Animations spec as part of
the &quot;update animations and send events&quot; procedure.

We used to sort events by the timeline time at the point when they were created, but the spec
says to sort them by their scheduled event time which is specific to each time of Web Animations
event (AnimationPlaybackEvent): &quot;finish&quot;, &quot;cancel&quot; and &quot;remove&quot;.

Since the &quot;timeline time&quot; is only relevant to AnimationPlaybackEvent, we move it from AnimationEventBase
to that interface, and add a new scheduledTime property as well.

Then, in updateAnimationsAndSendEvents(), we now use the compareAnimationEventsByCompositeOrder()
function to sort the events. First, we sort AnimationPlaybackEvent events among themselves by their
relative &quot;scheduled event time&quot; when they don&apos;t match, and when they do by the type of animation
related to the event (CSS Transitions, then CSS Animations and finally script-originated animations).
Second, we sort TransitionEvent events and third (and last), AnimationEvent events. Those events are
always sorted to retain the order in which they were enqueued.

Finally, we refactored TransitionEvent and AnimationEvent to no longer expect a timeline time and to
set the related WebAnimation object first to match the argument order of AnimationEventBase.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events-expected.txt:
* Source/WebCore/animation/AnimationEventBase.cpp:
(WebCore::AnimationEventBase::AnimationEventBase):
* Source/WebCore/animation/AnimationEventBase.h:
(WebCore::AnimationEventBase::create):
(WebCore::AnimationEventBase::timelineTime const): Deleted.
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
(WebCore::AnimationPlaybackEvent::bindingsTimelineTime const):
* Source/WebCore/animation/AnimationPlaybackEvent.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::enqueueDOMEvent):
* Source/WebCore/animation/DeclarativeAnimation.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::removeReplacedAnimations):
(WebCore::DocumentTimeline::convertTimelineTimeToOriginRelativeTime const):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/DocumentTimelinesController.cpp:
(WebCore::DocumentTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel):
(WebCore::WebAnimation::enqueueAnimationPlaybackEvent):
(WebCore::WebAnimation::finishNotificationSteps):
(WebCore::WebAnimation::convertAnimationTimeToTimelineTime const):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareAnimationEventsByCompositeOrder):
* Source/WebCore/animation/WebAnimationUtilities.h:
* Source/WebCore/dom/AnimationEvent.cpp:
(WebCore::AnimationEvent::AnimationEvent):
* Source/WebCore/dom/AnimationEvent.h:
* Source/WebCore/dom/TransitionEvent.cpp:
(WebCore::TransitionEvent::TransitionEvent):
* Source/WebCore/dom/TransitionEvent.h:

Canonical link: <a href="https://commits.webkit.org/256771@main">https://commits.webkit.org/256771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acb5b9ba3ee6fdbbb24144642063f158a1cfbb5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/5973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106234 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166542 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6184 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34708 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102947 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4621 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83319 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31582 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74510 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/10 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/9 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21237 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4702 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2260 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40517 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->