### PR TITLE
[ BigSur Debug JSC ] Multiple .lockdown tests are constant failures

### DIFF
--- a/JSTests/microbenchmarks/array-from-derived-object-func.js
+++ b/JSTests/microbenchmarks/array-from-derived-object-func.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/microbenchmarks/array-from-object-func.js
+++ b/JSTests/microbenchmarks/array-from-object-func.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/microbenchmarks/bit-test-constant.js
+++ b/JSTests/microbenchmarks/bit-test-constant.js
@@ -1,6 +1,5 @@
 //@ skip if not $jitTests
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
+//@ $skipModes << :lockdown
 
 let glob = 0
 

--- a/JSTests/microbenchmarks/bit-test-load.js
+++ b/JSTests/microbenchmarks/bit-test-load.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
 let glob = 0
 let arr = new Int32Array(8)
 

--- a/JSTests/microbenchmarks/bit-test-nonconstant.js
+++ b/JSTests/microbenchmarks/bit-test-nonconstant.js
@@ -1,4 +1,5 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 let glob = 0
 
 function doTest(number, bit) {

--- a/JSTests/microbenchmarks/data-view-accesses-2.js
+++ b/JSTests/microbenchmarks/data-view-accesses-2.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
 "use strict";
 
 function assert(b, m = "") {

--- a/JSTests/microbenchmarks/delete-property-allocation-sinking.js
+++ b/JSTests/microbenchmarks/delete-property-allocation-sinking.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function assert(condition) {
     if (!condition)

--- a/JSTests/microbenchmarks/delete-property-inline-cache.js
+++ b/JSTests/microbenchmarks/delete-property-inline-cache.js
@@ -1,4 +1,5 @@
 //@ skip if $model =~ /^Apple Watch/
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function C() {
     this.x = 4;

--- a/JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js
+++ b/JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js
@@ -1,4 +1,6 @@
 //@ skip if $model =~ /^Apple Watch/
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function assert(b) {
     if (!b)
         throw new Error;

--- a/JSTests/microbenchmarks/elidable-new-object-dag.js
+++ b/JSTests/microbenchmarks/elidable-new-object-dag.js
@@ -1,5 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/microbenchmarks/elidable-new-object-then-call.js
+++ b/JSTests/microbenchmarks/elidable-new-object-then-call.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;
 }

--- a/JSTests/microbenchmarks/elidable-new-object-tree.js
+++ b/JSTests/microbenchmarks/elidable-new-object-tree.js
@@ -1,5 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/microbenchmarks/function-to-string.js
+++ b/JSTests/microbenchmarks/function-to-string.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function f(x, y, z) {
     // comment in the body
     const w = 42;

--- a/JSTests/microbenchmarks/get-and-put-by-val-double-index-dont-fall-off-a-cliff.js
+++ b/JSTests/microbenchmarks/get-and-put-by-val-double-index-dont-fall-off-a-cliff.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 const numPixels = 24000000;
 let source = new Uint8Array(numPixels);
 let target = new Uint8Array(numPixels);

--- a/JSTests/microbenchmarks/get-by-val-polymorphic-ic-1.js
+++ b/JSTests/microbenchmarks/get-by-val-polymorphic-ic-1.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function assert(b, m) {
     if (!b)
         throw new Error(m);

--- a/JSTests/microbenchmarks/get-by-val-polymorphic-ic-4.js
+++ b/JSTests/microbenchmarks/get-by-val-polymorphic-ic-4.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function assert(b, m) {
     if (!b)
         throw new Error(m);

--- a/JSTests/microbenchmarks/get-by-val-polymorphic-ic-5.js
+++ b/JSTests/microbenchmarks/get-by-val-polymorphic-ic-5.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function assert(b, m) {
     if (!b)
         throw new Error(m);

--- a/JSTests/microbenchmarks/get-private-name.js
+++ b/JSTests/microbenchmarks/get-private-name.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function assert(b, m = "Assertion failed") {
     if (!b)
         throw new Error(m);

--- a/JSTests/microbenchmarks/hoist-get-by-offset-tower-with-inferred-types.js
+++ b/JSTests/microbenchmarks/hoist-get-by-offset-tower-with-inferred-types.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function foo(o)
 {
     var result = 0;

--- a/JSTests/microbenchmarks/int52-rand-function.js
+++ b/JSTests/microbenchmarks/int52-rand-function.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 let seed = 49734321;
 
 Math.random = (function() {

--- a/JSTests/microbenchmarks/memcpy-loop.js
+++ b/JSTests/microbenchmarks/memcpy-loop.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function doTest(arr1) {
     let arr2 = []
     for (let i=0; i<arr1.length; ++i) {

--- a/JSTests/microbenchmarks/memcpy-typed-loop-large.js
+++ b/JSTests/microbenchmarks/memcpy-typed-loop-large.js
@@ -1,6 +1,5 @@
 //@ skip if not $jitTests
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
+//@ $skipModes << :lockdown
 
 function doTest(arr1, arr2) {
     if (arr1.length != arr2.length)

--- a/JSTests/microbenchmarks/object-is.js
+++ b/JSTests/microbenchmarks/object-is.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function incognito(value) {
     var array = [];
     array.push(value);

--- a/JSTests/microbenchmarks/obvious-sink-pathology-taken.js
+++ b/JSTests/microbenchmarks/obvious-sink-pathology-taken.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;
 }

--- a/JSTests/microbenchmarks/oob-sane-chain-double.js
+++ b/JSTests/microbenchmarks/oob-sane-chain-double.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function assert(b) {
     if (!b)
         throw new Error;

--- a/JSTests/microbenchmarks/polyvariant-delete-property.js
+++ b/JSTests/microbenchmarks/polyvariant-delete-property.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function assert(condition) {
     if (!condition)

--- a/JSTests/microbenchmarks/richards-empty-try-catch.js
+++ b/JSTests/microbenchmarks/richards-empty-try-catch.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/JSTests/microbenchmarks/richards-try-catch.js
+++ b/JSTests/microbenchmarks/richards-try-catch.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
 //@ requireOptions("--useDataICInFTL=true", "--useDataICSharing=true")
 
 // Copyright 2006-2008 the V8 project authors. All rights reserved.

--- a/JSTests/microbenchmarks/sinkable-new-object-dag.js
+++ b/JSTests/microbenchmarks/sinkable-new-object-dag.js
@@ -1,5 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/microbenchmarks/sinkable-new-object-taken.js
+++ b/JSTests/microbenchmarks/sinkable-new-object-taken.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;
 }

--- a/JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js
+++ b/JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;
 }

--- a/JSTests/microbenchmarks/sinkable-new-object.js
+++ b/JSTests/microbenchmarks/sinkable-new-object.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;
 }

--- a/JSTests/microbenchmarks/string-replace-string.js
+++ b/JSTests/microbenchmarks/string-replace-string.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function test(a, b, c)
 {
     return a.replace(b, c);

--- a/JSTests/microbenchmarks/to-number-boolean.js
+++ b/JSTests/microbenchmarks/to-number-boolean.js
@@ -1,4 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 var array = [];
 var casted = [];
 for (var i = 0; i < 1e3; ++i) {

--- a/JSTests/microbenchmarks/typed-array-get-set-by-val-profiling.js
+++ b/JSTests/microbenchmarks/typed-array-get-set-by-val-profiling.js
@@ -1,5 +1,6 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 // The type of arrayObject is polymorphic, but the access we do on it are not.
 function nonPolymorphicUint8ClampedArraySetter(arrayObject, isTypedArray) {

--- a/JSTests/stress/allow-math-ic-b3-code-duplication.js
+++ b/JSTests/stress/allow-math-ic-b3-code-duplication.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function test1() {
     var o1;

--- a/JSTests/stress/arith-abs-on-various-types.js
+++ b/JSTests/stress/arith-abs-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js
+++ b/JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 // Checked int_min < value < 0
 function opaqueCheckedBetweenIntMinAndZeroExclusive(arg) {

--- a/JSTests/stress/arith-acos-on-various-types.js
+++ b/JSTests/stress/arith-acos-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let acosOfHalf = Math.acos(0.5);
 

--- a/JSTests/stress/arith-acosh-on-various-types.js
+++ b/JSTests/stress/arith-acosh-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let acoshOfFour = Math.acosh(4);
 

--- a/JSTests/stress/arith-asin-on-various-types.js
+++ b/JSTests/stress/arith-asin-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let asinOfHalf = Math.asin(0.5);
 

--- a/JSTests/stress/arith-asinh-on-various-types.js
+++ b/JSTests/stress/arith-asinh-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let asinhOfFour = Math.asinh(4);
 

--- a/JSTests/stress/arith-atan-on-various-types.js
+++ b/JSTests/stress/arith-atan-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let atanOfFour = Math.atan(4);
 

--- a/JSTests/stress/arith-atanh-on-various-types.js
+++ b/JSTests/stress/arith-atanh-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let atanhOfHalf = Math.atanh(0.5);
 

--- a/JSTests/stress/arith-cbrt-on-various-types.js
+++ b/JSTests/stress/arith-cbrt-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let cbrtOfHalf = Math.cbrt(0.5);
 

--- a/JSTests/stress/arith-ceil-on-various-types.js
+++ b/JSTests/stress/arith-ceil-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-clz32-on-various-types.js
+++ b/JSTests/stress/arith-clz32-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-cos-on-various-types.js
+++ b/JSTests/stress/arith-cos-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let cosOfFour = Math.cos(4);
 

--- a/JSTests/stress/arith-cosh-on-various-types.js
+++ b/JSTests/stress/arith-cosh-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let coshOfFour = Math.cosh(4);
 

--- a/JSTests/stress/arith-expm1-on-various-types.js
+++ b/JSTests/stress/arith-expm1-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let expm1OfHalf = Math.expm1(0.5);
 

--- a/JSTests/stress/arith-floor-on-various-types.js
+++ b/JSTests/stress/arith-floor-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-fround-on-various-types.js
+++ b/JSTests/stress/arith-fround-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let froundOfPi = Math.fround(Math.PI);
 let froundOfE = Math.fround(Math.E);

--- a/JSTests/stress/arith-log10-on-various-types.js
+++ b/JSTests/stress/arith-log10-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let log10OfHalf = Math.log10(0.5);
 

--- a/JSTests/stress/arith-log2-on-various-types.js
+++ b/JSTests/stress/arith-log2-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let log2OfHalf = Math.log2(0.5);
 

--- a/JSTests/stress/arith-negate-on-various-types.js
+++ b/JSTests/stress/arith-negate-on-various-types.js
@@ -1,9 +1,7 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-round-on-various-types.js
+++ b/JSTests/stress/arith-round-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-sin-on-various-types.js
+++ b/JSTests/stress/arith-sin-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let sinOfFour = Math.sin(4);
 

--- a/JSTests/stress/arith-sinh-on-various-types.js
+++ b/JSTests/stress/arith-sinh-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let sinhOfFour = Math.sinh(4);
 

--- a/JSTests/stress/arith-sqrt-on-various-types.js
+++ b/JSTests/stress/arith-sqrt-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/arith-tan-on-various-types.js
+++ b/JSTests/stress/arith-tan-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let tanOfFour = Math.tan(4);
 

--- a/JSTests/stress/arith-tanh-on-various-types.js
+++ b/JSTests/stress/arith-tanh-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let tanhOfFour = Math.tanh(4);
 

--- a/JSTests/stress/arith-trunc-on-various-types.js
+++ b/JSTests/stress/arith-trunc-on-various-types.js
@@ -1,10 +1,8 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ requireOptions("--forceUnlinkedDFG=0")
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 let validInputTestCases = [
     // input as string, expected result as string.

--- a/JSTests/stress/bit-op-with-object-returning-int32.js
+++ b/JSTests/stress/bit-op-with-object-returning-int32.js
@@ -1,6 +1,5 @@
 //@ skip if not $jitTests
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
+//@ $skipModes << :lockdown
 
 function assert(a, e) {
     if (a !== e)

--- a/JSTests/stress/bitwise-not-fixup-rules.js
+++ b/JSTests/stress/bitwise-not-fixup-rules.js
@@ -1,6 +1,5 @@
 //@ skip unless $jitTests
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
+//@ $skipModes << :lockdown
 
 function assert(a, e) {
     if (a !== e)

--- a/JSTests/stress/call-var-args-phantom-arguments-handler-strict.js
+++ b/JSTests/stress/call-var-args-phantom-arguments-handler-strict.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 "use strict";
 
 function shouldBe(actual, expected) {

--- a/JSTests/stress/call-var-args-phantom-arguments-strict.js
+++ b/JSTests/stress/call-var-args-phantom-arguments-strict.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 "use strict";
 
 function shouldBe(actual, expected) {

--- a/JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js
+++ b/JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function empty() {}
 function empty2() {}
 

--- a/JSTests/stress/compare-strict-eq-on-various-types.js
+++ b/JSTests/stress/compare-strict-eq-on-various-types.js
@@ -1,9 +1,7 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown
 //@ defaultNoEagerRun
 "use strict";
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 function opaqueKitString() {
     return "Kit";

--- a/JSTests/stress/elide-new-object-dag-then-exit.js
+++ b/JSTests/stress/elide-new-object-dag-then-exit.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js
+++ b/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js
@@ -1,11 +1,9 @@
 //@ crashOK!
+//@ $skipModes << :lockdown
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);
 }
-
-if (!$vm.useJIT())
-    $vm.exit();
 
 var putter = function(o) {
     o._unsupported = not_string;

--- a/JSTests/stress/int8-repeat-in-then-out-of-bounds.js
+++ b/JSTests/stress/int8-repeat-in-then-out-of-bounds.js
@@ -1,7 +1,5 @@
+//@ $skipModes << :lockdown
 //@ if $jitTests then defaultNoEagerRun(*NO_CJIT_OPTIONS) else skip end
-
-if (typeof $vm != "undefined" && !$vm.useJIT())
-    $vm.exit();
 
 function foo(a, inBounds) {
     a[0] = 1;

--- a/JSTests/stress/new-regex-inline.js
+++ b/JSTests/stress/new-regex-inline.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function assert(a) {
     if (!a)

--- a/JSTests/stress/obviously-elidable-new-object-then-exit.js
+++ b/JSTests/stress/obviously-elidable-new-object-then-exit.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;
 }

--- a/JSTests/stress/private-name-assignment-in-constructor.js
+++ b/JSTests/stress/private-name-assignment-in-constructor.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 class Foo {
   #foo;
   constructor() {

--- a/JSTests/stress/spread-forward-call-varargs-stack-overflow.js
+++ b/JSTests/stress/spread-forward-call-varargs-stack-overflow.js
@@ -1,4 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # Takes very long time to reproduce failure.
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 function assert(b) {
     if (!b)

--- a/JSTests/stress/tail-call-var-args-phantom-arguments-handler-strict.js
+++ b/JSTests/stress/tail-call-var-args-phantom-arguments-handler-strict.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 "use strict";
 
 function shouldBe(actual, expected) {

--- a/JSTests/stress/tail-call-var-args-phantom-arguments-strict.js
+++ b/JSTests/stress/tail-call-var-args-phantom-arguments-strict.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 "use strict";
 
 function shouldBe(actual, expected) {

--- a/JSTests/stress/undecided-arrays-should-not-need-original-array-for-length.js
+++ b/JSTests/stress/undecided-arrays-should-not-need-original-array-for-length.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 function findFoo(name, array, bail) {
     let some = array.some
     if (bail)

--- a/JSTests/stress/v8-deltablue-strict.js
+++ b/JSTests/stress/v8-deltablue-strict.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 "use strict";
 
 // Copyright 2008 the V8 project authors. All rights reserved.

--- a/JSTests/stress/v8-richards-strict.js
+++ b/JSTests/stress/v8-richards-strict.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 "use strict";
 
 // Copyright 2006-2008 the V8 project authors. All rights reserved.

--- a/PerformanceTests/JetStream/cdjs/main.js
+++ b/PerformanceTests/JetStream/cdjs/main.js
@@ -26,6 +26,7 @@
 // This is run as a JSC stress test. Let the harness know that this is a slow test.
 //@ slow!
 //@ skip if $architecture == "x86"
+//@ $skipModes << :lockdown if $buildType == "debug"
 
 load("constants.js");
 load("util.js");

--- a/PerformanceTests/SunSpider/tests/v8-v6/v8-deltablue.js
+++ b/PerformanceTests/SunSpider/tests/v8-v6/v8-deltablue.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 // Copyright 2008 the V8 project authors. All rights reserved.
 // Copyright 1996 John Maloney and Mario Wolczko.
 

--- a/PerformanceTests/SunSpider/tests/v8-v6/v8-richards.js
+++ b/PerformanceTests/SunSpider/tests/v8-v6/v8-richards.js
@@ -1,3 +1,5 @@
+//@ $skipModes << :lockdown if $buildType == "debug"
+
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1500,7 +1500,7 @@ def defaultRunCfg(cfg, subsetOptions, *optionalTestSpecificOptions)
         runDefaultCfg(cfg, *optionalTestSpecificOptions)
         runBytecodeCacheCfg(cfg, *optionalTestSpecificOptions)
         runMiniModeCfg(cfg, *optionalTestSpecificOptions)
-        runLockdownCfg(cfg, *optionalTestSpecificOptions)
+        runLockdownCfg(cfg, *optionalTestSpecificOptions) unless $skipModes.include?(:lockdown)
         if $jitTests
             if not subsetOptions.has_key?(:skipNoLLInt)
                 runNoLLIntCfg(cfg, *optionalTestSpecificOptions)
@@ -2390,7 +2390,7 @@ def handleCollectionDirectory(collection)
             | path |
             
             $benchmark = path.basename
-            
+            $skipModes = Set.new
             $runCommandOptions = {}
             $testSpecificRequiredOptions = []
             defaultRun unless parseRunCommands


### PR DESCRIPTION
#### bb2a6104c6b477672fa126eb1ee0084932f2f347
<pre>
[ BigSur Debug JSC ] Multiple .lockdown tests are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248000">https://bugs.webkit.org/show_bug.cgi?id=248000</a>
&lt;rdar://problem/102442315&gt;

Reviewed by Yusuke Suzuki.

This patch fixes some timeout failures when the JSC stress tests are run in the lockdown
test mode.

1. Introduce @skipModes which allows tests to be skipped from a test mode.
2. Use @skipModes to skip tests that require the JIT from the lockdown test mode.
   This replaces the old method of checking $vm.useJIT() at runtime, which is less
   efficient.
3. Use @skipModes to skip tests that are too slow from the lockdown test mode when
   run on a debug build.
4. Use @skipModes to skip a few tests from the lockdown test mode because these tests
   are too slow even when run on a Release build with lockdown test mode.

* JSTests/microbenchmarks/array-from-derived-object-func.js:
* JSTests/microbenchmarks/array-from-object-func.js:
* JSTests/microbenchmarks/bit-test-constant.js:
* JSTests/microbenchmarks/bit-test-load.js:
* JSTests/microbenchmarks/bit-test-nonconstant.js:
* JSTests/microbenchmarks/data-view-accesses-2.js:
* JSTests/microbenchmarks/delete-property-allocation-sinking.js:
* JSTests/microbenchmarks/delete-property-inline-cache.js:
* JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js:
* JSTests/microbenchmarks/elidable-new-object-dag.js:
* JSTests/microbenchmarks/elidable-new-object-then-call.js:
* JSTests/microbenchmarks/elidable-new-object-tree.js:
* JSTests/microbenchmarks/function-to-string.js:
* JSTests/microbenchmarks/get-and-put-by-val-double-index-dont-fall-off-a-cliff.js:
* JSTests/microbenchmarks/get-by-val-polymorphic-ic-1.js:
* JSTests/microbenchmarks/get-by-val-polymorphic-ic-4.js:
* JSTests/microbenchmarks/get-by-val-polymorphic-ic-5.js:
* JSTests/microbenchmarks/get-private-name.js:
* JSTests/microbenchmarks/hoist-get-by-offset-tower-with-inferred-types.js:
* JSTests/microbenchmarks/int52-rand-function.js:
* JSTests/microbenchmarks/memcpy-loop.js:
* JSTests/microbenchmarks/memcpy-typed-loop-large.js:
* JSTests/microbenchmarks/object-is.js:
* JSTests/microbenchmarks/obvious-sink-pathology-taken.js:
* JSTests/microbenchmarks/oob-sane-chain-double.js:
* JSTests/microbenchmarks/polyvariant-delete-property.js:
* JSTests/microbenchmarks/richards-empty-try-catch.js:
* JSTests/microbenchmarks/richards-try-catch.js:
* JSTests/microbenchmarks/sinkable-new-object-dag.js:
* JSTests/microbenchmarks/sinkable-new-object-taken.js:
* JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js:
* JSTests/microbenchmarks/sinkable-new-object.js:
* JSTests/microbenchmarks/string-replace-string.js:
* JSTests/microbenchmarks/to-number-boolean.js:
* JSTests/microbenchmarks/typed-array-get-set-by-val-profiling.js:
* JSTests/stress/allow-math-ic-b3-code-duplication.js:
* JSTests/stress/arith-abs-on-various-types.js:
* JSTests/stress/arith-abs-to-arith-negate-range-optimizaton.js:
* JSTests/stress/arith-acos-on-various-types.js:
* JSTests/stress/arith-acosh-on-various-types.js:
* JSTests/stress/arith-asin-on-various-types.js:
* JSTests/stress/arith-asinh-on-various-types.js:
* JSTests/stress/arith-atan-on-various-types.js:
* JSTests/stress/arith-atanh-on-various-types.js:
* JSTests/stress/arith-cbrt-on-various-types.js:
* JSTests/stress/arith-ceil-on-various-types.js:
* JSTests/stress/arith-clz32-on-various-types.js:
* JSTests/stress/arith-cos-on-various-types.js:
* JSTests/stress/arith-cosh-on-various-types.js:
* JSTests/stress/arith-expm1-on-various-types.js:
* JSTests/stress/arith-floor-on-various-types.js:
* JSTests/stress/arith-fround-on-various-types.js:
* JSTests/stress/arith-log10-on-various-types.js:
* JSTests/stress/arith-log2-on-various-types.js:
* JSTests/stress/arith-negate-on-various-types.js:
* JSTests/stress/arith-round-on-various-types.js:
* JSTests/stress/arith-sin-on-various-types.js:
* JSTests/stress/arith-sinh-on-various-types.js:
* JSTests/stress/arith-sqrt-on-various-types.js:
* JSTests/stress/arith-tan-on-various-types.js:
* JSTests/stress/arith-tanh-on-various-types.js:
* JSTests/stress/arith-trunc-on-various-types.js:
* JSTests/stress/bit-op-with-object-returning-int32.js:
* JSTests/stress/bitwise-not-fixup-rules.js:
* JSTests/stress/call-var-args-phantom-arguments-handler-strict.js:
* JSTests/stress/call-var-args-phantom-arguments-strict.js:
* JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js:
* JSTests/stress/compare-strict-eq-on-various-types.js:
* JSTests/stress/elide-new-object-dag-then-exit.js:
* JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js:
* JSTests/stress/int8-repeat-in-then-out-of-bounds.js:
* JSTests/stress/new-regex-inline.js:
* JSTests/stress/obviously-elidable-new-object-then-exit.js:
* JSTests/stress/private-name-assignment-in-constructor.js:
* JSTests/stress/spread-forward-call-varargs-stack-overflow.js:
* JSTests/stress/tail-call-var-args-phantom-arguments-handler-strict.js:
* JSTests/stress/tail-call-var-args-phantom-arguments-strict.js:
* JSTests/stress/undecided-arrays-should-not-need-original-array-for-length.js:
* JSTests/stress/v8-deltablue-strict.js:
* JSTests/stress/v8-richards-strict.js:
* PerformanceTests/JetStream/cdjs/main.js:
* PerformanceTests/SunSpider/tests/v8-v6/v8-deltablue.js:
* PerformanceTests/SunSpider/tests/v8-v6/v8-richards.js:
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/256875@main">https://commits.webkit.org/256875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b37e21c895cba9437cfc276bf8ddf2655b88d797

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106580 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6561 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35060 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103271 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4926 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83678 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31936 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86769 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74827 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/filter-persistence (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87991 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/356 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83433 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/338 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28433 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5134 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86137 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2319 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40850 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19408 "Passed tests") | 
<!--EWS-Status-Bubble-End-->