### PR TITLE
[GTK] Deprecate event parameter of WebKitWebView::context-menu signal

### DIFF
--- a/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp
@@ -52,6 +52,13 @@ struct _WebKitContextMenuPrivate {
     GList* items;
     WebKitContextMenuItem* parentItem;
     GRefPtr<GVariant> userData;
+#if PLATFORM(GTK)
+#if USE(GTK4)
+    GRefPtr<GdkEvent> event;
+#else
+    GUniquePtr<GdkEvent> event;
+#endif
+#endif
 };
 
 WEBKIT_DEFINE_TYPE(WebKitContextMenu, webkit_context_menu, G_TYPE_OBJECT)
@@ -93,6 +100,17 @@ WebKitContextMenu* webkitContextMenuCreate(const Vector<WebContextMenuItemData>&
 
     return menu;
 }
+
+#if PLATFORM(GTK)
+#if USE(GTK4)
+void webkitContextMenuSetEvent(WebKitContextMenu* menu, GRefPtr<GdkEvent>&& event)
+#else
+void webkitContextMenuSetEvent(WebKitContextMenu* menu, GUniquePtr<GdkEvent>&& event)
+#endif
+{
+    menu->priv->event = WTFMove(event);
+}
+#endif
 
 void webkitContextMenuSetParentItem(WebKitContextMenu* menu, WebKitContextMenuItem* item)
 {
@@ -372,3 +390,37 @@ GVariant* webkit_context_menu_get_user_data(WebKitContextMenu* menu)
 
     return menu->priv->userData.get();
 }
+
+#if PLATFORM(GTK)
+/**
+ * webkit_context_menu_get_event:
+ * @menu: a #WebKitContextMenu
+ *
+ * Gets the #GdkEvent that triggered the context menu. This function only returns a valid
+ * #GdkEvent when called for a #WebKitContextMenu passed to #WebKitWebView::context-menu
+ * signal; in all other cases, %NULL is returned.
+ *
+ * The returned #GdkEvent is expected to be one of the following types:
+ * <itemizedlist>
+ * <listitem><para>
+ * a #GdkEventButton of type %GDK_BUTTON_PRESS when the context menu was triggered with mouse.
+ * </para></listitem>
+ * <listitem><para>
+ * a #GdkEventKey of type %GDK_KEY_PRESS if the keyboard was used to show the menu.
+ * </para></listitem>
+ * <listitem><para>
+ * a generic #GdkEvent of type %GDK_NOTHING when the #GtkWidget::popup-menu signal was used to show the context menu.
+ * </para></listitem>
+ * </itemizedlist>
+ *
+ * Returns: (transfer none): the menu event or %NULL.
+ *
+ * Since: 2.40
+ */
+GdkEvent* webkit_context_menu_get_event(WebKitContextMenu* menu)
+{
+    g_return_val_if_fail(WEBKIT_IS_CONTEXT_MENU(menu), nullptr);
+
+    return menu->priv->event.get();
+}
+#endif

--- a/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
+++ b/Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h
@@ -22,8 +22,20 @@
 #include "WebContextMenuItemGlib.h"
 #include "WebKitContextMenu.h"
 
+#if PLATFORM(GTK)
+#include <WebCore/GRefPtrGtk.h>
+#include <WebCore/GUniquePtrGtk.h>
+#endif
+
 WebKitContextMenu* webkitContextMenuCreate(const Vector<WebKit::WebContextMenuItemData>&);
 void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenuItemGlib>&);
 void webkitContextMenuPopulate(WebKitContextMenu*, Vector<WebKit::WebContextMenuItemData>&);
 void webkitContextMenuSetParentItem(WebKitContextMenu*, WebKitContextMenuItem*);
 WebKitContextMenuItem* webkitContextMenuGetParentItem(WebKitContextMenu*);
+#if PLATFORM(GTK)
+#if USE(GTK4)
+void webkitContextMenuSetEvent(WebKitContextMenu*, GRefPtr<GdkEvent>&&);
+#else
+void webkitContextMenuSetEvent(WebKitContextMenu*, GUniquePtr<GdkEvent>&&);
+#endif
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in
@@ -23,6 +23,9 @@
 #define WebKitContextMenu_h
 
 #include <glib-object.h>
+#if PLATFORM(GTK)
+#include <gtk/gtk.h>
+#endif
 #include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
 
 G_BEGIN_DECLS
@@ -112,6 +115,11 @@ webkit_context_menu_set_user_data        (WebKitContextMenu     *menu,
 
 WEBKIT_API GVariant *
 webkit_context_menu_get_user_data        (WebKitContextMenu     *menu);
+
+#if PLATFORM(GTK)
+WEBKIT_API GdkEvent *
+webkit_context_menu_get_event            (WebKitContextMenu     *menu);
+#endif
 
 G_END_DECLS
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp
@@ -272,6 +272,10 @@ static GVariant* serializeNode(JSCValue* node)
 
 static gboolean contextMenuCallback(WebKitWebPage* page, WebKitContextMenu* menu, WebKitWebHitTestResult* hitTestResult, gpointer)
 {
+#if PLATFORM(GTK)
+    g_assert_null(webkit_context_menu_get_event(menu));
+#endif
+
     const char* pageURI = webkit_web_page_get_uri(page);
     if (!g_strcmp0(pageURI, "ContextMenuTestDefault")) {
         webkit_context_menu_set_user_data(menu, serializeContextMenu(menu));

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp
@@ -66,6 +66,7 @@ public:
     {
         g_assert_true(WEBKIT_IS_CONTEXT_MENU(contextMenu));
         test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(contextMenu));
+        g_assert_true(webkit_context_menu_get_event(contextMenu) == event);
         test->checkContextMenuEvent(event);
         g_assert_true(WEBKIT_IS_HIT_TEST_RESULT(hitTestResult));
         test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(hitTestResult));
@@ -326,7 +327,7 @@ public:
     {
     }
 
-    bool contextMenu(WebKitContextMenu* contextMenu, GdkEvent* event, WebKitHitTestResult* hitTestResult)
+    bool contextMenu(WebKitContextMenu* contextMenu, GdkEvent*, WebKitHitTestResult* hitTestResult)
     {
         GList* iter = webkit_context_menu_get_items(contextMenu);
 
@@ -1166,7 +1167,6 @@ void beforeAll()
     kServer = new WebKitTestServer();
     kServer->run(serverCallback);
 
-    // FIXME: Rework context menu API in GTK4 to not expose GdkEvent.
     ContextMenuDefaultTest::add("WebKitWebView", "default-menu", testContextMenuDefaultMenu);
     ContextMenuDefaultTest::add("WebKitWebView", "context-menu-key", testContextMenuKey);
     ContextMenuDefaultTest::add("WebKitWebView", "popup-event-signal", testPopupEventSignal);


### PR DESCRIPTION
#### 07a9bc7be85d6549f876018d1886a8b4335acc25
<pre>
[GTK] Deprecate event parameter of WebKitWebView::context-menu signal
<a href="https://bugs.webkit.org/show_bug.cgi?id=248078">https://bugs.webkit.org/show_bug.cgi?id=248078</a>

Reviewed by Michael Catanzaro.

Deprecate it in current API and remove it for GTK4 API. Add
webkit_context_menu_get_event() instead.

* Source/WebKit/Shared/API/glib/WebKitContextMenu.cpp:
(webkitContextMenuSetEvent):
(webkit_context_menu_get_event):
* Source/WebKit/Shared/API/glib/WebKitContextMenuPrivate.h:
* Source/WebKit/UIProcess/API/glib/WebKitContextMenu.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
(webkitWebViewPopulateContextMenu):
(gValueGetEvent): Deleted.
(webkitWebViewContextMenuMarshal): Deleted.
(webkitWebViewContextMenuMarshalVa): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebExtensionTest.cpp:
(contextMenuCallback):
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestContextMenu.cpp:
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/256886@main">https://commits.webkit.org/256886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/201adb26455b9815cc9dabe98087b7956e3f2ab2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106639 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6642 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35122 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89511 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102790 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83741 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5192 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2327 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1634 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->