### PR TITLE
CodeGeneratorExtensions tweaks to improve generated Web Extension code.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -111,7 +111,7 @@ void WebExtensionCallbackHandler::reportError(NSString *message)
     JSValue *error = [JSValue valueWithNewErrorFromMessage:message inContext:[JSContext contextWithJSGlobalContextRef:m_globalContext.get()]];
 
     callWithArguments<1>(m_rejectFunction, m_globalContext, {
-        toJSValue(m_globalContext.get(), error)
+        toJSValueRef(m_globalContext.get(), error)
     });
 }
 
@@ -123,24 +123,24 @@ id WebExtensionCallbackHandler::call()
 id WebExtensionCallbackHandler::call(id argument)
 {
     return callWithArguments<1>(m_callbackFunction, m_globalContext, {
-        toJSValue(m_globalContext.get(), argument)
+        toJSValueRef(m_globalContext.get(), argument)
     });
 }
 
 id WebExtensionCallbackHandler::call(id argumentOne, id argumentTwo)
 {
     return callWithArguments<2>(m_callbackFunction, m_globalContext, {
-        toJSValue(m_globalContext.get(), argumentOne),
-        toJSValue(m_globalContext.get(), argumentTwo)
+        toJSValueRef(m_globalContext.get(), argumentOne),
+        toJSValueRef(m_globalContext.get(), argumentTwo)
     });
 }
 
 id WebExtensionCallbackHandler::call(id argumentOne, id argumentTwo, id argumentThree)
 {
     return callWithArguments<3>(m_callbackFunction, m_globalContext, {
-        toJSValue(m_globalContext.get(), argumentOne),
-        toJSValue(m_globalContext.get(), argumentTwo),
-        toJSValue(m_globalContext.get(), argumentThree)
+        toJSValueRef(m_globalContext.get(), argumentOne),
+        toJSValueRef(m_globalContext.get(), argumentTwo),
+        toJSValueRef(m_globalContext.get(), argumentThree)
     });
 }
 
@@ -244,7 +244,7 @@ NSDictionary *toNSDictionary(JSContextRef context, JSValueRef value)
     return [result copy];
 }
 
-JSValueRef toJSValue(JSContextRef context, NSString *string, NullOrEmptyString nullOrEmptyString)
+JSValueRef toJSValueRef(JSContextRef context, NSString *string, NullOrEmptyString nullOrEmptyString)
 {
     ASSERT(context);
 
@@ -259,11 +259,11 @@ JSValueRef toJSValue(JSContextRef context, NSString *string, NullOrEmptyString n
     }
 }
 
-JSValueRef toJSValue(JSContextRef context, NSURL *url, NullOrEmptyString nullOrEmptyString)
+JSValueRef toJSValueRef(JSContextRef context, NSURL *url, NullOrEmptyString nullOrEmptyString)
 {
     ASSERT(context);
 
-    return toJSValue(context, url.absoluteURL.absoluteString, nullOrEmptyString);
+    return toJSValueRef(context, url.absoluteURL.absoluteString, nullOrEmptyString);
 }
 
 NSString *toNSString(JSStringRef string)

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -116,7 +116,7 @@ inline JSRetainPtr<JSStringRef> toJSString(const char* string)
     return JSRetainPtr<JSStringRef>(Adopt, JSStringCreateWithUTF8CString(string));
 }
 
-inline JSValueRef toJSNullIfNull(JSContextRef context, JSValueRef value)
+inline JSValueRef toJSValueRefOrJSNull(JSContextRef context, JSValueRef value)
 {
     ASSERT(context);
     return value ? value : JSValueMakeNull(context);
@@ -145,7 +145,12 @@ id toNSObject(JSContextRef, JSValueRef, Class containingObjectsOfClass = Nil);
 NSString *toNSString(JSContextRef, JSValueRef, NullStringPolicy = NullStringPolicy::NullAndUndefinedAsNullString);
 NSDictionary *toNSDictionary(JSContextRef, JSValueRef);
 
-inline JSValueRef toJSValue(JSContextRef context, id object)
+inline JSValue *toJSValue(JSContextRef context, JSValueRef value)
+{
+    return [JSValue valueWithJSValueRef:value inContext:[JSContext contextWithJSGlobalContextRef:JSContextGetGlobalContext(context)]];
+}
+
+inline JSValueRef toJSValueRef(JSContextRef context, id object)
 {
     ASSERT(context);
 
@@ -158,8 +163,8 @@ inline JSValueRef toJSValue(JSContextRef context, id object)
     return [JSValue valueWithObject:object inContext:[JSContext contextWithJSGlobalContextRef:JSContextGetGlobalContext(context)]].JSValueRef;
 }
 
-JSValueRef toJSValue(JSContextRef, NSString *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
-JSValueRef toJSValue(JSContextRef, NSURL *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
+JSValueRef toJSValueRef(JSContextRef, NSString *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
+JSValueRef toJSValueRef(JSContextRef, NSURL *, NullOrEmptyString = NullOrEmptyString::NullStringAsEmptyString);
 
 NSString *toNSString(JSStringRef);
 
@@ -167,7 +172,7 @@ inline JSObjectRef toJSError(JSContextRef context, NSString *string)
 {
     ASSERT(context);
 
-    JSValueRef messageArgument = toJSValue(context, string, NullOrEmptyString::NullStringAsEmptyString);
+    JSValueRef messageArgument = toJSValueRef(context, string, NullOrEmptyString::NullStringAsEmptyString);
     return JSObjectMakeError(context, 1, &messageArgument, nullptr);
 }
 
@@ -176,10 +181,10 @@ inline JSRetainPtr<JSStringRef> toJSString(NSString *string)
     return JSRetainPtr<JSStringRef>(Adopt, JSStringCreateWithCFString(string ? (__bridge CFStringRef)string : CFSTR("")));
 }
 
-inline JSValueRef toJSNullIfNull(JSContextRef context, id object)
+inline JSValueRef toJSValueRefOrJSNull(JSContextRef context, id object)
 {
     ASSERT(context);
-    return object ? toJSValue(context, object) : JSValueMakeNull(context);
+    return object ? toJSValueRef(context, object) : JSValueMakeNull(context);
 }
 
 JSValueRef deserializeJSONString(JSContextRef, NSString *jsonString);

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -500,7 +500,6 @@ EOF
             foreach my $parameter (@specifiedParameters) {
                 $self->_includeHeaders(\%contentsIncludes, $parameter->type, $parameter);
                 $optionalArgumentCount++ if $parameter->extendedAttributes->{"Optional"};
-                $needsScriptContext = 1 if $parameter->type->name eq "function" && !$parameter->extendedAttributes->{"CallbackHandler"};
                 $needsPage = 1 if $parameter->extendedAttributes->{"CallbackHandler"} && $interface->extendedAttributes->{"NeedsPageWithCallbackHandler"};
                 $needsFrame = 1 if $parameter->extendedAttributes->{"CallbackHandler"} && $interface->extendedAttributes->{"NeedsFrameWithCallbackHandler"};
                 $callbackHandlerArgument = $parameter->name if $parameter->extendedAttributes->{"CallbackHandler"} && $parameter->extendedAttributes->{"Optional"};
@@ -964,7 +963,7 @@ EOF
 EOF
     }
 
-    if ($$self{codeGenerator}->IsPrimitiveType($signature->type) && !$signature->extendedAttributes->{"Optional"}) {
+    if ($$self{codeGenerator}->IsPrimitiveType($signature->type) && $signature->type->name ne "boolean" && !$signature->extendedAttributes->{"Optional"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -995,7 +994,7 @@ EOF
 
         push(@$contents, <<EOF);
 
-    if ($variable && !JSValueIsObject(context, $variable)) {
+    if ($variable && !$variable.isObject) {
         NSString *mustBeAnObjectString = @"Invalid '${variableLabel}' value passed to ${call}. Expected an object.";
         *exception = toJSError(context, mustBeAnObjectString);
         return ${result};
@@ -1165,8 +1164,7 @@ sub _platformType
     return "NSString" if $idlTypeName eq "any" && $signature->extendedAttributes->{"Serialization"};
     return "NSDictionary" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSDictionary"};
     return "NSObject" if $idlTypeName eq "any" && $signature && $signature->extendedAttributes->{"NSObject"};
-    return "JSValueRef" if $idlTypeName eq "DOMWindow" || $idlTypeName eq "any";
-    return "JSObjectRef" if $idlTypeName eq "function";
+    return "JSValue" if $idlTypeName eq "DOMWindow" || $idlTypeName eq "function" || $idlTypeName eq "any";
     return "bool" if $idlTypeName eq "boolean";
 
     return unless ref($idlType) eq "IDLType";
@@ -1195,13 +1193,13 @@ sub _platformTypeConstructor
         return "toNSDictionary(context, $argumentName)" if $signature->extendedAttributes->{"NSDictionary"};
         return "dynamic_objc_cast<NSArray>(toNSObject(context, $argumentName))" if $signature->extendedAttributes->{"NSArray"};
         return "toNSObject(context, $argumentName)" if $signature->extendedAttributes->{"NSObject"};
-        return $argumentName;
+        return "toJSValue(context, $argumentName)";
     }
 
     return "toJSCallbackHandler(context, $argumentName, impl->runtime())" if $idlTypeName eq "function" && $signature->extendedAttributes->{"CallbackHandler"};
     return "dynamic_objc_cast<NSArray>(toNSObject(context, $argumentName, $arrayType.class))" if $idlTypeName eq "array" && $arrayType;
     return "JSValueToBoolean(context, $argumentName)" if $idlTypeName eq "boolean";
-    return "JSValueToObject(context, $argumentName, exception)" if $idlTypeName eq "function";
+    return "toJSValue(context, $argumentName)" if $idlTypeName eq "function";
 
     return unless ref($idlType) eq "IDLType";
 
@@ -1221,6 +1219,7 @@ sub _platformTypeVariableDeclaration
     my $constructor = $self->_platformTypeConstructor($signature, $argumentName) if $argumentName;
 
     my %objCTypes = (
+        "JSValue"       => 1,
         "NSArray"       => 1,
         "NSDictionary"  => 1,
         "NSURL"         => 1,
@@ -1229,6 +1228,7 @@ sub _platformTypeVariableDeclaration
     );
 
     my $nullValue = "nullptr";
+    $nullValue = "false" if $platformType eq "bool";
     $nullValue = "std::numeric_limits<double>::quiet_NaN()" if $platformType eq "double";
     $nullValue = "nil" if $objCTypes{$platformType};
     $nullValue = "JSValueMakeUndefined(context)" if $platformType eq "JSValueRef";
@@ -1282,8 +1282,8 @@ sub _returnExpression
     my $returnIDLTypeName = $returnIDLType->name;
 
     return "deserializeJSONString(context, $expression)" if $returnIDLTypeName eq "any" && $signature->extendedAttributes->{"Serialization"} && $signature->extendedAttributes->{"Serialization"} eq "JSON";
-    return "toJSNullIfNull(context, $expression)" if $returnIDLTypeName eq "any" || $returnIDLTypeName eq "DOMWindow";
-    return "toJSValue(context, ${expression}, $nullOrEmptyString)" if $$self{codeGenerator}->IsStringType($returnIDLType);
+    return "toJSValueRefOrJSNull(context, $expression)" if $returnIDLTypeName eq "any" || $returnIDLTypeName eq "DOMWindow";
+    return "toJSValueRef(context, ${expression}, $nullOrEmptyString)" if $$self{codeGenerator}->IsStringType($returnIDLType);
     return "JSValueMakeUndefined(context)" if $returnIDLTypeName eq "void";
     return "JSValueMakeBoolean(context, ${expression})" if $returnIDLTypeName eq "boolean";
     return "JSValueMakeNumber(context, ${expression})" if $$self{codeGenerator}->IsPrimitiveType($returnIDLType);


### PR DESCRIPTION
#### 156f516a94342550ffd68575a4f41f29ecc18d82
<pre>
CodeGeneratorExtensions tweaks to improve generated Web Extension code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248050">https://bugs.webkit.org/show_bug.cgi?id=248050</a>

Reviewed by Brian Weinstein.

Tweaks include:
* Using the ObjC JSValue class instead of JSValueRef in argument types to avoid needing JSContextRef also.
* Properly handle the boolean IDL type which is needed for upcoming test functions.

* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::WebExtensionCallbackHandler::reportError): Use toJSValueRef().
(WebKit::WebExtensionCallbackHandler::call): Use toJSValueRef().
(WebKit::toJSValueRef): Renamed from toJSValue.
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
(WebKit::toJSValueRefOrJSNull): Renamed from toJSNullIfNull().
(WebKit::toJSValue): Added.
(WebKit::toJSValueRef): Renamed from toJSValue().
(WebKit::toJSError): Use toJSValueRef().
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile): No need for automatic NeedsScriptContext for fucntions now that JSValue is used.
(_installAutomaticExceptions): Use JSValue&apos;s isObject property. Don&apos;t use isnan() on bool types.
(_platformType): Use JSValue instead of JSValueRef.
(_platformTypeConstructor): Use new toJSValue() helper.
(_platformTypeVariableDeclaration): Added JSValue to %objCTypes. Use false for bool initial value.
(_returnExpression): Use toJSValueRefOrJSNull() and toJSValueRef().

Canonical link: <a href="https://commits.webkit.org/256801@main">https://commits.webkit.org/256801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cdc660cea245b260f1a16b3d3bcdc857069832e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106395 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6353 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34865 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103095 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83482 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31757 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86601 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/168 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/155 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4716 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40672 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->