### PR TITLE
Plumb ScrollingNodeIDs through to the UI process

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -249,7 +249,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & RemoteLayerTreeTransaction::BackingStoreChanged
         || properties.changedProperties & RemoteLayerTreeTransaction::BackingStoreAttachmentChanged)
     {
-        RemoteLayerBackingStore* backingStore = properties.backingStore.get();
+        auto* backingStore = properties.backingStore.get();
         if (backingStore && properties.backingStoreAttached)
             backingStore->applyBackingStoreToLayer(layer, layerContentsType, layerTreeHost->replayCGDisplayListsIntoBackingStore());
         else {
@@ -303,6 +303,11 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
 
     if (properties.changedProperties & RemoteLayerTreeTransaction::EventRegionChanged)
         node.setEventRegion(properties.eventRegion);
+
+#if ENABLE(SCROLLING_THREAD)
+    if (properties.changedProperties & RemoteLayerTreeTransaction::ScrollingNodeIDChanged)
+        node.setScrollingNodeID(properties.scrollingNodeID);
+#endif
 
 #if PLATFORM(IOS_FAMILY)
     applyPropertiesToUIView(node.uiView(), properties, relatedLayers);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -38,6 +38,7 @@
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/Model.h>
 #include <WebCore/PlatformCALayer.h>
+#include <WebCore/ScrollTypes.h>
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -97,11 +98,12 @@ public:
         CustomAppearanceChanged             = 1LLU << 36,
         UserInteractionEnabledChanged       = 1LLU << 37,
         EventRegionChanged                  = 1LLU << 38,
+        ScrollingNodeIDChanged              = 1LLU << 39,
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-        SeparatedChanged                    = 1LLU << 39,
+        SeparatedChanged                    = 1LLU << 40,
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-        SeparatedPortalChanged              = 1LLU << 40,
-        DescendentOfSeparatedPortalChanged  = 1LLU << 41,
+        SeparatedPortalChanged              = 1LLU << 41,
+        DescendentOfSeparatedPortalChanged  = 1LLU << 42,
 #endif
 #endif
     };
@@ -165,6 +167,9 @@ public:
         WebCore::Path shapePath;
         WebCore::GraphicsLayer::PlatformLayerID maskLayerID { 0 };
         WebCore::GraphicsLayer::PlatformLayerID clonedLayerID { 0 };
+#if ENABLE(SCROLLING_THREAD)
+        WebCore::ScrollingNodeID scrollingNodeID { 0 };
+#endif
         double timeOffset { 0 };
         float speed { 1 };
         float contentsScale { 1 };
@@ -188,6 +193,7 @@ public:
         bool contentsHidden { false };
         bool userInteractionEnabled { true };
         WebCore::EventRegion eventRegion;
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         bool isSeparated { false };
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
@@ -400,7 +406,8 @@ template<> struct EnumTraits<WebKit::RemoteLayerTreeTransaction::LayerChange> {
         WebKit::RemoteLayerTreeTransaction::LayerChange::AntialiasesEdgesChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::CustomAppearanceChanged,
         WebKit::RemoteLayerTreeTransaction::LayerChange::UserInteractionEnabledChanged,
-        WebKit::RemoteLayerTreeTransaction::LayerChange::EventRegionChanged
+        WebKit::RemoteLayerTreeTransaction::LayerChange::EventRegionChanged,
+        WebKit::RemoteLayerTreeTransaction::LayerChange::ScrollingNodeIDChanged
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         , WebKit::RemoteLayerTreeTransaction::LayerChange::SeparatedChanged
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -115,6 +115,9 @@ RemoteLayerTreeTransaction::LayerProperties::LayerProperties(const LayerProperti
     , shapePath(other.shapePath)
     , maskLayerID(other.maskLayerID)
     , clonedLayerID(other.clonedLayerID)
+#if ENABLE(SCROLLING_THREAD)
+    , scrollingNodeID(other.scrollingNodeID)
+#endif
     , timeOffset(other.timeOffset)
     , speed(other.speed)
     , contentsScale(other.contentsScale)
@@ -227,6 +230,11 @@ void RemoteLayerTreeTransaction::LayerProperties::encode(IPC::Encoder& encoder) 
 
     if (changedProperties & ClonedContentsChanged)
         encoder << clonedLayerID;
+
+#if ENABLE(SCROLLING_THREAD)
+    if (changedProperties & ScrollingNodeIDChanged)
+        encoder << scrollingNodeID;
+#endif
 
     if (changedProperties & ContentsRectChanged)
         encoder << contentsRect;
@@ -420,6 +428,13 @@ bool RemoteLayerTreeTransaction::LayerProperties::decode(IPC::Decoder& decoder, 
         if (!decoder.decode(result.clonedLayerID))
             return false;
     }
+
+#if ENABLE(SCROLLING_THREAD)
+    if (result.changedProperties & ScrollingNodeIDChanged) {
+        if (!decoder.decode(result.scrollingNodeID))
+            return false;
+    }
+#endif
 
     if (result.changedProperties & ContentsRectChanged) {
         if (!decoder.decode(result.contentsRect))
@@ -879,6 +894,11 @@ static void dumpChangedLayers(TextStream& ts, const RemoteLayerTreeTransaction::
 
         if (layerProperties.changedProperties & RemoteLayerTreeTransaction::ClonedContentsChanged)
             ts.dumpProperty("clonedLayer", layerProperties.clonedLayerID);
+
+#if ENABLE(SCROLLING_THREAD)
+        if (layerProperties.changedProperties & RemoteLayerTreeTransaction::ScrollingNodeIDChanged)
+            ts.dumpProperty("scrollingNodeID", layerProperties.scrollingNodeID);
+#endif
 
         if (layerProperties.changedProperties & RemoteLayerTreeTransaction::ContentsRectChanged)
             ts.dumpProperty("contentsRect", layerProperties.contentsRect);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -75,6 +75,11 @@ public:
 
     static NSString *appendLayerDescription(NSString *description, CALayer *);
 
+#if ENABLE(SCROLLING_THREAD)
+    WebCore::ScrollingNodeID scrollingNodeID() const { return m_scrollingNodeID; }
+    void setScrollingNodeID(WebCore::ScrollingNodeID nodeID) { m_scrollingNodeID = nodeID; }
+#endif
+
 private:
     void initializeLayer();
 
@@ -86,6 +91,10 @@ private:
 #endif
 
     WebCore::EventRegion m_eventRegion;
+
+#if ENABLE(SCROLLING_THREAD)
+    WebCore::ScrollingNodeID m_scrollingNodeID { 0 };
+#endif
 
     WebCore::GraphicsLayer::PlatformLayerID m_actingScrollContainerID { 0 };
     Vector<WebCore::GraphicsLayer::PlatformLayerID> m_stationaryScrollContainerIDs;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp
@@ -909,7 +909,7 @@ void PlatformCALayerRemote::updateCustomAppearance(GraphicsLayer::CustomAppearan
     m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::CustomAppearanceChanged);
 }
 
-void PlatformCALayerRemote::setEventRegion(const WebCore::EventRegion& eventRegion)
+void PlatformCALayerRemote::setEventRegion(const EventRegion& eventRegion)
 {
     if (m_properties.eventRegion == eventRegion)
         return;
@@ -917,6 +917,22 @@ void PlatformCALayerRemote::setEventRegion(const WebCore::EventRegion& eventRegi
     m_properties.eventRegion = eventRegion;
     m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::EventRegionChanged);
 }
+
+#if ENABLE(SCROLLING_THREAD)
+ScrollingNodeID PlatformCALayerRemote::scrollingNodeID() const
+{
+    return m_properties.scrollingNodeID;
+}
+
+void PlatformCALayerRemote::setScrollingNodeID(ScrollingNodeID nodeID)
+{
+    if (nodeID == m_properties.scrollingNodeID)
+        return;
+
+    m_properties.scrollingNodeID = nodeID;
+    m_properties.notePropertiesChanged(RemoteLayerTreeTransaction::ScrollingNodeIDChanged);
+}
+#endif
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
 bool PlatformCALayerRemote::isSeparated() const

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -179,6 +179,11 @@ public:
 
     void setEventRegion(const WebCore::EventRegion&) override;
 
+#if ENABLE(SCROLLING_THREAD)
+    WebCore::ScrollingNodeID scrollingNodeID() const override;
+    void setScrollingNodeID(WebCore::ScrollingNodeID) override;
+#endif
+
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool isSeparated() const override;
     void setIsSeparated(bool) override;


### PR DESCRIPTION
#### 4b08e3ef1c8ab35d9693c34e0378ac813966722e
<pre>
Plumb ScrollingNodeIDs through to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=248070">https://bugs.webkit.org/show_bug.cgi?id=248070</a>
rdar://102499187

Reviewed by Alan Baradlay.

For scroller hit-testing we use the ScrollingNodeIDs that are pushed onto platform
layers via GraphicsLayer. UI-side compositing needs these ScrollingNodeIDs in the
UI process, so pass them along via PlatformCALayerRemote.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode):
(WebKit::dumpChangedLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::scrollingNodeID const):
(WebKit::RemoteLayerTreeNode::setScrollingNodeID):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.cpp:
(WebKit::PlatformCALayerRemote::setEventRegion):
(WebKit::PlatformCALayerRemote::scrollingNodeID const):
(WebKit::PlatformCALayerRemote::setScrollingNodeID):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:

Canonical link: <a href="https://commits.webkit.org/256842@main">https://commits.webkit.org/256842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaeb9b01b00db3e3c3a82ff4ab2c1eb9bb2fbcc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106455 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6416 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34926 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103153 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4820 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83542 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31831 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88524 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74723 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-persistence (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/230 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/216 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4736 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5007 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40730 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->