### PR TITLE
Hidden buttons can't be used as the submitter in an implicit submission

### DIFF
--- a/LayoutTests/fast/forms/submit-form-with-hidden-button-expected.txt
+++ b/LayoutTests/fast/forms/submit-form-with-hidden-button-expected.txt
@@ -1,0 +1,10 @@
+Tests implicitly submitting with a hidden button.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS submitter.id is "hiddenButton"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/submit-form-with-hidden-button.html
+++ b/LayoutTests/fast/forms/submit-form-with-hidden-button.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<form id="form">
+<input id="text1" name="text1" value="Press Enter" autofocus>
+<input id="hiddenButton" type="submit" name="hiddenButton" value="Success" hidden>
+<input id="secondButton" type="submit" name="secondButton" value="Fail" style="visibility: hidden">
+</form>
+<script src="../../resources/js-test.js"></script>
+<script>
+description('Tests implicitly submitting with a hidden button.');
+
+let submitter = null;
+form.addEventListener("submit", event => {
+    submitter = event.submitter;
+    event.preventDefault();
+});
+
+text1.focus();
+
+const enterKeyEvent = new KeyboardEvent('keypress', { bubbles: true, cancelable: true, view: window, detail: 0,
+    key: 'Enter', code: 'Enter', keyIdentifier: '', keyCode: 13, charCode: 13, which: 13,
+    location: 0, ctrlKey: false, altKey: false, shiftKey: false, metaKey: false });
+text1.dispatchEvent(enterKeyEvent);
+
+shouldBeEqualToString('submitter.id', 'hiddenButton');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -228,10 +228,8 @@ void HTMLFormElement::submitImplicitly(Event& event, bool fromImplicitSubmission
             continue;
         HTMLFormControlElement& formElement = downcast<HTMLFormControlElement>(*listedElement);
         if (formElement.isSuccessfulSubmitButton()) {
-            if (formElement.renderer()) {
-                formElement.dispatchSimulatedClick(&event);
-                return;
-            }
+            formElement.dispatchSimulatedClick(&event);
+            return;
         } else if (formElement.canTriggerImplicitSubmission())
             ++submissionTriggerCount;
     }


### PR DESCRIPTION
#### ad3421ff11860bb575db3e52f74c4edb128a9169
<pre>
Hidden buttons can&apos;t be used as the submitter in an implicit submission
<a href="https://bugs.webkit.org/show_bug.cgi?id=247545">https://bugs.webkit.org/show_bug.cgi?id=247545</a>

Reviewed by Chris Dumez.

Removed the check for renderer to match the behaviors of other browsers and HTML5 spec:
<a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission</a>

* LayoutTests/fast/forms/submit-form-with-hidden-button-expected.txt: Added.
* LayoutTests/fast/forms/submit-form-with-hidden-button.html: Added.
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::submitImplicitly):

Canonical link: <a href="https://commits.webkit.org/256813@main">https://commits.webkit.org/256813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d3a8c478e6436b6366ca4c300e938f1cd38f054

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/29972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106397 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166688 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6355 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34867 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103097 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102543 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83484 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31784 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88470 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/170 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21377 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4949 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2286 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40674 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->