### PR TITLE
Introduce ThreadSafeWeakPtr

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmInstance.h
+++ b/Source/JavaScriptCore/wasm/WasmInstance.h
@@ -35,7 +35,7 @@
 #include "WriteBarrier.h"
 #include <wtf/BitVector.h>
 #include <wtf/RefPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace JSC {
 
@@ -46,7 +46,7 @@ namespace Wasm {
 
 class Instance;
 
-class Instance : public ThreadSafeRefCounted<Instance>, public CanMakeWeakPtr<Instance> {
+class Instance : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Instance> {
     friend LLIntOffsetsExtractor;
 
 public:
@@ -97,7 +97,7 @@ public:
     void setMemory(Ref<Memory>&& memory)
     {
         m_memory = WTFMove(memory);
-        m_memory.get()->registerInstance(this);
+        m_memory.get()->registerInstance(*this);
         updateCachedMemory();
     }
     void updateCachedMemory()

--- a/Source/JavaScriptCore/wasm/WasmMemory.cpp
+++ b/Source/JavaScriptCore/wasm/WasmMemory.cpp
@@ -306,8 +306,8 @@ Expected<PageCount, GrowFailReason> Memory::growShared(VM& vm, PageCount delta)
     m_growSuccessCallback(GrowSuccessTag, oldPageCount, newPageCount);
     // Update cache for instance
     for (auto& instance : m_instances) {
-        if (instance.get() != nullptr)
-            instance.get()->updateCachedMemory();
+        if (auto strongReference = instance.get())
+            strongReference->updateCachedMemory();
     }
     return oldPageCount;
 }
@@ -458,16 +458,16 @@ bool Memory::init(uint32_t offset, const uint8_t* data, uint32_t length)
     return true;
 }
 
-void Memory::registerInstance(Instance* instance)
+void Memory::registerInstance(Instance& instance)
 {
     size_t count = m_instances.size();
     for (size_t index = 0; index < count; index++) {
         if (m_instances.at(index).get() == nullptr) {
-            m_instances.at(index) = *instance;
+            m_instances.at(index) = { instance };
             return;
         }
     }
-    m_instances.append(*instance);
+    m_instances.append({ instance });
 }
 
 void Memory::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/wasm/WasmMemory.h
+++ b/Source/JavaScriptCore/wasm/WasmMemory.h
@@ -36,8 +36,8 @@
 #include <wtf/Function.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
-#include <wtf/WeakPtr.h>
 
 namespace WTF {
 class PrintStream;
@@ -94,7 +94,7 @@ public:
     bool copy(uint32_t, uint32_t, uint32_t);
     bool init(uint32_t, const uint8_t*, uint32_t);
 
-    void registerInstance(Instance*);
+    void registerInstance(Instance&);
 
     void check() {  ASSERT(!deletionHasBegun()); }
 
@@ -113,7 +113,7 @@ private:
     Ref<BufferMemoryHandle> m_handle;
     RefPtr<SharedArrayBufferContents> m_shared;
     WTF::Function<void(GrowSuccess, PageCount, PageCount)> m_growSuccessCallback;
-    Vector<WeakPtr<Instance>> m_instances;
+    Vector<ThreadSafeWeakPtr<Instance>> m_instances;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		5CC0EE7621629F1900A1A842 /* URL.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CC0EE7421629F1900A1A842 /* URL.cpp */; };
 		5CC0EE892162BC2200A1A842 /* URLCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CC0EE862162BC2200A1A842 /* URLCocoa.mm */; };
 		5CC0EE8A2162BC2200A1A842 /* NSURLExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CC0EE882162BC2200A1A842 /* NSURLExtras.mm */; };
+		5CFF32572925A2EC001050F2 /* ThreadSafeWeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CFF32562925A2EB001050F2 /* ThreadSafeWeakPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5FAD3AE221B9636600BEE178 /* URLHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5FAD3AE121B9636600BEE178 /* URLHelpers.cpp */; };
 		6311592628989A55006A9A12 /* LibraryPathDiagnostics.h in Headers */ = {isa = PBXBuildFile; fileRef = 6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6311592728989A55006A9A12 /* LibraryPathDiagnostics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */; };
@@ -1154,6 +1155,7 @@
 		5CC0EE862162BC2200A1A842 /* URLCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = URLCocoa.mm; sourceTree = "<group>"; };
 		5CC0EE872162BC2200A1A842 /* NSURLExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSURLExtras.h; sourceTree = "<group>"; };
 		5CC0EE882162BC2200A1A842 /* NSURLExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NSURLExtras.mm; sourceTree = "<group>"; };
+		5CFF32562925A2EB001050F2 /* ThreadSafeWeakPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadSafeWeakPtr.h; sourceTree = "<group>"; };
 		5D247B6214689B8600E78B76 /* libWTF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libWTF.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D247B6E14689C4700E78B76 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DebugRelease.xcconfig; sourceTree = "<group>"; };
@@ -2290,6 +2292,7 @@
 				5311BD591EA81A9600525281 /* ThreadMessage.h */,
 				A8A4733E151A825B004123FF /* ThreadSafeRefCounted.h */,
 				7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */,
+				5CFF32562925A2EB001050F2 /* ThreadSafeWeakPtr.h */,
 				4468567225094FE8008CCA05 /* ThreadSanitizerSupport.h */,
 				A8A4733F151A825B004123FF /* ThreadSpecific.h */,
 				0F66B2861DC97BAB004A1D3F /* TimeWithDynamicClockType.cpp */,
@@ -3229,6 +3232,7 @@
 				DD3DC92227A4BF8E007E5B61 /* ThreadMessage.h in Headers */,
 				DD3DC96927A4BF8E007E5B61 /* ThreadSafeRefCounted.h in Headers */,
 				DD3DC97C27A4BF8E007E5B61 /* ThreadSafetyAnalysis.h in Headers */,
+				5CFF32572925A2EC001050F2 /* ThreadSafeWeakPtr.h in Headers */,
 				DD3DC90F27A4BF8E007E5B61 /* ThreadSanitizerSupport.h in Headers */,
 				DD3DC99327A4BF8E007E5B61 /* ThreadSpecific.h in Headers */,
 				DD3DC8CE27A4BF8E007E5B61 /* TimeWithDynamicClockType.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -292,6 +292,7 @@ set(WTF_PUBLIC_HEADERS
     ThreadMessage.h
     ThreadSafetyAnalysis.h
     ThreadSafeRefCounted.h
+    ThreadSafeWeakPtr.h
     ThreadSanitizerSupport.h
     ThreadSpecific.h
     Threading.h

--- a/Source/WTF/wtf/MainThread.h
+++ b/Source/WTF/wtf/MainThread.h
@@ -84,6 +84,8 @@ inline void assertIsMainThread() WTF_ASSERTS_ACQUIRED_CAPABILITY(mainThread) { A
 extern NamedAssertion& mainRunLoop;
 inline void assertIsMainRunLoop() WTF_ASSERTS_ACQUIRED_CAPABILITY(mainRunLoop) { ASSERT(isMainRunLoop()); }
 
+enum class DestructionThread : uint8_t { Any, Main, MainRunLoop };
+
 } // namespace WTF
 
 using WTF::assertIsMainRunLoop;

--- a/Source/WTF/wtf/ThreadSafeRefCounted.h
+++ b/Source/WTF/wtf/ThreadSafeRefCounted.h
@@ -104,8 +104,6 @@ private:
 #endif
 };
 
-enum class DestructionThread { Any, Main, MainRunLoop };
-
 template<class T, DestructionThread destructionThread = DestructionThread::Any> class ThreadSafeRefCounted : public ThreadSafeRefCountedBase {
 public:
     void deref() const

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Lock.h>
+#include <wtf/MainThread.h>
+#include <wtf/RefPtr.h>
+
+namespace WTF {
+
+template<typename> class ThreadSafeWeakPtr;
+template<typename, DestructionThread> class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
+
+template<typename T>
+class ThreadSafeWeakPtrControlBlock {
+    WTF_MAKE_NONCOPYABLE(ThreadSafeWeakPtrControlBlock);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    void ref() const
+    {
+        Locker locker { m_lock };
+        ++m_weakReferenceCount;
+    }
+
+    void deref() const
+    {
+        bool shouldDeleteControlBlock { false };
+        {
+            Locker locker { m_lock };
+            ASSERT_WITH_SECURITY_IMPLICATION(m_weakReferenceCount);
+            if (!--m_weakReferenceCount && !m_strongReferenceCount)
+                shouldDeleteControlBlock = true;
+        }
+        if (shouldDeleteControlBlock)
+            delete this;
+    }
+
+    void strongRef() const
+    {
+        Locker locker { m_lock };
+        ASSERT_WITH_SECURITY_IMPLICATION(m_object);
+        ++m_strongReferenceCount;
+    }
+
+    template<DestructionThread destructionThread>
+    void strongDeref() const
+    {
+        bool shouldDeleteControlBlock { false };
+        T* object;
+
+        {
+            Locker locker { m_lock };
+            ASSERT_WITH_SECURITY_IMPLICATION(m_object);
+            if (LIKELY(--m_strongReferenceCount))
+                return;
+            object = std::exchange(m_object, nullptr);
+            if (!m_weakReferenceCount)
+                shouldDeleteControlBlock = true;
+        }
+
+        auto deleteObject = [object] {
+            delete static_cast<const T*>(object);
+        };
+        switch (destructionThread) {
+        case DestructionThread::Any:
+            deleteObject();
+            break;
+        case DestructionThread::Main:
+            ensureOnMainThread(WTFMove(deleteObject));
+            break;
+        case DestructionThread::MainRunLoop:
+            ensureOnMainRunLoop(WTFMove(deleteObject));
+            break;
+        }
+
+        if (shouldDeleteControlBlock)
+            delete this;
+    }
+
+    RefPtr<T> makeStrongReferenceIfPossible() const
+    {
+        Locker locker { m_lock };
+        if (m_object) {
+            // Calling the RefPtr constructor would call strongRef() and deadlock.
+            ++m_strongReferenceCount;
+            return adoptRef(m_object);
+        }
+        return nullptr;
+    }
+
+    bool objectHasBeenDeleted() const
+    {
+        Locker locker { m_lock };
+        return !m_object;
+    }
+
+private:
+    template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
+    explicit ThreadSafeWeakPtrControlBlock(T& object)
+        : m_object(&object) { }
+
+    mutable Lock m_lock;
+    mutable size_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
+    mutable size_t m_weakReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    mutable T* m_object WTF_GUARDED_BY_LOCK(m_lock) { nullptr };
+};
+
+template<typename T, DestructionThread destructionThread = DestructionThread::Any>
+class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr {
+    WTF_MAKE_NONCOPYABLE(ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    void ref() const { m_controlBlock.strongRef(); }
+    void deref() const { m_controlBlock.template strongDeref<destructionThread>(); }
+protected:
+    ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr() = default;
+private:
+    template<typename> friend class ThreadSafeWeakPtr;
+    ThreadSafeWeakPtrControlBlock<T>& m_controlBlock { *new ThreadSafeWeakPtrControlBlock<T>(static_cast<T&>(*this)) };
+};
+
+template<typename T>
+class ThreadSafeWeakPtr {
+public:
+    ThreadSafeWeakPtr() = default;
+
+    ThreadSafeWeakPtr(std::nullptr_t) { }
+
+    ThreadSafeWeakPtr(const ThreadSafeWeakPtr<T>& other)
+        : m_controlBlock(other.m_controlBlock) { }
+
+    template<typename U>
+    ThreadSafeWeakPtr(const U& retainedReference)
+        : m_controlBlock(controlBlock(retainedReference))
+    {
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_controlBlock->objectHasBeenDeleted());
+    }
+
+    template<typename U>
+    ThreadSafeWeakPtr(const U* retainedPointer)
+        : m_controlBlock(retainedPointer ? controlBlock(*retainedPointer) : nullptr)
+    {
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!retainedPointer || !m_controlBlock->objectHasBeenDeleted());
+    }
+
+    template<typename U>
+    ThreadSafeWeakPtr(const Ref<U>& strongReference)
+        : m_controlBlock(controlBlock(strongReference)) { }
+
+    template<typename U>
+    ThreadSafeWeakPtr(const RefPtr<U>& strongReference)
+        : m_controlBlock(strongReference ? controlBlock(*strongReference) : nullptr) { }
+
+    ThreadSafeWeakPtr(ThreadSafeWeakPtr&& other)
+        : m_controlBlock(std::exchange(other.m_controlBlock, nullptr)) { }
+
+    ThreadSafeWeakPtr& operator=(ThreadSafeWeakPtr&& other)
+    {
+        m_controlBlock = std::exchange(other.m_controlBlock, nullptr);
+        return *this;
+    }
+
+    template<typename U>
+    ThreadSafeWeakPtr& operator=(const U& retainedReference)
+    {
+        m_controlBlock = controlBlock(retainedReference);
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_controlBlock->objectHasBeenDeleted());
+        return *this;
+    }
+
+    template<typename U>
+    ThreadSafeWeakPtr& operator=(const U* retainedPointer)
+    {
+        m_controlBlock = retainedPointer ? controlBlock(*retainedPointer) : nullptr;
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!retainedPointer || !m_controlBlock->objectHasBeenDeleted());
+        return *this;
+    }
+
+    template<typename U>
+    ThreadSafeWeakPtr& operator=(const Ref<U>& strongReference)
+    {
+        m_controlBlock = controlBlock(strongReference);
+        return *this;
+    }
+
+    template<typename U>
+    ThreadSafeWeakPtr& operator=(const RefPtr<U>& strongReference)
+    {
+        m_controlBlock = strongReference ? controlBlock(*strongReference) : nullptr;
+        return *this;
+    }
+
+    RefPtr<T> get() const { return m_controlBlock->makeStrongReferenceIfPossible(); }
+
+private:
+    template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
+    ThreadSafeWeakPtrControlBlock<T>* controlBlock(const U& classOrChildClass)
+    {
+        return &reinterpret_cast<ThreadSafeWeakPtrControlBlock<T>&>(classOrChildClass.m_controlBlock);
+    }
+
+    template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
+    explicit ThreadSafeWeakPtr(ThreadSafeWeakPtrControlBlock<T>& controlBlock)
+        : m_controlBlock(&controlBlock) { }
+
+    RefPtr<ThreadSafeWeakPtrControlBlock<T>> m_controlBlock;
+};
+
+template<class T> ThreadSafeWeakPtr(const T&) -> ThreadSafeWeakPtr<T>;
+template<class T> ThreadSafeWeakPtr(const T*) -> ThreadSafeWeakPtr<T>;
+
+}
+
+using WTF::ThreadSafeWeakPtr;
+using WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -33,7 +33,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Function.h>
 #import <wtf/Ref.h>
-#import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/ThreadSafeWeakPtr.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/text/WTFString.h>
@@ -60,7 +60,7 @@ class SwapChain;
 class Texture;
 
 // https://gpuweb.github.io/gpuweb/#gpudevice
-class Device : public WGPUDeviceImpl, public ThreadSafeRefCounted<Device>, public CanMakeWeakPtr<Device> {
+class Device : public WGPUDeviceImpl, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<Device> create(id<MTLDevice>, String&& deviceLabel, HardwareCapabilities&&, Adapter&);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -70,7 +70,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     , m_adapter(adapter)
 {
 #if PLATFORM(MAC)
-    auto devices = MTLCopyAllDevicesWithObserver(&m_deviceObserver, [weakThis = WeakPtr { *this }](id<MTLDevice> device, MTLDeviceNotificationName) {
+    auto devices = MTLCopyAllDevicesWithObserver(&m_deviceObserver, [weakThis = ThreadSafeWeakPtr { *this }](id<MTLDevice> device, MTLDeviceNotificationName) {
         RefPtr<Device> strongThis = weakThis.get();
         if (!strongThis)
             return;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -628,7 +628,8 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
 
     if (m_client)
         m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = WeakPtr { *this }] (auto&& request) mutable {
-            if (!weakThis || !m_session)
+            auto strongThis = weakThis.get();
+            if (!strongThis || !m_session)
                 return completionHandler({ });
             if (!request.isNull())
                 restrictRequestReferrerToOriginIfNeeded(request);

--- a/Source/WebKit/NetworkProcess/storage/QuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/QuotaManager.h
@@ -28,10 +28,11 @@
 #include "QuotaIncreaseRequestIdentifier.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebKit {
 
-class QuotaManager : public ThreadSafeRefCounted<QuotaManager>, public CanMakeWeakPtr<QuotaManager> {
+class QuotaManager : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<QuotaManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using GetUsageFunction = Function<uint64_t()>;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -42,10 +42,6 @@ namespace WebKit {
 //      Idle => !isInWindow => Waiting => become isInWindow => Active => Completed
 class NavigationSOAuthorizationSession : public SOAuthorizationSession, private WebViewDidMoveToWindowObserver {
 public:
-    using SOAuthorizationSession::weakPtrFactory;
-    using SOAuthorizationSession::WeakValueType;
-    using SOAuthorizationSession::WeakPtrImplType;
-
     ~NavigationSOAuthorizationSession();
 
 protected:

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -40,20 +40,20 @@
 
 @interface WKSOSecretDelegate : NSObject <WKNavigationDelegate, WKUIDelegate> {
 @private
-    WeakPtr<WebKit::PopUpSOAuthorizationSession> _session;
+    ThreadSafeWeakPtr<WebKit::PopUpSOAuthorizationSession> _weakSession;
     BOOL _isFirstNavigation;
 }
 
-- (instancetype)initWithSession:(WebKit::PopUpSOAuthorizationSession *)session;
+- (instancetype)initWithSession:(WebKit::PopUpSOAuthorizationSession&)session;
 
 @end
 
 @implementation WKSOSecretDelegate
 
-- (instancetype)initWithSession:(WebKit::PopUpSOAuthorizationSession *)session
+- (instancetype)initWithSession:(WebKit::PopUpSOAuthorizationSession&)session
 {
     if ((self = [super init])) {
-        _session = session;
+        _weakSession = session;
         _isFirstNavigation = YES;
     }
     return self;
@@ -62,9 +62,10 @@
 // WKUIDelegate
 - (void)webViewDidClose:(WKWebView *)webView
 {
-    if (!_session)
+    auto strongSession = _weakSession.get();
+    if (!strongSession)
         return;
-    _session->close(webView);
+    strongSession->close(webView);
 }
 
 // WKNavigationDelegate
@@ -83,9 +84,10 @@
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    if (!_session)
+    auto strongSession = _weakSession.get();
+    if (!strongSession)
         return;
-    _session->close(webView);
+    strongSession->close(webView);
 }
 
 @end
@@ -189,7 +191,7 @@ void PopUpSOAuthorizationSession::initSecretWebView()
     [configuration setPreferences:secretViewPreferences.get()];
     m_secretWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
 
-    m_secretDelegate = adoptNS([[WKSOSecretDelegate alloc] initWithSession:this]);
+    m_secretDelegate = adoptNS([[WKSOSecretDelegate alloc] initWithSession:*this]);
     [m_secretWebView setUIDelegate:m_secretDelegate.get()];
     [m_secretWebView setNavigationDelegate:m_secretDelegate.get()];
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -30,7 +30,7 @@
 #include <pal/spi/cocoa/AppSSOSPI.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakObjCPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -52,7 +52,7 @@ class WebPageProxy;
 enum class SOAuthorizationLoadPolicy : uint8_t;
 
 // A session will only be executed once.
-class SOAuthorizationSession : public ThreadSafeRefCounted<SOAuthorizationSession, WTF::DestructionThread::MainRunLoop>, public CanMakeWeakPtr<SOAuthorizationSession> {
+class SOAuthorizationSession : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SOAuthorizationSession, WTF::DestructionThread::MainRunLoop> {
 public:
     enum class InitiatingAction : uint8_t {
         Redirect,

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -173,10 +173,11 @@ void SOAuthorizationSession::start()
     ASSERT((m_state == State::Idle || m_state == State::Waiting) && m_navigationAction);
     m_state = State::Active;
     AUTHORIZATIONSESSION_RELEASE_LOG("start: Moving m_state to Active.");
-    [m_soAuthorization getAuthorizationHintsWithURL:m_navigationAction->request().url() responseCode:0 completion:makeBlockPtr([this, weakThis = WeakPtr { *this }] (SOAuthorizationHints *authorizationHints, NSError *error) {
+    [m_soAuthorization getAuthorizationHintsWithURL:m_navigationAction->request().url() responseCode:0 completion:makeBlockPtr([this, weakThis = ThreadSafeWeakPtr { *this }] (SOAuthorizationHints *authorizationHints, NSError *error) {
         AUTHORIZATIONSESSION_RELEASE_LOG("start: Receive SOAuthorizationHints (error=%ld)", error ? error.code : 0);
 
-        if (!weakThis) {
+        auto strongThis = weakThis.get();
+        if (!strongThis) {
             RELEASE_LOG_ERROR(AppSSO, "SOAuthorizationSession::start (getAuthorizationHintsWithURL completion handler): Returning early because weakThis is now null.");
             return;
         }
@@ -202,10 +203,9 @@ void SOAuthorizationSession::continueStartAfterGetAuthorizationHints(const Strin
     }
 
     AUTHORIZATIONSESSION_RELEASE_LOG("continueStartAfterGetAuthorizationHints: Checking page for policy choice.");
-    m_page->decidePolicyForSOAuthorizationLoad(hints, [this, weakThis = WeakPtr { *this }] (SOAuthorizationLoadPolicy policy) {
-        if (!weakThis)
-            return;
-        continueStartAfterDecidePolicy(policy);
+    m_page->decidePolicyForSOAuthorizationLoad(hints, [weakThis = ThreadSafeWeakPtr { *this }] (SOAuthorizationLoadPolicy policy) {
+        if (auto strongThis = weakThis.get())
+            strongThis->continueStartAfterDecidePolicy(policy);
     });
 }
 
@@ -316,8 +316,9 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
         return;
     }
 
-    m_page->websiteDataStore().cookieStore().setCookies(WTFMove(cookies), [this, weakThis = WeakPtr { *this }, response = WTFMove(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
-        if (!weakThis)
+    m_page->websiteDataStore().cookieStore().setCookies(WTFMove(cookies), [this, weakThis = ThreadSafeWeakPtr { *this }, response = WTFMove(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
             return;
 
         AUTHORIZATIONSESSION_RELEASE_LOG("complete: Cookies are set.");
@@ -350,11 +351,12 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
 
     m_sheetWindow = [NSWindow windowWithContentViewController:m_viewController.get()];
 
-    m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = WeakPtr { *this }] (NSNotification *) {
-        if (!weakThis)
+    m_sheetWindowWillCloseObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification object:m_sheetWindow.get() queue:nil usingBlock:[weakThis = ThreadSafeWeakPtr { *this }] (NSNotification *) {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
             return;
         RELEASE_LOG(AppSSO, "presentViewController: Received NSWindowWillCloseNotification. Dismissing the view controller.");
-        weakThis->dismissViewController();
+        strongThis->dismissViewController();
     }];
     AUTHORIZATIONSESSION_RELEASE_LOG("presentViewController: Added m_sheetWindowWillCloseObserver (%p)", m_sheetWindowWillCloseObserver.get());
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h
@@ -38,9 +38,6 @@ namespace WebKit {
 class SubFrameSOAuthorizationSession final : public NavigationSOAuthorizationSession, public FrameLoadState::Observer {
 public:
     using Callback = CompletionHandler<void(bool)>;
-    using SOAuthorizationSession::weakPtrFactory;
-    using SOAuthorizationSession::WeakValueType;
-    using SOAuthorizationSession::WeakPtrImplType;
 
     static Ref<SOAuthorizationSession> create(RetainPtr<WKSOAuthorizationDelegate>, Ref<API::NavigationAction>&&, WebPageProxy&, Callback&&, WebCore::FrameIdentifier);
 

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/ProcessID.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
@@ -52,7 +53,7 @@ enum class SandboxPermission {
 };
 #endif
 
-class ProcessLauncher : public ThreadSafeRefCounted<ProcessLauncher>, public CanMakeWeakPtr<ProcessLauncher> {
+class ProcessLauncher : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ProcessLauncher> {
 public:
     class Client {
     public:

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -194,7 +194,7 @@ void ProcessLauncher::launchProcess()
 
     xpc_dictionary_set_value(bootstrapMessage.get(), "extra-initialization-data", extraInitializationData.get());
 
-    auto errorHandlerImpl = [weakProcessLauncher = WeakPtr { *this }, listeningPort, logName = CString(name)] (xpc_object_t event) {
+    auto errorHandlerImpl = [weakProcessLauncher = ThreadSafeWeakPtr { *this }, listeningPort, logName = CString(name)] (xpc_object_t event) {
         ASSERT(!event || xpc_get_type(event) == XPC_TYPE_ERROR);
 
         auto processLauncher = weakProcessLauncher.get();

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -66,7 +66,7 @@ public:
     uint64_t notificationID() const { return identifier(); }
 
     WebPageProxyIdentifier pageIdentifier() const { return m_pageIdentifier; }
-    IPC::Connection* sourceConnection() const { return m_sourceConnection.get(); }
+    RefPtr<IPC::Connection> sourceConnection() const { return m_sourceConnection.get(); }
 
 private:
     WebNotification(const WebCore::NotificationData&, WebPageProxyIdentifier, IPC::Connection&);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -177,7 +177,7 @@ void WebNotificationManagerProxy::providerDidShowNotification(uint64_t globalNot
 
     LOG(Notifications, "Provider did show notification (%s)", notification->coreNotificationID().toString().utf8().data());
 
-    auto* connection = notification->sourceConnection();
+    auto connection = notification->sourceConnection();
     if (!connection)
         return;
 
@@ -201,7 +201,7 @@ static void dispatchDidClickNotification(WebNotification* notification)
     }
 #endif
 
-    if (auto* connection = notification->sourceConnection())
+    if (auto connection = notification->sourceConnection())
         connection->send(Messages::WebNotificationManager::DidClickNotification(notification->coreNotificationID()), 0);
 }
 
@@ -269,7 +269,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
     }
 
     for (auto& notification : closedNotifications) {
-        if (auto* connection = notification->sourceConnection()) {
+        if (auto connection = notification->sourceConnection()) {
             LOG(Notifications, "Provider did close notification (%s)", notification->coreNotificationID().toString().utf8().data());
             Vector<UUID> notificationIDs = { notification->coreNotificationID() };
             connection->send(Messages::WebNotificationManager::DidCloseNotifications(notificationIDs), 0);


### PR DESCRIPTION
#### 4b51a0df4d5cf653afd99c08091c1887dce58913
<pre>
Introduce ThreadSafeWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=248051">https://bugs.webkit.org/show_bug.cgi?id=248051</a>
rdar://102483501

Reviewed by Chris Dumez.

ThreadSafeWeakPtr is similar to std::weak_ptr, but with a few key differences to make it fit into WebKit better.
The first is that sizeof(ThreadSafeWeakPtr&lt;T&gt;) is sizeof(void*) and, at least in libc++&apos;s implementation,
sizeof(std::weak_ptr&lt;T&gt;) is 2*sizeof(void*).  That is because each std::weak_ptr contains a pointer to the object
and a pointer to the control block containing the strong and weak reference counts.  Instead of that, we give the
object and the control blocks pointers to each other.  By doing that, we get the ability to make a Ref/RefPtr
from only a pointer to the object, so we can continue to use Ref/RefPtr with types that have thread safe weak pointers.

Another difference between ThreadSafeWeakPtr and std::weak_ptr is that ThreadSafeWeakPtr allows you to create a weak
pointer from a raw pointer, which is often used to make a ThreadSafeWeakPtr from *this without an unnecessary
ref/deref cycle.  It does this safely by release asserting that the object is still alive when this happens,
which has half the cost of a ref/deref cycle.

We also support DestructionThread like we do in ThreadSafeRefCounted, and we have double-delete protection like
have have in ThreadSafeRefCountedBase::derefBase by setting ThreadSafeWeakPtrControlBlock.m_object to null when
we delete the object, so that if something makes a Ref to the object during its destructor execution, it won&apos;t
free the memory twice.

This is just the initial introduction of this class.  I still need to make WeakHashSet work with ThreadSafeWeakPtr
and update the 17 more classes that inherit from both ThreadSafeRefCounted and CanMakeWeakPtr.

ThreadSafeWeakPtr is a different kind of smart pointer than WeakPtr because all you can do with it is get a RefPtr,
which requires that the types be reference counted.  We have many types that inherit from CanMakeWeakPtr that are not
reference counted, and we don&apos;t want to change that with this PR.  I could use some crazy SFINAE to make WeakPtr
just return a different type when it&apos;s thread safe, but that is a lot of work for little benefit to get a pointer type
that has the same name but still behaves quite differently internally and in its API, so I decided to make a different
smart pointer type.

* Source/JavaScriptCore/wasm/WasmInstance.h:
(JSC::Wasm::Instance::setMemory):
* Source/JavaScriptCore/wasm/WasmMemory.cpp:
(JSC::Wasm::Memory::growShared):
(JSC::Wasm::Memory::registerInstance):
* Source/JavaScriptCore/wasm/WasmMemory.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/MainThread.h:
* Source/WTF/wtf/ThreadSafeRefCounted.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h: Added.
(WTF::ThreadSafeWeakPtrControlBlock::ref const):
(WTF::ThreadSafeWeakPtrControlBlock::deref const):
(WTF::ThreadSafeWeakPtrControlBlock::strongRef const):
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::refCount const):
(WTF::ThreadSafeWeakPtrControlBlock::ThreadSafeWeakPtrControlBlock):
(WTF::ThreadSafeWeakPtrControlBlock::WTF_GUARDED_BY_LOCK):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::refCount const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr):
(WTF::ThreadSafeWeakPtr::ThreadSafeWeakPtr):
(WTF::ThreadSafeWeakPtr::operator=):
(WTF::ThreadSafeWeakPtr::get const):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::idbStorageManager):
* Source/WebKit/NetworkProcess/storage/QuotaManager.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(-[WKSOSecretDelegate initWithSession:]):
(-[WKSOSecretDelegate webViewDidClose:]):
(-[WKSOSecretDelegate webView:didFinishNavigation:]):
(WebKit::PopUpSOAuthorizationSession::initSecretWebView):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::start):
(WebKit::SOAuthorizationSession::continueStartAfterGetAuthorizationHints):
(WebKit::SOAuthorizationSession::complete):
(WebKit::SOAuthorizationSession::presentViewController):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
(WebKit::WebNotification::sourceConnection const):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::providerDidShowNotification):
(WebKit::dispatchDidClickNotification):
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::ThreadSafeInstanceCounter::ThreadSafeInstanceCounter):
(TestWebKitAPI::ThreadSafeInstanceCounter::~ThreadSafeInstanceCounter):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/256848@main">https://commits.webkit.org/256848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71fb35719bb5dec1bf9804aa365602285aa9e230

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96998 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106527 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6494 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35000 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89390 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102669 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83613 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31893 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87932 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/300 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83377 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/282 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5074 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86073 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2305 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1516 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19395 "Passed tests") | 
<!--EWS-Status-Bubble-End-->