### PR TITLE
REGRESSION (250836@main): [ iOS ] fast/forms/textfield-outline.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/forms/textfield-outline.html
+++ b/LayoutTests/fast/forms/textfield-outline.html
@@ -7,9 +7,11 @@
             var tf = document.getElementById('tf');
             tf.focus();
             if (window.testRunner) {
+                testRunner.waitUntilDone();
                 await UIHelper.keyDown("a");
                 await UIHelper.keyDown("b");
                 await UIHelper.keyDown("c");
+                testRunner.notifyDone();
             }
         }
         </script>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2237,8 +2237,6 @@ imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitm
 
 js/dom/Promise-reject-large-string.html [ DumpJSConsoleLogInStdErr ]
 
-webkit.org/b/241205 [ Release arm64 ] fast/forms/textfield-outline.html [ Pass Failure ]
-
 webkit.org/b/242904 [ Debug ] fast/dom/lazy-image-loading-document-leak.html [ Pass Failure ]
 
 # The Notifications API is not supported on iOS


### PR DESCRIPTION
#### 93ece5e17f0a9a8fe3a937f19d79c3a4caedb399
<pre>
REGRESSION (250836@main): [ iOS ] fast/forms/textfield-outline.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=241205">https://bugs.webkit.org/show_bug.cgi?id=241205</a>
rdar://94255807

Reviewed by Simon Fraser.

The test fast/forms/textfield-outline.html became flaky because 250836@main introduced
asynchronous appearance changes when there is a programmatic selection being set on a frame.
This caused a race condition between the test runner completing and the render tree being
updated with the cursor in the correct scrollX position.

I went part of the way to fixing this test in 252417@main by switching from synchronous to
asynchronous keydown events in the test. However, the test still had a race condition because
the test runner wasn&apos;t being told to wait for all three asynchronous key downs to complete.

This simply puts the testRunner in &quot;asynchronous mode&quot; by calling testRunner.waitUntilDone and
testRunner.notifyDone.

* LayoutTests/fast/forms/textfield-outline.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/256856@main">https://commits.webkit.org/256856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ed025ead938e172adab7e52470bc3d77c97d8fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106531 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6498 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35004 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103225 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102673 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83617 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/304 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/286 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4744 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1520 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40803 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->