### PR TITLE
Fix TypeError in parameter destructuring in async function should be a rejected promise

### DIFF
--- a/JSTests/stress/catch-rest-parameter.js
+++ b/JSTests/stress/catch-rest-parameter.js
@@ -1,0 +1,188 @@
+function assert(b) {
+    if (!b)
+        throw "bad assert!";
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`
+            bad error:      ${String(error)}
+            expected error: ${errorMessage}
+        `);
+}
+
+let expected = "TypeError: undefined is not an object (evaluating '[[]]')";
+
+// AsyncFunction
+(() => {
+    async function f(...[[]]) { }
+    let isExpected = false;
+    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    async function f([[]]) { }
+    let isExpected = false;
+    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    async function f(a, ...[[]]) { }
+    let isExpected = false;
+    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    var a = 1, b = 2, c = 3;
+    async function f(arg0, ...args) {
+        a = arg0;
+        b = args[0];
+        c = args[1];
+    }
+    let isExpected = true;
+    f(4, 5, 6).then(e => isExpected = true).catch(e => isExpected = false);
+    drainMicrotasks();
+    assert(isExpected && a === 4 && b === 5 && c === 6);
+})();
+
+
+// AsyncArrowFunction
+(() => {
+    let f = async (...[[]]) => { };
+    let isExpected = false;
+    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    let f = async ([[]]) => { };
+    let isExpected = false;
+    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    let f = async (a, ...[[]]) => { };
+    let isExpected = false;
+    f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    var a = 1, b = 2, c = 3;
+    let f = async (arg0, ...args) => {
+        a = arg0;
+        b = args[0];
+        c = args[1];
+    };
+    let isExpected = true;
+    f(4, 5, 6).then(e => isExpected = true).catch(e => isExpected = false);
+    drainMicrotasks();
+    assert(isExpected && a === 4 && b === 5 && c === 6);
+})();
+
+
+// AsyncMethod
+(() => {
+    class x { static async f(...[[]]) { } }
+    let isExpected = false;
+    x.f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    class x { static async f([[]]) { } }
+    let isExpected = false;
+    x.f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    class x { static async f(a, ...[[]]) { } }
+    let isExpected = false;
+    x.f().then(e => isExpected = false).catch(e => isExpected = e == expected);
+    drainMicrotasks();
+    assert(isExpected);
+})();
+
+(() => {
+    var a = 1, b = 2, c = 3;
+    class x {
+        static async f(arg0, ...args) {
+            a = arg0;
+            b = args[0];
+            c = args[1];
+        }
+    }
+    let isExpected = true;
+    x.f(4, 5, 6).then(e => isExpected = true).catch(e => isExpected = false);
+    drainMicrotasks();
+    assert(isExpected && a === 4 && b === 5 && c === 6);
+})();
+
+// AsyncGenerator
+shouldThrow(async function* f([[]]) { }, expected);
+shouldThrow(async function* f(...[[]]) { }, expected);
+shouldThrow(async function* f(a, ...[[]]) { }, expected);
+(() => {
+    var a = 1, b = 2, c = 3;
+    async function* f(arg0, ...args) {
+        a = arg0;
+        b = args[0];
+        c = args[1];
+    }
+    f(4, 5, 6);
+    drainMicrotasks();
+    assert(a === 1 && b === 2 && c === 3);
+})();
+
+// Generator
+shouldThrow(function* f([[]]) { }, expected);
+shouldThrow(function* f(...[[]]) { }, expected);
+shouldThrow(function* f(a, ...[[]]) { }, expected);
+(() => {
+    var a = 1, b = 2, c = 3;
+    function* f(arg0, ...args) {
+        a = arg0;
+        b = args[0];
+        c = args[1];
+    }
+    f(4, 5, 6);
+    assert(a === 1 && b === 2 && c === 3);
+})();
+
+// Function
+shouldThrow(function f([[]]) { }, expected);
+shouldThrow(function f(...[[]]) { }, expected);
+shouldThrow(function f(a, ...[[]]) { }, expected);
+(() => {
+    var a = 1, b = 2, c = 3;
+    function f(arg0, ...args) {
+        a = arg0;
+        b = args[0];
+        c = args[1];
+    }
+    f(4, 5, 6);
+    assert(a === 4 && b === 5 && c === 6);
+})();

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1290,7 +1290,16 @@ namespace JSC {
         Vector<std::pair<FunctionMetadataNode*, FunctionVariableType>> m_functionsToInitialize;
         bool m_needToInitializeArguments { false };
         RestParameterNode* m_restParameter { nullptr };
-        
+
+        struct AsyncFuncParametersTryCatchInfo {
+            RefPtr<Label> catchStartLabel { nullptr };
+            RefPtr<RegisterID> thrownValue { nullptr };
+        }; 
+        std::optional<AsyncFuncParametersTryCatchInfo> m_asyncFuncParametersTryCatchInfo;
+
+        template<typename EmitBytecodeFunctor>
+        void asyncFuncParametersTryCatchWrap(const EmitBytecodeFunctor&);
+
         Vector<TryRange> m_tryRanges;
         SegmentedVector<TryData, 8> m_tryData;
 


### PR DESCRIPTION
#### 29265f95211bfd7902bcd648b87a863509a3c50f
<pre>
Fix TypeError in parameter destructuring in async function should be a rejected promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=247785">https://bugs.webkit.org/show_bug.cgi?id=247785</a>
rdar://102325201

Reviewed by Yusuke Suzuki.

Rest parameter should be caught in async function. So, running this
JavaScript program should print &quot;caught&quot;.
```
async function f(...[[]]) { }
f().catch(e =&gt; print(&quot;caught&quot;));
```

V8 (used console.log)
```
$ node input.js
caught
```

GraalJS
```
$ js input.js
caught
```

<a href="https://tc39.es/ecma262/#sec-async-function-definitions">https://tc39.es/ecma262/#sec-async-function-definitions</a>
...
AsyncFunctionDeclaration[Yield, Await, Default] :
    async [no LineTerminator here] function BindingIdentifier[?Yield, ?Await] ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
    [+Default] async [no LineTerminator here] function ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }

AsyncFunctionExpression :
    async [no LineTerminator here] function BindingIdentifier[~Yield, +Await]opt ( FormalParameters[~Yield, +Await] ) { AsyncFunctionBody }
...

According to the spec, it indicates `FormalParameters` is used for Async
Function, where `FormalParameters` can be converted to `FunctionRestParameter`.

<a href="https://tc39.es/ecma262/#sec-parameter-lists">https://tc39.es/ecma262/#sec-parameter-lists</a>
...
FormalParameters[Yield, Await] :
    [empty]
    FunctionRestParameter[?Yield, ?Await]
    FormalParameterList[?Yield, ?Await]
    FormalParameterList[?Yield, ?Await] ,
    FormalParameterList[?Yield, ?Await] , FunctionRestParameter[?Yield, ?Await]
...

And based on RS: EvaluateAsyncFunctionBody, it will invoke the promise.reject
callback function with abrupt value ([[value]] of non-normal completion record).

<a href="https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncfunctionbody">https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncfunctionbody</a>
...
2. Let declResult be Completion(FunctionDeclarationInstantiation(functionObject, argumentsList)).
3. If declResult is an abrupt completion, then
    a. Perform ! Call(promiseCapability.[[Reject]], undefined, « declResult.[[Value]] »).
...

In that case, any non-normal results of evaluating rest parameters should be
caught and passed to the reject callback function.

To resolve this problem, we should allow the emitted RestParameterNode be wrapped
by the catch handler for promise. However, we should remove `m_restParameter` and
emit rest parameter byte code in `initializeDefaultParameterValuesAndSetupFunctionScopeStack`
if we can prove that change has no side effect. In that case, we can only use one
exception handler.

Current fix is to add another exception handler. And move the handler byte codes to
the bottom of code block in order to make other byte codes as much compact as possible.

Input:
```
async function f(arg0, ...[[]]) { }
f();
```

Dumped Byte Codes:
```
...

bb#2
Predecessors: [ #1 ]
[  20] mov                dst:loc9, src:&lt;JSValue()&gt;(const0)
...

bb#3
Predecessors: [ #2 ]
[  29] get_rest_length    dst:loc11, numParametersToSkip:1
...

bb#12
Predecessors: [ #8 #9 #10 ]
[ 138] new_func_exp       dst:loc10, scope:loc4, functionDecl:0
...

bb#13
Predecessors: [ ]
[ 170] catch              exception:loc10, thrownValue:loc8
[ 174] jmp                targetLabel:8(-&gt;182)
Successors: [ #15 ]

bb#14
Predecessors: [ #7 #11 ]
[ 176] catch              exception:loc10, thrownValue:loc8
[ 180] jmp                targetLabel:2(-&gt;182)
Successors: [ #15 ]

bb#15
Predecessors: [ #13 #14 ]
[ 182] mov                dst:loc12, src:Undefined(const1)
...

Exception Handlers:
         1: { start: [  20] end: [  29] target: [ 170] } synthesized catch
         2: { start: [  29] end: [ 138] target: [ 176] } synthesized catch
```

* JSTests/stress/catch-rest-parameter.js: Added.
(throwError):
(shouldThrow):
(async f):
(throwError.async f):
(throwError.async let):
(async let):
(x.async f):
(x):
(async shouldThrow):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
(JSC::BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeStack):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:

Canonical link: <a href="https://commits.webkit.org/256864@main">https://commits.webkit.org/256864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4f28e72fa5123b35133c73dc4b3c557661c665

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106555 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6530 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35031 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103249 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102703 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83647 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31916 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87964 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/333 "Hash fa4f28e7 for PR 6561 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83408 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28427 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5107 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86108 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40832 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19401 "Passed tests") | 
<!--EWS-Status-Bubble-End-->