### PR TITLE
[Live Range Selection] editing/pasteboard/copy-with-shadow-tree-crash.html fails

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-with-shadow-tree-crash-live-range-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-with-shadow-tree-crash-live-range-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not crash. PASS
+

--- a/LayoutTests/editing/pasteboard/copy-with-shadow-tree-crash-live-range.html
+++ b/LayoutTests/editing/pasteboard/copy-with-shadow-tree-crash-live-range.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html><!-- webkit-test-runner [ LiveRangeSelectionEnabled=true ] -->
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+onload = () => {
+  let div0 = document.createElement('div');
+  document.body.appendChild(div0);
+  let span0 = document.createElement('span');
+  div0.appendChild(span0);
+  let div1 = document.createElement('div');
+  document.body.appendChild(div1);
+  span0.attachShadow({mode: 'open'}).appendChild(document.createElement('img'));
+  document.execCommand('SelectAll');
+  document.body.appendChild(document.createElement('input'));
+  document.designMode = 'on';
+  document.execCommand('InsertHTML', false, 'This test passes if WebKit does not crash. PASS');
+  document.designMode = 'off';
+  getSelection().modify('extend', 'left', 'lineboundary');
+  getSelection().modify('extend', 'right', 'lineboundary');
+  getSelection().extend(div1);
+  document.execCommand('Copy');
+};
+</script>

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -188,8 +188,6 @@ String DOMSelection::type() const
 unsigned DOMSelection::rangeCount() const
 {
     auto frame = this->frame();
-    if (frame && frame->settings().liveRangeSelectionEnabled())
-        return frame->selection().isInDocumentTree();
     return !frame || frame->selection().isNone() ? 0 : 1;
 }
 


### PR DESCRIPTION
#### 8230e6a4e70d8792cbb3b38d64d5fd0f5f47ff66
<pre>
[Live Range Selection] editing/pasteboard/copy-with-shadow-tree-crash.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248068">https://bugs.webkit.org/show_bug.cgi?id=248068</a>

Reviewed by Wenson Hsieh.

The bug was caused by DOMSelection::rangeCount returning 0 whenever range crosses shadow boundaries.
Remove this check since DOMSelection shouldn&apos;t be considered as empty when there are selections anywhere.

* LayoutTests/editing/pasteboard/copy-with-shadow-tree-crash-live-range-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-with-shadow-tree-crash-live-range.html: Added.
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::rangeCount const):

Canonical link: <a href="https://commits.webkit.org/256822@main">https://commits.webkit.org/256822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e6bd010c37a83230c107f4b4bd1cbf97ea11eb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106439 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166730 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6400 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34910 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103139 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102586 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83528 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31819 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/213 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/19991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/200 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21412 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/4992 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2289 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40711 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->