### PR TITLE
REGRESSION (249229@main): CSS filter does not update on hover

### DIFF
--- a/LayoutTests/css3/filters/change-filter-style-expected.html
+++ b/LayoutTests/css3/filters/change-filter-style-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .filtered {
+            width: 200px;
+            height: 200px;
+            filter: saturate(1);
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div class="filtered"></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/change-filter-style.html
+++ b/LayoutTests/css3/filters/change-filter-style.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .filtered {
+            width: 200px;
+            height: 200px;
+            filter: saturate(0.2);
+            background-color: green;
+        }
+        
+        body.changed .filtered {
+            filter: saturate(1);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate(); // Wait for one paint.
+            document.body.classList.add('changed');
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="filtered"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -139,7 +139,7 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, const FilterImageV
         return nullptr;
 
     LOG_WITH_STREAM(Filters, stream
-        << "FilterEffect " << filterName() << " " << this << " apply():"
+        << "FilterEffect " << filterName() << " " << this << " apply(): " << *this
         << "\n  filterPrimitiveSubregion " << primitiveSubregion
         << "\n  absolutePaintRect " << absoluteImageRect
         << "\n  maxEffectRect " << filter.maxEffectRect(primitiveSubregion)

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
@@ -28,6 +28,7 @@
 
 #include "ImageBuffer.h"
 #include <wtf/SortedArrayMap.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -68,6 +69,11 @@ AtomString FilterFunction::filterName(Type filterType)
     
     ASSERT(namesMap.tryGet(filterType));
     return namesMap.get(filterType, ""_s);
+}
+
+TextStream& operator<<(TextStream& ts, const FilterFunction& filterFunction)
+{
+    return filterFunction.externalRepresentation(ts, FilterRepresentation::Debugging);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -102,6 +102,8 @@ private:
     Type m_filterType;
 };
 
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, const FilterFunction&);
+
 } // namespace WebCore
 
 namespace WTF {

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -48,9 +48,12 @@ RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperati
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin = operations.hasFilterThatShouldBeRestrictedBySecurityOrigin();
 
     auto filter = adoptRef(*new CSSFilter(renderingMode, filterScale, clipOperation, hasFilterThatMovesPixels, hasFilterThatShouldBeRestrictedBySecurityOrigin));
-
-    if (!filter->buildFilterFunctions(renderer, operations, targetBoundingBox, destinationContext))
+    if (!filter->buildFilterFunctions(renderer, operations, targetBoundingBox, destinationContext)) {
+        LOG_WITH_STREAM(Filters, stream << "CSSFilter::create: failed to build filters " << operations);
         return nullptr;
+    }
+
+    LOG_WITH_STREAM(Filters, stream << "CSSFilter::create built filter " << filter.get() << " for " << operations);
 
     if (renderingMode == RenderingMode::Accelerated && !filter->supportsAcceleratedRendering())
         filter->setRenderingMode(RenderingMode::Unaccelerated);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5293,7 +5293,7 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
 #if ENABLE(CSS_COMPOSITING)
     updateBlendMode();
 #endif
-    updateFiltersAfterStyleChange();
+    updateFiltersAfterStyleChange(diff, oldStyle);
     
     compositor().layerStyleChanged(diff, *this, oldStyle);
 
@@ -5415,7 +5415,7 @@ void RenderLayer::clearLayerScrollableArea()
     }
 }
 
-void RenderLayer::updateFiltersAfterStyleChange()
+void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     if (!hasFilter()) {
         clearLayerFilters();
@@ -5429,6 +5429,9 @@ void RenderLayer::updateFiltersAfterStyleChange()
         m_filters->updateReferenceFilterClients(renderer().style().filter());
     } else if (m_filters)
         m_filters->removeReferenceFilterClients();
+
+    if (diff >= StyleDifference::RepaintLayer && oldStyle && oldStyle->filter() != renderer().style().filter())
+        clearLayerFilters();
 }
 
 void RenderLayer::updateLayerScrollableArea()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1153,7 +1153,7 @@ private:
     bool paintingInsideReflection() const { return m_paintingInsideReflection; }
     void setPaintingInsideReflection(bool b) { m_paintingInsideReflection = b; }
 
-    void updateFiltersAfterStyleChange();
+    void updateFiltersAfterStyleChange(StyleDifference, const RenderStyle* oldStyle);
     void updateFilterPaintingStrategy();
 
 #if ENABLE(CSS_COMPOSITING)


### PR DESCRIPTION
#### a0b92719854d2bb1e7cdf41c3d4cedc514ba3a3e
<pre>
REGRESSION (249229@main): CSS filter does not update on hover
<a href="https://bugs.webkit.org/show_bug.cgi?id=247233">https://bugs.webkit.org/show_bug.cgi?id=247233</a>
rdar://101836748

Reviewed by Darin Adler.

249229@main made it so that we don&apos;t recreate CSSFilter on every paint,
but there was no code to update the filters when style changed.

So have `RenderLayer::updateFiltersAfterStyleChange()` clear the filters
when filter style changes; we&apos;ll recreate them on the next paint.

Also improve some logging output that helped when debugging this.

* LayoutTests/css3/filters/change-filter-style-expected.html: Added.
* LayoutTests/css3/filters/change-filter-style.html: Added.
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::apply):
* Source/WebCore/platform/graphics/filters/FilterFunction.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::create):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/256920@main">https://commits.webkit.org/256920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdb88b64d457c6bf7122e230aaa2f0c8ce2d506f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106577 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166850 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6558 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35057 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103269 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4925 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83675 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31939 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88636 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74830 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/remove-filter (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/353 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20115 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/336 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4772 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44050 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1576 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40851 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->