### PR TITLE
Cleanup StyleProperties::fontSynthesisValue()

### DIFF
--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -717,52 +717,26 @@ String StyleProperties::fontVariantValue() const
 
 String StyleProperties::fontSynthesisValue() const
 {
-    StringBuilder result;
-
-    auto getExplicitLonghandValue = [&](CSSPropertyID propertyID) -> CSSValue* {
-        auto foundPropertyIndex = findPropertyIndex(propertyID);
-        if (foundPropertyIndex == -1)
-            return nullptr;
-
-        auto property = propertyAt(foundPropertyIndex);
-        if (property.isImplicit())
-            return nullptr;
-
-        return property.value();
-    };
-
     // font-synthesis: none | [ weight || style || small-caps ]
-    auto weightValue = getExplicitLonghandValue(CSSPropertyFontSynthesisWeight);
-    auto styleValue = getExplicitLonghandValue(CSSPropertyFontSynthesisStyle);
-    auto capsValue = getExplicitLonghandValue(CSSPropertyFontSynthesisSmallCaps);
+    auto weight = propertyAsValueID(CSSPropertyFontSynthesisWeight).value_or(CSSValueInvalid);
+    auto style = propertyAsValueID(CSSPropertyFontSynthesisStyle).value_or(CSSValueInvalid);
+    auto caps = propertyAsValueID(CSSPropertyFontSynthesisSmallCaps).value_or(CSSValueInvalid);
 
-    auto weightValueID = valueID(weightValue);
-    auto styleValueID = valueID(styleValue);
-    auto capsValueID = valueID(capsValue);
-
-    if (weightValueID != CSSValueInvalid && weightValueID == styleValueID && weightValueID == capsValueID) {
-        // Handle `none` or CSS wide-keywords.
-        if (weightValue->isCSSWideKeyword() || weightValueID == CSSValueNone)
-            return weightValue->cssText();
-    }
+    // Handle `none` or CSS wide-keywords that are common to all longhands.
+    if ((isCSSWideKeyword(weight) || weight == CSSValueNone) && weight == style && weight == caps)
+        return nameString(weight);
 
     // If one of the longhands is a CSS-wide keyword but not all of them are, this is not a valid shorthand.
-    if ((weightValue && weightValue->isCSSWideKeyword()) || (styleValue && styleValue->isCSSWideKeyword()) || (capsValue && capsValue->isCSSWideKeyword()))
-        return String();
+    if (isCSSWideKeyword(weight) || isCSSWideKeyword(style) || isCSSWideKeyword(caps))
+        return emptyString();
 
-    auto appendWithPrefixIfNeeded = [&](ASCIILiteral word) {
-        if (!result.isEmpty())
-            result.append(' ');
-        result.append(word);
-    };
-
-    if (weightValueID == CSSValueAuto)
-        appendWithPrefixIfNeeded("weight"_s);
-    if (styleValueID == CSSValueAuto)
-        appendWithPrefixIfNeeded("style"_s);
-    if (capsValueID == CSSValueAuto)
-        appendWithPrefixIfNeeded("small-caps"_s);
-
+    StringBuilder result;
+    if (weight == CSSValueAuto)
+        result.append("weight"_s);
+    if (style == CSSValueAuto)
+        result.append(result.isEmpty() ? "" : " ", "style"_s);
+    if (caps == CSSValueAuto)
+        result.append(result.isEmpty() ? "" : " ", "small-caps"_s);
     return result.toString();
 }
 


### PR DESCRIPTION
#### 55fafd865860fec1a636313be31d403366cf9715
<pre>
Cleanup StyleProperties::fontSynthesisValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248127">https://bugs.webkit.org/show_bug.cgi?id=248127</a>
rdar://102544812

Reviewed by Darin Adler.

- Use `propertyAsValueID` instead of custom lambda, it is possible since longhands are never added implicitly.
- Always do checks against the value ID (it is now possible now that we include the `isCSSWideKeyword()` function)
- Use pattern consistent with other methods for appending the strings to the string builder.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::fontSynthesisValue const):

Canonical link: <a href="https://commits.webkit.org/256877@main">https://commits.webkit.org/256877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5080eb936257d01dac15754db3e46e122fc4dbdc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106603 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/166874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6590 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35085 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103291 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83703 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/376 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/358 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5157 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2321 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1599 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->