### PR TITLE
[Web Animations] Make WPT test at animation-model/keyframe-effects/effect-value-context.html pass reliably

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Effect values reflect changes to font-size on element
-FAIL Effect values reflect changes to font-size on parent element assert_equals: Effect value after updating font-size on parent element expected "300px" but got "150px"
+PASS Effect values reflect changes to font-size on parent element
 PASS Effect values reflect changes to font-size when computed style is not immediately flushed
 PASS Effect values reflect changes to font-size from reparenting
 PASS Effect values reflect changes to target element

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-filling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-filling-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Filling effect values reflect changes to font-size on element
-FAIL Filling effect values reflect changes to font-size on parent element assert_equals: Effect value after updating font-size on parent element expected "400px" but got "200px"
+PASS Filling effect values reflect changes to font-size on parent element
 FAIL Filling effect values reflect changes to variables on element assert_equals: Effect value after updating variable expected "200px" but got "100px"
 FAIL Filling effect values reflect changes to variables on parent element assert_equals: Effect value after updating variable expected "400px" but got "200px"
 PASS Filling effect values reflect changes to the the animation's keyframes
@@ -9,8 +9,8 @@ PASS Filling effect values reflect changes to the the animation's iteration comp
 PASS Filling effect values reflect changes to the base value when using additive animation
 PASS Filling effect values reflect changes to the base value when using additive animation on a single keyframe
 PASS Filling effect values reflect changes to the base value when using the fill value is an implicit keyframe
-FAIL Filling effect values reflect changes to the base value via a parent element assert_equals: Effect value after updating font-size on parent expected "400px" but got "300px"
+PASS Filling effect values reflect changes to the base value via a parent element
 PASS Filling effect values reflect changes to underlying animations
-FAIL Filling effect values reflect changes to underlying animations via a a parent element assert_equals: Effect value after updating parent font-size expected "400px" but got "300px"
+PASS Filling effect values reflect changes to underlying animations via a a parent element
 PASS Filling effect values reflect changes to underlying animations made by directly changing the keyframes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/boxShadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/boxShadow-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL boxShadow responsive to style changes assert_not_equals: got disallowed value "rgb(255, 0, 0) 100px 100px 0px 0px"
+PASS boxShadow responsive to style changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/shapeOutside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/shapeOutside-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL shapeOutside responsive to style changes assert_not_equals: got disallowed value "circle(100px at 50% 50%)"
+PASS shapeOutside responsive to style changes
 FAIL shapeOutside responsive to inherited shapeOutside changes assert_equals: expected "circle(200px at 50% 50%)" but got "circle(150px at 50% 50%)"
 

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -77,6 +77,13 @@ bool KeyframeEffectStack::hasMatchingEffect(const Function<bool(const KeyframeEf
     return false;
 }
 
+bool KeyframeEffectStack::containsProperty(CSSPropertyID property) const
+{
+    return hasMatchingEffect([property] (const KeyframeEffect& effect) {
+        return effect.animatesProperty(property);
+    });
+}
+
 bool KeyframeEffectStack::requiresPseudoElement() const
 {
     return hasMatchingEffect([] (const KeyframeEffect& effect) {

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -52,6 +52,7 @@ public:
     Vector<WeakPtr<KeyframeEffect>> sortedEffects();
     const AnimationList* cssAnimationList() const { return m_cssAnimationList.get(); }
     void setCSSAnimationList(RefPtr<const AnimationList>&&);
+    bool containsProperty(CSSPropertyID) const;
     bool isCurrentlyAffectingProperty(CSSPropertyID) const;
     bool requiresPseudoElement() const;
     OptionSet<AnimationImpact> applyKeyframeEffects(RenderStyle& targetStyle, const RenderStyle* previousLastStyleChangeEventStyle, const Style::ResolutionContext&);

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2484,6 +2484,11 @@ static inline bool hasValidStyleForProperty(Element& element, CSSPropertyID prop
     if (!element.document().childNeedsStyleRecalc())
         return true;
 
+    if (auto* keyframeEffectStack = Styleable(element, PseudoId::None).keyframeEffectStack()) {
+        if (keyframeEffectStack->containsProperty(propertyID))
+            return false;
+    }
+
     auto isQueryContainer = [&](Element& element) {
         auto* style = element.renderStyle();
         return style && style->containerType() != ContainerType::Normal;


### PR DESCRIPTION
#### 6f8d19cd85068115052db71b6702482d87e28d51
<pre>
[Web Animations] Make WPT test at animation-model/keyframe-effects/effect-value-context.html pass reliably
<a href="https://bugs.webkit.org/show_bug.cgi?id=186490">https://bugs.webkit.org/show_bug.cgi?id=186490</a>
rdar://41000137

Reviewed by Antti Koivisto.

We added support for recomputing keyframes when the computed font-size changes in bug 237357, allowing
any keyframe values depending on font-size to produce the expected values. However, we have a bug when
font-size changes on a parent element where the logic under ComputedStyleExtractor::propertyValue() will
not invalidate style because the code does not think the style needs updating.

So we update hasValidStyleForProperty() to account for animations affecting the property for which
the computed style is requested.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-filling-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/boxShadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/shapeOutside-expected.txt:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::containsProperty const):
* Source/WebCore/animation/KeyframeEffectStack.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::hasValidStyleForProperty):

Canonical link: <a href="https://commits.webkit.org/256889@main">https://commits.webkit.org/256889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e010d86b9f777d2c8cab948af35894c8c8c329e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106645 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6652 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35128 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89517 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103335 "Failed to checkout and rebase branch from PR 6629") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102796 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83748 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/400 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2330 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1640 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->