### PR TITLE
Clean up LayerProperties a little

### DIFF
--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -237,7 +237,7 @@ public:
     virtual float cornerRadius() const = 0;
     virtual void setCornerRadius(float) = 0;
 
-    virtual void setEdgeAntialiasingMask(unsigned) = 0;
+    virtual void setAntialiasesEdges(bool) = 0;
     
     // Only used by LayerTypeShapeLayer.
     virtual FloatRoundedRect shapeRoundedRect() const = 0;

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -754,7 +754,7 @@ Ref<PlatformCALayer> TileController::createTileLayer(const IntRect& tileRect, Ti
     layer->setPosition(tileRect.location());
     layer->setBorderColor(m_tileDebugBorderColor);
     layer->setBorderWidth(m_tileDebugBorderWidth);
-    layer->setEdgeAntialiasingMask(0);
+    layer->setAntialiasesEdges(false);
     layer->setOpaque(m_tilesAreOpaque);
     layer->setName(makeString("tile at ", tileRect.location().x(), ',', tileRect.location().y()));
     layer->setContentsScale(m_deviceScaleFactor * temporaryScaleFactor);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -157,7 +157,7 @@ public:
     float cornerRadius() const override;
     void setCornerRadius(float) override;
 
-    void setEdgeAntialiasingMask(unsigned) override;
+    void setAntialiasesEdges(bool) override;
 
     FloatRoundedRect shapeRoundedRect() const override;
     void setShapeRoundedRect(const FloatRoundedRect&) override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -940,10 +940,10 @@ void PlatformCALayerCocoa::setCornerRadius(float value)
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void PlatformCALayerCocoa::setEdgeAntialiasingMask(unsigned mask)
+void PlatformCALayerCocoa::setAntialiasesEdges(bool antialiases)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    [m_layer setEdgeAntialiasingMask:mask];
+    [m_layer setEdgeAntialiasingMask:antialiases ? (kCALayerLeftEdge | kCALayerRightEdge | kCALayerBottomEdge | kCALayerTopEdge) : 0];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCALayerWin.cpp
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCALayerWin.cpp
@@ -621,9 +621,9 @@ void PlatformCALayerWin::setTimeOffset(CFTimeInterval value)
     setNeedsCommit();
 }
 
-void PlatformCALayerWin::setEdgeAntialiasingMask(unsigned mask)
+void PlatformCALayerWin::setAntialiasesEdges(bool antialiasesEdges)
 {
-    CACFLayerSetEdgeAntialiasingMask(m_layer.get(), mask);
+    CACFLayerSetEdgeAntialiasingMask(m_layer.get(), antialiasesEdges ? (kCACFLayerLeftEdge | kCACFLayerRightEdge | kCACFLayerBottomEdge | kCACFLayerTopEdge) : 0);
     setNeedsCommit();
 }
 

--- a/Source/WebCore/platform/graphics/ca/win/PlatformCALayerWin.h
+++ b/Source/WebCore/platform/graphics/ca/win/PlatformCALayerWin.h
@@ -150,7 +150,7 @@ public:
     WindRule shapeWindRule() const override;
     void setShapeWindRule(WindRule) override;
 
-    void setEdgeAntialiasingMask(unsigned) override;
+    void setAntialiasesEdges(bool) override;
 
     GraphicsLayer::CustomAppearance customAppearance() const override { return m_customAppearance; }
     void updateCustomAppearance(GraphicsLayer::CustomAppearance customAppearance) override { m_customAppearance = customAppearance; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -264,8 +264,8 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & RemoteLayerTreeTransaction::AnimationsChanged)
         PlatformCAAnimationRemote::updateLayerAnimations(layer, layerTreeHost, properties.addedAnimations, properties.keyPathsOfAnimationsToRemove);
 
-    if (properties.changedProperties & RemoteLayerTreeTransaction::EdgeAntialiasingMaskChanged)
-        layer.edgeAntialiasingMask = properties.edgeAntialiasingMask;
+    if (properties.changedProperties & RemoteLayerTreeTransaction::AntialiasesEdgesChanged)
+        layer.edgeAntialiasingMask = properties.antialiasesEdges ? (kCALayerLeftEdge | kCALayerRightEdge | kCALayerBottomEdge | kCALayerTopEdge) : 0;
 
     if (properties.changedProperties & RemoteLayerTreeTransaction::CustomAppearanceChanged)
         updateCustomAppearance(layer, properties.customAppearance);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -93,7 +93,7 @@ public:
         BackingStoreAttachmentChanged       = 1LLU << 32,
         FiltersChanged                      = 1LLU << 33,
         AnimationsChanged                   = 1LLU << 34,
-        EdgeAntialiasingMaskChanged         = 1LLU << 35,
+        AntialiasesEdgesChanged             = 1LLU << 35,
         CustomAppearanceChanged             = 1LLU << 36,
         UserInteractionEnabledChanged       = 1LLU << 37,
         EventRegionChanged                  = 1LLU << 38,
@@ -157,42 +157,42 @@ public:
         HashSet<String> keyPathsOfAnimationsToRemove;
 
         WebCore::FloatPoint3D position;
-        WebCore::FloatPoint3D anchorPoint;
+        WebCore::FloatPoint3D anchorPoint { 0.5, 0.5, 0 };
         WebCore::FloatRect bounds;
-        WebCore::FloatRect contentsRect;
+        WebCore::FloatRect contentsRect { 0, 0, 1, 1 };
         std::unique_ptr<RemoteLayerBackingStore> backingStore;
         std::unique_ptr<WebCore::FilterOperations> filters;
         WebCore::Path shapePath;
-        WebCore::GraphicsLayer::PlatformLayerID maskLayerID;
-        WebCore::GraphicsLayer::PlatformLayerID clonedLayerID;
-        double timeOffset;
-        float speed;
-        float contentsScale;
-        float cornerRadius;
-        float borderWidth;
-        float opacity;
-        WebCore::Color backgroundColor;
-        WebCore::Color borderColor;
-        unsigned edgeAntialiasingMask;
-        WebCore::GraphicsLayer::CustomAppearance customAppearance;
-        WebCore::PlatformCALayer::FilterType minificationFilter;
-        WebCore::PlatformCALayer::FilterType magnificationFilter;
-        WebCore::BlendMode blendMode;
-        WebCore::WindRule windRule;
-        bool hidden;
-        bool backingStoreAttached;
-        bool geometryFlipped;
-        bool doubleSided;
-        bool masksToBounds;
-        bool opaque;
-        bool contentsHidden;
-        bool userInteractionEnabled;
+        WebCore::GraphicsLayer::PlatformLayerID maskLayerID { 0 };
+        WebCore::GraphicsLayer::PlatformLayerID clonedLayerID { 0 };
+        double timeOffset { 0 };
+        float speed { 1 };
+        float contentsScale { 1 };
+        float cornerRadius { 0 };
+        float borderWidth { 0 };
+        float opacity { 1 };
+        WebCore::Color backgroundColor { WebCore::Color::transparentBlack };
+        WebCore::Color borderColor { WebCore::Color::black };
+        WebCore::GraphicsLayer::CustomAppearance customAppearance { WebCore::GraphicsLayer::CustomAppearance::None };
+        WebCore::PlatformCALayer::FilterType minificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
+        WebCore::PlatformCALayer::FilterType magnificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
+        WebCore::BlendMode blendMode { WebCore::BlendMode::Normal };
+        WebCore::WindRule windRule { WebCore::WindRule::NonZero };
+        bool antialiasesEdges { true };
+        bool hidden { false };
+        bool backingStoreAttached { true };
+        bool geometryFlipped { false };
+        bool doubleSided { false };
+        bool masksToBounds { false };
+        bool opaque { false };
+        bool contentsHidden { false };
+        bool userInteractionEnabled { true };
         WebCore::EventRegion eventRegion;
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-        bool isSeparated;
+        bool isSeparated { false };
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-        bool isSeparatedPortal;
-        bool isDescendentOfSeparatedPortal;
+        bool isSeparatedPortal { false };
+        bool isDescendentOfSeparatedPortal { false };
 #endif
 #endif
     };
@@ -397,7 +397,7 @@ template<> struct EnumTraits<WebKit::RemoteLayerTreeTransaction::LayerChange> {
         WebKit::RemoteLayerTreeTransaction::LayerChange::BackingStoreAttachmentChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::FiltersChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::AnimationsChanged,
-        WebKit::RemoteLayerTreeTransaction::LayerChange::EdgeAntialiasingMaskChanged,
+        WebKit::RemoteLayerTreeTransaction::LayerChange::AntialiasesEdgesChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::CustomAppearanceChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::UserInteractionEnabledChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::EventRegionChanged

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -841,10 +841,13 @@ void PlatformCALayerRemote::setCornerRadius(float value)
     m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::CornerRadiusChanged);
 }
 
-void PlatformCALayerRemote::setEdgeAntialiasingMask(unsigned value)
+void PlatformCALayerRemote::setAntialiasesEdges(bool antialiases)
 {
-    m_properties.edgeAntialiasingMask = value;
-    m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::EdgeAntialiasingMaskChanged);
+    if (antialiases == m_properties.antialiasesEdges)
+        return;
+
+    m_properties.antialiasesEdges = antialiases;
+    m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::AntialiasesEdgesChanged);
 }
 
 FloatRoundedRect PlatformCALayerRemote::shapeRoundedRect() const

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -162,7 +162,7 @@ public:
     float cornerRadius() const override;
     void setCornerRadius(float) override;
 
-    void setEdgeAntialiasingMask(unsigned) override;
+    void setAntialiasesEdges(bool) override;
 
     // FIXME: Having both shapeRoundedRect and shapePath is redundant. We could use shapePath for everything.
     WebCore::FloatRoundedRect shapeRoundedRect() const override;


### PR DESCRIPTION
#### 606c220f2c38d31cecf182702426567e81209415
<pre>
Clean up LayerProperties a little
<a href="https://bugs.webkit.org/show_bug.cgi?id=248021">https://bugs.webkit.org/show_bug.cgi?id=248021</a>
rdar://102450702

Reviewed by Tim Horton.

Convert RemoteLayerTreeTransaction::LayerProperties to use C++ initializers.

edgeAntialiasingMask was initialized with a CALayer enum. We only ever set
the values for all edges, so convert this to a bool, and use the CA enum
when we actually touch CALayer.

Order `antialiasesEdges` with the other bools.

* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/TileController.cpp:
(WebCore::TileController::createTileLayer):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::setAntialiasesEdges):
(WebCore::PlatformCALayerCocoa::setEdgeAntialiasingMask): Deleted.
* Source/WebCore/platform/graphics/ca/win/PlatformCALayerWin.cpp:
(PlatformCALayerWin::setAntialiasesEdges):
(PlatformCALayerWin::setEdgeAntialiasingMask): Deleted.
* Source/WebCore/platform/graphics/ca/win/PlatformCALayerWin.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode):
(WebKit::dumpChangedLayers):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::setAntialiasesEdges):
(WebKit::PlatformCALayerRemote::setEdgeAntialiasingMask): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:

Canonical link: <a href="https://commits.webkit.org/256815@main">https://commits.webkit.org/256815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be1c813759f4c575de3d5e3fae9ba8a595df032

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106405 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166692 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6363 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34875 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103105 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102550 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83492 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31793 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88476 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/178 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/165 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4721 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4957 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40680 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->