### PR TITLE
Make WebCore::FormData::EncodingType an enum class

### DIFF
--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -224,7 +224,7 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
         formData = FormData::createMultiPart(domFormData);
         boundary = String::fromLatin1(formData->boundary().data());
     } else {
-        formData = FormData::create(domFormData, attributes.method() == Method::Get ? FormData::FormURLEncoded : FormData::parseEncodingType(encodingType));
+        formData = FormData::create(domFormData, attributes.method() == Method::Get ? FormData::EncodingType::FormURLEncoded : FormData::parseEncodingType(encodingType));
         if (copiedAttributes.method() == Method::Post && isMailtoForm) {
             // Convert the form data into a string that we put into the URL.
             appendMailtoPostFormDataToURL(actionURL, *formData, encodingType);

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -127,7 +127,7 @@ private:
 
 class FormData : public RefCounted<FormData> {
 public:
-    enum EncodingType {
+    enum class EncodingType : uint8_t {
         FormURLEncoded, // for application/x-www-form-urlencoded
         TextPlain, // for text/plain
         MultipartFormData // for multipart/form-data
@@ -139,7 +139,7 @@ public:
     static Ref<FormData> create(Vector<uint8_t>&&);
     static Ref<FormData> create(const Vector<char>&);
     static Ref<FormData> create(const Vector<uint8_t>&);
-    static Ref<FormData> create(const DOMFormData&, EncodingType = FormURLEncoded);
+    static Ref<FormData> create(const DOMFormData&, EncodingType = EncodingType::FormURLEncoded);
     static Ref<FormData> createMultiPart(const DOMFormData&);
     WEBCORE_EXPORT ~FormData();
 
@@ -187,10 +187,10 @@ public:
     static EncodingType parseEncodingType(const String& type)
     {
         if (equalLettersIgnoringASCIICase(type, "text/plain"_s))
-            return TextPlain;
+            return EncodingType::TextPlain;
         if (equalLettersIgnoringASCIICase(type, "multipart/form-data"_s))
-            return MultipartFormData;
-        return FormURLEncoded;
+            return EncodingType::MultipartFormData;
+        return EncodingType::FormURLEncoded;
     }
 
     WEBCORE_EXPORT uint64_t lengthInBytes() const;

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -192,7 +192,7 @@ void finishMultiPartHeader(Vector<char>& buffer)
 
 void addKeyValuePairAsFormData(Vector<char>& buffer, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType encodingType)
 {
-    if (encodingType == FormData::TextPlain) {
+    if (encodingType == FormData::EncodingType::TextPlain) {
         append(buffer, key);
         append(buffer, '=');
         append(buffer, value);

--- a/Source/WebCore/platform/network/FormDataBuilder.h
+++ b/Source/WebCore/platform/network/FormDataBuilder.h
@@ -41,7 +41,7 @@ void addContentTypeToMultiPartHeader(Vector<char>&, const CString& mimeType);
 void finishMultiPartHeader(Vector<char>&);
 
 // Helper functions used by HTMLFormElement for non-multi-part form data.
-void addKeyValuePairAsFormData(Vector<char>&, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType = FormData::FormURLEncoded);
+void addKeyValuePairAsFormData(Vector<char>&, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType = FormData::EncodingType::FormURLEncoded);
 void encodeStringAsFormData(Vector<char>&, const CString&);
 
 }


### PR DESCRIPTION
#### c96586445467c64864f70b75b916508f53e2aefc
<pre>
Make WebCore::FormData::EncodingType an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=248086">https://bugs.webkit.org/show_bug.cgi?id=248086</a>
&lt;rdar://102515978&gt;

Reviewed by Chris Dumez.

Convert FormData::EncodingType to an enum class so its backing
type can be changed to uint8_t.  The other changes are to fix
the namespace for the enum values.

* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::create):
* Source/WebCore/platform/network/FormData.h:
(WebCore::FormData::EncodingType):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::addKeyValuePairAsFormData):
* Source/WebCore/platform/network/FormDataBuilder.h:

Canonical link: <a href="https://commits.webkit.org/256852@main">https://commits.webkit.org/256852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f1e3a7df457158040d2bc0c1dcc2adb18279035

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/96973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106502 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166788 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/100948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6468 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/34976 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103199 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83590 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31879 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/275 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/259 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21478 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5051 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/43989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40779 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->