### PR TITLE
[Curl] Use CURLINFO_SSL_VERIFYRESULT to get the result of the certificate verification

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -381,7 +381,10 @@ CURLcode CurlHandle::willSetupSslCtxCallback(CURL*, void* sslCtx, void* userData
 
 int CurlHandle::sslErrors() const
 {
-    return m_sslVerifier ? m_sslVerifier->sslErrors() : 0;
+    if (auto verifyResult = getSSLVerifyResult(); verifyResult && *verifyResult != X509_V_OK)
+        return static_cast<int>(CurlSSLVerifier::convertToSSLCertificateFlags(*verifyResult));
+
+    return 0;
 }
 
 CURLcode CurlHandle::perform()
@@ -777,6 +780,19 @@ std::optional<long> CurlHandle::getHttpVersion()
     return version;
 }
 
+std::optional<long> CurlHandle::getSSLVerifyResult() const
+{
+    if (!m_handle)
+        return std::nullopt;
+
+    long verifyResult;
+    auto errorCode = curl_easy_getinfo(m_handle, CURLINFO_SSL_VERIFYRESULT, &verifyResult);
+    if (errorCode != CURLE_OK)
+        return std::nullopt;
+
+    return verifyResult;
+}
+
 std::optional<SSL*> CurlHandle::sslConnection() const
 {
     curl_tlssessioninfo* info = nullptr;
@@ -912,15 +928,19 @@ void CurlHandle::addExtraNetworkLoadMetrics(NetworkLoadMetrics& networkLoadMetri
 
 std::optional<CertificateInfo> CurlHandle::certificateInfo() const
 {
-    if (m_sslVerifier && !m_sslVerifier->certificateInfo().isEmpty())
-        return m_sslVerifier->certificateInfo();
-
-    // If you use an existing HTTP/2 connection, SSLVerifier does not exist.
     if (m_certificateInfo)
         return *m_certificateInfo;
 
+    if (m_sslVerifier) {
+        if (auto certificateInfo = m_sslVerifier->createCertificateInfo(getSSLVerifyResult())) {
+            m_certificateInfo = WTFMove(certificateInfo);
+            return *m_certificateInfo;
+        }
+    }
+
+    // If you use an existing HTTP/2 connection, SSLVerifier does not exist.
     if (auto ssl = sslConnection()) {
-        if (auto certificateInfo = OpenSSL::createCertificateInfo(*ssl)) {
+        if (auto certificateInfo = OpenSSL::createCertificateInfo(getSSLVerifyResult(), *ssl)) {
             m_certificateInfo = WTFMove(certificateInfo);
             return *m_certificateInfo;
         }

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -301,6 +301,7 @@ public:
     std::optional<long> getHttpAuthAvail();
     std::optional<long> getProxyAuthAvail();
     std::optional<long> getHttpVersion();
+    std::optional<long> getSSLVerifyResult() const;
     std::optional<NetworkLoadMetrics> getNetworkLoadMetrics(MonotonicTime startTime);
     void addExtraNetworkLoadMetrics(NetworkLoadMetrics&);
 

--- a/Source/WebCore/platform/network/curl/CurlSSLVerifier.h
+++ b/Source/WebCore/platform/network/curl/CurlSSLVerifier.h
@@ -49,8 +49,9 @@ public:
 
     CurlSSLVerifier(void* sslCtx);
 
-    int sslErrors() { return m_sslErrors; }
-    const CertificateInfo& certificateInfo() const { return m_certificateInfo; }
+    std::unique_ptr<WebCore::CertificateInfo> createCertificateInfo(std::optional<long>&&);
+
+    static SSLCertificateFlags convertToSSLCertificateFlags(unsigned);
 
 private:
     static int verifyCallback(int, X509_STORE_CTX*);
@@ -61,8 +62,7 @@ private:
     void logTLSKey(const SSL*);
 #endif
 
-    int m_sslErrors { 0 };
-    CertificateInfo m_certificateInfo;
+    CertificateInfo::CertificateChain m_certificateChain;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.h
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.h
@@ -31,8 +31,8 @@
 
 namespace OpenSSL {
 
-std::unique_ptr<WebCore::CertificateInfo> createCertificateInfo(SSL*);
-std::optional<WebCore::CertificateInfo> createCertificateInfo(X509_STORE_CTX*);
+std::unique_ptr<WebCore::CertificateInfo> createCertificateInfo(std::optional<long>&&, SSL*);
+WebCore::CertificateInfo::CertificateChain createCertificateChain(X509_STORE_CTX*);
 std::optional<WebCore::CertificateSummary> createSummaryInfo(const Vector<uint8_t>& pem);
 
 String tlsVersion(const SSL*);


### PR DESCRIPTION
#### 58dd451692d4c6eb0c0bc367b3bd5a841d80c651
<pre>
[Curl] Use CURLINFO_SSL_VERIFYRESULT to get the result of the certificate verification
<a href="https://bugs.webkit.org/show_bug.cgi?id=208806">https://bugs.webkit.org/show_bug.cgi?id=208806</a>

Reviewed by Fujii Hironori.

There are cases where SSL certificate verification has failed,
but the result of the certificate verification to 0 (X509_V_OK).
We can fix this by using CURLINFO_SSL_VERIFYRESULT.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::sslErrors const):
(WebCore::CurlHandle::getSSLVerifyResult const):
(WebCore::CurlHandle::certificateInfo const):
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlSSLVerifier.cpp:
(WebCore::CurlSSLVerifier::createCertificateInfo):
(WebCore::CurlSSLVerifier::collectInfo):
(WebCore::CurlSSLVerifier::convertToSSLCertificateFlags):
(WebCore::convertToSSLCertificateFlags): Deleted.
* Source/WebCore/platform/network/curl/CurlSSLVerifier.h:
(WebCore::CurlSSLVerifier::sslErrors): Deleted.
(WebCore::CurlSSLVerifier::certificateInfo const): Deleted.
(): Deleted.
* Source/WebCore/platform/network/curl/OpenSSLHelper.cpp:
(OpenSSL::pemDataFromCtx):
(OpenSSL::createCertificateInfo):
(OpenSSL::createCertificateChain):
* Source/WebCore/platform/network/curl/OpenSSLHelper.h:

Canonical link: <a href="https://commits.webkit.org/256827@main">https://commits.webkit.org/256827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37cc65d050628ba8d11a11adbe0ebfa7cbfbdc20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106461 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166745 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6423 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34932 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103159 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102606 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83548 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31835 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88527 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74727 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/close-quickly (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/236 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/222 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4727 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5013 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40735 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->