### PR TITLE
[libpas] Implement pas_root_visit_conservative_candidate_pointers_in_address_range

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -32,6 +32,12 @@
 #include <TargetConditionals.h>
 #endif
 
+/* PAS_CPU() - the target CPU architecture */
+#define PAS_CPU(FEATURE) (defined PAS_CPU_##FEATURE  && PAS_CPU_##FEATURE)
+
+/* PAS_HAVE() - specific system features (headers, functions or similar) that are present or not */
+#define PAS_HAVE(FEATURE) (defined PAS_HAVE_##FEATURE && PAS_HAVE_##FEATURE)
+
 /* PAS_COMPILER() - the target compiler */
 #define PAS_COMPILER(FEATURE) (defined PAS_COMPILER_##FEATURE  && PAS_COMPILER_##FEATURE)
 
@@ -172,6 +178,19 @@
 
 #if defined(__SCE__)
 #define PAS_PLATFORM_PLAYSTATION 1
+#endif
+
+#if PAS_COMPILER(GCC_COMPATIBLE)
+/* __LP64__ is not defined on 64bit Windows since it uses LLP64. Using __SIZEOF_POINTER__ is simpler. */
+#if __SIZEOF_POINTER__ == 8
+#define PAS_CPU_ADDRESS64 1
+#elif __SIZEOF_POINTER__ == 4
+#define PAS_CPU_ADDRESS32 1
+#else
+#error "Unsupported pointer width"
+#endif
+#else
+#error "Unsupported compiler for libpas"
 #endif
 
 #endif /* PAS_PLATFORM_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -44,6 +44,7 @@
 
 #if PAS_OS(DARWIN)
 #include <mach/mach_init.h>
+#include <mach/vm_param.h>
 #endif
 
 static bool count_static_heaps_callback(pas_heap* heap, void* arg)
@@ -387,6 +388,113 @@ pas_root* pas_root_ensure_for_libmalloc_enumeration(void)
     pas_root_for_libmalloc_enumeration = root;
 
     return root;
+}
+
+#define PAS_SYSTEM_COMPACT_POINTER_SIZE 4
+
+#if PAS_CPU(ADDRESS64)
+#if PAS_ARM64 && PAS_OS(DARWIN)
+#if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
+#define PAS_HAVE_36BIT_ADDRESS 1
+#endif
+#endif
+#endif // PAS_CPU(ADDRESS64)
+
+static inline vm_address_t decode_system_compact_pointer(pas_root* root, uint32_t value)
+{
+    PAS_UNUSED_PARAM(root);
+#if PAS_HAVE(36BIT_ADDRESS)
+    /* Our address region is 36-bit, thus we encode a 16-byte aligned pointer into 32-bit value by shifting it by 4. */
+    return (vm_address_t)(((uintptr_t)value) << 4);
+#else
+    /* The other platforms are not supporting CompactPtr. */
+    PAS_UNUSED_PARAM(value);
+    return 0;
+#endif
+}
+
+static inline bool is_compact_pointer_enabled()
+{
+#if PAS_HAVE(36BIT_ADDRESS)
+    return true;
+#else
+    /* macOS (48bit address space) or watchOS (32bit address space) */
+    return false;
+#endif
+}
+
+kern_return_t pas_root_visit_conservative_candidate_pointers_in_address_range(task_t task, void* context, vm_address_t zone_address, vm_address_t address, size_t size, memory_reader_t reader, pas_pointer_visitor_t visitor)
+{
+    kern_return_t result;
+    void* pointer;
+    uintptr_t cursor;
+    uintptr_t mapped_memory;
+    pas_root* root;
+    size_t number_of_candidates;
+    pas_conservative_candidate_pointer_and_location candidates[PAS_MAX_CANDIDATE_POINTERS];
+
+    if (!is_compact_pointer_enabled())
+        return KERN_SUCCESS;
+
+    result = reader(task, (vm_address_t)((malloc_zone_t*)zone_address + 1), sizeof(pas_root), &pointer);
+    if (result != KERN_SUCCESS)
+        return result;
+    root = (pas_root*)pointer;
+
+    result = reader(task, address, size, &pointer);
+    if (result != KERN_SUCCESS)
+        return result;
+
+    /* pointer can be unaligned. */
+    mapped_memory = (uintptr_t)pointer;
+    cursor = pas_round_up(mapped_memory, PAS_SYSTEM_COMPACT_POINTER_SIZE);
+
+    number_of_candidates = 0;
+    for (; (cursor + PAS_SYSTEM_COMPACT_POINTER_SIZE) <= (mapped_memory + size); cursor += PAS_SYSTEM_COMPACT_POINTER_SIZE) {
+        vm_address_t address_of_pointer;
+        vm_address_t candidate_pointer;
+
+        address_of_pointer = address + (cursor - mapped_memory);
+        candidate_pointer = decode_system_compact_pointer(root, *((const uint32_t*)cursor));
+
+        if (!candidate_pointer)
+            continue;
+
+#if PAS_CPU(ADDRESS64)
+
+#if PAS_ARM
+        if (candidate_pointer > MACH_VM_MAX_ADDRESS_RAW)
+            continue;
+#else
+        if (candidate_pointer > (1ULL << 48))
+            continue;
+#endif
+
+        /* First 4GB on 64bit process is unmapped. */
+        if (candidate_pointer < (4ULL << 30))
+            continue;
+#endif
+
+        /* FIXME: We can add more filtering via pas_root information later. */
+
+        candidates[number_of_candidates].address_of_pointer = address_of_pointer;
+        candidates[number_of_candidates].candidate_pointer = candidate_pointer;
+        number_of_candidates += 1;
+        if (number_of_candidates == PAS_MAX_CANDIDATE_POINTERS) {
+            result = visitor(context, candidates, number_of_candidates);
+            if (result != KERN_SUCCESS)
+                return result;
+            number_of_candidates = 0;
+        }
+    }
+
+    if (number_of_candidates) {
+        result = visitor(context, candidates, number_of_candidates);
+        if (result != KERN_SUCCESS)
+            return result;
+    }
+
+    return KERN_SUCCESS;
 }
 
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -123,6 +123,18 @@ PAS_API extern pas_root* pas_root_for_libmalloc_enumeration;
 /* This creates the root used for libmalloc enumeration, if there wasn't one already. Clients of
    libpas can choose not to call this, for example because they want to set up enumeration manually. */
 PAS_API pas_root* pas_root_ensure_for_libmalloc_enumeration(void);
+
+#define PAS_MAX_CANDIDATE_POINTERS 256
+
+typedef struct pas_conservative_candidate_pointer_and_location {
+    vm_address_t address_of_pointer;
+    vm_address_t candidate_pointer;
+} pas_conservative_candidate_pointer_and_location;
+
+typedef kern_return_t (*pas_pointer_visitor_t)(void* context, const pas_conservative_candidate_pointer_and_location*, size_t num_candidates);
+
+PAS_API kern_return_t pas_root_visit_conservative_candidate_pointers_in_address_range(task_t task, void* context, vm_address_t zone_address, vm_address_t address, size_t size, memory_reader_t reader, pas_pointer_visitor_t visitor);
+
 #endif
 
 PAS_END_EXTERN_C;


### PR DESCRIPTION
#### 2d62c3414e1f589b6fe09124b2012c88012cfda8
<pre>
[libpas] Implement pas_root_visit_conservative_candidate_pointers_in_address_range
<a href="https://bugs.webkit.org/show_bug.cgi?id=248122">https://bugs.webkit.org/show_bug.cgi?id=248122</a>
rdar://102540311

Reviewed by Mark Lam.

This patch implements a function pas_root_visit_conservative_candidate_pointers_in_address_range. It takes a remote address and
size, then calling a callback for pointers in this region. This allows libpas to report customized pointer scheme including
compact pointers.

* Source/bmalloc/libpas/src/libpas/pas_platform.h:
* Source/bmalloc/libpas/src/libpas/pas_root.c:
(decode_system_compact_pointer):
(pas_root_visit_conservative_candidate_pointers_in_address_range):
* Source/bmalloc/libpas/src/libpas/pas_root.h:

Canonical link: <a href="https://commits.webkit.org/256874@main">https://commits.webkit.org/256874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd886c13639dfe4dd60a1505c4deabface141c69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97077 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106594 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166865 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6579 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35074 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103282 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102746 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83693 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31946 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88002 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/367 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83443 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/349 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21550 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28438 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4753 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5148 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86151 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40865 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19416 "Passed tests") | 
<!--EWS-Status-Bubble-End-->