### PR TITLE
[WebIDL] Make maplike<> and setlike<> generated methods enumerable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt
@@ -65,7 +65,11 @@ PASS FontFaceSet interface object name
 PASS FontFaceSet interface: existence and properties of interface prototype object
 PASS FontFaceSet interface: existence and properties of interface prototype object's "constructor" property
 PASS FontFaceSet interface: existence and properties of interface prototype object's @@unscopables property
-FAIL FontFaceSet interface: setlike<FontFace> assert_equals: entries enumerable expected false but got true
+FAIL FontFaceSet interface: setlike<FontFace> assert_equals: @@iterator should equal values expected function "function values() {
+    [native code]
+}" but got function "function entries() {
+    [native code]
+}"
 PASS FontFaceSet interface: operation add(FontFace)
 PASS FontFaceSet interface: operation delete(FontFace)
 PASS FontFaceSet interface: operation clear()

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
@@ -1,0 +1,30 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial namespace CSS: original namespace defined
+PASS Partial namespace CSS: member names are unique
+PASS Highlight interface: existence and properties of interface object
+FAIL Highlight interface object length assert_equals: wrong value for Highlight.length expected 0 but got 1
+PASS Highlight interface object name
+PASS Highlight interface: existence and properties of interface prototype object
+PASS Highlight interface: existence and properties of interface prototype object's "constructor" property
+PASS Highlight interface: existence and properties of interface prototype object's @@unscopables property
+PASS Highlight interface: setlike<AbstractRange>
+FAIL Highlight interface: attribute priority assert_true: The prototype object must have a property "priority" expected true got false
+FAIL Highlight interface: attribute type assert_true: The prototype object must have a property "type" expected true got false
+FAIL Highlight must be primary interface of new Highlight(new Range()) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
+FAIL Stringification of new Highlight(new Range()) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
+FAIL Highlight interface: new Highlight(new Range()) must inherit property "priority" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
+FAIL Highlight interface: new Highlight(new Range()) must inherit property "type" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
+FAIL HighlightRegistry interface: existence and properties of interface object assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL HighlightRegistry interface object length assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL HighlightRegistry interface object name assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL HighlightRegistry interface: existence and properties of interface prototype object assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL HighlightRegistry interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL HighlightRegistry interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL HighlightRegistry interface: maplike<DOMString, Highlight> undefined is not an object (evaluating 'this.get_interface_object().prototype')
+FAIL HighlightRegistry must be primary interface of CSS.highlights assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
+FAIL Stringification of CSS.highlights assert_class_string: class string of CSS.highlights expected "[object HighlightRegistry]" but got "[object HighlightRegister]"
+PASS CSS namespace: operation escape(CSSOMString)
+PASS CSS namespace: attribute highlights
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.js
@@ -1,0 +1,17 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://drafts.csswg.org/css-highlight-api-1/
+
+'use strict';
+
+idl_test(
+  ['css-highlight-api'],
+  ['cssom'],
+  idl_array => {
+    idl_array.add_objects({
+      Highlight: ['new Highlight(new Range())'],
+      HighlightRegistry: ['CSS.highlights'],
+    });
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/idlharness.window-expected.txt
@@ -1854,9 +1854,6 @@ PASS XPathNSResolver interface: existence and properties of interface prototype 
 PASS XPathNSResolver interface: existence and properties of interface prototype object's "constructor" property
 PASS XPathNSResolver interface: existence and properties of interface prototype object's @@unscopables property
 PASS XPathNSResolver interface: operation lookupNamespaceURI(DOMString?)
-PASS Stringification of document.createNSResolver(document.body)
-PASS XPathNSResolver interface: document.createNSResolver(document.body) must inherit property "lookupNamespaceURI(DOMString?)" with the proper type
-PASS XPathNSResolver interface: calling lookupNamespaceURI(DOMString?) on document.createNSResolver(document.body) with too few arguments must throw TypeError
 PASS XPathEvaluator interface: existence and properties of interface object
 PASS XPathEvaluator interface object length
 PASS XPathEvaluator interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/idlharness.https.any-expected.txt
@@ -39,7 +39,7 @@ PASS FileSystemDirectoryHandle interface object name
 PASS FileSystemDirectoryHandle interface: existence and properties of interface prototype object
 PASS FileSystemDirectoryHandle interface: existence and properties of interface prototype object's "constructor" property
 PASS FileSystemDirectoryHandle interface: existence and properties of interface prototype object's @@unscopables property
-FAIL FileSystemDirectoryHandle interface: async iterable<USVString, FileSystemHandle> undefined is not an object (evaluating 'iteratorDesc.writable')
+FAIL FileSystemDirectoryHandle interface: async iterable<USVString, FileSystemHandle> undefined is not an object (evaluating 'iteratorDesc.enumerable')
 PASS FileSystemDirectoryHandle interface: operation getFileHandle(USVString, optional FileSystemGetFileOptions)
 PASS FileSystemDirectoryHandle interface: operation getDirectoryHandle(USVString, optional FileSystemGetDirectoryOptions)
 PASS FileSystemDirectoryHandle interface: operation removeEntry(USVString, optional FileSystemRemoveOptions)

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/idlharness.https.any.worker-expected.txt
@@ -39,7 +39,7 @@ PASS FileSystemDirectoryHandle interface object name
 PASS FileSystemDirectoryHandle interface: existence and properties of interface prototype object
 PASS FileSystemDirectoryHandle interface: existence and properties of interface prototype object's "constructor" property
 PASS FileSystemDirectoryHandle interface: existence and properties of interface prototype object's @@unscopables property
-FAIL FileSystemDirectoryHandle interface: async iterable<USVString, FileSystemHandle> undefined is not an object (evaluating 'iteratorDesc.writable')
+FAIL FileSystemDirectoryHandle interface: async iterable<USVString, FileSystemHandle> undefined is not an object (evaluating 'iteratorDesc.enumerable')
 PASS FileSystemDirectoryHandle interface: operation getFileHandle(USVString, optional FileSystemGetFileOptions)
 PASS FileSystemDirectoryHandle interface: operation getDirectoryHandle(USVString, optional FileSystemGetDirectoryOptions)
 PASS FileSystemDirectoryHandle interface: operation removeEntry(USVString, optional FileSystemRemoveOptions)

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-highlight-api.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-highlight-api.idl
@@ -3,11 +3,18 @@
 // (https://github.com/w3c/webref)
 // Source: CSS Custom Highlight API Module Level 1 (https://drafts.csswg.org/css-highlight-api-1/)
 
+enum HighlightType {
+  "highlight",
+  "spelling-error",
+  "grammar-error"
+};
+
 [Exposed=Window]
 interface Highlight {
   constructor(AbstractRange... initialRanges);
   setlike<AbstractRange>;
   attribute long priority;
+  attribute HighlightType type;
 };
 
 partial namespace CSS {

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js
@@ -2433,44 +2433,6 @@ IdlInterface.prototype.test_to_json_operation = function(desc, memberHolderObjec
     }
 };
 
-IdlInterface.prototype.test_member_iterable = function(member)
-{
-    subsetTestByKey(this.name, test, function()
-    {
-        var isPairIterator = member.idlType.length === 2;
-        var proto = this.get_interface_object().prototype;
-        var iteratorDesc = Object.getOwnPropertyDescriptor(proto, Symbol.iterator);
-
-        assert_true(iteratorDesc.writable, "@@iterator property should be writable");
-        assert_true(iteratorDesc.configurable, "@@iterator property should be configurable");
-        assert_false(iteratorDesc.enumerable, "@@iterator property should not be enumerable");
-        assert_equals(typeof iteratorDesc.value, "function", "@@iterator property should be a function");
-        assert_equals(iteratorDesc.value.length, 0, "@@iterator function object length should be 0");
-        assert_equals(iteratorDesc.value.name, isPairIterator ? "entries" : "values", "@@iterator function object should have the right name");
-
-        if (isPairIterator) {
-            assert_equals(proto["entries"], proto[Symbol.iterator], "entries method should be the same as @@iterator method");
-            [
-                ["entries", 0],
-                ["keys", 0],
-                ["values", 0],
-                ["forEach", 1]
-            ].forEach(([property, length]) => {
-                var desc = Object.getOwnPropertyDescriptor(proto, property);
-                assert_equals(typeof desc.value, "function", property + " property should be a function");
-                assert_equals(desc.value.length, length, property + " function object should have the right length");
-                assert_equals(desc.value.name, property, property + " function object should have the right name");
-            });
-        } else {
-            assert_equals(proto[Symbol.iterator], Array.prototype[Symbol.iterator], "@@iterator method should be the same as Array prototype's");
-            ["entries", "keys", "values", "forEach", Symbol.iterator].forEach(property => {
-                var propertyName = property === Symbol.iterator ? "@@iterator" : property;
-                assert_equals(proto[property], Array.prototype[property], propertyName + " method should be the same as Array prototype's");
-            });
-        }
-    }.bind(this), this.name + " interface: iterable<" + member.idlType.map(function(t) { return t.idlType; }).join(", ") + ">");
-};
-
 IdlInterface.prototype.test_member_maplike = function(member) {
     subsetTestByKey(this.name, test, () => {
         const proto = this.get_interface_object().prototype;
@@ -2487,14 +2449,14 @@ IdlInterface.prototype.test_member_maplike = function(member) {
             methods.push(
                 ["set", 2],
                 ["delete", 1],
-                ["clear", 1]
+                ["clear", 0]
             );
         }
 
         for (const [name, length] of methods) {
             const desc = Object.getOwnPropertyDescriptor(proto, name);
             assert_equals(typeof desc.value, "function", `${name} should be a function`);
-            assert_equals(desc.enumerable, false, `${name} enumerable`);
+            assert_equals(desc.enumerable, true, `${name} enumerable`);
             assert_equals(desc.configurable, true, `${name} configurable`);
             assert_equals(desc.writable, true, `${name} writable`);
             assert_equals(desc.value.length, length, `${name} function object length should be ${length}`);
@@ -2510,10 +2472,10 @@ IdlInterface.prototype.test_member_maplike = function(member) {
         const sizeDesc = Object.getOwnPropertyDescriptor(proto, "size");
         assert_equals(typeof sizeDesc.get, "function", `size getter should be a function`);
         assert_equals(sizeDesc.set, undefined, `size should not have a setter`);
-        assert_equals(sizeDesc.enumerable, false, `size enumerable`);
+        assert_equals(sizeDesc.enumerable, true, `size enumerable`);
         assert_equals(sizeDesc.configurable, true, `size configurable`);
-        assert_equals(sizeDesc.get.length, 0, `size getter length should have the right length`);
-        assert_equals(sizeDesc.get.name, "get size", `size getter have the right name`);
+        assert_equals(sizeDesc.get.length, 0, `size getter length`);
+        assert_equals(sizeDesc.get.name, "get size", `size getter name`);
     }, `${this.name} interface: maplike<${member.idlType.map(t => t.idlType).join(", ")}>`);
 };
 
@@ -2532,14 +2494,14 @@ IdlInterface.prototype.test_member_setlike = function(member) {
             methods.push(
                 ["add", 1],
                 ["delete", 1],
-                ["clear", 1]
+                ["clear", 0]
             );
         }
 
         for (const [name, length] of methods) {
             const desc = Object.getOwnPropertyDescriptor(proto, name);
             assert_equals(typeof desc.value, "function", `${name} should be a function`);
-            assert_equals(desc.enumerable, false, `${name} enumerable`);
+            assert_equals(desc.enumerable, true, `${name} enumerable`);
             assert_equals(desc.configurable, true, `${name} configurable`);
             assert_equals(desc.writable, true, `${name} writable`);
             assert_equals(desc.value.length, length, `${name} function object length should be ${length}`);
@@ -2555,42 +2517,92 @@ IdlInterface.prototype.test_member_setlike = function(member) {
         const sizeDesc = Object.getOwnPropertyDescriptor(proto, "size");
         assert_equals(typeof sizeDesc.get, "function", `size getter should be a function`);
         assert_equals(sizeDesc.set, undefined, `size should not have a setter`);
-        assert_equals(sizeDesc.enumerable, false, `size enumerable`);
+        assert_equals(sizeDesc.enumerable, true, `size enumerable`);
         assert_equals(sizeDesc.configurable, true, `size configurable`);
-        assert_equals(sizeDesc.get.length, 0, `size getter length should have the right length`);
-        assert_equals(sizeDesc.get.name, "size", `size getter have the right name`);
+        assert_equals(sizeDesc.get.length, 0, `size getter length`);
+        assert_equals(sizeDesc.get.name, "get size", `size getter name`);
     }, `${this.name} interface: setlike<${member.idlType.map(t => t.idlType).join(", ")}>`);
 };
 
-IdlInterface.prototype.test_member_async_iterable = function(member)
-{
-    subsetTestByKey(this.name, test, function()
-    {
-        var isPairIterator = member.idlType.length === 2;
-        var proto = this.get_interface_object().prototype;
-        var iteratorDesc = Object.getOwnPropertyDescriptor(proto, Symbol.asyncIterator);
+IdlInterface.prototype.test_member_iterable = function(member) {
+    subsetTestByKey(this.name, test, () => {
+        const isPairIterator = member.idlType.length === 2;
+        const proto = this.get_interface_object().prototype;
 
-        assert_true(iteratorDesc.writable, "@@asyncIterator property should be writable");
-        assert_true(iteratorDesc.configurable, "@@asyncIterator property should be configurable");
-        assert_false(iteratorDesc.enumerable, "@@asyncIterator property should not be enumerable");
-        assert_equals(typeof iteratorDesc.value, "function", "@@asyncIterator property should be a function");
-        assert_equals(iteratorDesc.value.length, 0, "@@asyncIterator function object length should be 0");
-        assert_equals(iteratorDesc.value.name, isPairIterator ? "entries" : "values", "@@asyncIterator function object should have the right name");
+        const methods = [
+            ["entries", 0],
+            ["keys", 0],
+            ["values", 0],
+            ["forEach", 1]
+        ];
+
+        for (const [name, length] of methods) {
+            const desc = Object.getOwnPropertyDescriptor(proto, name);
+            assert_equals(typeof desc.value, "function", `${name} should be a function`);
+            assert_equals(desc.enumerable, true, `${name} enumerable`);
+            assert_equals(desc.configurable, true, `${name} configurable`);
+            assert_equals(desc.writable, true, `${name} writable`);
+            assert_equals(desc.value.length, length, `${name} function object length should be ${length}`);
+            assert_equals(desc.value.name, name, `${name} function object should have the right name`);
+
+            if (!isPairIterator) {
+                assert_equals(desc.value, Array.prototype[name], `${name} equality with Array.prototype version`);
+            }
+        }
+
+        const iteratorDesc = Object.getOwnPropertyDescriptor(proto, Symbol.iterator);
+        assert_equals(iteratorDesc.enumerable, false, `@@iterator enumerable`);
+        assert_equals(iteratorDesc.configurable, true, `@@iterator configurable`);
+        assert_equals(iteratorDesc.writable, true, `@@iterator writable`);
 
         if (isPairIterator) {
-            assert_equals(proto["entries"], proto[Symbol.asyncIterator], "entries method should be the same as @@asyncIterator method");
-            ["entries", "keys", "values"].forEach(property => {
-                var desc = Object.getOwnPropertyDescriptor(proto, property);
-                assert_equals(typeof desc.value, "function", property + " property should be a function");
-                assert_equals(desc.value.length, 0, property + " function object length should be 0");
-                assert_equals(desc.value.name, property, property + " function object should have the right name");
-            });
+            assert_equals(iteratorDesc.value, proto.entries, `@@iterator equality with entries`);
         } else {
-            assert_equals(proto["values"], proto[Symbol.asyncIterator], "values method should be the same as @@asyncIterator method");
-            assert_false("entries" in proto, "should not have an entries method");
-            assert_false("keys" in proto, "should not have a keys method");
+            assert_equals(iteratorDesc.value, Array.prototype[Symbol.iterator], `@@iterator equality with Array.prototype version`);
         }
-    }.bind(this), this.name + " interface: async iterable<" + member.idlType.map(function(t) { return t.idlType; }).join(", ") + ">");
+    }, `${this.name} interface: iterable<${member.idlType.map(t => t.idlType).join(", ")}>`);
+};
+
+IdlInterface.prototype.test_member_async_iterable = function(member) {
+    subsetTestByKey(this.name, test, () => {
+        const isPairIterator = member.idlType.length === 2;
+        const proto = this.get_interface_object().prototype;
+
+        // Note that although the spec allows arguments, which will be passed to the @@asyncIterator
+        // method (which is either values or entries), those arguments must always be optional. So
+        // length of 0 is still correct for values and entries.
+        const methods = [
+            ["values", 0],
+        ];
+
+        if (isPairIterator) {
+            methods.push(
+                ["entries", 0],
+                ["keys", 0]
+            );
+        }
+
+        for (const [name, length] of methods) {
+            const desc = Object.getOwnPropertyDescriptor(proto, name);
+            assert_equals(typeof desc.value, "function", `${name} should be a function`);
+            assert_equals(desc.enumerable, true, `${name} enumerable`);
+            assert_equals(desc.configurable, true, `${name} configurable`);
+            assert_equals(desc.writable, true, `${name} writable`);
+            assert_equals(desc.value.length, length, `${name} function object length should be ${length}`);
+            assert_equals(desc.value.name, name, `${name} function object should have the right name`);
+        }
+
+        const iteratorDesc = Object.getOwnPropertyDescriptor(proto, Symbol.asyncIterator);
+        assert_equals(iteratorDesc.enumerable, false, `@@iterator enumerable`);
+        assert_equals(iteratorDesc.configurable, true, `@@iterator configurable`);
+        assert_equals(iteratorDesc.writable, true, `@@iterator writable`);
+
+        if (isPairIterator) {
+            assert_equals(iteratorDesc.value, proto.entries, `@@iterator equality with entries`);
+        } else {
+            assert_equals(iteratorDesc.value, proto.values, `@@iterator equality with values`);
+        }
+    }, `${this.name} interface: async iterable<${member.idlType.map(t => t.idlType).join(", ")}>`);
 };
 
 IdlInterface.prototype.test_member_stringifier = function(member)
@@ -2751,21 +2763,26 @@ IdlInterface.prototype.test_object = function(desc)
         expected_typeof = "object";
     }
 
-    this.test_primary_interface_of(desc, obj, exception, expected_typeof);
+    if (this.is_callback()) {
+        assert_equals(exception, null, "Unexpected exception when evaluating object");
+        assert_equals(typeof obj, expected_typeof, "wrong typeof object");
+    } else {
+        this.test_primary_interface_of(desc, obj, exception, expected_typeof);
 
-    var current_interface = this;
-    while (current_interface)
-    {
-        if (!(current_interface.name in this.array.members))
+        var current_interface = this;
+        while (current_interface)
         {
-            throw new IdlHarnessError("Interface " + current_interface.name + " not found (inherited by " + this.name + ")");
+            if (!(current_interface.name in this.array.members))
+            {
+                throw new IdlHarnessError("Interface " + current_interface.name + " not found (inherited by " + this.name + ")");
+            }
+            if (current_interface.prevent_multiple_testing && current_interface.already_tested)
+            {
+                return;
+            }
+            current_interface.test_interface_of(desc, obj, exception, expected_typeof);
+            current_interface = this.array.members[current_interface.base];
         }
-        if (current_interface.prevent_multiple_testing && current_interface.already_tested)
-        {
-            return;
-        }
-        current_interface.test_interface_of(desc, obj, exception, expected_typeof);
-        current_interface = this.array.members[current_interface.base];
     }
 };
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt
@@ -15,7 +15,7 @@ FAIL ReadableStream interface: operation getReader(optional ReadableStreamGetRea
 FAIL ReadableStream interface: operation pipeThrough(ReadableWritablePair, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
 FAIL ReadableStream interface: operation pipeTo(WritableStream, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
 FAIL ReadableStream interface: operation tee() assert_true: property should be enumerable expected true got false
-FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'iteratorDesc.writable')
+FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'desc.value')
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt
@@ -15,7 +15,7 @@ FAIL ReadableStream interface: operation getReader(optional ReadableStreamGetRea
 FAIL ReadableStream interface: operation pipeThrough(ReadableWritablePair, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
 FAIL ReadableStream interface: operation pipeTo(WritableStream, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
 FAIL ReadableStream interface: operation tee() assert_true: property should be enumerable expected true got false
-FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'iteratorDesc.writable')
+FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'desc.value')
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt
@@ -15,7 +15,7 @@ FAIL ReadableStream interface: operation getReader(optional ReadableStreamGetRea
 FAIL ReadableStream interface: operation pipeThrough(ReadableWritablePair, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
 FAIL ReadableStream interface: operation pipeTo(WritableStream, optional StreamPipeOptions) assert_true: property should be enumerable expected true got false
 FAIL ReadableStream interface: operation tee() assert_true: property should be enumerable expected true got false
-FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'iteratorDesc.writable')
+FAIL ReadableStream interface: async iterable<any> undefined is not an object (evaluating 'desc.value')
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/webaudio/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webaudio/idlharness.https.window-expected.txt
@@ -1093,7 +1093,7 @@ PASS AudioParamMap interface object name
 PASS AudioParamMap interface: existence and properties of interface prototype object
 PASS AudioParamMap interface: existence and properties of interface prototype object's "constructor" property
 PASS AudioParamMap interface: existence and properties of interface prototype object's @@unscopables property
-FAIL AudioParamMap interface: maplike<DOMString, AudioParam> assert_equals: forEach enumerable expected false but got true
+PASS AudioParamMap interface: maplike<DOMString, AudioParam>
 PASS AudioParamMap must be primary interface of worklet_node.parameters
 PASS Stringification of worklet_node.parameters
 PASS AudioWorkletNode interface: existence and properties of interface object

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
@@ -480,7 +480,7 @@ PASS RTCStatsReport interface object name
 PASS RTCStatsReport interface: existence and properties of interface prototype object
 PASS RTCStatsReport interface: existence and properties of interface prototype object's "constructor" property
 PASS RTCStatsReport interface: existence and properties of interface prototype object's @@unscopables property
-FAIL RTCStatsReport interface: maplike<DOMString, object> assert_equals: forEach enumerable expected false but got true
+PASS RTCStatsReport interface: maplike<DOMString, object>
 PASS RTCError interface: existence and properties of interface object
 PASS RTCError interface object length
 PASS RTCError interface object name

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt
@@ -71,7 +71,11 @@ PASS FontFaceSet interface object name
 PASS FontFaceSet interface: existence and properties of interface prototype object
 PASS FontFaceSet interface: existence and properties of interface prototype object's "constructor" property
 PASS FontFaceSet interface: existence and properties of interface prototype object's @@unscopables property
-FAIL FontFaceSet interface: setlike<FontFace> assert_equals: entries enumerable expected false but got true
+FAIL FontFaceSet interface: setlike<FontFace> assert_equals: @@iterator should equal values expected function "function values() {
+    [native code]
+}" but got function "function entries() {
+    [native code]
+}"
 PASS FontFaceSet interface: operation add(FontFace)
 PASS FontFaceSet interface: operation delete(FontFace)
 PASS FontFaceSet interface: operation clear()

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -235,7 +235,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
     $sizeAttribute->isReadOnly(1);
     $sizeAttribute->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($sizeAttribute->extendedAttributes, $interface->mapLike->extendedAttributes);
-    $sizeAttribute->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->attributes}, $sizeAttribute);
 
     # https://webidl.spec.whatwg.org/#es-map-get-has
@@ -247,7 +246,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
     push(@{$getOperation->arguments}, ($getArgument));
     $getOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($getOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-    $getOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $getOperation);
 
     my $hasOperation = IDLOperation->new();
@@ -258,7 +256,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
     push(@{$hasOperation->arguments}, ($hasArgument));
     $hasOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($hasOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-    $hasOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $hasOperation);
 
     # https://webidl.spec.whatwg.org/#es-map-entries
@@ -266,7 +263,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
     $entriesOperation->name("entries");
     $entriesOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($entriesOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-    $entriesOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $entriesOperation);
 
     # https://webidl.spec.whatwg.org/#es-map-keys-values
@@ -274,14 +270,12 @@ sub AddMapLikeAttributesAndOperationIfNeeded
     $keysOperation->name("keys");
     $keysOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($keysOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-    $keysOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $keysOperation);
 
     my $valuesOperation = IDLOperation->new();
     $valuesOperation->name("values");
     $valuesOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($valuesOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-    $valuesOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $valuesOperation);
 
     # https://webidl.spec.whatwg.org/#es-forEach
@@ -311,7 +305,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
         push(@{$setOperation->arguments}, ($setValueArgument));
         $setOperation->type(IDLParser::makeSimpleType("any"));
         IDLParser::copyExtendedAttributes($setOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-        $setOperation->extendedAttributes->{NotEnumerable} = 1;
         push(@{$interface->operations}, $setOperation);
     }
 
@@ -321,7 +314,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
         $clearOperation->name("clear");
         $clearOperation->type(IDLParser::makeSimpleType("any"));
         IDLParser::copyExtendedAttributes($clearOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-        $clearOperation->extendedAttributes->{NotEnumerable} = 1;
         push(@{$interface->operations}, $clearOperation);
     }
 
@@ -335,7 +327,6 @@ sub AddMapLikeAttributesAndOperationIfNeeded
         push(@{$deleteOperation->arguments}, ($deleteArgument));
         $deleteOperation->type(IDLParser::makeSimpleType("any"));
         IDLParser::copyExtendedAttributes($deleteOperation->extendedAttributes, $interface->mapLike->extendedAttributes);
-        $deleteOperation->extendedAttributes->{NotEnumerable} = 1;
         push(@{$interface->operations}, $deleteOperation);
     }
 }
@@ -354,7 +345,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
     $sizeAttribute->isReadOnly(1);
     $sizeAttribute->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($sizeAttribute->extendedAttributes, $interface->setLike->extendedAttributes);
-    $sizeAttribute->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->attributes}, $sizeAttribute);
 
     # https://webidl.spec.whatwg.org/#es-set-has
@@ -366,7 +356,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
     push(@{$hasOperation->arguments}, ($hasArgument));
     $hasOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($hasOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-    $hasOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $hasOperation);
 
     # https://webidl.spec.whatwg.org/#es-set-entries-keys
@@ -374,14 +363,12 @@ sub AddSetLikeAttributesAndOperationIfNeeded
     $entriesOperation->name("entries");
     $entriesOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($entriesOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-    $entriesOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $entriesOperation);
 
     my $keysOperation = IDLOperation->new();
     $keysOperation->name("keys");
     $keysOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($keysOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-    $keysOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $keysOperation);
 
     # https://webidl.spec.whatwg.org/#es-set-values
@@ -389,7 +376,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
     $valuesOperation->name("values");
     $valuesOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($valuesOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-    $valuesOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $valuesOperation);
 
     # https://webidl.spec.whatwg.org/#es-forEach
@@ -401,7 +387,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
     push(@{$forEachOperation->arguments}, ($forEachArgument));
     $forEachOperation->type(IDLParser::makeSimpleType("any"));
     IDLParser::copyExtendedAttributes($forEachOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-    $forEachOperation->extendedAttributes->{NotEnumerable} = 1;
     push(@{$interface->operations}, $forEachOperation);
 
     return if $interface->setLike->isReadOnly;
@@ -416,7 +401,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
         push(@{$addOperation->arguments}, ($addArgument));
         $addOperation->type(IDLParser::makeSimpleType("any"));
         IDLParser::copyExtendedAttributes($addOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-        $addOperation->extendedAttributes->{NotEnumerable} = 1;
         push(@{$interface->operations}, $addOperation);
     }
 
@@ -426,7 +410,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
         $clearOperation->name("clear");
         $clearOperation->type(IDLParser::makeSimpleType("any"));
         IDLParser::copyExtendedAttributes($clearOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-        $clearOperation->extendedAttributes->{NotEnumerable} = 1;
         push(@{$interface->operations}, $clearOperation);
     }
 
@@ -439,7 +422,6 @@ sub AddSetLikeAttributesAndOperationIfNeeded
         push(@{$deleteOperation->arguments}, ($deleteArgument));
         $deleteOperation->type(IDLParser::makeSimpleType("any"));
         IDLParser::copyExtendedAttributes($deleteOperation->extendedAttributes, $interface->setLike->extendedAttributes);
-        $deleteOperation->extendedAttributes->{NotEnumerable} = 1;
         push(@{$interface->operations}, $deleteOperation);
     }
 }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
@@ -124,16 +124,16 @@ template<> void JSTestMapLikeDOMConstructor::initializeProperties(VM& vm, JSDOMG
 static const HashTableValue JSTestMapLikePrototypeTableValues[] =
 {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLikeConstructor, 0 } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLike_size, 0 } },
-    { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_get, 1 } },
-    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_has, 1 } },
-    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_entries, 0 } },
-    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_keys, 0 } },
-    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_values, 0 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLike_size, 0 } },
+    { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_get, 1 } },
+    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_has, 1 } },
+    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_entries, 0 } },
+    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_keys, 0 } },
+    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_values, 0 } },
     { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_forEach, 1 } },
-    { "set"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_set, 2 } },
-    { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_clear, 0 } },
-    { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_delete, 1 } },
+    { "set"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_set, 2 } },
+    { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_clear, 0 } },
+    { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikePrototypeFunction_delete, 1 } },
 };
 
 const ClassInfo JSTestMapLikePrototype::s_info = { "TestMapLike"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTestMapLikePrototype) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
@@ -129,15 +129,15 @@ static const HashTableValue JSTestMapLikeWithOverriddenOperationsPrototypeTableV
 {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLikeWithOverriddenOperationsConstructor, 0 } },
     { "set"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLikeWithOverriddenOperations_set, setJSTestMapLikeWithOverriddenOperations_set } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLikeWithOverriddenOperations_size, 0 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestMapLikeWithOverriddenOperations_size, 0 } },
     { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_clear, 0 } },
-    { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_get, 1 } },
-    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_has, 1 } },
-    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_entries, 0 } },
-    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_keys, 0 } },
-    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_values, 0 } },
+    { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_get, 1 } },
+    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_has, 1 } },
+    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_entries, 0 } },
+    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_keys, 0 } },
+    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_values, 0 } },
     { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_forEach, 1 } },
-    { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_delete, 1 } },
+    { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestMapLikeWithOverriddenOperationsPrototypeFunction_delete, 1 } },
 };
 
 const ClassInfo JSTestMapLikeWithOverriddenOperationsPrototype::s_info = { "TestMapLikeWithOverriddenOperations"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTestMapLikeWithOverriddenOperationsPrototype) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
@@ -121,12 +121,12 @@ template<> void JSTestReadOnlyMapLikeDOMConstructor::initializeProperties(VM& vm
 static const HashTableValue JSTestReadOnlyMapLikePrototypeTableValues[] =
 {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestReadOnlyMapLikeConstructor, 0 } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestReadOnlyMapLike_size, 0 } },
-    { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_get, 1 } },
-    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_has, 1 } },
-    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_entries, 0 } },
-    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_keys, 0 } },
-    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_values, 0 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestReadOnlyMapLike_size, 0 } },
+    { "get"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_get, 1 } },
+    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_has, 1 } },
+    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_entries, 0 } },
+    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_keys, 0 } },
+    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_values, 0 } },
     { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlyMapLikePrototypeFunction_forEach, 1 } },
 };
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
@@ -120,12 +120,12 @@ template<> void JSTestReadOnlySetLikeDOMConstructor::initializeProperties(VM& vm
 static const HashTableValue JSTestReadOnlySetLikePrototypeTableValues[] =
 {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestReadOnlySetLikeConstructor, 0 } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestReadOnlySetLike_size, 0 } },
-    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_has, 1 } },
-    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_entries, 0 } },
-    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_keys, 0 } },
-    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_values, 0 } },
-    { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_forEach, 1 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestReadOnlySetLike_size, 0 } },
+    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_has, 1 } },
+    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_entries, 0 } },
+    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_keys, 0 } },
+    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_values, 0 } },
+    { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestReadOnlySetLikePrototypeFunction_forEach, 1 } },
 };
 
 const ClassInfo JSTestReadOnlySetLikePrototype::s_info = { "TestReadOnlySetLike"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTestReadOnlySetLikePrototype) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
@@ -123,15 +123,15 @@ template<> void JSTestSetLikeDOMConstructor::initializeProperties(VM& vm, JSDOMG
 static const HashTableValue JSTestSetLikePrototypeTableValues[] =
 {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLikeConstructor, 0 } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLike_size, 0 } },
-    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_has, 1 } },
-    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_entries, 0 } },
-    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_keys, 0 } },
-    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_values, 0 } },
-    { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_forEach, 1 } },
-    { "add"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_add, 1 } },
-    { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_clear, 0 } },
-    { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_delete, 1 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLike_size, 0 } },
+    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_has, 1 } },
+    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_entries, 0 } },
+    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_keys, 0 } },
+    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_values, 0 } },
+    { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_forEach, 1 } },
+    { "add"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_add, 1 } },
+    { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_clear, 0 } },
+    { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikePrototypeFunction_delete, 1 } },
 };
 
 const ClassInfo JSTestSetLikePrototype::s_info = { "TestSetLike"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTestSetLikePrototype) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
@@ -128,14 +128,14 @@ static const HashTableValue JSTestSetLikeWithOverriddenOperationsPrototypeTableV
 {
     { "constructor"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLikeWithOverriddenOperationsConstructor, 0 } },
     { "add"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLikeWithOverriddenOperations_add, setJSTestSetLikeWithOverriddenOperations_add } },
-    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLikeWithOverriddenOperations_size, 0 } },
+    { "size"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestSetLikeWithOverriddenOperations_size, 0 } },
     { "delete"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_delete, 0 } },
-    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_has, 1 } },
-    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_entries, 0 } },
-    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_keys, 0 } },
-    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_values, 0 } },
-    { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_forEach, 1 } },
-    { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_clear, 0 } },
+    { "has"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_has, 1 } },
+    { "entries"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_entries, 0 } },
+    { "keys"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_keys, 0 } },
+    { "values"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_values, 0 } },
+    { "forEach"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_forEach, 1 } },
+    { "clear"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestSetLikeWithOverriddenOperationsPrototypeFunction_clear, 0 } },
 };
 
 const ClassInfo JSTestSetLikeWithOverriddenOperationsPrototype::s_info = { "TestSetLikeWithOverriddenOperations"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSTestSetLikeWithOverriddenOperationsPrototype) };


### PR DESCRIPTION
#### 559702ad5ccdf4dc7db8ddf877b01c6197ca8d7f
<pre>
[WebIDL] Make maplike&lt;&gt; and setlike&lt;&gt; generated methods enumerable
<a href="https://bugs.webkit.org/show_bug.cgi?id=245771">https://bugs.webkit.org/show_bug.cgi?id=245771</a>
&lt;rdar://100798576&gt;

Reviewed by Sam Weinig and Yusuke Suzuki.

This change makes maplike&lt;&gt; and setlike&lt;&gt; generated method enumerable per latest spec change [1],
aligning WebKit with Blink and Gecko.

Since the methods are being tested via wpt/resources/idlharness.js, it was synced along with
a few other changes, causing some expectations to be adjusted.

Also, syncs CSS Custom Highlight API&apos;s idlharness.js test to ensure that setlike&lt;&gt; declarations
are tested as well.

[1] <a href="https://github.com/whatwg/webidl/pull/1166">https://github.com/whatwg/webidl/pull/1166</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt:
HighlightRegistry&apos;s maplike&lt;DOMString, Highlight&gt; tests are failing because the interface was renamed in the spec, but not yet in our codebase.

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window.js: Sync from upstream, commit 2ecf81b0ea0b6c45035038d8d381c6d2962d2347.
* LayoutTests/imported/w3c/web-platform-tests/interfaces/css-highlight-api.idl: Sync from upstream, commit 11ec24d28e86b8809d7f17833b7306bb5c8401ec.
* LayoutTests/imported/w3c/web-platform-tests/resources/idlharness.js: Sync from upstream, commit 56ec9beaab4ecd393f99d256a2ac2a4e66a09f9c.
* LayoutTests/imported/w3c/web-platform-tests/*-expected.txt: Adjust expectations.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-font-loading/idlharness.https-expected.txt: Adjust expectations.
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(AddMapLikeAttributesAndOperationIfNeeded):
(AddSetLikeAttributesAndOperationIfNeeded):
* Source/WebCore/bindings/scripts/test/JS/*: Updated.

Canonical link: <a href="https://commits.webkit.org/256838@main">https://commits.webkit.org/256838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/615f2ef63250c360dfe85f3bb5aa9eb6cd824c50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106494 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6457 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34965 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103194 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102638 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83581 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74762 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/save-multiple-filters (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/267 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/253 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5044 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2300 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40773 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->