### PR TITLE
WPT Fetch Private Network Access tests dumping the render tree as test output on iOS 16 simulator.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window-expected.txt
@@ -1,8 +1,0 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x41
-  RenderBlock {HTML} at (0,0) size 800x41
-    RenderBody {BODY} at (8,13) size 784x15
-      RenderBlock {PRE} at (0,0) size 784x15
-        RenderText {#text} at (0,0) size 328x15
-          text run at (0,0) width 328: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window.html
@@ -1,1 +1,0 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window-expected.txt
@@ -1,8 +1,0 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x41
-  RenderBlock {HTML} at (0,0) size 800x41
-    RenderBody {BODY} at (8,13) size 784x15
-      RenderBlock {PRE} at (0,0) size 784x15
-        RenderText {#text} at (0,0) size 328x15
-          text run at (0,0) width 328: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window.html
@@ -1,1 +1,0 @@
-<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window-expected.txt
@@ -1,8 +1,0 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x41
-  RenderBlock {HTML} at (0,0) size 800x41
-    RenderBody {BODY} at (8,13) size 784x15
-      RenderBlock {PRE} at (0,0) size 784x15
-        RenderText {#text} at (0,0) size 336x15
-          text run at (0,0) width 336: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window-expected.txt
@@ -1,8 +1,0 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x41
-  RenderBlock {HTML} at (0,0) size 800x41
-    RenderBody {BODY} at (8,13) size 784x15
-      RenderBlock {PRE} at (0,0) size 784x15
-        RenderText {#text} at (0,0) size 336x15
-          text run at (0,0) width 336: "{\"error\": {\"code\": 404, \"message\": \"404\"}}"

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2007,10 +2007,6 @@ webkit.org/b/228114 imported/w3c/web-platform-tests/fetch/content-type/script.wi
 
 webkit.org/b/230418 imported/w3c/web-platform-tests/fetch/data-urls/base64.any.worker.html [ Pass Crash ]
 
-# These tests are dumping the render tree.
-webkit.org/b/247682 imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window.html [ Skip ]
-webkit.org/b/247682 imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window.html [ Skip ]
-
 # These are timing out.
 webkit.org/b/247632 imported/w3c/web-platform-tests/fetch/metadata/generated/element-a.sub.html [ Skip ]
 webkit.org/b/247632 imported/w3c/web-platform-tests/fetch/metadata/generated/element-area.sub.html [ Skip ]


### PR DESCRIPTION
#### 274b3310fed1d8c58417ca13194d647fe90d8d57
<pre>
WPT Fetch Private Network Access tests dumping the render tree as test output on iOS 16 simulator.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247682">https://bugs.webkit.org/show_bug.cgi?id=247682</a>
rdar://102144343

Unreviewed test gardening.

These tests don&apos;t exist upstream and mistakenly had files generated for them during
the fetch WPT resync in 256738@main

* LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window.html: Removed.
* LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window.html: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/private-network-access/non-secure-context.window-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/private-network-access/secure-context.https.window-expected.txt: Removed.
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/256870@main">https://commits.webkit.org/256870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b71a4a79776cf3a1d753ee488d84281a0359a8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30172 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/106574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6555 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35054 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89445 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102726 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83672 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5128 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2316 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1573 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->