### PR TITLE
REGRESSION(256180@main): Enabling accelerated drawing caused some ImageOnly Failures

### DIFF
--- a/LayoutTests/compositing/geometry/css-clip-oversize.html
+++ b/LayoutTests/compositing/geometry/css-clip-oversize.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1300" />
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-14581" />
     <style>
         .parent {
             position: absolute;

--- a/LayoutTests/compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html
+++ b/LayoutTests/compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>This tests that when the compositing layer has multiple tile layers the content gets clipped properly across layers.</title>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-7">
 <style>
   .container {
     position: fixed;

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/border-radius-on-scroll-container.html
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/border-radius-on-scroll-container.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-38; totalPixels=0-15" />
+<meta name="fuzzy" content="maxDifference=0-38; totalPixels=0-30" />
 <style>
 body {
     font-family: monospace;

--- a/LayoutTests/css3/blending/background-blend-mode-data-uri-svg-image.html
+++ b/LayoutTests/css3/blending/background-blend-mode-data-uri-svg-image.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-132" />
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-264" />
 <!-- This file should two green squares, each having a dotted border. -->
 
 <link rel="stylesheet" href="resources/blending-style.css">

--- a/LayoutTests/fast/borders/border-painting-inset.html
+++ b/LayoutTests/fast/borders/border-painting-inset.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-265" />
+<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-490" />
 <title>This test that inset borders are painted.</title>
 <style>
   .borderBox {

--- a/LayoutTests/fast/borders/border-painting-outset.html
+++ b/LayoutTests/fast/borders/border-painting-outset.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-265" />
+<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-490" />
 <title>This test that outset borders are painted.</title>
 <style>
   .borderBox {

--- a/LayoutTests/fast/borders/hidpi-border-painting-groove.html
+++ b/LayoutTests/fast/borders/hidpi-border-painting-groove.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=400-800" />
+<meta name="fuzzy" content="maxDifference=0-38;totalPixels=400-1008" />
 <title>This test that groove borders are painted.</title>
 <style>
   .borderBox {

--- a/LayoutTests/fast/borders/hidpi-border-painting-ridge.html
+++ b/LayoutTests/fast/borders/hidpi-border-painting-ridge.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=400-800" />
+<meta name="fuzzy" content="maxDifference=0-38;totalPixels=400-1008" />
 <title>This test that ridge borders are painted.</title>
 <style>
   .borderBox {

--- a/LayoutTests/fast/borders/wrong-border-color-when-radius-is-present.html
+++ b/LayoutTests/fast/borders/wrong-border-color-when-radius-is-present.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-100" />
+<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-384" />
 <title>This tests if borders with border-radius use the same pair of dark, light colors as non-radius borders.</title>
 <style>
   div {

--- a/LayoutTests/fast/box-shadow/inset-shadow-split-inline.html
+++ b/LayoutTests/fast/box-shadow/inset-shadow-split-inline.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-32;totalPixels=0-80" />    
 <style>
     .container {
         width: 500px;

--- a/LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html
+++ b/LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-32" />
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-461" />
 <title>This tests that parent clipping is applied properly when border-radius is present.</title>
 <style>
   .container {

--- a/LayoutTests/imported/blink/fast/sub-pixel/sub-pixel-transparency-layer.html
+++ b/LayoutTests/imported/blink/fast/sub-pixel/sub-pixel-transparency-layer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2500" />
 <style>
 #subPixelContainer {
 	width: 100.5px;

--- a/LayoutTests/imported/mozilla/svg/path-02.svg
+++ b/LayoutTests/imported/mozilla/svg/path-02.svg
@@ -3,6 +3,7 @@
      http://creativecommons.org/publicdomain/zero/1.0/
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
+  <meta name="fuzzy" content="maxDifference=0-52; totalPixels=0-120" />
   <title>Testcase for path with errors</title>
 
   <!-- From https://bugzilla.mozilla.org/show_bug.cgi?id=553905 -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-skewY.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-skewY.html
@@ -7,7 +7,7 @@
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#two-d-transform-functions">
     <link rel="match" href="reference/transforms-skewY-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-200">
+    <meta name="fuzzy" content="maxDifference=0-28;totalPixels=0-200">
     <meta name="assert" content="If the skew for Y axis not provided, greenSquare will not cover redSquare.">
     <style type="text/css">
       .greenSquare {

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/masked.html
@@ -1,4 +1,5 @@
 <!doctype HTML>
+<meta name="fuzzy" content="maxDifference=0-37; totalPixels=0-124" />
 <title>Tests that an SVG mask applies to a foreignObject element</title>
 <link rel="match" href="masked-ref.html">
 <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2375,4 +2375,3 @@ webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-stream
 [ BigSur+ Release ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.html?101-last [ Pass Failure ]
 [ BigSur+ Debug ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-last [ Failure ]
 [ BigSur+ Release ] imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-last [ Pass Failure ]
-


### PR DESCRIPTION
#### 6409da485414c4b67aa5519e7a67293c43665879
<pre>
REGRESSION(256180@main): Enabling accelerated drawing caused some ImageOnly Failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248018">https://bugs.webkit.org/show_bug.cgi?id=248018</a>
rdar://problem/102449694

Reviewed by Simon Fraser.

Adjusting tolerances for tests that were constant ImageOnlyFailures after accelerated drawing was enabled.

* LayoutTests/compositing/geometry/css-clip-oversize.html:
* LayoutTests/compositing/hidpi-compositing-layer-with-tile-layers-on-subpixel-position.html:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/border-radius-on-scroll-container.html:
* LayoutTests/css3/blending/background-blend-mode-data-uri-svg-image.html:
* LayoutTests/fast/borders/border-painting-inset.html:
* LayoutTests/fast/borders/border-painting-outset.html:
* LayoutTests/fast/borders/hidpi-border-painting-groove.html:
* LayoutTests/fast/borders/hidpi-border-painting-ridge.html:
* LayoutTests/fast/borders/wrong-border-color-when-radius-is-present.html:
* LayoutTests/fast/box-shadow/inset-shadow-split-inline.html:
* LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html:
* LayoutTests/imported/blink/fast/sub-pixel/sub-pixel-transparency-layer.html:
* LayoutTests/imported/mozilla/svg/path-02.svg:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/256844@main">https://commits.webkit.org/256844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80646592a9c0d8036b694596caf8dd0bf8b467af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106434 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166724 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6395 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34905 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103134 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4793 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83523 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31815 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74706 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/208 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/195 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21407 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4737 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4987 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40706 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->