### PR TITLE
Fix MessageReceivers for Web Extensions.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1112,6 +1112,7 @@ void WebExtensionContext::webViewWebContentProcessDidTerminate(WKWebView *webVie
     // FIXME: <https://webkit.org/b/246484> Disconnect message ports for the crashed web view.
 
     if (webView == m_backgroundWebView) {
+        m_backgroundWebView = nullptr;
         loadBackgroundWebView();
         return;
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -33,9 +33,11 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "CocoaHelpers.h"
+#import "WebExtensionContextMessages.h"
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxyMessages.h"
 #import "WebPageProxy.h"
+#import "WebProcessPool.h"
 #import <wtf/HashMap.h>
 #import <wtf/HashSet.h>
 #import <wtf/NeverDestroyed.h>
@@ -77,8 +79,10 @@ bool WebExtensionController::load(WebExtensionContext& extensionContext, NSError
         return handler;
     });
 
-    for (auto& process : m_processes)
-        process.send(Messages::WebExtensionControllerProxy::Load(extensionContext.parameters()), m_identifier);
+    for (auto& processPool : m_processPools)
+        processPool.addMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.identifier(), extensionContext);
+
+    sendToAllProcesses(Messages::WebExtensionControllerProxy::Load(extensionContext.parameters()), m_identifier);
 
     return true;
 }
@@ -100,8 +104,10 @@ bool WebExtensionController::unload(WebExtensionContext& extensionContext, NSErr
     if (!extensionContext.unload(outError))
         return false;
 
-    for (auto& process : m_processes)
-        process.send(Messages::WebExtensionControllerProxy::Unload(extensionContext.identifier()), m_identifier);
+    sendToAllProcesses(Messages::WebExtensionControllerProxy::Unload(extensionContext.identifier()), extensionContext.identifier());
+
+    for (auto& processPool : m_processPools)
+        processPool.removeMessageReceiver(Messages::WebExtensionContext::messageReceiverName(), extensionContext.identifier());
 
     return true;
 }
@@ -111,8 +117,9 @@ void WebExtensionController::addPage(WebPageProxy& page)
     ASSERT(!m_pages.contains(page));
     m_pages.add(page);
 
-    if (m_processes.add(page.process()))
-        page.process().addMessageReceiver(Messages::WebExtensionController::messageReceiverName(), m_identifier, *this);
+    auto& processPool = page.process().processPool();
+    if (m_processPools.add(processPool))
+        processPool.addMessageReceiver(Messages::WebExtensionController::messageReceiverName(), m_identifier, *this);
 
     for (auto& entry : m_registeredSchemeHandlers)
         page.setURLSchemeHandlerForScheme(entry.value.copyRef(), entry.key);
@@ -123,20 +130,19 @@ void WebExtensionController::removePage(WebPageProxy& page)
     ASSERT(m_pages.contains(page));
     m_pages.remove(page);
 
-    // The process might have already been deallocated and removed from the weak set.
-    if (!m_processes.contains(page.process()))
+    // The process pool might have already been deallocated and removed from the weak set.
+    auto& processPool = page.process().processPool();
+    if (!m_processPools.contains(processPool))
         return;
 
-    // Only remove the message receiver and process if no other pages use the same process.
-    Ref<WebProcessProxy> process = page.process();
-    for (auto& page : m_pages) {
-        if (page.process() == process)
+    // Only remove the message receiver and process pool if no other pages use the same process pool.
+    for (auto& knownPage : m_pages) {
+        if (knownPage.process().processPool() == processPool)
             return;
     }
 
-    process->removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), m_identifier);
-
-    m_processes.remove(process.get());
+    processPool.removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), m_identifier);
+    m_processPools.remove(processPool);
 }
 
 RefPtr<WebExtensionContext> WebExtensionController::extensionContext(const WebExtension& extension) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -37,27 +37,22 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<WebExtensionContextIdentifier, WebExtensionContext*>& webExtensionContexts()
+static HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContext>>& webExtensionContexts()
 {
-    static NeverDestroyed<HashMap<WebExtensionContextIdentifier, WebExtensionContext*>> contexts;
+    static NeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContext>>> contexts;
     return contexts;
 }
 
 WebExtensionContext* WebExtensionContext::get(WebExtensionContextIdentifier identifier)
 {
-    return webExtensionContexts().get(identifier);
+    return webExtensionContexts().get(identifier).get();
 }
 
 WebExtensionContext::WebExtensionContext()
     : m_identifier(WebExtensionContextIdentifier::generate())
 {
+    ASSERT(!webExtensionContexts().contains(m_identifier));
     webExtensionContexts().add(m_identifier, this);
-}
-
-WebExtensionContext::~WebExtensionContext()
-{
-    ASSERT(webExtensionContexts().contains(m_identifier));
-    webExtensionContexts().remove(m_identifier);
 }
 
 WebExtensionContextParameters WebExtensionContext::parameters() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -79,8 +79,6 @@ public:
 
     explicit WebExtensionContext(Ref<WebExtension>&&);
 
-    ~WebExtensionContext();
-
     using PermissionsMap = HashMap<String, WallTime>;
     using PermissionMatchPatternsMap = HashMap<Ref<WebExtensionMatchPattern>, WallTime>;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -37,27 +37,22 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<WebExtensionControllerIdentifier, WebExtensionController*>& webExtensionControllers()
+static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>& webExtensionControllers()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WebExtensionController*>> controllers;
+    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>> controllers;
     return controllers;
 }
 
 WebExtensionController* WebExtensionController::get(WebExtensionControllerIdentifier identifier)
 {
-    return webExtensionControllers().get(identifier);
+    return webExtensionControllers().get(identifier).get();
 }
 
 WebExtensionController::WebExtensionController()
     : m_identifier(WebExtensionControllerIdentifier::generate())
 {
+    ASSERT(!webExtensionControllers().contains(m_identifier));
     webExtensionControllers().add(m_identifier, this);
-}
-
-WebExtensionController::~WebExtensionController()
-{
-    ASSERT(webExtensionControllers().contains(m_identifier));
-    webExtensionControllers().remove(m_identifier);
 }
 
 WebExtensionControllerParameters WebExtensionController::parameters() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -34,6 +34,8 @@
 #include "WebExtensionContextIdentifier.h"
 #include "WebExtensionControllerIdentifier.h"
 #include "WebExtensionURLSchemeHandler.h"
+#include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #include <wtf/Forward.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakHashSet.h>
@@ -47,7 +49,7 @@ namespace WebKit {
 
 class WebExtensionContext;
 class WebPageProxy;
-class WebProcessProxy;
+class WebProcessPool;
 struct WebExtensionControllerParameters;
 
 class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExtensionController>, public IPC::MessageReceiver {
@@ -58,7 +60,6 @@ public:
     static WebExtensionController* get(WebExtensionControllerIdentifier);
 
     explicit WebExtensionController();
-    ~WebExtensionController();
 
     using WebExtensionContextSet = HashSet<Ref<WebExtensionContext>>;
     using WebExtensionSet = HashSet<Ref<WebExtension>>;
@@ -83,6 +84,9 @@ public:
     const WebExtensionContextSet& extensionContexts() const { return m_extensionContexts; }
     WebExtensionSet extensions() const;
 
+    template<typename T, typename U>
+    void sendToAllProcesses(const T& message, ObjectIdentifier<U> destinationID);
+
     _WKWebExtensionController *wrapper() const { return (_WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }
 #endif
 
@@ -96,10 +100,28 @@ private:
     WebExtensionContextSet m_extensionContexts;
     WebExtensionContextBaseURLMap m_extensionContextBaseURLMap;
     WeakHashSet<WebPageProxy> m_pages;
-    WeakHashSet<WebProcessProxy> m_processes;
+    WeakHashSet<WebProcessPool> m_processPools;
     HashMap<String, Ref<WebExtensionURLSchemeHandler>> m_registeredSchemeHandlers;
 #endif
 };
+
+template<typename T, typename U>
+void WebExtensionController::sendToAllProcesses(const T& message, ObjectIdentifier<U> destinationID)
+{
+    HashSet<WebProcessProxy*> seenProcesses;
+    seenProcesses.reserveInitialCapacity(m_pages.capacity());
+
+    for (auto& page : m_pages) {
+        auto& process = page.process();
+        if (seenProcesses.contains(&process))
+            continue;
+
+        seenProcesses.add(&process);
+
+        if (process.canSendMessage())
+            process.send(T(message), destinationID);
+    }
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -530,6 +530,9 @@ public:
     void hardwareConsoleStateChanged();
 #endif
 
+    bool operator==(const WebProcessPool& other) const { return (this == &other); }
+    bool operator!=(const WebProcessPool& other) const { return !(this == &other); }
+
 private:
     void platformInitialize();
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -42,8 +42,6 @@ public:
     static RefPtr<WebExtensionContextProxy> get(WebExtensionContextIdentifier);
     static Ref<WebExtensionContextProxy> getOrCreate(WebExtensionContextParameters);
 
-    ~WebExtensionContextProxy();
-
     WebExtensionContextIdentifier identifier() { return m_identifier; }
 
     bool operator==(const WebExtensionContextProxy& other) const { return (this == &other); }

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "MessageReceiver.h"
+#include "WebExtensionContextProxy.h"
 #include "WebExtensionControllerParameters.h"
 #include <wtf/Forward.h>
 #include <wtf/URLHash.h>
@@ -38,7 +39,6 @@ class DOMWrapperWorld;
 
 namespace WebKit {
 
-class WebExtensionContextProxy;
 class WebFrame;
 class WebPage;
 
@@ -49,8 +49,6 @@ class WebExtensionControllerProxy final : public RefCounted<WebExtensionControll
 public:
     static RefPtr<WebExtensionControllerProxy> get(WebExtensionControllerIdentifier);
     static Ref<WebExtensionControllerProxy> getOrCreate(WebExtensionControllerParameters);
-
-    ~WebExtensionControllerProxy();
 
     using WebExtensionContextProxySet = HashSet<Ref<WebExtensionContextProxy>>;
     using WebExtensionContextProxyBaseURLMap = HashMap<URL, Ref<WebExtensionContextProxy>>;


### PR DESCRIPTION
#### c370224a221cafc67bfde137de67c887bce864b6
<pre>
Fix MessageReceivers for Web Extensions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248098">https://bugs.webkit.org/show_bug.cgi?id=248098</a>

Reviewed by Brian Weinstein.

Use the WebProcessPool instead of WebProcessProxy to register MessageReceivers in the UIProcess.
The previous approach was not following the WKWebView process change when it navigated.
Also use WeakPtr in the global HashMaps that track the controllers and contexts, this lets
us eliminate some code that manages the map since the WeakPtr will clear on destruct already.
This is also true for the MessageReceiverMap.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate): Drive-by ASSERT fix when the
background tries to load again.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load):
(WebKit::WebExtensionController::unload):
(WebKit::WebExtensionController::addPage):
(WebKit::WebExtensionController::removePage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::webExtensionContexts):
(WebKit::WebExtensionContext::WebExtensionContext):
(WebKit::WebExtensionContext::~WebExtensionContext): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::webExtensionControllers):
(WebKit::WebExtensionController::WebExtensionController):
(WebKit::WebExtensionController::~WebExtensionController): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::sendToAllProcesses):
* Source/WebKit/UIProcess/WebProcessPool.h: Added operator == and != to make comparison easier.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::webExtensionContextProxies):
(WebKit::WebExtensionContextProxy::get):
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy):
(WebKit::WebExtensionContextProxy::~WebExtensionContextProxy): Deleted.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::webExtensionControllerProxies):
(WebKit::WebExtensionControllerProxy::get):
(WebKit::WebExtensionControllerProxy::getOrCreate):
(WebKit::WebExtensionControllerProxy::WebExtensionControllerProxy):
(WebKit::WebExtensionControllerProxy::~WebExtensionControllerProxy): Deleted.
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:

Canonical link: <a href="https://commits.webkit.org/256857@main">https://commits.webkit.org/256857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cccb04d207d262b35252671a89c1b2d116c7121

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106532 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6499 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35005 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103226 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102674 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83618 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/305 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/287 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5079 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40806 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->