### PR TITLE
Improve PlatformMouseEvent constructor to replace four bool args with OptionSet<PlatformEvent::Modifier>

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4,7 +4,7 @@
  *           (C) 2001 Peter Kelly (pmk@post.com)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *           (C) 2007 Eric Seidel (eric@webkit.org)
  *
  * This library is free software; you can redistribute it and/or
@@ -3474,7 +3474,7 @@ bool Element::dispatchMouseForceWillBegin()
     if (!frame)
         return false;
 
-    PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), NoButton, PlatformEvent::NoType, 1, false, false, false, false, WallTime::now(), ForceAtClick, NoTap };
+    PlatformMouseEvent platformMouseEvent { frame->eventHandler().lastKnownMousePosition(), frame->eventHandler().lastKnownMouseGlobalPosition(), NoButton, PlatformEvent::NoType, 1, { }, WallTime::now(), ForceAtClick, NoTap };
     auto mouseForceWillBeginEvent = MouseEvent::create(eventNames().webkitmouseforcewillbeginEvent, document().windowProxy(), platformMouseEvent, 0, nullptr);
     mouseForceWillBeginEvent->setTarget(Ref { *this });
     dispatchEvent(mouseForceWillBeginEvent);

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Igalia S.L
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1646,7 +1646,7 @@ void ContextMenuController::showContextMenuAt(Frame& frame, const IntPoint& clic
     clearContextMenu();
     
     // Simulate a click in the middle of the accessibility object.
-    PlatformMouseEvent mouseEvent(clickPoint, clickPoint, RightButton, PlatformEvent::MousePressed, 1, false, false, false, false, WallTime::now(), ForceAtClick, NoTap);
+    PlatformMouseEvent mouseEvent(clickPoint, clickPoint, RightButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), ForceAtClick, NoTap);
     frame.eventHandler().handleMousePressEvent(mouseEvent);
     bool handled = frame.eventHandler().sendContextMenuEvent(mouseEvent);
     if (handled)

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -128,16 +128,8 @@ bool isDraggableLink(const Element& element)
     
 static PlatformMouseEvent createMouseEvent(const DragData& dragData)
 {
-    bool shiftKey = false;
-    bool ctrlKey = false;
-    bool altKey = false;
-    bool metaKey = false;
-
-    PlatformKeyboardEvent::getCurrentModifierState(shiftKey, ctrlKey, altKey, metaKey);
-
-    return PlatformMouseEvent(dragData.clientPosition(), dragData.globalPosition(),
-                              LeftButton, PlatformEvent::MouseMoved, 0, shiftKey, ctrlKey, altKey,
-                              metaKey, WallTime::now(), ForceAtClick, NoTap);
+    auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
+    return PlatformMouseEvent(dragData.clientPosition(), dragData.globalPosition(), LeftButton, PlatformEvent::MouseMoved, 0, modifiers, WallTime::now(), ForceAtClick, NoTap);
 }
 
 DragController::DragController(Page& page, std::unique_ptr<DragClient>&& client)

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@webkit.org)
  * Copyright (C) 2012 Digia Plc. and/or its subsidiary(-ies)
  *
@@ -3383,8 +3383,7 @@ bool EventHandler::sendContextMenuEventForKey()
 #else
     PlatformEvent::Type eventType = PlatformEvent::MousePressed;
 #endif
-
-    PlatformMouseEvent platformMouseEvent(position, globalPosition, RightButton, eventType, 1, false, false, false, false, WallTime::now(), ForceAtClick, NoTap);
+    PlatformMouseEvent platformMouseEvent(position, globalPosition, RightButton, eventType, 1, { }, WallTime::now(), ForceAtClick, NoTap);
 
     return sendContextMenuEvent(platformMouseEvent);
 }
@@ -3469,12 +3468,8 @@ void EventHandler::fakeMouseMoveEventTimerFired()
     if (!m_frame.page() || !m_frame.page()->isVisible() || !m_frame.page()->focusController().isActive())
         return;
 
-    bool shiftKey;
-    bool ctrlKey;
-    bool altKey;
-    bool metaKey;
-    PlatformKeyboardEvent::getCurrentModifierState(shiftKey, ctrlKey, altKey, metaKey);
-    PlatformMouseEvent fakeMouseMoveEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition, NoButton, PlatformEvent::MouseMoved, 0, shiftKey, ctrlKey, altKey, metaKey, WallTime::now(), 0, NoTap);
+    auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
+    PlatformMouseEvent fakeMouseMoveEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition, NoButton, PlatformEvent::MouseMoved, 0, modifiers, WallTime::now(), 0, NoTap);
     mouseMoved(fakeMouseMoveEvent);
 }
 #endif // !ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -723,8 +723,8 @@ bool EventHandler::tryToBeginDragAtPoint(const IntPoint& clientPosition, const I
     IntPoint adjustedClientPosition = roundedIntPoint(adjustedClientPositionAsFloatPoint);
     IntPoint adjustedGlobalPosition = protectedFrame->view()->windowToContents(adjustedClientPosition);
 
-    PlatformMouseEvent syntheticMousePressEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MousePressed, 1, false, false, false, false, WallTime::now(), 0, NoTap);
-    PlatformMouseEvent syntheticMouseMoveEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MouseMoved, 0, false, false, false, false, WallTime::now(), 0, NoTap);
+    PlatformMouseEvent syntheticMousePressEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), 0, NoTap);
+    PlatformMouseEvent syntheticMouseMoveEvent(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent };
     auto documentPoint = protectedFrame->view() ? protectedFrame->view()->windowToContents(syntheticMouseMoveEvent.position()) : syntheticMouseMoveEvent.position();

--- a/Source/WebCore/platform/PlatformKeyboardEvent.cpp
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,20 @@
 namespace WebCore {
 
 std::optional<OptionSet<PlatformEvent::Modifier>> PlatformKeyboardEvent::s_currentModifiers;    
+
+bool PlatformKeyboardEvent::currentCapsLockState()
+{
+    return currentStateOfModifierKeys().contains(PlatformEvent::Modifier::CapsLockKey);
+}
+
+void PlatformKeyboardEvent::getCurrentModifierState(bool& shiftKey, bool& ctrlKey, bool& altKey, bool& metaKey)
+{
+    auto currentModifiers = currentStateOfModifierKeys();
+    shiftKey = currentModifiers.contains(PlatformEvent::Modifier::ShiftKey);
+    ctrlKey = currentModifiers.contains(PlatformEvent::Modifier::ControlKey);
+    altKey = currentModifiers.contains(PlatformEvent::Modifier::AltKey);
+    metaKey = currentModifiers.contains(PlatformEvent::Modifier::MetaKey);
+}
 
 void PlatformKeyboardEvent::setCurrentModifierState(OptionSet<Modifier> modifiers)
 {

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2005, 2006, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,9 +48,8 @@ const double ForceAtForceClick = 2;
         {
         }
 
-        PlatformMouseEvent(const IntPoint& position, const IntPoint& globalPosition, MouseButton button, PlatformEvent::Type type,
-                           int clickCount, bool shiftKey, bool ctrlKey, bool altKey, bool metaKey, WallTime timestamp, double force, SyntheticClickType syntheticClickType, PointerID pointerId = mousePointerID)
-            : PlatformEvent(type, shiftKey, ctrlKey, altKey, metaKey, timestamp)
+        PlatformMouseEvent(const IntPoint& position, const IntPoint& globalPosition, MouseButton button, PlatformEvent::Type type, int clickCount, OptionSet<PlatformEvent::Modifier> modifiers, WallTime timestamp, double force, SyntheticClickType syntheticClickType, PointerID pointerId = mousePointerID)
+            : PlatformEvent(type, modifiers, timestamp)
             , m_button(button)
             , m_syntheticClickType(syntheticClickType)
             , m_position(position)

--- a/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
+++ b/Source/WebCore/platform/cocoa/KeyEventCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004, 2006, 2007, 2008, 2009, 2010 Apple Inc.  All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,20 +38,6 @@
 #endif
 
 namespace WebCore {
-
-bool PlatformKeyboardEvent::currentCapsLockState()
-{
-    return currentStateOfModifierKeys().contains(PlatformEvent::Modifier::CapsLockKey);
-}
-
-void PlatformKeyboardEvent::getCurrentModifierState(bool& shiftKey, bool& ctrlKey, bool& altKey, bool& metaKey)
-{
-    auto currentModifiers = currentStateOfModifierKeys();
-    shiftKey = currentModifiers.contains(PlatformEvent::Modifier::ShiftKey);
-    ctrlKey = currentModifiers.contains(PlatformEvent::Modifier::ControlKey);
-    altKey = currentModifiers.contains(PlatformEvent::Modifier::AltKey);
-    metaKey = currentModifiers.contains(PlatformEvent::Modifier::MetaKey);
-}
 
 // https://w3c.github.io/uievents-key/
 String keyForCharCode(unichar charCode)

--- a/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp
@@ -1332,13 +1332,9 @@ void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardsCo
     }
 }
 
-bool PlatformKeyboardEvent::currentCapsLockState()
+OptionSet<PlatformEvent::Modifier> PlatformKeyboardEvent::currentStateOfModifierKeys()
 {
-    return false;
-}
-
-void PlatformKeyboardEvent::getCurrentModifierState(bool&, bool&, bool&, bool&)
-{
+    return { }; // FIXME: Implement.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/win/KeyEventWin.cpp
+++ b/Source/WebCore/platform/win/KeyEventWin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -248,17 +248,21 @@ void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type, bool)
     ASSERT_NOT_REACHED();
 }
 
-bool PlatformKeyboardEvent::currentCapsLockState()
+OptionSet<PlatformEvent::Modifier> PlatformKeyboardEvent::currentStateOfModifierKeys()
 {
-     return GetKeyState(VK_CAPITAL) & 1;
-}
+    OptionSet<PlatformEvent::Modifier> modifiers;
 
-void PlatformKeyboardEvent::getCurrentModifierState(bool& shiftKey, bool& ctrlKey, bool& altKey, bool& metaKey)
-{
-    shiftKey = GetKeyState(VK_SHIFT) & HIGH_BIT_MASK_SHORT;
-    ctrlKey = GetKeyState(VK_CONTROL) & HIGH_BIT_MASK_SHORT;
-    altKey = GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT;
-    metaKey = false;
+    if (GetKeyState(VK_SHIFT) & HIGH_BIT_MASK_SHORT)
+        modifiers.add(PlatformEvent::Modifier::ShiftKey);
+    if (GetKeyState(VK_CONTROL) & HIGH_BIT_MASK_SHORT)
+        modifiers.add(PlatformEvent::Modifier::ControlKey);
+    if (GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT)
+        modifiers.add(PlatformEvent::Modifier::AltKey);
+    // No meta key.
+    if (GetKeyState(VK_CAPITAL) & 1)
+        modifiers.add(PlatformEvent::Modifier::CapsLockKey);
+
+    return modifiers;
 }
 
 }

--- a/Source/WebKit/Shared/WebEventConversion.cpp
+++ b/Source/WebKit/Shared/WebEventConversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,22 @@
 
 namespace WebKit {
 
+OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier> modifiers)
+{
+    OptionSet<WebCore::PlatformEvent::Modifier> result;
+    if (modifiers.contains(WebEventModifier::ShiftKey))
+        result.add(WebCore::PlatformEvent::Modifier::ShiftKey);
+    if (modifiers.contains(WebEventModifier::ControlKey))
+        result.add(WebCore::PlatformEvent::Modifier::ControlKey);
+    if (modifiers.contains(WebEventModifier::AltKey))
+        result.add(WebCore::PlatformEvent::Modifier::AltKey);
+    if (modifiers.contains(WebEventModifier::MetaKey))
+        result.add(WebCore::PlatformEvent::Modifier::MetaKey);
+    if (modifiers.contains(WebEventModifier::CapsLockKey))
+        result.add(WebCore::PlatformEvent::Modifier::CapsLockKey);
+    return result;
+}
+
 class WebKit2PlatformMouseEvent : public WebCore::PlatformMouseEvent {
 public:
     WebKit2PlatformMouseEvent(const WebMouseEvent& webEvent)
@@ -71,16 +87,7 @@ public:
             ASSERT_NOT_REACHED();
         }
 
-        if (webEvent.shiftKey())
-            m_modifiers.add(Modifier::ShiftKey);
-        if (webEvent.controlKey())
-            m_modifiers.add(Modifier::ControlKey);
-        if (webEvent.altKey())
-            m_modifiers.add(Modifier::AltKey);
-        if (webEvent.metaKey())
-            m_modifiers.add(Modifier::MetaKey);
-        if (webEvent.capsLockKey())
-            m_modifiers.add(Modifier::CapsLockKey);
+        m_modifiers = platform(webEvent.modifiers());
 
         m_timestamp = webEvent.timestamp();
 
@@ -141,16 +148,7 @@ public:
         // PlatformEvent
         m_type = PlatformEvent::Wheel;
 
-        if (webEvent.shiftKey())
-            m_modifiers.add(Modifier::ShiftKey);
-        if (webEvent.controlKey())
-            m_modifiers.add(Modifier::ControlKey);
-        if (webEvent.altKey())
-            m_modifiers.add(Modifier::AltKey);
-        if (webEvent.metaKey())
-            m_modifiers.add(Modifier::MetaKey);
-        if (webEvent.capsLockKey())
-            m_modifiers.add(Modifier::CapsLockKey);
+        m_modifiers = platform(webEvent.modifiers());
 
         m_timestamp = webEvent.timestamp();
 
@@ -207,16 +205,7 @@ public:
             ASSERT_NOT_REACHED();
         }
 
-        if (webEvent.shiftKey())
-            m_modifiers.add(Modifier::ShiftKey);
-        if (webEvent.controlKey())
-            m_modifiers.add(Modifier::ControlKey);
-        if (webEvent.altKey())
-            m_modifiers.add(Modifier::AltKey);
-        if (webEvent.metaKey())
-            m_modifiers.add(Modifier::MetaKey);
-        if (webEvent.capsLockKey())
-            m_modifiers.add(Modifier::CapsLockKey);
+        m_modifiers = platform(webEvent.modifiers());
 
         m_timestamp = webEvent.timestamp();
 
@@ -353,16 +342,7 @@ public:
             ASSERT_NOT_REACHED();
         }
 
-        if (webEvent.shiftKey())
-            m_modifiers.add(Modifier::ShiftKey);
-        if (webEvent.controlKey())
-            m_modifiers.add(Modifier::ControlKey);
-        if (webEvent.altKey())
-            m_modifiers.add(Modifier::AltKey);
-        if (webEvent.metaKey())
-            m_modifiers.add(Modifier::MetaKey);
-        if (webEvent.capsLockKey())
-            m_modifiers.add(Modifier::CapsLockKey);
+        m_modifiers = platform(webEvent.modifiers());
 
         m_timestamp = webEvent.timestamp();
 
@@ -412,16 +392,7 @@ public:
             ASSERT_NOT_REACHED();
         }
 
-        if (webEvent.shiftKey())
-            m_modifiers.add(Modifier::ShiftKey);
-        if (webEvent.controlKey())
-            m_modifiers.add(Modifier::ControlKey);
-        if (webEvent.altKey())
-            m_modifiers.add(Modifier::AltKey);
-        if (webEvent.metaKey())
-            m_modifiers.add(Modifier::MetaKey);
-        if (webEvent.capsLockKey())
-            m_modifiers.add(Modifier::CapsLockKey);
+        m_modifiers = platform(webEvent.modifiers());
 
         m_timestamp = webEvent.timestamp();
 

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,6 +55,8 @@ class WebTouchPoint;
 #if ENABLE(MAC_GESTURE_EVENTS)
 class WebGestureEvent;
 #endif
+
+OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>);
 
 WebCore::PlatformMouseEvent platform(const WebMouseEvent&);
 WebCore::PlatformWheelEvent platform(const WebWheelEvent&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2893,12 +2893,12 @@ WebContextMenu* WebPage::contextMenuAtPointInWindow(const IntPoint& point)
     corePage()->contextMenuController().clearContextMenu();
 
     // Simulate a mouse click to generate the correct menu.
-    PlatformMouseEvent mousePressEvent(point, point, RightButton, PlatformEvent::MousePressed, 1, false, false, false, false, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
+    PlatformMouseEvent mousePressEvent(point, point, RightButton, PlatformEvent::MousePressed, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     corePage()->userInputBridge().handleMousePressEvent(mousePressEvent);
     Ref mainFrame = corePage()->mainFrame();
     bool handled = corePage()->userInputBridge().handleContextMenuEvent(mousePressEvent, mainFrame);
     auto* menu = handled ? &contextMenu() : nullptr;
-    PlatformMouseEvent mouseReleaseEvent(point, point, RightButton, PlatformEvent::MouseReleased, 1, false, false, false, false, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
+    PlatformMouseEvent mouseReleaseEvent(point, point, RightButton, PlatformEvent::MouseReleased, 1, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     corePage()->userInputBridge().handleMouseReleaseEvent(mouseReleaseEvent);
 
     return menu;
@@ -4772,7 +4772,7 @@ void WebPage::dragEnded(WebCore::IntPoint clientPosition, WebCore::IntPoint glob
     if (!view)
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
-    PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MouseMoved, 0, false, false, false, false, WallTime::now(), 0, WebCore::NoTap);
+    PlatformMouseEvent event(adjustedClientPosition, adjustedGlobalPosition, LeftButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, WebCore::NoTap);
     m_page->mainFrame().eventHandler().dragSourceEndedAt(event, dragOperationMask);
 
     send(Messages::WebPageProxy::DidEndDragging());

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -957,7 +957,7 @@ static NSURL *createUniqueWebDataURL();
         return;
     // FIXME: These are fake modifier keys here, but they should be real ones instead.
     WebCore::PlatformMouseEvent event(WebCore::IntPoint(windowLoc), WebCore::IntPoint(WebCore::globalPoint(windowLoc, [view->platformWidget() window])),
-        WebCore::LeftButton, WebCore::PlatformEvent::MouseMoved, 0, false, false, false, false, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
+        WebCore::LeftButton, WebCore::PlatformEvent::MouseMoved, 0, { }, WallTime::now(), WebCore::ForceAtClick, WebCore::NoTap);
     _private->coreFrame->eventHandler().dragSourceEndedAt(event, coreDragOperationMask(dragOperationMask));
 }
 #endif // ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)

--- a/Source/WebKitLegacy/win/WebDropSource.cpp
+++ b/Source/WebKitLegacy/win/WebDropSource.cpp
@@ -100,7 +100,7 @@ PlatformMouseEvent generateMouseEvent(WebView* webView, bool isDrag)
     if (SUCCEEDED(webView->viewWindow(&viewWindow)))
         ::ScreenToClient(viewWindow, reinterpret_cast<LPPOINT>(&localpt));
     return PlatformMouseEvent(IntPoint(localpt.x, localpt.y), IntPoint(pt.x, pt.y),
-        isDrag ? LeftButton : NoButton, PlatformEvent::MouseMoved, 0, false, false, false, false, WallTime::now(), 0, NoTap);
+        isDrag ? LeftButton : NoButton, PlatformEvent::MouseMoved, 0, { }, WallTime::now(), 0, NoTap);
 }
 
 STDMETHODIMP WebDropSource::QueryContinueDrag(_In_ BOOL fEscapePressed, _In_ DWORD grfKeyState)


### PR DESCRIPTION
#### 809039232b9afe0013756f3b8f81cb250dbcbece
<pre>
Improve PlatformMouseEvent constructor to replace four bool args with OptionSet&lt;PlatformEvent::Modifier&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=248131">https://bugs.webkit.org/show_bug.cgi?id=248131</a>
&lt;rdar://102548165&gt;

Reviewed by Michael Catanzaro.

Improve the PlatformMouseEvent constructor by replacing four
bool modifier key arguments (shift, ctrl, alt, meta) with one
OptionSet&lt;PlatformEvent::Modifier&gt; argument.

Previously, WebKit would convert an OptionSet&lt;WebEventModifier&gt;
into individual bool values (one for each modifier key), pass
these to the PlatformMouseEvent() constructor, then pass them to
the PlatformEvent() constructor, then convert them back into an
OptionSet&lt;PlatformEvent::Modifier&gt;.

Instead, introduce WebKit::platform(OptionSet&lt;WebEventModifier&gt;)
to convert to OptionSet&lt;PlatformEvent::Modifier&gt;, and use it to
remove duplicate code in WebEventConversion.cpp.

In WebCore, a few classes would declare four bool variables,
call PlatformKeyboardEvent::getCurrentModifierState(), call
PlatformKeyboardEvent::currentStateOfModifierKeys() which
returned an OptionSet&lt;PlatformEvent::Modifier&gt;, update the bool
variables and return, pass them to the PlatformMouseEvent()
constructor, then pass them to the PlatformEvent() constructor,
then convert them into an OptionSet&lt;PlatformEvent::Modifier&gt;.
Cut out the extra work by calling currentStateOfModifierKeys()
directly and pass to PlatformMouseEvent().

Finally, share more keyboard code by implementing
PlatformKeyboardEvent::currentStateOfModifierKeys() for all
ports.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchMouseForceWillBegin):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::showContextMenuAt):
* Source/WebCore/page/DragController.cpp:
(WebCore::createMouseEvent):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::sendContextMenuEventForKey):
(WebCore::EventHandler::fakeMouseMoveEventTimerFired):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::tryToBeginDragAtPoint):
- Replace (false, false, false, false) with ({ }) argument.
- Use PlatformKeyboardEvent::currentStateOfModifierKeys() in
  place of PlatformKeyboardEvent::getCurrentModifierState().

* Source/WebCore/platform/PlatformKeyboardEvent.cpp:
(WebCore::PlatformKeyboardEvent::currentCapsLockState): Add.
(WebCore::PlatformKeyboardEvent::getCurrentModifierState): Add.
* Source/WebCore/platform/cocoa/KeyEventCocoa.mm:
(WebCore::PlatformKeyboardEvent::currentCapsLockState): Delete.
(WebCore::PlatformKeyboardEvent::getCurrentModifierState): Delete.
- Move currentCapsLockState() and getCurrentModifierState() from
  KeyEventCocoa.mm to PlatformKeyboardEvent.cpp since this code
  can now be shared by implementing currentStateOfModifierKeys()
  in all ports.

* Source/WebCore/platform/PlatformMouseEvent.h:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
- Update PlatformMouseEvent() constructor arguments.

* Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp:
(WebCore::PlatformKeyboardEvent::currentStateOfModifierKeys): Add.
(WebCore::PlatformKeyboardEvent::currentCapsLockState): Delete.
(WebCore::PlatformKeyboardEvent::getCurrentModifierState): Delete.
* Source/WebCore/platform/libwpe/PlatformKeyboardEventLibWPE.cpp:
(WebCore::PlatformKeyboardEvent::currentStateOfModifierKeys): Add.
(WebCore::PlatformKeyboardEvent::currentCapsLockState): Delete.
(WebCore::PlatformKeyboardEvent::getCurrentModifierState): Delete.
* Source/WebCore/platform/win/KeyEventWin.cpp:
(WebCore::PlatformKeyboardEvent::currentStateOfModifierKeys): Add.
(WebCore::PlatformKeyboardEvent::currentCapsLockState): Delete.
(WebCore::PlatformKeyboardEvent::getCurrentModifierState): Delete.
- Implement currentStateOfModifierKeys() in all ports by combining
  currentCapsLockState() and getCurrentModifierState().

* Source/WebKit/Shared/WebEventConversion.cpp:
(WebKit::platform): Add.
- Add conversion function from OptionSet&lt;WebEventModifier&gt; to
  OptionSet&lt;PlatformEvent::Modifier&gt;.
(WebKit::WebKit2PlatformMouseEvent::WebKit2PlatformMouseEvent):
(WebKit::WebKit2PlatformWheelEvent::WebKit2PlatformWheelEvent):
(WebKit::WebKit2PlatformKeyboardEvent::WebKit2PlatformKeyboardEvent):
(WebKit::WebKit2PlatformTouchEvent::WebKit2PlatformTouchEvent):
(WebKit::WebKit2PlatformGestureEvent::WebKit2PlatformGestureEvent):
- Use new platform() function to replace duplicate code.

* Source/WebKit/Shared/WebEventConversion.h:
(WebKit::platform): Add.
- Declare new conversion function.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::contextMenuAtPointInWindow):
(WebKit::WebPage::dragEnded):
- Replace (false, false, false, false) with ({ }) argument.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::dispatchSyntheticMouseMove):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::requestAdditionalItemsForDragSession):
(WebKit::WebPage::inspectorNodeSearchMovedToPosition):
(WebKit::WebPage::dispatchSyntheticMouseEventsForSelectionGesture):
- Make use of platform() conversion function.
- Replace (false, false, false, false) with ({ }) argument.

* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _dragSourceEndedAt:operation:]):
* Source/WebKitLegacy/win/WebDropSource.cpp:
(generateMouseEvent):
- Replace (false, false, false, false) with ({ }) argument.

Canonical link: <a href="https://commits.webkit.org/256892@main">https://commits.webkit.org/256892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774fa16f96e657a73e4a8c8590dda1a5fe671e48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106609 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166880 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6615 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35091 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103297 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/4962 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83709 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31961 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86812 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74849 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/382 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21565 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5163 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44071 "Found 2 new test failures: fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2331 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40880 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->