### PR TITLE
[JSC] WeakMap / WeakSet constructor should accept symbols

### DIFF
--- a/JSTests/stress/weak-map-constructor-symbol.js
+++ b/JSTests/stress/weak-map-constructor-symbol.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function test() {
+    var symbol = Symbol("Hello");
+    var map = new WeakMap([
+        [ symbol, 42 ]
+    ]);
+    shouldBe(map.get(symbol), 42);
+    shouldThrow(() => {
+        var registered = Symbol.for("Hello");
+        new WeakMap([ [ registered, 42 ] ]);
+    }, `TypeError: WeakMap keys must be objects or non-registered symbols`);
+}
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/JSTests/stress/weak-set-constructor-symbol.js
+++ b/JSTests/stress/weak-set-constructor-symbol.js
@@ -1,0 +1,34 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function test() {
+    var symbol = Symbol("Hello");
+    var set = new WeakSet([
+        symbol
+    ]);
+    shouldBe(set.has(symbol), true);
+    shouldThrow(() => {
+        var registered = Symbol.for("Hello");
+        new WeakSet([ registered ]);
+    }, `TypeError: WeakSet values must be objects or non-registered symbols`);
+}
+
+for (var i = 0; i < 1e4; ++i)
+    test();

--- a/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapConstructor.cpp
@@ -96,10 +96,11 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakMap, (JSGlobalObject* globalObject, CallFr
         RETURN_IF_EXCEPTION(scope, void());
 
         if (canPerformFastSet) {
-            if (key.isObject())
-                weakMap->set(vm, asObject(key), value);
-            else
+            if (UNLIKELY(!canBeHeldWeakly(key))) {
                 throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakMapInvalidKeyError);
+                return;
+            }
+            weakMap->set(vm, key.asCell(), value);
             return;
         }
 

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -114,7 +114,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapSet, (JSGlobalObject* globalObject, Cal
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
     if (UNLIKELY(!canBeHeldWeakly(key)))
-        return JSValue::encode(throwTypeError(globalObject, scope, WeakMapInvalidKeyError));
+        return throwVMTypeError(globalObject, scope, WeakMapInvalidKeyError);
     map->set(vm, key.asCell(), callFrame->argument(1));
     return JSValue::encode(callFrame->thisValue());
 }

--- a/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetConstructor.cpp
@@ -83,10 +83,11 @@ JSC_DEFINE_HOST_FUNCTION(constructWeakSet, (JSGlobalObject* globalObject, CallFr
     scope.release();
     forEachInIterable(globalObject, iterable, [&](VM&, JSGlobalObject* globalObject, JSValue nextValue) {
         if (canPerformFastAdd) {
-            if (nextValue.isObject())
-                weakSet->add(vm, asObject(nextValue));
-            else
+            if (UNLIKELY(!canBeHeldWeakly(nextValue))) {
                 throwTypeError(asObject(adderFunction)->globalObject(), scope, WeakSetInvalidValueError);
+                return;
+            }
+            weakSet->add(vm, nextValue.asCell());
             return;
         }
 

--- a/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakSetPrototype.cpp
@@ -103,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakSetAdd, (JSGlobalObject* globalObject, Cal
         return JSValue::encode(jsUndefined());
     JSValue key = callFrame->argument(0);
     if (UNLIKELY(!canBeHeldWeakly(key)))
-        return JSValue::encode(throwTypeError(globalObject, scope, WeakSetInvalidValueError));
+        return throwVMTypeError(globalObject, scope, WeakSetInvalidValueError);
     set->add(vm, key.asCell());
     return JSValue::encode(callFrame->thisValue());
 }


### PR DESCRIPTION
#### dd4f45d5e334782e7e809d3a28be5d1f04bd2f5a
<pre>
[JSC] WeakMap / WeakSet constructor should accept symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=247997">https://bugs.webkit.org/show_bug.cgi?id=247997</a>
rdar://102440538

Reviewed by Alexey Shvayka.

This patch fixes missing handling of symbols in WeakMap / WeakSet constructors.

* JSTests/stress/weak-map-constructor-symbol.js: Added.
(shouldBe):
(shouldThrow):
* JSTests/stress/weak-set-constructor-symbol.js: Added.
(shouldBe):
(shouldThrow):
(test.set shouldThrow):
* Source/JavaScriptCore/runtime/WeakMapConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/WeakSetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/256758@main">https://commits.webkit.org/256758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/220a8c1f45a313e7ff85be70727d970aa02bb700

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106289 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6239 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34759 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/102994 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102436 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83375 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87707 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/63 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83148 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/56 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28369 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4844 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85830 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2253 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40561 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19346 "Passed tests") | 
<!--EWS-Status-Bubble-End-->