### PR TITLE
Add an API test for notificationclose

### DIFF
--- a/Tools/TestWebKitAPI/TestNotificationProvider.cpp
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.cpp
@@ -160,4 +160,21 @@ bool TestNotificationProvider::simulateNotificationClick()
     return true;
 }
 
+bool TestNotificationProvider::simulateNotificationClose()
+{
+    if (!m_pendingNotification.first)
+        return false;
+
+    callOnMainThread([pair = std::exchange(m_pendingNotification, { })] {
+        auto id = adoptWK(WKUInt64Create(pair.second));
+        auto idRef = static_cast<WKTypeRef>(id.get());
+        auto wkArray = adoptWK(WKArrayCreate(&idRef, 1));
+
+        WKNotificationManagerProviderDidCloseNotifications(pair.first, wkArray.get());
+        WKRelease(pair.first);
+    });
+
+    return true;
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/TestNotificationProvider.h
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.h
@@ -47,6 +47,7 @@ public:
     void showWebNotification(WKPageRef, WKNotificationRef);
     void closeWebNotification(WKNotificationRef);
     bool simulateNotificationClick();
+    bool simulateNotificationClose();
 
     bool hasReceivedShowNotification() const { return m_hasReceivedShowNotification; }
     bool hasReceivedCloseNotification() const { return m_hasReceivedCloseNotification; }


### PR DESCRIPTION
#### 95b0e0107f7038f1531b48e7c72d65507a8d3b6d
<pre>
Add an API test for notificationclose
<a href="https://bugs.webkit.org/show_bug.cgi?id=248084">https://bugs.webkit.org/show_bug.cgi?id=248084</a>
rdar://problem/102515514

Reviewed by Chris Dumez.

* Tools/TestWebKitAPI/TestNotificationProvider.cpp:
(TestWebKitAPI::TestNotificationProvider::simulateNotificationClose):
* Tools/TestWebKitAPI/TestNotificationProvider.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:

Canonical link: <a href="https://commits.webkit.org/257130@main">https://commits.webkit.org/257130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/720612013f71c62905da0924ecb0957c4dde6463

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97968 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107430 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167703 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7645 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35954 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104058 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84569 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32800 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1160 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1142 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4901 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41695 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->