### PR TITLE
Use CFEqual to check for VideoFrame pixel primaries

### DIFF
--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -452,41 +452,41 @@ static PlatformVideoColorSpace computeVideoFrameColorSpace(CVPixelBufferRef pixe
 
     std::optional<PlatformVideoColorPrimaries> primaries;
     auto pixelPrimaries = CVBufferGetAttachment(pixelBuffer, kCVImageBufferColorPrimariesKey, nil);
-    if (pixelPrimaries == kCVImageBufferColorPrimaries_ITU_R_709_2)
+    if (safeCFEqual(pixelPrimaries, kCVImageBufferColorPrimaries_ITU_R_709_2))
         primaries = PlatformVideoColorPrimaries::Bt709;
-    else if (pixelPrimaries == kCVImageBufferColorPrimaries_EBU_3213)
+    else if (safeCFEqual(pixelPrimaries, kCVImageBufferColorPrimaries_EBU_3213))
         primaries = PlatformVideoColorPrimaries::JedecP22Phosphors;
-    else if (pixelPrimaries == PAL::kCMFormatDescriptionColorPrimaries_DCI_P3)
+    else if (safeCFEqual(pixelPrimaries, PAL::kCMFormatDescriptionColorPrimaries_DCI_P3))
         primaries = PlatformVideoColorPrimaries::SmpteRp431;
-    else if (pixelPrimaries == PAL::kCMFormatDescriptionColorPrimaries_P3_D65)
+    else if (safeCFEqual(pixelPrimaries, PAL::kCMFormatDescriptionColorPrimaries_P3_D65))
         primaries = PlatformVideoColorPrimaries::SmpteEg432;
-    else if (pixelPrimaries == PAL::kCMFormatDescriptionColorPrimaries_ITU_R_2020)
+    else if (safeCFEqual(pixelPrimaries, PAL::kCMFormatDescriptionColorPrimaries_ITU_R_2020))
         primaries = PlatformVideoColorPrimaries::Bt2020;
 
     std::optional<PlatformVideoTransferCharacteristics> transfer;
     auto pixelTransfer = CVBufferGetAttachment(pixelBuffer, kCVImageBufferTransferFunctionKey, nil);
-    if (pixelTransfer == kCVImageBufferTransferFunction_ITU_R_709_2)
+    if (safeCFEqual(pixelTransfer, kCVImageBufferTransferFunction_ITU_R_709_2))
         transfer = PlatformVideoTransferCharacteristics::Bt709;
-    else if (pixelTransfer == kCVImageBufferTransferFunction_SMPTE_240M_1995)
+    else if (safeCFEqual(pixelTransfer, kCVImageBufferTransferFunction_SMPTE_240M_1995))
         transfer = PlatformVideoTransferCharacteristics::Smpte240m;
-    else if (pixelTransfer == PAL::kCMFormatDescriptionTransferFunction_SMPTE_ST_2084_PQ)
+    else if (safeCFEqual(pixelTransfer, PAL::kCMFormatDescriptionTransferFunction_SMPTE_ST_2084_PQ))
         transfer = PlatformVideoTransferCharacteristics::SmpteSt2084;
-    else if (pixelTransfer == PAL::kCMFormatDescriptionTransferFunction_SMPTE_ST_428_1)
+    else if (safeCFEqual(pixelTransfer, PAL::kCMFormatDescriptionTransferFunction_SMPTE_ST_428_1))
         transfer = PlatformVideoTransferCharacteristics::SmpteSt4281;
-    else if (pixelTransfer == PAL::kCMFormatDescriptionTransferFunction_ITU_R_2100_HLG)
+    else if (safeCFEqual(pixelTransfer, PAL::kCMFormatDescriptionTransferFunction_ITU_R_2100_HLG))
         transfer = PlatformVideoTransferCharacteristics::AribStdB67Hlg;
-    else if (pixelTransfer == PAL::kCMFormatDescriptionTransferFunction_Linear)
+    else if (safeCFEqual(pixelTransfer, PAL::kCMFormatDescriptionTransferFunction_Linear))
         transfer = PlatformVideoTransferCharacteristics::Linear;
-    else if (PAL::canLoad_CoreMedia_kCMFormatDescriptionTransferFunction_sRGB() && pixelTransfer == PAL::get_CoreMedia_kCMFormatDescriptionTransferFunction_sRGB())
+    else if (PAL::canLoad_CoreMedia_kCMFormatDescriptionTransferFunction_sRGB() && safeCFEqual(pixelTransfer, PAL::get_CoreMedia_kCMFormatDescriptionTransferFunction_sRGB()))
         transfer = PlatformVideoTransferCharacteristics::Iec6196621;
 
     std::optional<PlatformVideoMatrixCoefficients> matrix;
     auto pixelMatrix = CVBufferGetAttachment(pixelBuffer, kCVImageBufferYCbCrMatrixKey, nil);
-    if (pixelMatrix == PAL::kCMFormatDescriptionYCbCrMatrix_ITU_R_2020)
+    if (safeCFEqual(pixelMatrix, PAL::kCMFormatDescriptionYCbCrMatrix_ITU_R_2020))
         matrix = PlatformVideoMatrixCoefficients::Bt2020NonconstantLuminance;
-    else if (pixelMatrix == kCVImageBufferYCbCrMatrix_ITU_R_709_2)
+    else if (safeCFEqual(pixelMatrix, kCVImageBufferYCbCrMatrix_ITU_R_709_2))
         matrix = PlatformVideoMatrixCoefficients::Bt709;
-    else if (pixelMatrix == kCVImageBufferYCbCrMatrix_SMPTE_240M_1995)
+    else if (safeCFEqual(pixelMatrix, kCVImageBufferYCbCrMatrix_SMPTE_240M_1995))
         matrix = PlatformVideoMatrixCoefficients::Smpte240m;
 
     auto pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer);


### PR DESCRIPTION
#### 7560d94d186b3c91eb1d51fbabb78a4dbf615685
<pre>
Use CFEqual to check for VideoFrame pixel primaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=248082">https://bugs.webkit.org/show_bug.cgi?id=248082</a>
rdar://102425691

Reviewed by Eric Carlson.

* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::computeVideoFrameColorSpace):

Canonical link: <a href="https://commits.webkit.org/257017@main">https://commits.webkit.org/257017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05ee2685192127ec2a9ef5e20b5b74542635556d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106701 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166973 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6727 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35184 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103390 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5059 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83810 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32035 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74956 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/472 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20213 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44159 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40980 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->