### PR TITLE
[JSC] SymbolTableRareData should be set after store-store-fence

### DIFF
--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -103,8 +103,8 @@ void SymbolTable::visitChildrenImpl(JSCell* thisCell, Visitor& visitor)
 
     visitor.append(thisSymbolTable->m_arguments);
     
-    if (thisSymbolTable->m_rareData)
-        visitor.append(thisSymbolTable->m_rareData->m_codeBlock);
+    if (auto* rareData = thisSymbolTable->m_rareData.get())
+        visitor.append(rareData->m_codeBlock);
     
     // Save some memory. This is O(n) to rebuild and we do so on the fly.
     ConcurrentJSLocker locker(thisSymbolTable->m_lock);
@@ -164,7 +164,7 @@ SymbolTable* SymbolTable::cloneScopePart(VM& vm)
         result->m_arguments.set(vm, result, arguments);
     
     if (m_rareData) {
-        result->m_rareData = makeUnique<SymbolTableRareData>();
+        result->ensureRareData();
 
         {
             auto iter = m_rareData->m_uniqueIDMap.begin();
@@ -201,11 +201,11 @@ void SymbolTable::prepareForTypeProfiling(const ConcurrentJSLocker&)
     if (m_rareData)
         return;
 
-    m_rareData = makeUnique<SymbolTableRareData>();
+    auto& rareData = ensureRareData();
 
     for (auto iter = m_map.begin(), end = m_map.end(); iter != end; ++iter) {
-        m_rareData->m_uniqueIDMap.set(iter->key, TypeProfilerNeedsUniqueIDGeneration);
-        m_rareData->m_offsetToVariableMap.set(iter->value.varOffset(), iter->key);
+        rareData.m_uniqueIDMap.set(iter->key, TypeProfilerNeedsUniqueIDGeneration);
+        rareData.m_offsetToVariableMap.set(iter->value.varOffset(), iter->key);
     }
 }
 
@@ -219,11 +219,9 @@ CodeBlock* SymbolTable::rareDataCodeBlock()
 
 void SymbolTable::setRareDataCodeBlock(CodeBlock* codeBlock)
 {
-    if (!m_rareData)
-        m_rareData = makeUnique<SymbolTableRareData>();
-
-    ASSERT(!m_rareData->m_codeBlock);
-    m_rareData->m_codeBlock.set(codeBlock->vm(), this, codeBlock);
+    auto& rareData = ensureRareData();
+    ASSERT(!rareData.m_codeBlock);
+    rareData.m_codeBlock.set(codeBlock->vm(), this, codeBlock);
 }
 
 GlobalVariableID SymbolTable::uniqueIDForVariable(const ConcurrentJSLocker&, UniquedStringImpl* key, VM& vm)
@@ -283,6 +281,14 @@ RefPtr<TypeSet> SymbolTable::globalTypeSetForVariable(const ConcurrentJSLocker& 
         return nullptr;
 
     return iter->value;
+}
+
+SymbolTable::SymbolTableRareData& SymbolTable::ensureRareDataSlow()
+{
+    auto rareData = makeUnique<SymbolTableRareData>();
+    WTF::storeStoreFence();
+    m_rareData = WTFMove(rareData);
+    return *m_rareData;
 }
 
 void SymbolTable::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -597,22 +597,27 @@ public:
         add(locker, key, std::forward<Entry>(entry));
     }
 
-    bool hasPrivateNames() const { return m_rareData && m_rareData->m_privateNames.size(); }
+    bool hasPrivateNames() const
+    {
+        if (auto* rareData = m_rareData.get())
+            return rareData->m_privateNames.size();
+        return false;
+    }
+
     ALWAYS_INLINE PrivateNameIteratorRange privateNames()
     {
         // Use of the IteratorRange must be guarded to prevent ASSERT failures in checkValidity().
         ASSERT(hasPrivateNames());
-        return makeIteratorRange(m_rareData->m_privateNames.begin(), m_rareData->m_privateNames.end());
+        auto& rareData = ensureRareData();
+        return makeIteratorRange(rareData.m_privateNames.begin(), rareData.m_privateNames.end());
     }
 
     void addPrivateName(const RefPtr<UniquedStringImpl>& key, PrivateNameEntry value)
     {
         ASSERT(key && !key->isSymbol());
-        if (!m_rareData)
-            m_rareData = WTF::makeUnique<SymbolTableRareData>();
-
-        ASSERT(m_rareData->m_privateNames.find(key) == m_rareData->m_privateNames.end());
-        m_rareData->m_privateNames.add(key, value);
+        auto& rareData = ensureRareData();
+        ASSERT(rareData.m_privateNames.find(key) == rareData.m_privateNames.end());
+        rareData.m_privateNames.add(key, value);
     }
 
     template<typename Entry>
@@ -740,17 +745,6 @@ public:
     void finalizeUnconditionally(VM&);
     void dump(PrintStream&) const;
 
-private:
-    JS_EXPORT_PRIVATE SymbolTable(VM&);
-    ~SymbolTable();
-    
-    JS_EXPORT_PRIVATE void finishCreation(VM&);
-
-    Map m_map;
-    ScopeOffset m_maxScopeOffset;
-public:
-    mutable ConcurrentJSLock m_lock;
-
     struct SymbolTableRareData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         UniqueIDMap m_uniqueIDMap;
@@ -759,6 +753,24 @@ public:
         WriteBarrier<CodeBlock> m_codeBlock;
         PrivateNameEnvironment m_privateNames;
     };
+
+private:
+    JS_EXPORT_PRIVATE SymbolTable(VM&);
+    ~SymbolTable();
+    SymbolTableRareData& ensureRareData()
+    {
+        if (LIKELY(m_rareData))
+            return *m_rareData;
+        return ensureRareDataSlow();
+    }
+    
+    JS_EXPORT_PRIVATE void finishCreation(VM&);
+    JS_EXPORT_PRIVATE SymbolTableRareData& ensureRareDataSlow();
+
+    Map m_map;
+    ScopeOffset m_maxScopeOffset;
+public:
+    mutable ConcurrentJSLock m_lock;
 
 private:
     unsigned m_usesNonStrictEval : 1;


### PR DESCRIPTION
#### 1d5e1b435724f80c4d98673e9abcf4faa66ab317
<pre>
[JSC] SymbolTableRareData should be set after store-store-fence
<a href="https://bugs.webkit.org/show_bug.cgi?id=248114">https://bugs.webkit.org/show_bug.cgi?id=248114</a>
rdar://102536737

Reviewed by Mark Lam.

This patch inserts storeStoreFence when setting SymbolTableRareData since
this data structure is read by concurrent GC thread.

* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::visitChildrenImpl):
(JSC::SymbolTable::cloneScopePart):
(JSC::SymbolTable::prepareForTypeProfiling):
(JSC::SymbolTable::setRareDataCodeBlock):
(JSC::SymbolTable::ensureRareDataSlow):
* Source/JavaScriptCore/runtime/SymbolTable.h:

Canonical link: <a href="https://commits.webkit.org/256868@main">https://commits.webkit.org/256868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58d94bdc7214c8d3eebab7c53e8d6ef9b67e9cd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106567 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6546 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35046 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89438 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102717 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83663 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87976 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83420 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5121 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1564 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40839 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19402 "Passed tests") | 
<!--EWS-Status-Bubble-End-->