### PR TITLE
A stopped service worker fails to pass header and referrer on fetch request

### DIFF
--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Setup activating worker
+PASS Service worker load uses preload through calling fetch on the fetch event request
+

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+var activeWorker;
+var uuid = token();
+var url = "/WebKit/service-workers/resources/fetch-service-worker-preload-script.py?getResponseFromRequestWithCustomHeader=yes&customHeader=1&token=" + uuid;
+var frame;
+const channel = new MessageChannel();
+
+function waitUntilActivating()
+{
+    return new Promise(resolve => {
+        channel.port2.onmessage = (event) => {
+            if (event.data === "activating")
+                resolve();
+        };
+    });
+}
+
+function triggerActivation()
+{
+    activeWorker.postMessage("activate");
+}
+
+promise_test(async (test) => {
+    if (window.testRunner) {
+        testRunner.setUseSeparateServiceWorkerProcess(true);
+        await fetch("").then(() => { }, () => { });
+    }
+
+    let registration = await navigator.serviceWorker.register("/WebKit/service-workers/fetch-service-worker-preload-worker.js", { scope : url });
+    if (!registration.installing) {
+        registration.unregister();
+        registration = await navigator.serviceWorker.register("/WebKit/service-workers/fetch-service-worker-preload-worker.js", { scope : url });
+    }
+
+    activeWorker = registration.installing;
+    activeWorker.postMessage({ port: channel.port1 }, [channel.port1]);
+
+    return waitUntilActivating();
+}, "Setup activating worker");
+
+promise_test(async (test) => {
+    fetch(url + "&value=use-preload", { method: 'POST' });
+
+    // Load iframe, with activating worker, so only preload will start.
+    const promise = withIframe(url);
+
+    triggerActivation();
+
+    const frame = await promise;
+    assert_equals(frame.contentWindow.value, "my-custom-header");
+
+    // We should have only one GET fetch to url: the service worker preload
+    const response = await fetch(url + "&count=True");
+    assert_equals(await response.text(), "1");
+}, "Service worker load uses preload through calling fetch on the fetch event request");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-worker.js
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-worker.js
@@ -41,6 +41,13 @@ self.addEventListener('fetch', async (event) => {
         return;
     }
 
+    if (event.request.url.includes("getResponseFromRequestWithCustomHeader")) {
+        const newRequest = new Request(event.request, {
+            headers: { "x-custom-header": "my-custom-header" },
+        });
+        event.respondWith(fetch(newRequest));
+        return;
+    }
 
     if (event.request.url.includes("getCloneResponseFromNavigationPreload") && event.preloadResponse) {
         event.respondWith((async () => {

--- a/LayoutTests/http/wpt/service-workers/resources/fetch-service-worker-preload-script.py
+++ b/LayoutTests/http/wpt/service-workers/resources/fetch-service-worker-preload-script.py
@@ -41,5 +41,8 @@ def main(request, response):
         response.headers.set(b"Content-Type", b"text/vcard")
         return value.decode()
 
+    if b"customHeader" in request.GET:
+        value = request.headers.get(b"x-custom-header", b"no custom header")
+
     response.headers.set(b"Content-Type", b"text/html")
     return "<html><body><script>window.value = '%s';</script></body></html>" % value.decode()

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -207,7 +207,6 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
 {
     m_request = input.m_request;
     m_requestURL = m_request.url();
-    m_navigationPreloadIdentifier = input.navigationPreloadIdentifier();
 
     m_options = input.m_options;
     m_referrer = input.m_referrer;


### PR DESCRIPTION
#### 157a46485c50713332ff3eab7c3ae81a67abe448
<pre>
A stopped service worker fails to pass header and referrer on fetch request
<a href="https://bugs.webkit.org/show_bug.cgi?id=242910">https://bugs.webkit.org/show_bug.cgi?id=242910</a>
rdar://problem/97616866

Reviewed by Alex Christensen.

We can use the preoload if we try to load the same request or a cloned request.
We cannot in general reuse the preload if the request is changing a bit.
Remove the setting of the navigation preload identifier when creating a new request from another.

* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html: Added.
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-worker.js:
(async event.event.request.url.includes.event.preloadResponse.async return):
* LayoutTests/http/wpt/service-workers/resources/fetch-service-worker-preload-script.py:
(main):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):

Canonical link: <a href="https://commits.webkit.org/257110@main">https://commits.webkit.org/257110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29f794c928fd44e31543db65b411802d711bbf76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106481 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166764 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6443 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34951 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103178 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4845 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83568 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31854 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74748 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/255 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20035 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21462 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4886 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/43973 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40763 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->