### PR TITLE
Unable to postMessage a WebAssembly module to a worklet

### DIFF
--- a/LayoutTests/fast/storage/serialized-script-value.html
+++ b/LayoutTests/fast/storage/serialized-script-value.html
@@ -6,7 +6,7 @@
     <body>
         <script>
 
-const currentVersion = 0x0b;
+const currentVersion = 0x0c;
 
 // Here's a little Q&D helper for future adventurers needing to rebaseline this.
 

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-wasm-module.https-expected.txt
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-wasm-module.https-expected.txt
@@ -1,0 +1,9 @@
+
+PASS # AUDIT TASK RUNNER STARTED.
+PASS Executing "Test postMessage from AudioWorkletProcessor to AudioWorkletNode"
+PASS Audit report
+PASS > [Test postMessage from AudioWorkletProcessor to AudioWorkletNode]
+PASS   event.module from main thread is an valid WASM module is true.
+PASS < [Test postMessage from AudioWorkletProcessor to AudioWorkletNode] All assertions passed. (total 1 assertions)
+PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-wasm-module.https.html
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-wasm-module.https.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>
+    Test passing WASM module to an AudioWorklet
+  </title>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+   <script src="/webaudio/resources/audit.js"></script>
+ </head>
+ <body>
+   <script id="layout-test-code">
+     let audit = Audit.createTaskRunner();
+
+     let context = new AudioContext();
+     let module = null;
+
+     let filePath = 'processors/wasm-module-processor.js';
+
+     function createWasmModule() {
+       return fetch('/wasm/serialization/module/resources/incrementer.wasm')
+       .then(response => {
+         if (!response.ok)
+           throw new Error(response.statusText);
+         return response.arrayBuffer();
+       })
+       .then(WebAssembly.compile);
+     }
+
+     audit.define(
+         'Test postMessage from AudioWorkletProcessor to AudioWorkletNode',
+         (task, should) => {
+           let workletNode =
+               new AudioWorkletNode(context, 'wasm-module-processor');
+
+           workletNode.port.onmessage = (event) => {
+             let data = event.data;
+             switch (data.state) {
+               case 'created':
+                 // Send a WASM module back to the worklet.
+                 createWasmModule().then(module => {
+                   workletNode.port.postMessage({ message: "send module", module });
+                 });
+                 break;
+
+               case 'received message':
+                 should(data.isValidModule, 'event.module from main thread is an valid WASM module')
+                     .beTrue();
+                 task.done();
+                 break;
+
+               default:
+                 should(false,
+                        `Got unexpected message from worklet: ${data.state}`)
+                     .beTrue();
+                 task.done();
+                 break;
+             }
+           };
+
+           workletNode.port.onmessageerror = (event) => {
+             should(false, 'Got messageerror from worklet').beTrue();
+             task.done();
+           };
+         });
+
+       context.audioWorklet.addModule(filePath).then(() => {
+         audit.run();
+       });
+   </script>
+ </body>
+</html>

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/processors/wasm-module-processor.js
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/processors/wasm-module-processor.js
@@ -1,0 +1,47 @@
+/**
+ * @class WASMModuleProcessor
+ * @extends AudioWorkletProcessor
+ *
+ * This processor class demonstrates passing WASM modules to and from
+ * audio worklets.
+ */
+class WASMModuleProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.port.onmessage = this.handleMessage.bind(this);
+    this.port.onmessageerror = this.handleMessageError.bind(this);
+    this.port.postMessage({state: 'created'});
+  }
+
+  testModule(module) {
+    try {
+      let instance = new WebAssembly.Instance(module);
+      let increment = instance.exports["increment"];
+      if (typeof increment != "function")
+        return false;
+      let result = increment(42);
+      return result == 43;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  handleMessage(event) {
+    this.port.postMessage({
+      state: 'received message',
+      isValidModule: this.testModule(event.data.module)
+    });
+  }
+
+  handleMessageError(event) {
+    this.port.postMessage({
+      state: 'received messageerror'
+    });
+  }
+
+  process() {
+    return true;
+  }
+}
+
+registerProcessor('wasm-module-processor', WASMModuleProcessor);

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/broadcastchannel-success-and-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/broadcastchannel-success-and-failure-expected.txt
@@ -1,10 +1,5 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: DataCloneError: The object can not be cloned.
 
-Harness Error (FAIL), message = Unhandled rejection: The object can not be cloned.
-
-TIMEOUT WebAssembly.Module cannot cross agent clusters, BroadcastChannel edition Test timed out
-
-Harness Error (FAIL), message = Unhandled rejection: The object can not be cloned.
+Harness Error (TIMEOUT), message = null
 
 TIMEOUT WebAssembly.Module cannot cross agent clusters, BroadcastChannel edition Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/broadcastchannel-success-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/broadcastchannel-success-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Structured cloning of WebAssembly.Module: BroadcastChannel within the same agent cluster promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Structured cloning of WebAssembly.Module: BroadcastChannel within the same agent cluster
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-messagechannel-success-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-messagechannel-success-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL postMessaging to a dedicated worker via MessageChannel allows them to instantiate promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS postMessaging to a dedicated worker via MessageChannel allows them to instantiate
 

--- a/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-sharedworker-failure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-sharedworker-failure-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL WebAssembly.Modules cannot cross agent clusters, shared worker edition The object can not be cloned.
+FAIL WebAssembly.Modules cannot cross agent clusters, shared worker edition assert_unreached: Reached unreachable code
 

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -51,10 +51,13 @@
 #include "JSWorkerGlobalScope.h"
 #include "JSWorkletGlobalScope.h"
 #include "JSWritableStream.h"
+#include "ProcessIdentifier.h"
 #include "RejectedPromiseTracker.h"
 #include "ScriptController.h"
 #include "ScriptModuleLoader.h"
+#include "ServiceWorkerGlobalScope.h"
 #include "ShadowRealmGlobalScope.h"
+#include "SharedWorkerGlobalScope.h"
 #include "StructuredClone.h"
 #include "WebCoreJSClientData.h"
 #include "WorkerGlobalScope.h"
@@ -70,6 +73,7 @@
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <JavaScriptCore/WasmStreamingCompiler.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
+#include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {
 using namespace JSC;
@@ -622,6 +626,22 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
     return wrapper;
 }
 
+String JSDOMGlobalObject::defaultAgentClusterID()
+{
+    return makeString(Process::identifier().toUInt64(), "-default");
+}
+
+String JSDOMGlobalObject::agentClusterID() const
+{
+#if ENABLE(SERVICE_WORKER)
+    // Service workers may run in process but they need to be in a separate agent cluster.
+    if (is<ServiceWorkerGlobalScope>(scriptExecutionContext()))
+        return makeString(Process::identifier().toUInt64(), "-serviceworker");
+#endif
+    if (is<SharedWorkerGlobalScope>(scriptExecutionContext()))
+        return makeString(Process::identifier().toUInt64(), "-sharedworker");
+    return defaultAgentClusterID();
+}
 
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& context, DOMWrapperWorld& world)
 {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/WeakGCMap.h>
+#include <wtf/Forward.h>
 
 namespace WebCore {
 
@@ -73,6 +74,10 @@ public:
     DOMGuardedObjectSet& guardedObjects(NoLockingNecessaryTag) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!vm().heap.mutatorShouldBeFenced()); return m_guardedObjects; }
 
     ScriptExecutionContext* scriptExecutionContext() const;
+
+    // https://tc39.es/ecma262/#sec-agent-clusters
+    String agentClusterID() const;
+    static String defaultAgentClusterID();
 
     // Make binding code generation easier.
     JSDOMGlobalObject* globalObject() { return this; }

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -191,7 +191,7 @@ ExceptionOr<void> BroadcastChannel::postMessage(JSC::JSGlobalObject& globalObjec
         return Exception { InvalidStateError, "This BroadcastChannel is closed"_s };
 
     Vector<RefPtr<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(globalObject, message, { }, ports);
+    auto messageData = SerializedScriptValue::create(globalObject, message, { }, ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
     ASSERT(ports.isEmpty());

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -162,7 +162,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     LOG(MessagePorts, "Attempting to post message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
     Vector<RefPtr<MessagePort>> ports;
-    auto messageData = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports);
+    auto messageData = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
 

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -35,6 +35,7 @@
 #include "NetworkProcessConnection.h"
 #include "NetworkProcessMessages.h"
 #include "WebCoreArgumentCoders.h"
+#include "WebMessagePortChannelProvider.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
@@ -113,6 +114,9 @@ void WebSWClientConnection::scheduleUnregisterJobInServer(ServiceWorkerRegistrat
 
 void WebSWClientConnection::postMessageToServiceWorker(ServiceWorkerIdentifier destinationIdentifier, MessageWithMessagePorts&& message, const ServiceWorkerOrClientIdentifier& sourceIdentifier)
 {
+    for (auto& port : message.transferredPorts)
+        WebMessagePortChannelProvider::singleton().messagePortSentToRemote(port.first);
+
     send(Messages::WebSWServerConnection::PostMessageToServiceWorker { destinationIdentifier, WTFMove(message), sourceIdentifier });
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -45,6 +45,7 @@
 #include "WebDatabaseProvider.h"
 #include "WebDocumentLoader.h"
 #include "WebFrameLoaderClient.h"
+#include "WebMessagePortChannelProvider.h"
 #include "WebNotificationClient.h"
 #include "WebPage.h"
 #include "WebPreferencesKeys.h"
@@ -357,6 +358,9 @@ void WebSWContextManagerConnection::navigationPreloadFailed(SWServerConnectionId
 
 void WebSWContextManagerConnection::postMessageToServiceWorkerClient(const ScriptExecutionContextIdentifier& destinationIdentifier, const MessageWithMessagePorts& message, ServiceWorkerIdentifier sourceIdentifier, const String& sourceOrigin)
 {
+    for (auto& port : message.transferredPorts)
+        WebMessagePortChannelProvider::singleton().messagePortSentToRemote(port.first);
+
     m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::PostMessageToServiceWorkerClient(destinationIdentifier, message, sourceIdentifier, sourceOrigin), 0);
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
@@ -28,6 +28,7 @@
 
 #include "Logging.h"
 #include "NetworkProcessConnection.h"
+#include "WebMessagePortChannelProvider.h"
 #include "WebProcess.h"
 #include "WebSharedWorkerServerConnectionMessages.h"
 #include <WebCore/ProcessIdentifier.h>
@@ -56,6 +57,7 @@ IPC::Connection* WebSharedWorkerObjectConnection::messageSenderConnection() cons
 void WebSharedWorkerObjectConnection::requestSharedWorker(const WebCore::SharedWorkerKey& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&& port, const WebCore::WorkerOptions& workerOptions)
 {
     CONNECTION_RELEASE_LOG("requestSharedWorker: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
+    WebMessagePortChannelProvider::singleton().messagePortSentToRemote(port.first);
     send(Messages::WebSharedWorkerServerConnection::RequestSharedWorker { sharedWorkerKey, sharedWorkerObjectIdentifier, WTFMove(port), workerOptions });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -69,15 +69,18 @@ void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePor
 void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     m_inProcessPortMessages.add(local, Vector<MessageWithMessagePorts> { });
-    ASSERT(!m_inProcessPortMessages.get(local).size());
 
     networkProcessConnection().send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
 }
 
 void WebMessagePortChannelProvider::messagePortDisentangled(const MessagePortIdentifier& port)
 {
-    auto inProcessPortMessages = m_inProcessPortMessages.take(port);
     networkProcessConnection().send(Messages::NetworkConnectionToWebProcess::MessagePortDisentangled { port }, 0);
+}
+
+void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::MessagePortIdentifier& port)
+{
+    auto inProcessPortMessages = m_inProcessPortMessages.take(port);
     for (auto& message : inProcessPortMessages)
         postMessageToRemote(WTFMove(message), port);
 }
@@ -112,6 +115,9 @@ void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&
         WebProcess::singleton().messagesAvailableForPort(remoteTarget);
         return;
     }
+
+    for (auto& port : message.transferredPorts)
+        messagePortSentToRemote(port.first);
 
     networkProcessConnection().send(Messages::NetworkConnectionToWebProcess::PostMessageToRemote { message, remoteTarget }, 0);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -36,6 +36,8 @@ class WebMessagePortChannelProvider final : public WebCore::MessagePortChannelPr
 public:
     static WebMessagePortChannelProvider& singleton();
 
+    void messagePortSentToRemote(const WebCore::MessagePortIdentifier&);
+
 private:
     WebMessagePortChannelProvider();
     ~WebMessagePortChannelProvider() final;


### PR DESCRIPTION
#### a9d61c9d9e2e1e146eb0165e25df76a326997790
<pre>
Unable to postMessage a WebAssembly module to a worklet
<a href="https://bugs.webkit.org/show_bug.cgi?id=220038">https://bugs.webkit.org/show_bug.cgi?id=220038</a>
rdar://72596556

Reviewed by Darin Adler.

We were previously unable to send WASM modules (and WASM memory) via message
ports, even if the destination was in the same process (e.g. another window on
the same page or a dedicated worker).

There were two reasons for this:
- MessagePort::postMessage() was using the default SerializationContext, which
  doesn&apos;t allow encoding on WASM types. I updated the serialization context to
  address that.
- Such WASM types are not serializable over IPC and despite the changes in
  255948@main, messages would often still go over IPC, even when the
  destination is in the same process. To address this, I now mark MessagePorts
  as out-of-process when they get sent over IPC, instead of doing it when they
  get disentangled (which can happen when sending the port to an in-process
  dedicated worker)

* LayoutTests/fast/storage/serialized-script-value.html:
* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-wasm-module.https-expected.txt: Added.
* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-wasm-module.https.html: Added.
* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/processors/wasm-module-processor.js: Added.
(WASMModuleProcessor):
(WASMModuleProcessor.prototype.testModule):
(WASMModuleProcessor.prototype.handleMessage):
(WASMModuleProcessor.prototype.handleMessageError):
(WASMModuleProcessor.prototype.process):
* LayoutTests/imported/w3c/web-platform-tests/wasm/serialization/module/window-messagechannel-success-expected.txt:
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::defaultAgentClusterID):
(WebCore::JSDOMGlobalObject::agentClusterID const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::agentClusterIDFromGlobalObject):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readTerminal):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::postMessage):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::postMessageToServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::postMessageToServiceWorkerClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote):
(WebKit::WebMessagePortChannelProvider::messagePortDisentangled):
(WebKit::WebMessagePortChannelProvider::messagePortSentToRemote):
(WebKit::WebMessagePortChannelProvider::postMessageToRemote):
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/256853@main">https://commits.webkit.org/256853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/284a06ecc460f3c2ca54bc79e59f95c5ec67e699

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106499 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166784 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6463 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34972 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103195 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83585 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31876 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86702 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88567 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74767 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/269 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/254 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4743 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5045 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40774 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->