### PR TITLE
[JSC] Use FixedVector in Air::UseCounts

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -56,10 +56,12 @@ public:
         }
 
         unsigned gpArraySize = AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP));
-        m_gpNumWarmUsesAndDefs.resize(gpArraySize);
+        m_gpNumWarmUsesAndDefs = FixedVector<float>(gpArraySize);
+        m_gpNumWarmUsesAndDefs.fill(0);
         m_gpConstDefs.ensureSize(gpArraySize);
         unsigned fpArraySize = AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP));
-        m_fpNumWarmUsesAndDefs.resize(fpArraySize);
+        m_fpNumWarmUsesAndDefs = FixedVector<float>(fpArraySize);
+        m_fpNumWarmUsesAndDefs.fill(0);
         m_fpConstDefs.ensureSize(fpArraySize);
 
         for (BasicBlock* block : code) {
@@ -117,8 +119,8 @@ public:
     }
 
 private:
-    Vector<float> m_gpNumWarmUsesAndDefs;
-    Vector<float> m_fpNumWarmUsesAndDefs;
+    FixedVector<float> m_gpNumWarmUsesAndDefs;
+    FixedVector<float> m_fpNumWarmUsesAndDefs;
     BitVector m_gpConstDefs;
     BitVector m_fpConstDefs;
 };


### PR DESCRIPTION
#### f3c2df425b6028919516c68b4757a14a5bb43977
<pre>
[JSC] Use FixedVector in Air::UseCounts
<a href="https://bugs.webkit.org/show_bug.cgi?id=248124">https://bugs.webkit.org/show_bug.cgi?id=248124</a>
rdar://102540727

Reviewed by Mark Lam.

Use FixedVector in Air::UseCounts since the size won&apos;t be changed.

* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):

Canonical link: <a href="https://commits.webkit.org/256873@main">https://commits.webkit.org/256873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71d658c8f818751e1ab3c8a4266612692f62aa97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106588 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6570 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35068 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103277 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102741 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83686 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31941 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86772 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/87997 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/363 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83439 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/344 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28436 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5142 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86146 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40856 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19413 "Passed tests") | 
<!--EWS-Status-Bubble-End-->