### PR TITLE
[web-animations] web-animations/interfaces/KeyframeEffect/getKeyframes.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/getKeyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/getKeyframes-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL getKeyframes() should serialize its css values with a on keyframe sequence which requires value serilaization of its values assert_equals: value for 'backgroundColor' on ComputedKeyframe #0 expected "rgb(1, 2, 3)" but got "rgb(1,2,3)"
+PASS getKeyframes() should serialize its css values with a on keyframe sequence which requires value serilaization of its values
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -626,7 +626,14 @@ auto KeyframeEffect::getKeyframes(Document& document) -> Vector<ComputedKeyframe
 
     if (!m_parsedKeyframes.isEmpty() || m_blendingKeyframesSource == BlendingKeyframesSource::WebAnimation || !m_blendingKeyframes.containsAnimatableProperty()) {
         for (size_t i = 0; i < m_parsedKeyframes.size(); ++i) {
-            ComputedKeyframe computedKeyframe { m_parsedKeyframes[i] };
+            auto& parsedKeyframe = m_parsedKeyframes[i];
+            ComputedKeyframe computedKeyframe { parsedKeyframe };
+            for (auto& [cssPropertyId, stringValue] : computedKeyframe.styleStrings) {
+                if (cssPropertyId == CSSPropertyCustom)
+                    continue;
+                if (auto cssValue = parsedKeyframe.style->getPropertyCSSValue(cssPropertyId))
+                    stringValue = cssValue->cssText();
+            }
             computedKeyframe.easing = timingFunctionForKeyframeAtIndex(i)->cssText();
             computedKeyframes.append(WTFMove(computedKeyframe));
         }


### PR DESCRIPTION
#### 47042b3dade14b3c2ae99642888fba679ae33995
<pre>
[web-animations] web-animations/interfaces/KeyframeEffect/getKeyframes.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=248028">https://bugs.webkit.org/show_bug.cgi?id=248028</a>

Reviewed by Antti Koivisto.

In the case of script-originated keyframe effects, calling getKeyframes() simply uses the style strings
as they were provided via the API, so those values have not been parsed yet. However, the ParsedKeyframe
we create the ComputedKeyframe from has those parsed values stored via a MutableStyleProperties member,
so we can just replace the string values with the parsed ones.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/getKeyframes-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):

Canonical link: <a href="https://commits.webkit.org/256781@main">https://commits.webkit.org/256781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/736d332e9bd37d00e18666c5e3ef4940be4fad9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106351 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166634 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6307 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34821 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89208 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103052 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102499 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83437 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31681 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88428 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/125 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21332 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2264 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40630 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->