### PR TITLE
Progress HTMLDocumentParser state on non-interrupted cases

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Google, Inc. All Rights Reserved.
+ * Copyright (C) 2010-2022 Google, Inc. All Rights Reserved.
  * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -444,6 +444,8 @@ void HTMLDocumentParser::end()
 
     // Informs the rest of WebCore that parsing is really finished (and deletes this).
     m_treeBuilder->finished();
+
+    DocumentParser::stopParsing();
 }
 
 void HTMLDocumentParser::attemptToRunDeferredScriptsAndEnd()


### PR DESCRIPTION
<pre>
Progress HTMLDocumentParser state on non-interrupted cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=247911">https://bugs.webkit.org/show_bug.cgi?id=247911</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=181346">https://src.chromium.org/viewvc/blink?view=revision&revision=181346</a>

Before this patch, HTMLDocumentParser never progressed to StoppedState but stuck in
StoppingState when parsing finished without being interrupted. This patch adds a call to
|DocumentParser::stopParsing()| to ensure its |m_state| progress to StoppedState.

* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(HTMLDocumentParser::end): Add condition to stop parser to progress state to "StoppedState"
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc7fa0b95f91ccf54a656441a352bcf680d08a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106384 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166668 "Found 30 new test failures: accessibility/w3c-svg-elements-not-exposed.html, animations/import-crash.html, css3/masking/mask-image-client-crash.html, editing/execCommand/delete-selection-has-style-live-range.html, editing/text-placeholder/insert-into-text-field.html, fast/canvas/canvas-before-css.html, fast/css/cached-sheet-restore-crash.html, fast/css/css-imports-2.html, fast/css/getComputedStyle/pending-stylesheet.html, fast/css/import-and-insert-rule-no-update.html ... (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6340 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34852 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89258 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103084 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102530 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83470 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88453 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/156 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/144 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21360 "Found 30 new test failures: accessibility/w3c-svg-name-calculation.html, animations/dynamic-stylesheet-loading.html, animations/import.html, css3/color-filters/color-filter-caret-color.html, css3/masking/mask-image-initial-value-crash.html, editing/pasteboard/4076267-3.html, editing/selection/3690703.html, editing/selection/line-wrap-1.html, editing/text-placeholder/insert-into-text-field.html, fast/canvas/canvas-bezier-same-endpoint.html ... (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4936 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40657 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->