### PR TITLE
[ iOS16 ] fast/events/ios/rotation/orientationchange-event-listener-on.body.html is a almost constant failure

### DIFF
--- a/LayoutTests/fast/events/ios/rotation/orientationchange-event-listener-on.body-expected.txt
+++ b/LayoutTests/fast/events/ios/rotation/orientationchange-event-listener-on.body-expected.txt
@@ -3,9 +3,8 @@ Tests the behavior of the resize / orientationchange event listeners on both the
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-Before rotation
-After rotation
-PASS eventListenerCalls is 4
+Triggering rotation...
+PASS gotAllEvents() became true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/events/ios/rotation/orientationchange-event-listener-on.body.html
+++ b/LayoutTests/fast/events/ios/rotation/orientationchange-event-listener-on.body.html
@@ -24,44 +24,48 @@
 
         function doTest()
         {
-            debug('Before rotation');
             if (!window.testRunner)
                 return;
 
-            testRunner.runUIScript(getRotationUIScript(), function(result) {
-                debug('After rotation');
-                shouldBe("eventListenerCalls", "4");
-                finishJSTest();
-            });
+            debug("Triggering rotation...");
+            testRunner.runUIScript(getRotationUIScript(), function(result) { });
+            shouldBecomeEqual("gotAllEvents()", "true", finishJSTest);
         }
 
-        eventListenerCalls = 0;
+        didFireResizeEventOnWindow = false;
+        didFireResizeEventOnBody = false;
+        didFireOrientationChangeEventOnWindow = false;
+        didFireOrientationChangeEventOnBody = false;
+
+        function gotAllEvents()
+        {
+            return didFireResizeEventOnWindow && didFireResizeEventOnBody && didFireOrientationChangeEventOnWindow && didFireOrientationChangeEventOnBody;
+        }
+
         window.addEventListener('resize', function() {
-            ++eventListenerCalls;
+            didFireResizeEventOnWindow = true;
         }, false);
 
         window.addEventListener('orientationchange', function() {
-            ++eventListenerCalls;
+            didFireOrientationChangeEventOnWindow = true;
         }, false);
 
         document.body.addEventListener('resize', function() {
             testFailed("In body's resize event listener");
-            ++eventListenerCalls;
         }, false);
 
         document.body.addEventListener('orientationchange', function() {
             testFailed("In body's orientationchange event listener");
-            ++eventListenerCalls;
         }, false);
 
         function bodyOrientationChange()
         {
-            ++eventListenerCalls;
+            didFireOrientationChangeEventOnBody = true;
         }
 
         function bodyResize()
         {
-            ++eventListenerCalls;
+            didFireResizeEventOnBody = true;
         }
 
         window.addEventListener('load', doTest, false);

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2124,7 +2124,6 @@ webkit.org/b/231619 editing/pasteboard/dom-paste/dom-paste-consecutive-confirmat
 webkit.org/b/231619 [ Debug ] editing/pasteboard/dom-paste/dom-paste-rejection.html [ Pass Timeout ]
 webkit.org/b/231619 editing/pasteboard/dom-paste/dom-paste-requires-user-gesture.html [ Pass Failure Timeout ]
 
-webkit.org/b/245691 fast/events/ios/rotation/orientationchange-event-listener-on.body.html [ Pass Timeout Failure ]
 webkit.org/b/231622 fast/events/ios/rotation/do-not-shrink-to-fit-content-after-rotation.html [ Pass Timeout ]
 
 webkit.org/b/231623 [ Debug ] fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html [ Pass Timeout ]


### PR DESCRIPTION
#### 42f515d614d6b6cab6ae378079d0ddcc53c22fbf
<pre>
[ iOS16 ] fast/events/ios/rotation/orientationchange-event-listener-on.body.html is a almost constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=245691">https://bugs.webkit.org/show_bug.cgi?id=245691</a>
rdar://100424168

Reviewed by Wenson Hsieh.

The point of the test is to make sure that both the body and window event listeners get called for the
orientationchange and the resize events. The number of events doesn&apos;t really matter, we just need to
make sure they all get called at least once.

Update the test accordingly to address the flakiness.

* LayoutTests/fast/events/ios/rotation/orientationchange-event-listener-on.body-expected.txt:
* LayoutTests/fast/events/ios/rotation/orientationchange-event-listener-on.body.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/256788@main">https://commits.webkit.org/256788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fc2a24595714d8a31ccfa12d750cbbf3bdec481

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106276 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166574 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6228 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34748 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102984 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4656 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83364 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/51 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/47 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21267 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4832 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2270 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40550 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->