### PR TITLE
[GTK][WPE] Fix relocation issues running the MiniBrowser or the layout tests when the path on disk changes

### DIFF
--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -70,6 +70,11 @@ class GLibPort(Port):
     def _built_libraries_path(self, *path):
         return self._build_path(*(('lib',) + path))
 
+    def _prepend_to_env_value(self, new_value, current_value):
+        if len(current_value) > 0:
+            return new_value + ":" + current_value
+        return new_value
+
     def setup_test_run(self, device_type=None):
         super(GLibPort, self).setup_test_run(device_type)
 
@@ -84,6 +89,8 @@ class GLibPort(Port):
         environment['TEST_RUNNER_INJECTED_BUNDLE_FILENAME'] = self._build_path('lib', 'libTestRunnerInjectedBundle.so')
         environment['TEST_RUNNER_TEST_PLUGIN_PATH'] = self._build_path('lib', 'plugins')
         environment['WEBKIT_EXEC_PATH'] = self._build_path('bin')
+        environment['WEBKIT_FONTS_CONF_DIR'] = self.path_from_webkit_base('Tools', 'WebKitTestRunner', 'gtk', 'fonts')
+        environment['LD_LIBRARY_PATH'] = self._prepend_to_env_value(self._build_path('lib'), environment.get('LD_LIBRAY_PATH', ''))
         self._copy_value_from_environ_if_set(environment, 'LIBGL_ALWAYS_SOFTWARE')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_OUTPUTDIR')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_JHBUILD')
@@ -128,6 +135,13 @@ class GLibPort(Port):
                 "--suppressions=%s" % (xmlfile, suppressionsfile)
 
         return environment
+
+    def setup_environ_for_minibrowser(self):
+        env = os.environ.copy()
+        env['WEBKIT_EXEC_PATH'] = self._build_path('bin')
+        env['WEBKIT_INJECTED_BUNDLE_PATH'] = self._build_path('lib')
+        env['LD_LIBRARY_PATH'] = self._prepend_to_env_value(self._build_path('lib'), env.get('LD_LIBRAY_PATH', ''))
+        return env
 
     def _get_crash_log(self, name, pid, stdout, stderr, newer_than, target_host=None):
         return GDBCrashLogGenerator(self._executive, name, pid, newer_than,

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -192,7 +192,7 @@ class GtkPort(GLibPort):
 
         if self._should_use_jhbuild():
             command = self._jhbuild_wrapper + command
-        return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False)
+        return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=self.setup_environ_for_minibrowser())
 
     @memoized
     def _is_gtk4_build(self):

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -70,10 +70,14 @@ class GtkPortTest(port_testcase.PortTestCase):
         })
         with OutputCapture(level=logging.INFO) as captured:
             port.show_results_html_file('test.html')
+            mock_command, mock_env = captured.root.log.getvalue().split(' env=')
         self.assertEqual(
-            captured.root.log.getvalue(),
-            "MOCK run_command: ['/mock-build/bin/MiniBrowser', 'file://test.html'], cwd=/mock-checkout\n",
+            mock_command,
+            "MOCK run_command: ['/mock-build/bin/MiniBrowser', 'file://test.html'], cwd=/mock-checkout,"
         )
+        # Check the environment variables defined by port.setup_environ_for_minibrowser()
+        for mb_env_var in ['LD_LIBRARY_PATH', 'WEBKIT_INJECTED_BUNDLE_PATH', 'WEBKIT_EXEC_PATH']:
+            self.assertTrue(mb_env_var in mock_env)
 
     def test_default_timeout_ms(self):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release')).default_timeout_ms(), 15000)

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -122,13 +122,11 @@ class WPEPort(GLibPort):
             return "cog"
         return "minibrowser"
 
-    def browser_env(self):
-        env = os.environ.copy()
+    def setup_environ_for_minibrowser(self):
+        env = super(WPEPort, self).setup_environ_for_minibrowser()
 
         if self.browser_name() == "cog":
-            env.update({'WEBKIT_EXEC_PATH': self._build_path('bin'),
-                        'COG_MODULEDIR': self.cog_path_to('platform'),
-                        'WEBKIT_INJECTED_BUNDLE_PATH': self._build_path('lib')})
+            env['COG_MODULEDIR'] = self.cog_path_to('platform')
 
         return env
 
@@ -143,7 +141,6 @@ class WPEPort(GLibPort):
                 miniBrowser = None
             else:
                 print("Using Cog as MiniBrowser")
-                env = self.browser_env()
                 has_platform_arg = any((a == "-P" or a.startswith("--platform=") for a in args))
                 if not has_platform_arg:
                     args.insert(0, "--platform=gtk4")
@@ -160,4 +157,4 @@ class WPEPort(GLibPort):
 
         if self._should_use_jhbuild():
             command = self._jhbuild_wrapper + command
-        return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=env)
+        return self._executive.run_command(command + args, cwd=self.webkit_base(), stdout=None, return_stderr=False, decode_output=False, env=self.setup_environ_for_minibrowser())

--- a/Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp
@@ -74,6 +74,10 @@ void initializeFontConfigSetting()
     if (g_getenv("WEBKIT_SKIP_WEBKITTESTRUNNER_FONTCONFIG_INITIALIZATION"))
         return;
 
+    const char* webkitFontsConfDir = g_getenv("WEBKIT_FONTS_CONF_DIR");
+    if (!webkitFontsConfDir)
+        webkitFontsConfDir = FONTS_CONF_DIR;
+
     FcInit();
 
     // If a test resulted a font being added or removed via the @font-face rule, then
@@ -86,7 +90,7 @@ void initializeFontConfigSetting()
     // Load our configuration file, which sets up proper aliases for family
     // names like sans, serif and monospace.
     FcConfig* config = FcConfigCreate();
-    GUniquePtr<gchar> fontConfigFilename(g_build_filename(FONTS_CONF_DIR, "fonts.conf", nullptr));
+    GUniquePtr<gchar> fontConfigFilename(g_build_filename(webkitFontsConfDir, "fonts.conf", nullptr));
     if (!g_file_test(fontConfigFilename.get(), G_FILE_TEST_IS_REGULAR))
         g_error("Cannot find fonts.conf at %s\n", fontConfigFilename.get());
     if (!FcConfigParseAndLoad(config, reinterpret_cast<FcChar8*>(fontConfigFilename.get()), true))
@@ -106,7 +110,7 @@ void initializeFontConfigSetting()
     }
 
     // Ahem is used by many layout tests.
-    GUniquePtr<gchar> ahemFontFilename(g_build_filename(FONTS_CONF_DIR, "AHEM____.TTF", nullptr));
+    GUniquePtr<gchar> ahemFontFilename(g_build_filename(webkitFontsConfDir, "AHEM____.TTF", nullptr));
     if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(ahemFontFilename.get())))
         g_error("Could not load font at %s!", ahemFontFilename.get()); 
 
@@ -124,13 +128,13 @@ void initializeFontConfigSetting()
     };
 
     for (size_t i = 0; fontFilenames[i]; ++i) {
-        GUniquePtr<gchar> fontFilename(g_build_filename(FONTS_CONF_DIR, "..", "..", "fonts", fontFilenames[i], nullptr));
+        GUniquePtr<gchar> fontFilename(g_build_filename(webkitFontsConfDir, "..", "..", "fonts", fontFilenames[i], nullptr));
         if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(fontFilename.get())))
             g_error("Could not load font at %s!", fontFilename.get()); 
     }
 
     // A font with no valid Fontconfig encoding to test https://bugs.webkit.org/show_bug.cgi?id=47452
-    GUniquePtr<gchar> fontWithNoValidEncodingFilename(g_build_filename(FONTS_CONF_DIR, "FontWithNoValidEncoding.fon", nullptr));
+    GUniquePtr<gchar> fontWithNoValidEncodingFilename(g_build_filename(webkitFontsConfDir, "FontWithNoValidEncoding.fon", nullptr));
     if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(fontWithNoValidEncodingFilename.get())))
         g_error("Could not load font at %s!", fontWithNoValidEncodingFilename.get()); 
 

--- a/Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp
@@ -81,6 +81,10 @@ void activateFonts()
     if (g_getenv("WEBKIT_SKIP_WEBKITTESTRUNNER_FONTCONFIG_INITIALIZATION"))
         return;
 
+    const char* webkitFontsConfDir = g_getenv("WEBKIT_FONTS_CONF_DIR");
+    if (!webkitFontsConfDir)
+        webkitFontsConfDir = FONTS_CONF_DIR;
+
     FcInit();
 
     // If a test resulted a font being added or removed via the @font-face rule, then
@@ -93,7 +97,7 @@ void activateFonts()
     // Load our configuration file, which sets up proper aliases for family
     // names like sans, serif and monospace.
     FcConfig* config = FcConfigCreate();
-    GUniquePtr<gchar> fontConfigFilename(g_build_filename(FONTS_CONF_DIR, "fonts.conf", nullptr));
+    GUniquePtr<gchar> fontConfigFilename(g_build_filename(webkitFontsConfDir, "fonts.conf", nullptr));
     if (!g_file_test(fontConfigFilename.get(), G_FILE_TEST_IS_REGULAR))
         g_error("Cannot find fonts.conf at %s\n", fontConfigFilename.get());
     if (!FcConfigParseAndLoad(config, reinterpret_cast<FcChar8*>(fontConfigFilename.get()), true))
@@ -113,7 +117,7 @@ void activateFonts()
     }
 
     // Ahem is used by many layout tests.
-    GUniquePtr<gchar> ahemFontFilename(g_build_filename(FONTS_CONF_DIR, "AHEM____.TTF", nullptr));
+    GUniquePtr<gchar> ahemFontFilename(g_build_filename(webkitFontsConfDir, "AHEM____.TTF", nullptr));
     if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(ahemFontFilename.get())))
         g_error("Could not load font at %s!", ahemFontFilename.get()); 
 
@@ -131,13 +135,13 @@ void activateFonts()
     };
 
     for (size_t i = 0; fontFilenames[i]; ++i) {
-        GUniquePtr<gchar> fontFilename(g_build_filename(FONTS_CONF_DIR, "..", "..", "fonts", fontFilenames[i], nullptr));
+        GUniquePtr<gchar> fontFilename(g_build_filename(webkitFontsConfDir, "..", "..", "fonts", fontFilenames[i], nullptr));
         if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(fontFilename.get())))
             g_error("Could not load font at %s!", fontFilename.get()); 
     }
 
     // A font with no valid Fontconfig encoding to test https://bugs.webkit.org/show_bug.cgi?id=47452
-    GUniquePtr<gchar> fontWithNoValidEncodingFilename(g_build_filename(FONTS_CONF_DIR, "FontWithNoValidEncoding.fon", nullptr));
+    GUniquePtr<gchar> fontWithNoValidEncodingFilename(g_build_filename(webkitFontsConfDir, "FontWithNoValidEncoding.fon", nullptr));
     if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(fontWithNoValidEncodingFilename.get())))
         g_error("Could not load font at %s!", fontWithNoValidEncodingFilename.get()); 
 


### PR DESCRIPTION
#### 79f5dfafe126501c435ea8a87fe4dc725b62e1df
<pre>
[GTK][WPE] Fix relocation issues running the MiniBrowser or the layout tests when the path on disk changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=247985">https://bugs.webkit.org/show_bug.cgi?id=247985</a>

Reviewed by Žan Doberšek.

When WebKit is built the path of the repository (where you have the checkout)
is stored in the binaries in different ways:

 - The path to the WebKit libraries is stored as an rpath on the ELF binaries
 - The CMake system also defines some constant strings to the build like WEBKIT_EXEC_PATH
   and WEBKIT_INJECTED_BUNDLE_PATH that end going into the binaries as default values.

This default values can be overriden at run-time via environment variables,
but the current tooling was not doing that.

This means that if you build WebKit in a directory and then move the directory
to a different path (without rebuilding) you are going to find errors and crashes.

This is not an issue with the flatpak build, because the flatpak build maps the
buildirectory to /app so the path doesn&apos;t really change even if you move the dir.

But this is an issue for builds not using flatpak.
Specifically I found this on a bot that I&apos;m working on, where the builder builds
on a different path than the tester (and the tester downloads the build product).

Fix the problem by passing at runtime the required paths via environment variables.

* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort._prepend_to_env_value):
(GLibPort.setup_environ_for_server):
(GLibPort.setup_environ_for_minibrowser):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.run_minibrowser):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.setup_environ_for_minibrowser):
(WPEPort.run_minibrowser):
(WPEPort.browser_env): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp:
(WTR::initializeFontConfigSetting):
* Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp:
(WTR::activateFonts):
* Tools/Scripts/webkitpy/port/gtk_unittest.py

Canonical link: <a href="https://commits.webkit.org/256795@main">https://commits.webkit.org/256795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a760809a5148ac46e9dde87cc123489151877834

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106362 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166643 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6318 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34831 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103062 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102509 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83449 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31693 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100428 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88436 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/136 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4714 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4917 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40638 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->