### PR TITLE
Refactor caret animation out of FrameSelection

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1331,6 +1331,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/scrolling/ThreadedScrollingTree.h
 
     platform/AbortableTaskQueue.h
+    platform/CaretAnimator.h
     platform/CPUMonitor.h
     platform/ColorChooser.h
     platform/ColorChooserClient.h
@@ -1454,6 +1455,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/SharedBuffer.h
     platform/SharedBufferChunkReader.h
     platform/SharedStringHash.h
+    platform/SimpleCaretAnimator.h
     platform/SleepDisabler.h
     platform/SleepDisablerClient.h
     platform/SleepDisablerIdentifier.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1927,6 +1927,7 @@ page/scrolling/ScrollingTreeStickyNode.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+platform/CaretAnimator.cpp
 platform/CommonAtomStrings.cpp
 platform/ContentType.cpp
 platform/ContextMenu.cpp
@@ -2000,6 +2001,7 @@ platform/SerializedPlatformDataCue.cpp
 platform/SharedBuffer.cpp
 platform/SharedBufferChunkReader.cpp
 platform/SharedStringHash.cpp
+platform/SimpleCaretAnimator.cpp
 platform/SleepDisabler.cpp
 platform/SleepDisablerClient.cpp
 platform/SystemSoundManager.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6904,6 +6904,12 @@ void Document::serviceRequestAnimationFrameCallbacks()
         m_scriptedAnimationController->serviceRequestAnimationFrameCallbacks(domWindow()->frozenNowTimestamp());
 }
 
+void Document::serviceCaretAnimation()
+{
+    if (auto* window = domWindow())
+        selection().caretAnimator().serviceCaretAnimation(window->frozenNowTimestamp());
+}
+
 void Document::serviceRequestVideoFrameCallbacks()
 {
 #if ENABLE(VIDEO)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1151,6 +1151,8 @@ public:
     void serviceRequestAnimationFrameCallbacks();
     void serviceRequestVideoFrameCallbacks();
 
+    void serviceCaretAnimation();
+
     void windowScreenDidChange(PlatformDisplayID);
 
     void finishedParsing();

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1730,6 +1730,10 @@ void Page::updateRendering()
         document.serviceRequestAnimationFrameCallbacks();
     });
 
+    runProcessingStep(RenderingUpdateStep::CaretAnimation, [] (Document& document) {
+        document.serviceCaretAnimation();
+    });
+
     layoutIfNeeded();
 
     runProcessingStep(RenderingUpdateStep::ResizeObservations, [&] (Document& document) {
@@ -3935,6 +3939,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
 #endif
     case RenderingUpdateStep::VideoFrameCallbacks: ts << "VideoFrameCallbacks"; break;
     case RenderingUpdateStep::PrepareCanvasesForDisplay: ts << "PrepareCanvasesForDisplay"; break;
+    case RenderingUpdateStep::CaretAnimation: ts << "CaretAnimation"; break;
     }
     return ts;
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -234,6 +234,7 @@ enum class RenderingUpdateStep : uint32_t {
     FlushAutofocusCandidates        = 1 << 14,
     VideoFrameCallbacks             = 1 << 15,
     PrepareCanvasesForDisplay       = 1 << 16,
+    CaretAnimation                  = 1 << 17,
 };
 
 constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
@@ -251,6 +252,7 @@ constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
     RenderingUpdateStep::CursorUpdate,
     RenderingUpdateStep::EventRegionUpdate,
     RenderingUpdateStep::PrepareCanvasesForDisplay,
+    RenderingUpdateStep::CaretAnimation,
 };
 
 constexpr auto allRenderingUpdateSteps = updateRenderingSteps | OptionSet<RenderingUpdateStep> {

--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "CaretAnimator.h"
+
+#include "Page.h"
+
+namespace WebCore {
+
+Page* CaretAnimator::page() const
+{
+    if (auto* document = m_client.document())
+        return document->page();
+    
+    return nullptr;
+}
+
+void CaretAnimator::serviceCaretAnimation(ReducedResolutionSeconds timestamp)
+{
+    if (!isActive())
+        return;
+
+    updateAnimationProperties(timestamp);
+}
+
+void CaretAnimator::scheduleAnimation()
+{
+    if (auto* page = this->page())
+        page->scheduleRenderingUpdate(RenderingUpdateStep::CaretAnimation);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "ReducedResolutionSeconds.h"
+#include "Timer.h"
+
+namespace WebCore {
+
+class CaretAnimator;
+class Document;
+class Page;
+
+class CaretAnimationClient {
+public:
+    virtual ~CaretAnimationClient() = default;
+
+    virtual void caretAnimationDidUpdate(CaretAnimator&) { }
+
+    virtual Document* document() = 0;
+};
+
+class CaretAnimator {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    virtual ~CaretAnimator() = default;
+
+    virtual void start(ReducedResolutionSeconds currentTime) = 0;
+
+    void stop()
+    {
+        if (!m_isActive)
+            return;
+        didEnd();
+    }
+
+    bool isActive() const { return m_isActive; }
+
+    void serviceCaretAnimation(ReducedResolutionSeconds);
+
+    virtual String debugDescription() const = 0;
+
+    void setBlinkingSuspended(bool suspended) { m_isBlinkingSuspended = suspended; }
+    bool isBlinkingSuspended() const { return m_isBlinkingSuspended; }
+
+    virtual bool isVisible() const = 0;
+    virtual void setVisible(bool) = 0;
+
+protected:
+    explicit CaretAnimator(CaretAnimationClient& client)
+        : m_client(client)
+        , m_blinkTimer(*this, &CaretAnimator::scheduleAnimation)
+    { }
+
+    virtual void updateAnimationProperties(ReducedResolutionSeconds) = 0;
+
+    void didStart(ReducedResolutionSeconds currentTime, Seconds interval)
+    {
+        m_startTime = currentTime;
+        m_isActive = true;
+        m_blinkTimer.startOneShot(interval);
+    }
+
+    void didEnd()
+    {
+        m_isActive = false;
+        m_blinkTimer.stop();
+    }
+
+    Seconds timeSinceStart(ReducedResolutionSeconds currentTime) const
+    {
+        return currentTime - m_startTime;
+    }
+
+    Page* page() const;
+
+    CaretAnimationClient& m_client;
+    ReducedResolutionSeconds m_startTime;
+    Timer m_blinkTimer;
+
+private:
+    void scheduleAnimation();
+
+    bool m_isActive { false };
+    bool m_isBlinkingSuspended { false };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/SimpleCaretAnimator.cpp
+++ b/Source/WebCore/platform/SimpleCaretAnimator.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "SimpleCaretAnimator.h"
+
+#include "RenderTheme.h"
+
+namespace WebCore {
+
+SimpleCaretAnimator::SimpleCaretAnimator(CaretAnimationClient& client)
+    : CaretAnimator(client)
+{
+}
+
+void SimpleCaretAnimator::updateAnimationProperties(ReducedResolutionSeconds currentTime)
+{
+    auto caretBlinkInterval = RenderTheme::singleton().caretBlinkInterval();
+
+    // Ensure the caret is always visible when blinking is suspended.
+    if (isBlinkingSuspended() && isVisible()) {
+        m_blinkTimer.startOneShot(caretBlinkInterval);
+        return;
+    }
+
+    if (currentTime - m_lastTimeCaretPaintWasToggled >= caretBlinkInterval) {
+        setVisible(m_blinkState == CaretBlinkState::Off);
+        m_lastTimeCaretPaintWasToggled = currentTime;
+
+        m_blinkTimer.startOneShot(caretBlinkInterval);
+    }
+}
+
+void SimpleCaretAnimator::start(ReducedResolutionSeconds currentTime)
+{
+    m_lastTimeCaretPaintWasToggled = currentTime;
+    didStart(currentTime, RenderTheme::singleton().caretBlinkInterval());
+}
+
+String SimpleCaretAnimator::debugDescription() const
+{
+    TextStream textStream;
+    textStream << "SimpleCaretAnimator " << this << " active " << isActive() << " blink state = " << (m_blinkState == CaretBlinkState::On ? "On" : "Off");
+    return textStream.release();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/SimpleCaretAnimator.h
+++ b/Source/WebCore/platform/SimpleCaretAnimator.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "CaretAnimator.h"
+
+namespace WebCore {
+
+class SimpleCaretAnimator final : public CaretAnimator {
+public:
+    explicit SimpleCaretAnimator(CaretAnimationClient&);
+
+private:
+    enum class CaretBlinkState : bool { 
+        On, Off
+    };
+
+    void updateAnimationProperties(ReducedResolutionSeconds) final;
+    void start(ReducedResolutionSeconds) final;
+
+    String debugDescription() const final;
+
+    bool isVisible() const final { return m_blinkState == CaretBlinkState::On; }
+    void setVisible(bool visible) final 
+    {
+        if ((visible && m_blinkState == CaretBlinkState::On) || (!visible && m_blinkState == CaretBlinkState::Off))
+            return;
+
+        m_blinkState = visible ? CaretBlinkState::On : CaretBlinkState::Off;
+        m_client.caretAnimationDidUpdate(*this);
+    }
+
+    CaretBlinkState m_blinkState { CaretBlinkState::On };
+    ReducedResolutionSeconds m_lastTimeCaretPaintWasToggled;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 6063669dc45d7f10481798a4266f613e4b3cfb5e
<pre>
Refactor caret animation out of FrameSelection
<a href="https://bugs.webkit.org/show_bug.cgi?id=248112">https://bugs.webkit.org/show_bug.cgi?id=248112</a>
rdar://102535758

Reviewed by Simon Fraser and Darin Adler.

Simplifies `FrameSelection` by factoring out the animation logic into its own
class, to fit with how we handle other animations. Instead of `FrameSelection`
owning its own caret blinking timer, the caret is now subject to the repaint cycle
of `Page::updateRendering`.

This PR introduces a new `CaretAnimation` virtual class, with a `CaretAnimationSimple`
subclass to model how the current caret blinking works. This inheritence
hierarchy is modelled after how `ScrollAnimation` works.

The CaretAnimation now owns a timer, which when fired, schedules a rendering
update for the caret to update its appearance. When the rendering update happens,
`CaretAnimation::serviceAnimation` is triggered, which performs the actual
adjustment to the caret&apos;s presentation&apos;s properties. `FrameSelection::invalidateCaretRect`
is then triggered which causes the actual painting of the care to reflect its
new appearance.

Note that because the animation is now tied to `Page::updateRendering`,
`CaretAnimation::serviceAnimation` may be called at any given time, and so the
animation must track when the last time it was called was and account for this.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::serviceCaretAnimation):
* Source/WebCore/dom/Document.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::FrameSelection):
(WebCore::FrameSelection::willBeRemovedFromFrame):
(WebCore::FrameSelection::paintCaret):
(WebCore::FrameSelection::setCaretBlinkingSuspended):
(WebCore::FrameSelection::isCaretBlinkingSuspended const):
(WebCore::FrameSelection::caretAnimationDidUpdate):
(WebCore::FrameSelection::document):
(WebCore::FrameSelection::updateAppearance):
(WebCore::FrameSelection::setCaretVisibility):
(WebCore::FrameSelection::setCaretColor):
(WebCore::FrameSelection::caretBlinkTimerFired): Deleted.
(WebCore::FrameSelection::setCaretBlinks): Deleted.
* Source/WebCore/editing/FrameSelection.h:
(WebCore::FrameSelection::currentCaretAnimator):
(WebCore::FrameSelection::currentCaretAnimator const):
(WebCore::FrameSelection::setCaretBlinkingSuspended): Deleted.
(WebCore::FrameSelection::isCaretBlinkingSuspended const): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::Page::finalizeRenderingUpdate):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/CaretAnimator.cpp: Added.
(WebCore::CaretAnimator::page const):
(WebCore::CaretAnimator::serviceCaretAnimation):
(WebCore::CaretAnimator::scheduleAnimation):
* Source/WebCore/platform/CaretAnimator.h: Added.
(WebCore::CaretAnimationClient::caretAnimationDidUpdate):
(WebCore::CaretAnimationClient::caretAnimationWillStart):
(WebCore::CaretAnimationClient::caretAnimationDidEnd):
(WebCore::CaretAnimator::CaretAnimator):
(WebCore::CaretAnimator::stop):
(WebCore::CaretAnimator::isActive const):
(WebCore::CaretAnimator::setCaretBlinkingSuspended):
(WebCore::CaretAnimator::isCaretBlinkingSuspended const):
(WebCore::CaretAnimator::didStart):
(WebCore::CaretAnimator::didEnd):
(WebCore::CaretAnimator::timeSinceStart const):
* Source/WebCore/platform/SimpleCaretAnimator.cpp: Added.
(WebCore::SimpleCaretAnimator::SimpleCaretAnimator):
(WebCore::SimpleCaretAnimator::serviceAnimation):
(WebCore::SimpleCaretAnimator::start):
(WebCore::SimpleCaretAnimator::debugDescription const):
* Source/WebCore/platform/SimpleCaretAnimator.h: Added.

Canonical link: <a href="https://commits.webkit.org/257219@main">https://commits.webkit.org/257219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6e202ecdfa471b6db61b37270f0acb2e870f580

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107555 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167819 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7797 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36071 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104163 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5863 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84690 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32968 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89447 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1281 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22382 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4974 "Failed to update pull request") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44833 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41789 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->