### PR TITLE
Use ThreadSafeWeakPtr in ThreadGroup

### DIFF
--- a/Source/JavaScriptCore/heap/MachineStackMarker.h
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.h
@@ -59,7 +59,7 @@ private:
     void tryCopyOtherThreadStack(const ThreadSuspendLocker&, Thread&, void*, size_t capacity, size_t*);
     bool tryCopyOtherThreadStacks(const AbstractLocker&, void*, size_t capacity, size_t*, Thread&);
 
-    std::shared_ptr<ThreadGroup> m_threadGroup;
+    Ref<ThreadGroup> m_threadGroup;
 };
 
 #define DECLARE_AND_COMPUTE_CURRENT_THREAD_STATE(stateName) \

--- a/Source/WTF/wtf/ThreadGroup.cpp
+++ b/Source/WTF/wtf/ThreadGroup.cpp
@@ -28,6 +28,11 @@
 
 namespace WTF {
 
+Ref<ThreadGroup> ThreadGroup::create()
+{
+    return adoptRef(*new ThreadGroup);
+}
+
 ThreadGroup::~ThreadGroup()
 {
     Locker locker { m_lock };

--- a/Source/WTF/wtf/ThreadGroup.h
+++ b/Source/WTF/wtf/ThreadGroup.h
@@ -34,17 +34,13 @@ namespace WTF {
 
 enum class ThreadGroupAddResult { NewlyAdded, AlreadyAdded, NotAdded };
 
-class ThreadGroup final : public std::enable_shared_from_this<ThreadGroup> {
+class ThreadGroup final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ThreadGroup> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ThreadGroup);
 public:
     friend class Thread;
 
-    static std::shared_ptr<ThreadGroup> create()
-    {
-        return std::allocate_shared<ThreadGroup>(FastAllocator<ThreadGroup>());
-    }
-
+    WTF_EXPORT_PRIVATE static Ref<ThreadGroup> create();
     WTF_EXPORT_PRIVATE ThreadGroupAddResult add(Thread&);
     WTF_EXPORT_PRIVATE ThreadGroupAddResult add(const AbstractLocker&, Thread&);
     WTF_EXPORT_PRIVATE ThreadGroupAddResult addCurrentThread();
@@ -58,11 +54,6 @@ public:
     ThreadGroup() = default;
 
 private:
-    std::weak_ptr<ThreadGroup> weakFromThis()
-    {
-        return shared_from_this();
-    }
-
     // We use WordLock since it can be used when deallocating TLS.
     WordLock m_lock;
     ListHashSet<Ref<Thread>> m_threads;

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -46,6 +46,7 @@
 #include <wtf/StackStats.h>
 #include <wtf/ThreadAssertions.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WordLock.h>
 #include <wtf/text/AtomStringTable.h>
@@ -367,7 +368,7 @@ protected:
     // Use WordLock since WordLock does not depend on ThreadSpecific and this "Thread".
     WordLock m_mutex;
     StackBounds m_stack { StackBounds::emptyBounds() };
-    HashMap<ThreadGroup*, std::weak_ptr<ThreadGroup>> m_threadGroupMap;
+    HashMap<ThreadGroup*, ThreadSafeWeakPtr<ThreadGroup>> m_threadGroupMap;
     PlatformThreadHandle m_handle;
     uint32_t m_uid { ++s_uid };
 #if OS(WINDOWS)

--- a/Source/WTF/wtf/linux/RealTimeThreads.h
+++ b/Source/WTF/wtf/linux/RealTimeThreads.h
@@ -55,7 +55,7 @@ private:
     void discardRealTimeKitProxyTimerFired();
 #endif
 
-    std::shared_ptr<ThreadGroup> m_threadGroup;
+    Ref<ThreadGroup> m_threadGroup;
     bool m_enabled { true };
 #if USE(GLIB)
     std::optional<GRefPtr<GDBusProxy>> m_realTimeKitProxy;

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -297,13 +297,13 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
 
 static ThreadGroup& activeThreads()
 {
-    static LazyNeverDestroyed<std::shared_ptr<ThreadGroup>> activeThreads;
+    static LazyNeverDestroyed<Ref<ThreadGroup>> activeThreads;
     static std::once_flag initializeKey;
     std::call_once(initializeKey, [&] {
         Config::AssertNotFrozenScope assertScope;
         activeThreads.construct(ThreadGroup::create());
     });
-    return (*activeThreads.get());
+    return activeThreads.get();
 }
 
 void registerThreadForMachExceptionHandling(Thread& thread)

--- a/Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp
@@ -34,7 +34,7 @@ namespace TestWebKitAPI {
 enum class Mode { Add, AddCurrentThread };
 static void testThreadGroup(Mode mode)
 {
-    std::shared_ptr<ThreadGroup> threadGroup = ThreadGroup::create();
+    auto threadGroup = ThreadGroup::create();
     unsigned numberOfThreads = 16;
     unsigned waitingThreads = 0;
     bool restarting = false;
@@ -101,7 +101,7 @@ TEST(WTF, ThreadGroupAddCurrentThread)
 
 TEST(WTF, ThreadGroupDoNotAddDeadThread)
 {
-    std::shared_ptr<ThreadGroup> threadGroup = ThreadGroup::create();
+    auto threadGroup = ThreadGroup::create();
     Ref<Thread> thread = Thread::create("ThreadGroupWorker", [&] { });
     thread->waitForCompletion();
     EXPECT_TRUE(threadGroup->add(thread.get()) == ThreadGroupAddResult::NotAdded);
@@ -115,7 +115,7 @@ TEST(WTF, ThreadGroupAddDuplicateThreads)
     bool restarting = false;
     Lock lock;
     Condition restartCondition;
-    std::shared_ptr<ThreadGroup> threadGroup = ThreadGroup::create();
+    auto threadGroup = ThreadGroup::create();
     Ref<Thread> thread = Thread::create("ThreadGroupWorker", [&] {
         Locker locker { lock };
         restartCondition.wait(lock, [&] {
@@ -163,7 +163,7 @@ TEST(WTF, ThreadGroupRemove)
 
     Vector<Ref<Thread>> threads;
 
-    auto threadGroup = ThreadGroup::create();
+    RefPtr<ThreadGroup> threadGroup = ThreadGroup::create();
     for (unsigned i = 0; i < NumberOfThreads; i++) {
         auto thread = Thread::create("ThreadGroupWorker", [&]() {
             Locker locker { lock };


### PR DESCRIPTION
#### 9b28b7aca993535511058d22d563e75dc50b3911
<pre>
Use ThreadSafeWeakPtr in ThreadGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=248103">https://bugs.webkit.org/show_bug.cgi?id=248103</a>
rdar://102528206

Reviewed by Darin Adler and Chris Dumez.

We were using std::shared_ptr and std::weak_ptr in ThreadGroup, and the reason of this is because of lack of thread-safety
with WeakPtr / Ref. But now, we have ThreadSafeWeakPtr, so let&apos;s use it instead.

* Source/JavaScriptCore/heap/MachineStackMarker.h:
* Source/WTF/wtf/ThreadGroup.h:
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::didExit):
(WTF::Thread::addToThreadGroup):
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/linux/RealTimeThreads.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::activeThreads):
* Tools/TestWebKitAPI/Tests/WTF/ThreadGroup.cpp:
(TestWebKitAPI::testThreadGroup):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257595@main">https://commits.webkit.org/257595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2749687c36be0b369a0b6c2ec951d4f70cdf6dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108738 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168989 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85873 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106666 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105111 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33875 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21783 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90048 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2424 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23300 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/85889 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2327 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28881 "Passed tests") | 
| | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8488 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42775 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/88756 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2670 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4195 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19849 "Passed tests") | 
<!--EWS-Status-Bubble-End-->