### PR TITLE
[BuildStream] Allow additional rsync arguments and update FDO junction

### DIFF
--- a/Tools/buildstream/Makefile
+++ b/Tools/buildstream/Makefile
@@ -19,6 +19,7 @@ EXPORT_ARGS ?=
 
 RSYNC_HOST ?= software.igalia.com
 RSYNC_REMOTE_DIR ?= /var/www/software/webkit-sdk-repo
+RSYNC_ARGS ?=
 
 FLATPAK_RUNTIMES_REPO = $(CACHEDIR)/flatpak-runtimes-repo
 FLATPAK_PLATFORM_EXTENSIONS_REPO = $(CACHEDIR)/flatpak-platform-extensions-repo
@@ -118,10 +119,10 @@ CLEAN-$(FLATPAK_PLATFORM_EXTENSIONS_REPO):
 clean: CLEAN-$(FLATPAK_PLATFORM_EXTENSIONS_REPO)
 
 pull-repo:
-	./ostree-releng-scripts/rsync-repos --rsync-opts="-vz" --src ${RSYNC_HOST}:${RSYNC_REMOTE_DIR}/ --dest ${REPO}
+	./ostree-releng-scripts/rsync-repos --rsync-opts="-vz ${RSYNC_ARGS}" --src ${RSYNC_HOST}:${RSYNC_REMOTE_DIR}/ --dest ${REPO}
 
 push-repo:
-	./ostree-releng-scripts/rsync-repos --rsync-opts="-vz" --src ${REPO}/ --dest ${RSYNC_HOST}:${RSYNC_REMOTE_DIR}
+	./ostree-releng-scripts/rsync-repos --rsync-opts="-vz ${RSYNC_ARGS}" --src ${REPO}/ --dest ${RSYNC_HOST}:${RSYNC_REMOTE_DIR}
 
 dry-push-repo:
-	./ostree-releng-scripts/rsync-repos --rsync-opts="-vzn" --src ${REPO}/ --dest ${RSYNC_HOST}:${RSYNC_REMOTE_DIR}
+	./ostree-releng-scripts/rsync-repos --rsync-opts="-vzn ${RSYNC_ARGS}" --src ${REPO}/ --dest ${RSYNC_HOST}:${RSYNC_REMOTE_DIR}

--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -3,7 +3,7 @@ sources:
 - kind: git_tag
   url: gitlab_com:freedesktop-sdk/freedesktop-sdk.git
   track: 'release/22.08'
-  ref: freedesktop-sdk-22.08.2.1-168-g9b732aab03152bc450e206c630d9dfd187c318c3
+  ref: freedesktop-sdk-22.08.3-64-g754b0e0c6dc0e648a0f09fb5773612339555352f
 - kind: patch
   path: patches/fdo-0001-pipewire-base-Disable-AEC-module.patch
 config:


### PR DESCRIPTION
#### 45874415bcd0f00ab782391981b5d583b10cd194
<pre>
[BuildStream] Allow additional rsync arguments and update FDO junction
<a href="https://bugs.webkit.org/show_bug.cgi?id=248029">https://bugs.webkit.org/show_bug.cgi?id=248029</a>

Reviewed by Nikolas Zimmermann.

* Tools/buildstream/Makefile:
* Tools/buildstream/elements/freedesktop-sdk.bst:

Canonical link: <a href="https://commits.webkit.org/256798@main">https://commits.webkit.org/256798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920523e106c3a0c9726b44fee8e220bb150d1d04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106360 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166641 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6316 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34829 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103060 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102507 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83447 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31691 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88435 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87773 "Found 1 new JSC stress test failure: wasm.yaml/wasm/gc/sub.js.wasm-collect-continuously (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/134 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83218 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/122 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21338 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28388 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4915 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/85906 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2275 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40637 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19367 "Passed tests") | 
<!--EWS-Status-Bubble-End-->