### PR TITLE
Generate serialization of CertificateInfo

### DIFF
--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -388,7 +388,7 @@ static std::optional<RetainPtr<CFArrayRef>> decodeCertificateChain(Decoder& deco
 void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
 {
     encoder << LegacyCertificateInfoType::Trust;
-    encodeSecTrustRef(encoder, certificateInfo.trust());
+    encodeSecTrustRef(encoder, certificateInfo.trust().get());
 }
 
 std::optional<WebCore::CertificateInfo> Coder<WebCore::CertificateInfo>::decode(Decoder& decoder)
@@ -481,7 +481,7 @@ template<> struct Coder<GRefPtr<GByteArray>> {
 
 static Vector<GRefPtr<GByteArray>> certificatesDataListFromCertificateInfo(const WebCore::CertificateInfo &certificateInfo)
 {
-    auto* certificate = certificateInfo.certificate();
+    auto* certificate = certificateInfo.certificate().get();
     if (!certificate)
         return { };
 

--- a/Source/WebCore/platform/network/cf/CertificateInfo.h
+++ b/Source/WebCore/platform/network/cf/CertificateInfo.h
@@ -50,7 +50,7 @@ public:
         : m_trust(WTFMove(trust))
     {
     }
-    SecTrustRef trust() const { return m_trust.get(); }
+    const RetainPtr<SecTrustRef>& trust() const { return m_trust; }
 #elif PLATFORM(WIN)
     CertificateInfo(RetainPtr<CFArrayRef>&& certificateChain)
         : m_certificateChain(WTFMove(certificateChain))

--- a/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
@@ -92,14 +92,14 @@ bool CertificateInfo::containsNonRootSHA1SignedCertificate() const
 #if PLATFORM(COCOA)
     if (m_trust) {
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
-        auto chain = adoptCF(SecTrustCopyCertificateChain(trust()));
+        auto chain = adoptCF(SecTrustCopyCertificateChain(trust().get()));
 #endif
         // Allow only the root certificate (the last in the chain) to be SHA1.
-        for (CFIndex i = 0, size = SecTrustGetCertificateCount(trust()) - 1; i < size; ++i) {
+        for (CFIndex i = 0, size = SecTrustGetCertificateCount(trust().get()) - 1; i < size; ++i) {
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
             auto certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), i));
 #else
-            auto certificate = SecTrustGetCertificateAtIndex(trust(), i);
+            auto certificate = SecTrustGetCertificateAtIndex(trust().get(), i);
 #endif
             if (SecCertificateGetSignatureHashAlgorithm(certificate) == kSecSignatureHashAlgorithmSHA1)
                 return true;

--- a/Source/WebCore/platform/network/cocoa/CertificateInfoCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CertificateInfoCocoa.mm
@@ -33,18 +33,18 @@ void CertificateInfo::dump() const
 {
 #if PLATFORM(COCOA)
     if (m_trust) {
-        CFIndex entries = SecTrustGetCertificateCount(trust());
+        CFIndex entries = SecTrustGetCertificateCount(trust().get());
 
         NSLog(@"CertificateInfo SecTrust\n");
         NSLog(@"  Entries: %ld\n", entries);
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
-        auto chain = adoptCF(SecTrustCopyCertificateChain(trust()));
+        auto chain = adoptCF(SecTrustCopyCertificateChain(trust().get()));
 #endif
         for (CFIndex i = 0; i < entries; ++i) {
 #if HAVE(SEC_TRUST_COPY_CERTIFICATE_CHAIN)
             RetainPtr<CFStringRef> summary = adoptCF(SecCertificateCopySubjectSummary(checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), i))));
 #else
-            RetainPtr<CFStringRef> summary = adoptCF(SecCertificateCopySubjectSummary(SecTrustGetCertificateAtIndex(trust(), i)));
+            RetainPtr<CFStringRef> summary = adoptCF(SecCertificateCopySubjectSummary(SecTrustGetCertificateAtIndex(trust().get(), i)));
 #endif
             NSLog(@"  %@", (__bridge NSString *)summary.get());
         }

--- a/Source/WebCore/platform/network/soup/CertificateInfo.h
+++ b/Source/WebCore/platform/network/soup/CertificateInfo.h
@@ -45,12 +45,12 @@ public:
     CertificateInfo();
     explicit CertificateInfo(const WebCore::ResourceResponse&);
     explicit CertificateInfo(const WebCore::ResourceError&);
-    CertificateInfo(GTlsCertificate*, GTlsCertificateFlags);
+    CertificateInfo(GRefPtr<GTlsCertificate>&&, GTlsCertificateFlags);
     WEBCORE_EXPORT ~CertificateInfo();
 
     CertificateInfo isolatedCopy() const;
 
-    GTlsCertificate* certificate() const { return m_certificate.get(); }
+    const GRefPtr<GTlsCertificate>& certificate() const { return m_certificate; }
     void setCertificate(GTlsCertificate* certificate) { m_certificate = certificate; }
     GTlsCertificateFlags tlsErrors() const { return m_tlsErrors; }
     void setTLSErrors(GTlsCertificateFlags tlsErrors) { m_tlsErrors = tlsErrors; }

--- a/Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp
@@ -54,8 +54,8 @@ CertificateInfo::CertificateInfo(const ResourceError& resourceError)
 {
 }
 
-CertificateInfo::CertificateInfo(GTlsCertificate* certificate, GTlsCertificateFlags tlsErrors)
-    : m_certificate(certificate)
+CertificateInfo::CertificateInfo(GRefPtr<GTlsCertificate>&& certificate, GTlsCertificateFlags tlsErrors)
+    : m_certificate(WTFMove(certificate))
     , m_tlsErrors(tlsErrors)
 {
 }

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -353,7 +353,7 @@ std::optional<ResourceError> SoupNetworkSession::checkTLSErrors(const URL& reque
 
 void SoupNetworkSession::allowSpecificHTTPSCertificateForHost(const CertificateInfo& certificateInfo, const String& host)
 {
-    allowedCertificates().add(host, HostTLSCertificateSet()).iterator->value.add(certificateInfo.certificate());
+    allowedCertificates().add(host, HostTLSCertificateSet()).iterator->value.add(certificateInfo.certificate().get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -60,7 +60,7 @@ bool SWServerJobQueue::isCurrentlyProcessingJob(const ServiceWorkerJobDataIdenti
 static bool doCertificatesMatch(const CertificateInfo& first, const CertificateInfo& second)
 {
 #if PLATFORM(COCOA)
-    return first.trust() == second.trust() || certificatesMatch(first.trust(), second.trust());
+    return first.trust() == second.trust() || certificatesMatch(first.trust().get(), second.trust().get());
 #else
     // FIXME: Add support for certificate matching in CertificateInfo.
     UNUSED_PARAM(first);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -179,7 +179,7 @@ void NetworkProcess::deleteHSTSCacheForHostNames(PAL::SessionID sessionID, const
 void NetworkProcess::allowSpecificHTTPSCertificateForHost(const WebCore::CertificateInfo& certificateInfo, const String& host)
 {
     // FIXME: Remove this once rdar://30655740 is fixed.
-    [NSURLRequest setAllowsSpecificHTTPSCertificate:(NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(certificateInfo.trust()).get() forHost:host];
+    [NSURLRequest setAllowsSpecificHTTPSCertificate:(NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(certificateInfo.trust().get()).get() forHost:host];
 }
 
 void NetworkProcess::clearHSTSCache(PAL::SessionID sessionID, WallTime modifiedSince)

--- a/Source/WebKit/Platform/IPC/DaemonCoders.cpp
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.cpp
@@ -116,7 +116,7 @@ std::optional<WTF::WallTime> Coder<WTF::WallTime>::decode(Decoder& decoder)
 void Coder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& instance)
 {
 #if PLATFORM(COCOA)
-    auto data = adoptCF(SecTrustSerialize(instance.trust(), nullptr));
+    auto data = adoptCF(SecTrustSerialize(instance.trust().get(), nullptr));
     if (!data) {
         encoder << false;
         return;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -233,13 +233,6 @@ template<> struct ArgumentCoder<WebCore::EventTrackingRegions> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::EventTrackingRegions&);
 };
 
-template<> struct ArgumentCoder<WebCore::CertificateInfo> {
-    template<typename Encoder>
-    static void encode(Encoder&, const WebCore::CertificateInfo&);
-    template<typename Decoder>
-    static std::optional<WebCore::CertificateInfo> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::RectEdges<bool>> {
     static void encode(Encoder&, const WebCore::RectEdges<bool>&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::RectEdges<bool>&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1554,3 +1554,20 @@ enum class WebCore::PixelFormat : uint8_t {
 [Return=Ref] class WebCore::TextIndicator {
     WebCore::TextIndicatorData data();
 };
+
+#if USE(SOUP)
+header: "ArgumentCodersGLib.h"
+#endif
+class WebCore::CertificateInfo {
+#if PLATFORM(COCOA)
+    RetainPtr<SecTrustRef> trust()
+#endif
+#if USE(CURL)
+    int verificationError()
+    Vector<Vector<uint8_t>> certificateChain()
+#endif
+#if USE(SOUP)
+    GRefPtr<GTlsCertificate> certificate()
+    GTlsCertificateFlags tlsErrors()
+#endif
+}

--- a/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
+++ b/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
@@ -40,44 +40,6 @@ namespace IPC {
 
 using namespace WebCore;
 
-template<typename Encoder>
-void ArgumentCoder<CertificateInfo>::encode(Encoder& encoder, const CertificateInfo& certificateInfo)
-{
-    encoder << certificateInfo.verificationError();
-    encoder << certificateInfo.certificateChain().size();
-
-    for (auto certificate : certificateInfo.certificateChain())
-        encoder << certificate;
-}
-template void ArgumentCoder<WebCore::CertificateInfo>::encode<Encoder>(Encoder&, const WebCore::CertificateInfo&);
-
-template<typename Decoder>
-std::optional<CertificateInfo> ArgumentCoder<CertificateInfo>::decode(Decoder& decoder)
-{
-    std::optional<int> verificationError;
-    decoder >> verificationError;
-    if (!verificationError)
-        return std::nullopt;
-
-    std::optional<size_t> certificateChainSize;
-    decoder >> certificateChainSize;
-    if (!certificateChainSize)
-        return std::nullopt;
-
-    CertificateInfo::CertificateChain certificateChain;
-    for (size_t i = 0; i < *certificateChainSize; i++) {
-        std::optional<CertificateInfo::Certificate> certificate;
-        decoder >> certificate;
-        if (!certificate)
-            return std::nullopt;
-
-        certificateChain.append(WTFMove(*certificate));
-    }
-
-    return CertificateInfo { *verificationError, WTFMove(certificateChain) };
-}
-template std::optional<WebCore::CertificateInfo> ArgumentCoder<WebCore::CertificateInfo>::decode<Decoder>(Decoder&);
-
 void ArgumentCoder<ResourceError>::encodePlatformData(Encoder& encoder, const ResourceError& resourceError)
 {
     encoder << resourceError.type();

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.cpp
@@ -160,6 +160,19 @@ std::optional<GRefPtr<GTlsCertificate>> ArgumentCoder<GRefPtr<GTlsCertificate>>:
     return certificate;
 }
 
+void ArgumentCoder<GTlsCertificateFlags>::encode(Encoder& encoder, GTlsCertificateFlags flags)
+{
+    encoder << static_cast<uint32_t>(flags);
+}
+
+std::optional<GTlsCertificateFlags> ArgumentCoder<GTlsCertificateFlags>::decode(Decoder& decoder)
+{
+    auto flags = decoder.decode<uint32_t>();
+    if (!flags)
+        return std::nullopt;
+    return static_cast<GTlsCertificateFlags>(*flags);
+}
+
 void ArgumentCoder<GRefPtr<GUnixFDList>>::encode(Encoder& encoder, const GRefPtr<GUnixFDList>& fdList)
 {
     if (!fdList) {

--- a/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
+++ b/Source/WebKit/Shared/glib/ArgumentCodersGLib.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArgumentCoders.h"
+#include <gio/gio.h>
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GTlsCertificate GTlsCertificate;
@@ -42,6 +43,11 @@ template<> struct ArgumentCoder<GRefPtr<GVariant>> {
 template<> struct ArgumentCoder<GRefPtr<GTlsCertificate>> {
     static void encode(Encoder&, const GRefPtr<GTlsCertificate>&);
     static std::optional<GRefPtr<GTlsCertificate>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<GTlsCertificateFlags> {
+    static void encode(Encoder&, GTlsCertificateFlags);
+    static std::optional<GTlsCertificateFlags> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<GRefPtr<GUnixFDList>> {

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -44,23 +44,6 @@
 
 namespace IPC {
 
-template<>
-void ArgumentCoder<WebCore::CertificateInfo>::encode(Encoder& encoder, const WebCore::CertificateInfo& certificateInfo)
-{
-    encoder << certificateInfo.trust();
-}
-
-template<>
-std::optional<WebCore::CertificateInfo> ArgumentCoder<WebCore::CertificateInfo>::decode(Decoder& decoder)
-{
-    std::optional<RetainPtr<SecTrustRef>> trust;
-    decoder >> trust;
-    if (!trust)
-        return std::nullopt;
-
-    return WebCore::CertificateInfo(WTFMove(*trust));
-}
-
 static void encodeNSError(Encoder& encoder, NSError *nsError)
 {
     String domain = [nsError domain];

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -43,41 +43,6 @@
 namespace IPC {
 using namespace WebCore;
 
-template<typename Encoder>
-void ArgumentCoder<CertificateInfo>::encode(Encoder& encoder, const CertificateInfo& certificateInfo)
-{
-    GRefPtr<GTlsCertificate> certificate = certificateInfo.certificate();
-    encoder << certificate;
-    if (!certificate)
-        return;
-
-    encoder << static_cast<uint32_t>(certificateInfo.tlsErrors());
-}
-template void ArgumentCoder<CertificateInfo>::encode<Encoder>(Encoder&, const CertificateInfo&);
-
-template<typename Decoder>
-std::optional<CertificateInfo> ArgumentCoder<CertificateInfo>::decode(Decoder& decoder)
-{
-    std::optional<GRefPtr<GTlsCertificate>> certificate;
-    decoder >> certificate;
-    if (!certificate)
-        return std::nullopt;
-
-    CertificateInfo certificateInfo;
-    if (certificate.value()) {
-        std::optional<uint32_t> tlsErrors;
-        decoder >> tlsErrors;
-        if (!tlsErrors)
-            return std::nullopt;
-
-        certificateInfo.setCertificate(certificate->get());
-        certificateInfo.setTLSErrors(static_cast<GTlsCertificateFlags>(*tlsErrors));
-    }
-
-    return certificateInfo;
-}
-template std::optional<CertificateInfo> ArgumentCoder<CertificateInfo>::decode<Decoder>(Decoder&);
-
 void ArgumentCoder<ResourceError>::encodePlatformData(Encoder& encoder, const ResourceError& resourceError)
 {
     encoder << resourceError.domain();
@@ -112,7 +77,7 @@ bool ArgumentCoder<ResourceError>::decodePlatformData(Decoder& decoder, Resource
     if (!decoder.decode(certificateInfo))
         return false;
 
-    resourceError.setCertificate(certificateInfo.certificate());
+    resourceError.setCertificate(certificateInfo.certificate().get());
     resourceError.setTLSErrors(certificateInfo.tlsErrors());
     return true;
 }

--- a/Source/WebKit/UIProcess/API/C/mac/WKFrameMac.cpp
+++ b/Source/WebKit/UIProcess/API/C/mac/WKFrameMac.cpp
@@ -31,5 +31,5 @@
 
 SecTrustRef WKFrameGetServerTrust(WKFrameRef frame)
 {
-    return WebKit::toImpl(frame)->certificateInfo().trust();
+    return WebKit::toImpl(frame)->certificateInfo().trust().get();
 }

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -108,7 +108,7 @@
 
 - (SecTrustRef)serverTrust
 {
-    return _page->pageLoadState().certificateInfo().trust();
+    return _page->pageLoadState().certificateInfo().trust().get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -312,7 +312,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (NSArray *)certificateChain
 {
     if (WebKit::WebFrameProxy* mainFrame = _page->mainFrame())
-        return (__bridge NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(mainFrame->certificateInfo().trust()).autorelease();
+        return (__bridge NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(mainFrame->certificateInfo().trust().get()).autorelease();
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -852,7 +852,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
 - (SecTrustRef)serverTrust
 {
-    return _page->pageLoadState().certificateInfo().trust();
+    return _page->pageLoadState().certificateInfo().trust().get();
 }
 
 - (BOOL)canGoBack
@@ -2680,7 +2680,7 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
 - (NSArray *)_certificateChain
 {
     if (WebKit::WebFrameProxy* mainFrame = _page->mainFrame())
-        return (__bridge NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(mainFrame->certificateInfo().trust()).autorelease();
+        return (__bridge NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(mainFrame->certificateInfo().trust().get()).autorelease();
 
     return nil;
 }
@@ -3973,7 +3973,7 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
 
 - (NSArray *)certificateChain
 {
-    return (__bridge NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(_page->pageLoadState().certificateInfo().trust()).autorelease() ?: @[ ];
+    return (__bridge NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(_page->pageLoadState().certificateInfo().trust().get()).autorelease() ?: @[ ];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4459,7 +4459,7 @@ gboolean webkit_web_view_get_tls_info(WebKitWebView* webView, GTlsCertificate** 
 
     const auto& certificateInfo = mainFrame->certificateInfo();
     if (certificate)
-        *certificate = certificateInfo.certificate();
+        *certificate = certificateInfo.certificate().get();
     if (errors)
         *errors = certificateInfo.tlsErrors();
 

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -245,7 +245,7 @@ void RemoteWebInspectorUIProxy::platformShowCertificate(const CertificateInfo& c
     RetainPtr<SFCertificatePanel> certificatePanel = adoptNS([[SFCertificatePanel alloc] init]);
 
     ASSERT(m_window);
-    [certificatePanel beginSheetForWindow:m_window.get() modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust() showGroup:YES];
+    [certificatePanel beginSheetForWindow:m_window.get() modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust().get() showGroup:YES];
 
     // This must be called after the trust panel has been displayed, because the certificateView doesn't exist beforehand.
     SFCertificateView *certificateView = [certificatePanel certificateView];

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -646,7 +646,7 @@ void WebInspectorUIProxy::platformShowCertificate(const CertificateInfo& certifi
     if (!window)
         window = [NSApp keyWindow];
 
-    [certificatePanel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust() showGroup:YES];
+    [certificatePanel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust().get() showGroup:YES];
 
     // This must be called after the trust panel has been displayed, because the certificateView doesn't exist beforehand.
     SFCertificateView *certificateView = [certificatePanel certificateView];

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -190,12 +190,12 @@ static RetainPtr<NSArray> collectIcons(WebCore::Frame* frame, OptionSet<WebCore:
 
 - (NSArray *)_certificateChain
 {
-    return (NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(_frame->certificateInfo().trust()).autorelease();
+    return (NSArray *)WebCore::CertificateInfo::certificateChainFromSecTrust(_frame->certificateInfo().trust().get()).autorelease();
 }
 
 - (SecTrustRef)_serverTrust
 {
-    return _frame->certificateInfo().trust();
+    return _frame->certificateInfo().trust().get();
 }
 
 - (NSURL *)_provisionalURL

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -349,7 +349,7 @@ void WebInspectorFrontendClient::showCertificate(const CertificateInfo& certific
     if (!window)
         window = [NSApp keyWindow];
 
-    [certificatePanel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust() showGroup:YES];
+    [certificatePanel beginSheetForWindow:window modalDelegate:nil didEndSelector:NULL contextInfo:nullptr trust:certificateInfo.trust().get() showGroup:YES];
 
     // This must be called after the trust panel has been displayed, because the certificateView doesn't exist beforehand.
     SFCertificateView *certificateView = [certificatePanel certificateView];


### PR DESCRIPTION
#### 370c4c4a9b951d20505cf6ef5fe2200e243f0a14
<pre>
Generate serialization of CertificateInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=248101">https://bugs.webkit.org/show_bug.cgi?id=248101</a>
rdar://102527605

Reviewed by Youenn Fablet.

* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::Coder&lt;WebCore::CertificateInfo&gt;::encode):
(WTF::Persistence::certificatesDataListFromCertificateInfo):
* Source/WebCore/platform/network/cf/CertificateInfo.h:
(WebCore::CertificateInfo::trust const):
* Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp:
(WebCore::CertificateInfo::containsNonRootSHA1SignedCertificate const):
* Source/WebCore/platform/network/cocoa/CertificateInfoCocoa.mm:
(WebCore::CertificateInfo::dump const):
* Source/WebCore/platform/network/soup/CertificateInfo.h:
(WebCore::CertificateInfo::certificate const):
* Source/WebCore/platform/network/soup/CertificateInfoSoup.cpp:
(WebCore::CertificateInfo::CertificateInfo):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::SoupNetworkSession::allowSpecificHTTPSCertificateForHost):
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::doCertificatesMatch):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::allowSpecificHTTPSCertificateForHost):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::completeAuthentication):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::WebSocketTask):
* Source/WebKit/Platform/IPC/DaemonCoders.cpp:
(WebKit::Daemon::Coder&lt;WebCore::CertificateInfo&gt;::encode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::CertificateInfo&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::CertificateInfo&gt;::decode): Deleted.
* Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp:
(IPC::ArgumentCoder&lt;ResourceError&gt;::decodePlatformData):
* Source/WebKit/UIProcess/API/C/mac/WKFrameMac.cpp:
(WKFrameGetServerTrust):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState serverTrust]):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController certificateChain]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView serverTrust]):
(-[WKWebView _certificateChain]):
(-[WKWebView certificateChain]):
* Source/WebKit/UIProcess/API/glib/WebKitCredential.cpp:
(webkit_credential_get_certificate):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformShowCertificate):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformShowCertificate):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame _certificateChain]):
(-[WKWebProcessPlugInFrame _serverTrust]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorFrontendClient::showCertificate):

Canonical link: <a href="https://commits.webkit.org/257182@main">https://commits.webkit.org/257182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb9ed1daaa06b4d12b9ae3236a5357b095c623fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107464 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167738 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7694 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35987 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104089 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5790 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84608 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32945 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89379 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1197 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1171 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22317 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6016 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44769 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2464 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41719 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->