### PR TITLE
WebKit fails to render extreme border-radius

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Testing that child-background doesn't bleed through its parent border for a inner-border-radius that is larger than the content rect</title>
+    <link rel="help" href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius">
+    <link rel="assert" content="Testing that child-background doesn't bleed through its parent border for a inner-border-radius that is larger than the content rect">
+    <style>
+        body {
+            font-size: 24px;
+            color: black;
+            margin: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div> Test passes if no blue square is shown:</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Testing that child-background doesn't bleed through its parent border for a inner-border-radius that is larger than the content rect</title>
+    <link rel="help" href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius">
+    <link rel="assert" content="Testing that child-background doesn't bleed through its parent border for a inner-border-radius that is larger than the content rect">
+    <style>
+        body {
+            font-size: 24px;
+            color: black;
+            margin: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div> Test passes if no blue square is shown:</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Testing that child-background doesn't bleed through its parent border for a inner-border-radius that is larger than the content rect</title>
+    <link rel="match" href="inner-border-non-renderable-ref.html">
+    <link rel="help" href="https://w3c.github.io/csswg-drafts/css-backgrounds/#border-radius">
+    <link rel="assert" content="Testing that child-background doesn't bleed through its parent border for a inner-border-radius that is larger than the content rect">
+    <style>
+        body {
+            font-size: 24px;
+            color: black;
+            margin: 8px;
+        }
+        .clipping {
+            width: 300px;
+            height: 200px;
+            overflow: hidden;
+            border: 30px solid green;
+            border-top-color: gold;
+            border-top-right-radius: 150px 267px;
+            background-color: blue;
+        }
+        .composited {
+            width: 100%;
+            height: 100%;
+            background-color: blue;
+        }
+        .clip-test {
+            clip-path: inset(60px 10px 190px 320px);
+        }
+    </style>
+</head>
+<body>
+    <div> Test passes if no blue square is shown:</div>
+    <div class="clipping clip-test">
+        <div class="composited"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -829,8 +829,10 @@ void BorderPainter::paintOneBorderSide(const RoundedRect& outerBorder, const Rou
 
         clipBorderSidePolygon(outerBorder, innerBorder, side, adjacentSide1StylesMatch, adjacentSide2StylesMatch);
 
-        if (!innerBorder.isRenderable())
-            graphicsContext.clipOutRoundedRect(FloatRoundedRect(calculateAdjustedInnerBorder(innerBorder, side)));
+        if (!innerBorder.isRenderable())  {
+            auto adjustedInnerBorder = FloatRoundedRect(calculateAdjustedInnerBorder(innerBorder, side));
+            graphicsContext.clipOutRoundedRect(adjustedInnerBorder);
+        }
 
         float thickness = std::max(std::max(edgeToRender.widthForPainting(), adjacentEdge1.widthForPainting()), adjacentEdge2.widthForPainting());
         drawBoxSideFromPath(outerBorder.rect(), *path, edges, radii, edgeToRender.widthForPainting(), thickness, side,

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2000,6 +2000,12 @@ bool RenderBox::repaintLayerRectsForImage(WrappedImagePtr image, const FillLayer
     return false;
 }
 
+void RenderBox::clipContentForBorderRadius(GraphicsContext& context, const LayoutPoint& accumulatedOffset, float deviceScaleFactor)
+{
+    auto innerBorder = style().getRoundedInnerBorderFor(LayoutRect(accumulatedOffset, size()));
+    context.clipRoundedRect(innerBorder.pixelSnappedRoundedRectForPainting(deviceScaleFactor));
+}
+
 bool RenderBox::pushContentsClip(PaintInfo& paintInfo, const LayoutPoint& accumulatedOffset)
 {
     if (paintInfo.phase == PaintPhase::BlockBackground || paintInfo.phase == PaintPhase::SelfOutline || paintInfo.phase == PaintPhase::Mask)
@@ -2007,10 +2013,10 @@ bool RenderBox::pushContentsClip(PaintInfo& paintInfo, const LayoutPoint& accumu
 
     bool isControlClip = hasControlClip();
     bool isOverflowClip = hasNonVisibleOverflow() && !layer()->isSelfPaintingLayer();
-    
+
     if (!isControlClip && !isOverflowClip)
         return false;
-    
+
     if (paintInfo.phase == PaintPhase::Outline)
         paintInfo.phase = PaintPhase::ChildOutlines;
     else if (paintInfo.phase == PaintPhase::ChildBlockBackground) {
@@ -2022,7 +2028,7 @@ bool RenderBox::pushContentsClip(PaintInfo& paintInfo, const LayoutPoint& accumu
     FloatRect clipRect = snapRectToDevicePixels((isControlClip ? controlClipRect(accumulatedOffset) : overflowClipRect(accumulatedOffset, nullptr, IgnoreOverlayScrollbarSize, paintInfo.phase)), deviceScaleFactor);
     paintInfo.context().save();
     if (style().hasBorderRadius())
-        paintInfo.context().clipRoundedRect(style().getRoundedInnerBorderFor(LayoutRect(accumulatedOffset, size())).pixelSnappedRoundedRectForPainting(deviceScaleFactor));
+        clipContentForBorderRadius(paintInfo.context(), accumulatedOffset, deviceScaleFactor);
     paintInfo.context().clip(clipRect);
 
     if (paintInfo.phase == PaintPhase::EventRegion)

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -807,6 +807,8 @@ private:
     
     LayoutPoint topLeftLocationWithFlipping() const;
 
+    void clipContentForBorderRadius(GraphicsContext&, const LayoutPoint&, float);
+
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).
     LayoutRect m_frameRect;

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1780,6 +1780,8 @@ RoundedRect RenderStyle::getRoundedInnerBorderFor(const LayoutRect& borderRect, 
         adjustedRadii.shrink(topWidth, bottomWidth, leftWidth, rightWidth);
         roundedRect.includeLogicalEdges(adjustedRadii, isHorizontalWritingMode, includeLogicalLeftEdge, includeLogicalRightEdge);
     }
+    if (!roundedRect.isRenderable())
+        roundedRect.adjustRadii();
     return roundedRect;
 }
 


### PR DESCRIPTION
#### 8a3db1af14c197a24ab0425903d026408ff569f5
<pre>
WebKit fails to render extreme border-radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=244638">https://bugs.webkit.org/show_bug.cgi?id=244638</a>
rdar://99668793

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/inner-border-non-renderable.html: Added.
Testing that child-background doesn&apos;t bleed through its parent border for a inner-border-radius that is larger than the content rect.

* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintOneBorderSide):
Improving readability.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::clipContentForBorderRadius):
(WebCore::RenderBox::pushContentsClip):
The bug can be fixed by adjusting the inner-border radius, if not renderable, here. However, with we adjust it just here the bug can still be triggered in
other situations, for example, when applying a clip-path in an element with non-renderable border. Therefore, we are adjusting the non-renderable inner-border
directly in RenderStyle::getRoundedInnerBorderFor. Here, we are adding a helper function that still calls getRoundedInnerBorderFor for improving readability.

* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::getRoundedInnerBorderFor):
Adjusting the inner-border-radii for non-renderable inner-border.

Canonical link: <a href="https://commits.webkit.org/256943@main">https://commits.webkit.org/256943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a21d79b0a3c8ed0cbefbf9890af5b3d8f3eb2fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106801 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167067 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6841 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35281 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103485 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102944 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83909 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32123 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86989 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75049 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/562 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/546 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4785 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5347 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41068 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->