### PR TITLE
[iOS] PiP-then-Fullscreen results in broken controls in fullscreen mode

### DIFF
--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -411,6 +411,7 @@ void FullscreenManager::exitFullscreen()
         m_pendingExitFullscreen = false;
 
         INFO_LOG(identifier, "task - New top of fullscreen stack.");
+        m_pendingFullscreenElement = newTop;
         page->chrome().client().enterFullScreenForElement(*newTop);
     });
 }
@@ -442,7 +443,7 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
     if (m_pendingFullscreenElement != &element) {
         INFO_LOG(LOGIDENTIFIER, "Pending element mismatch; issuing exit fullscreen request");
         page()->chrome().client().exitFullScreenForElement(&element);
-        return true;
+        return false;
     }
 
     INFO_LOG(LOGIDENTIFIER);

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -87,6 +87,7 @@ WebFullScreenManager::WebFullScreenManager(WebPage* page)
     
 WebFullScreenManager::~WebFullScreenManager()
 {
+    clearElement();
 }
 
 WebCore::Element* WebFullScreenManager::element() 
@@ -140,26 +141,36 @@ bool WebFullScreenManager::supportsFullScreen(bool withKeyboard)
     return m_page->injectedBundleFullScreenClient().supportsFullScreen(m_page.get(), withKeyboard);
 }
 
-void WebFullScreenManager::setElement(WebCore::Element& element)
+static auto& eventsToObserve()
 {
-    if (m_element == &element)
-        return;
-
     static NeverDestroyed eventsToObserve = std::array {
         WebCore::eventNames().playEvent,
         WebCore::eventNames().pauseEvent,
         WebCore::eventNames().loadedmetadataEvent,
     };
+    return eventsToObserve.get();
+}
 
-    if (m_element) {
-        for (auto& eventName : eventsToObserve.get())
-            m_element->removeEventListener(eventName, *this, { true });
-    }
+void WebFullScreenManager::setElement(WebCore::Element& element)
+{
+    if (m_element == &element)
+        return;
+
+    clearElement();
 
     m_element = &element;
 
-    for (auto& eventName : eventsToObserve.get())
+    for (auto& eventName : eventsToObserve())
         m_element->addEventListener(eventName, *this, { true });
+}
+
+void WebFullScreenManager::clearElement()
+{
+    if (!m_element)
+        return;
+    for (auto& eventName : eventsToObserve())
+        m_element->removeEventListener(eventName, *this, { true });
+    m_element = nullptr;
 }
 
 void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element)
@@ -308,6 +319,7 @@ void WebFullScreenManager::didExitFullScreen()
     setFullscreenInsets(WebCore::FloatBoxExtent());
     setFullscreenAutoHideDuration(0_s);
     m_element->document().fullscreenManager().didExitFullscreen();
+    clearElement();
 }
 
 void WebFullScreenManager::setAnimatingFullScreen(bool animating)
@@ -354,6 +366,7 @@ void WebFullScreenManager::close()
 #if ENABLE(VIDEO)
     setMainVideoElement(nullptr);
 #endif
+    clearElement();
     m_closing = false;
 }
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -107,6 +107,7 @@ private:
     void handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event&) final;
 
     void setElement(WebCore::Element&);
+    void clearElement();
 
 #if ENABLE(VIDEO)
     void scheduleTextRecognitionForMainVideo();


### PR DESCRIPTION
#### 82b82f5d1af64357162fe4aa2c0ed7954f440dcd
<pre>
[iOS] PiP-then-Fullscreen results in broken controls in fullscreen mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=247991">https://bugs.webkit.org/show_bug.cgi?id=247991</a>
rdar://100442052

Reviewed by Eric Carlson.

WebFullScreenManager&apos;s m_element ivar is never cleared, which means the next time a video plays
within a page, the WebFullScreenManager thinks its still in fullscreen, and the playing element
is marked as the PIPStandbyElement. This causes the element&apos;s own m_videoFullscreenStandby ivar
to be set to true, and when that element is taken into fullscreen, it&apos;s fullscreen controls are
explicitly hidden.

No test was included because TestWebKitAPI is not allowed to enter fullscreen or PiP as its not
a &quot;real&quot; application.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::supportsFullScreen):
(WebKit::eventsToObserve):
(WebKit::WebFullScreenManager::setElement):
(WebKit::WebFullScreenManager::clearElement):

Canonical link: <a href="https://commits.webkit.org/256812@main">https://commits.webkit.org/256812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84ceaa81dc9d72830f0d3b3e922bac4ec3e87b30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106383 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166667 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6339 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34851 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89239 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103083 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102529 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83469 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31710 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74656 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/155 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21363 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4720 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4935 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40660 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->