### PR TITLE
[WPE] Do not generate click event for long touch presses

### DIFF
--- a/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
+++ b/Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h
@@ -41,12 +41,17 @@ public:
     enum class GesturedEvent {
         None,
         Click,
+        ContextMenu,
         Axis,
     };
 
     struct NoEvent { };
 
     struct ClickEvent {
+        struct wpe_input_pointer_event event;
+    };
+
+    struct ContextMenuEvent {
         struct wpe_input_pointer_event event;
     };
 
@@ -59,7 +64,7 @@ public:
         WebWheelEvent::Phase phase;
     };
 
-    using EventVariant = std::variant<NoEvent, ClickEvent, AxisEvent>;
+    using EventVariant = std::variant<NoEvent, ClickEvent, ContextMenuEvent, AxisEvent>;
 
     GesturedEvent gesturedEvent() const { return m_gesturedEvent; }
     EventVariant handleEvent(const struct wpe_input_touch_event_raw*);

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -234,6 +234,9 @@ void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& touchEvent, b
             event->modifiers &= ~wpe_input_pointer_modifier_button1;
             page.handleMouseEvent(NativeWebMouseEvent(event, page.deviceScaleFactor()));
         },
+        [&](TouchGestureController::ContextMenuEvent&) {
+            // FIXME: Generate contextmenuevent without accidentally generating mouseup/mousedown events
+        },
         [](TouchGestureController::AxisEvent&) { });
 }
 #endif

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -248,6 +248,7 @@ View::View(struct wpe_view_backend* backend, const API::PageConfiguration& baseC
                 WTF::switchOn(generatedEvent,
                     [](TouchGestureController::NoEvent&) { },
                     [](TouchGestureController::ClickEvent&) { },
+                    [](TouchGestureController::ContextMenuEvent&) { },
                     [&](TouchGestureController::AxisEvent& axisEvent)
                     {
 #if WPE_CHECK_VERSION(1, 5, 0)


### PR DESCRIPTION
#### 14aef58eda45d6e9a240ddff910a5234a1828d3d
<pre>
[WPE] Do not generate click event for long touch presses
<a href="https://bugs.webkit.org/show_bug.cgi?id=248076">https://bugs.webkit.org/show_bug.cgi?id=248076</a>

Reviewed by Michael Catanzaro.

Similar to the GTK port, a contextmenuevent should be generated for long
presses instead of a click event. We could generate a sequence of mouse
motion towards the desired point, mouse down, mouse up
(wpe_input_pointer_modifier_button2). This would cause the
contextmenuevent to be emitted, but also mousedown/mouseup events, which
are not expected. Since there seems to be no other way of doing this (at
the moment), implement a compromise: implement the detection of long tap
gestures, but don&apos;t generate the context mouse events yet.

Use a threshold value of 500 ms for detecting long tap gestures similar
to gtk-long-press-time&apos;s default of 500 ms.

See also: <a href="https://bugs.webkit.org/show_bug.cgi?id=251925">https://bugs.webkit.org/show_bug.cgi?id=251925</a>

* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::doneWithTouchEvent): Add no-op on
TouchGestureController::ContextMenuEvent.
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.cpp:
(WebKit::TouchGestureController::handleEvent): Generate ContextMenuEvent
for long presses.
* Source/WebKit/UIProcess/API/libwpe/TouchGestureController.h: Add
ContextMenu to GesturedEvent enum, create ContextMenuEvent and add it to
EventVariant.
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
(WKWPE::m_backend): Add no-op for
TouchGestureController::ContextMenuEvent.

Canonical link: <a href="https://commits.webkit.org/263030@main">https://commits.webkit.org/263030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53e364ff116e1729c45a0dce0a9fc4e71822f944

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3378 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3709 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4627 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2936 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4369 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2775 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3014 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/827 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->