### PR TITLE
Make WeakHashSet work with ThreadSafeWeakPtr

### DIFF
--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -27,17 +27,71 @@
 
 #include <wtf/Algorithms.h>
 #include <wtf/HashSet.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WTF {
 
+template<typename T, typename WeakPtrImpl, typename = void> struct WeakHashSetBase {
+    constexpr static bool isThreadSafe = false;
+    using WeakPtrImplSet = HashSet<Ref<WeakPtrImpl>>;
+    using WeakPtrType = WeakPtr<T, WeakPtrImpl>;
+    using IteratorNextItemStorage = T*;
+    template <typename V, EnableWeakPtrThreadingAssertions assertionsPolicy>
+    static typename WeakPtrImplSet::AddResult add(WeakPtrImplSet& set, const V& value)
+    {
+        return set.add(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<V&>(value), assertionsPolicy).m_impl);
+    }
+    using LockerType = std::unique_ptr<int>;
+    using LockType = int*;
+    int* lockIfThreadSafe() const { return nullptr; }
+    template <typename V> static RefPtr<WeakPtrImpl> valueToImpl(V& value)
+    {
+        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
+        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
+            return pointer;
+        return nullptr;
+    }
+    static WeakPtrType implToWeakPtr(const Ref<WeakPtrImpl>& impl) { return WeakPtrType { static_cast<T*>(impl->template get<T>()) }; }
+
+    WeakPtrImplSet m_set;
+    mutable unsigned m_operationCountSinceLastCleanup { 0 };
+};
+
+template<typename T, typename U> struct WeakHashSetBase<T, U, std::void_t<typename T::ThreadSafeWeakPtrCheck>> {
+    constexpr static bool isThreadSafe = true;
+    using WeakPtrImplSet = HashSet<Ref<ThreadSafeWeakPtrControlBlock<T>>>;
+    using WeakPtrType = ThreadSafeWeakPtr<T>;
+    using IteratorNextItemStorage = RefPtr<T>;
+    template <typename V, EnableWeakPtrThreadingAssertions>
+    static typename WeakPtrImplSet::AddResult add(WeakPtrImplSet& set, const V& value)
+    {
+        return set.add(value.m_controlBlock);
+    }
+    using LockerType = Locker<Lock>;
+    using LockType = Lock;
+    Lock& lockIfThreadSafe() const WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+    template <typename V> static RefPtr<ThreadSafeWeakPtrControlBlock<T>> valueToImpl(V& value)
+    {
+        return &value.m_controlBlock;
+    }
+    static WeakPtrType implToWeakPtr(const Ref<ThreadSafeWeakPtrControlBlock<T>>& impl) { return WeakPtrType { impl->template get<T>() }; }
+
+    mutable Lock m_lock;
+    mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    WeakPtrImplSet m_set WTF_GUARDED_BY_LOCK(m_lock);
+};
+
 template<typename T, typename WeakPtrImpl = DefaultWeakPtrImpl, EnableWeakPtrThreadingAssertions assertionsPolicy = EnableWeakPtrThreadingAssertions::Yes>
-class WeakHashSet final {
+class WeakHashSet final : public WeakHashSetBase<T, WeakPtrImpl> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    using WeakPtrImplSet = HashSet<Ref<WeakPtrImpl>>;
-    using AddResult = typename WeakPtrImplSet::AddResult;
+    using Base = WeakHashSetBase<T, WeakPtrImpl>;
+    using LockerType = typename Base::LockerType;
+    
+    WeakHashSet() { }
 
+    // FIXME: Do the old iteration style if it's not thread safe.
     class WeakHashSetConstIterator {
     public:
         using iterator_category = std::forward_iterator_tag;
@@ -47,20 +101,30 @@ public:
         using reference = const value_type&;
 
     private:
-        WeakHashSetConstIterator(const WeakPtrImplSet& set, typename WeakPtrImplSet::const_iterator position)
-            : m_position(position), m_endPosition(set.end())
+        WeakHashSetConstIterator(bool end, Vector<typename Base::WeakPtrType>&& snapshot)
+            : m_end(end)
+            , m_snapshot(WTFMove(snapshot))
         {
             skipEmptyBuckets();
         }
 
     public:
-        T* get() const { return static_cast<T*>((*m_position)->template get<T>()); }
+        T* get() const
+        {
+            ASSERT(m_nextItem);
+            if constexpr (Base::isThreadSafe)
+                return m_nextItem.get();
+            else
+                return m_nextItem;
+        }
         T& operator*() const { return *get(); }
         T* operator->() const { return get(); }
 
         WeakHashSetConstIterator& operator++()
         {
-            ASSERT(m_position != m_endPosition);
+            ASSERT(m_position < m_snapshot.size());
+            ASSERT(m_nextItem);
+            m_nextItem = nullptr;
             ++m_position;
             skipEmptyBuckets();
             return *this;
@@ -68,131 +132,170 @@ public:
 
         void skipEmptyBuckets()
         {
-            while (m_position != m_endPosition && !get())
+            while (m_position < m_snapshot.size()) {
+                if (auto item = m_snapshot[m_position].get()) {
+                    m_nextItem = item;
+                    return;
+                }
                 ++m_position;
+            }
         }
 
         bool operator==(const WeakHashSetConstIterator& other) const
         {
-            return m_position == other.m_position;
+            ASSERT(other.m_end);
+            return !m_nextItem;
         }
 
         bool operator!=(const WeakHashSetConstIterator& other) const
         {
-            return m_position != other.m_position;
+            return !(*this == other);
         }
 
     private:
         template <typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
 
-        typename WeakPtrImplSet::const_iterator m_position;
-        typename WeakPtrImplSet::const_iterator m_endPosition;
+        bool m_end;
+        Vector<typename Base::WeakPtrType> m_snapshot;
+        size_t m_position { 0 };
+        typename Base::IteratorNextItemStorage m_nextItem;
     };
-    typedef WeakHashSetConstIterator const_iterator;
-
-    WeakHashSet() { }
+    using const_iterator = WeakHashSetConstIterator;
 
     const_iterator begin() const
     {
-        increaseOperationCountSinceLastCleanup();
-        return WeakHashSetConstIterator(m_set, m_set.begin());
+        return WeakHashSetConstIterator(false, weakPtrs());
     }
 
     const_iterator end() const
     {
-        increaseOperationCountSinceLastCleanup();
-        return WeakHashSetConstIterator(m_set, m_set.end());
+        return WeakHashSetConstIterator(true, { });
     }
 
     template <typename U>
-    AddResult add(const U& value)
+    typename Base::WeakPtrImplSet::AddResult add(const U& value)
     {
         amortizedCleanupIfNeeded();
-        return m_set.add(*static_cast<const T&>(value).weakPtrFactory().template createWeakPtr<T>(const_cast<U&>(value), assertionsPolicy).m_impl);
+        LockerType locker { Base::lockIfThreadSafe() };
+        return Base::template add<U, assertionsPolicy>(set(), value);
     }
 
     template <typename U>
     bool remove(const U& value)
     {
         amortizedCleanupIfNeeded();
-        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return m_set.remove(*pointer);
+        if (auto impl = Base::valueToImpl(value)) {
+            LockerType locker { Base::lockIfThreadSafe() };
+            return set().remove(*impl);
+        }
         return false;
     }
 
     void clear()
     {
-        m_set.clear();
-        m_operationCountSinceLastCleanup = 0;
+        LockerType locker { Base::lockIfThreadSafe() };
+        set().clear();
+        Base::m_operationCountSinceLastCleanup = 0;
     }
 
     template <typename U>
     bool contains(const U& value) const
     {
-        increaseOperationCountSinceLastCleanup();
-        auto& weakPtrImpl = value.weakPtrFactory().m_impl;
-        if (auto* pointer = weakPtrImpl.pointer(); pointer && *pointer)
-            return m_set.contains(*pointer);
+        LockerType locker { Base::lockIfThreadSafe() };
+        ++Base::m_operationCountSinceLastCleanup;
+        if (auto impl = Base::valueToImpl(value))
+            return set().contains(*impl);
         return false;
     }
 
-    unsigned capacity() const { return m_set.capacity(); }
+    unsigned capacity() const
+    {
+        LockerType locker { Base::lockIfThreadSafe() };
+        return set().capacity();
+    }
 
-    bool computesEmpty() const { return begin() == end(); }
+    bool computesEmpty() const
+    {
+        return !computeSize();
+    }
 
     bool hasNullReferences() const
     {
-        return WTF::anyOf(m_set, [] (auto& value) { return !value.get(); });
+        LockerType locker { Base::lockIfThreadSafe() };
+        return WTF::anyOf(set(), [] (auto& value) { return !value.get(); });
     }
 
     unsigned computeSize() const
     {
         const_cast<WeakHashSet&>(*this).removeNullReferences();
-        return m_set.size();
+        LockerType locker { Base::lockIfThreadSafe() };
+        return set().size();
     }
 
     void forEach(const Function<void(T&)>& callback)
     {
-        increaseOperationCountSinceLastCleanup();
-        auto items = map(m_set, [](const Ref<WeakPtrImpl>& item) {
-            auto* pointer = static_cast<T*>(item->template get<T>());
-            return WeakPtr<T, WeakPtrImpl> { pointer };
-        });
-        for (auto& item : items) {
-            if (item && m_set.contains(*item.m_impl))
-                callback(*item);
-        }
+        return forEach(callback, weakPtrs());
     }
 
 #if ASSERT_ENABLED
-    void checkConsistency() const { m_set.checkConsistency(); }
+    void checkConsistency() const
+    {
+        LockerType locker { Base::lockIfThreadSafe() };
+        set().checkConsistency();
+    }
 #else
     void checkConsistency() const { }
 #endif
 
 private:
-    ALWAYS_INLINE void removeNullReferences()
+    template<typename, typename, typename> friend struct Mapper;
+
+    decltype(Base::m_set)& set() { return Base::m_set; }
+    const decltype(Base::m_set)& set() const { return Base::m_set; }
+
+    Vector<typename Base::WeakPtrType> weakPtrs() const
     {
-        m_set.removeIf([] (auto& value) { return !value.get(); });
-        m_operationCountSinceLastCleanup = 0;
+        LockerType locker { Base::lockIfThreadSafe() };
+        ++Base::m_operationCountSinceLastCleanup;
+        return map(set(), Base::implToWeakPtr);
     }
 
-    ALWAYS_INLINE unsigned increaseOperationCountSinceLastCleanup() const
+    void forEach(const Function<void(T&)>& callback, const Vector<typename Base::WeakPtrType>& weakPtrs)
     {
-        unsigned currentCount = m_operationCountSinceLastCleanup++;
-        return currentCount;
+        for (auto& weakPtr : weakPtrs) {
+            if (auto item = weakPtr.get()) {
+
+                // FIXME: Do we need this check? Are there really users that mutate the WeakHashSet
+                // during iteration and expect those changes to be reflected during iteration?
+                if constexpr (Base::isThreadSafe) {
+                    if (!set().contains(*weakPtr.m_impl)) {
+                        ASSERT_NOT_REACHED_WITH_MESSAGE("Don't mutate the WeakHashSet during iteration");
+                        continue;
+                    }
+                }
+
+                callback(*item);
+            }
+        }
+    }
+
+    ALWAYS_INLINE void removeNullReferences()
+    {
+        LockerType locker { Base::lockIfThreadSafe() };
+        set().removeIf([] (auto& value) { return !value->template get<T>(); });
+        Base::m_operationCountSinceLastCleanup = 0;
     }
 
     ALWAYS_INLINE void amortizedCleanupIfNeeded() const
     {
-        unsigned currentCount = increaseOperationCountSinceLastCleanup();
-        if (currentCount / 2 > m_set.size())
+        unsigned currentCount;
+        {
+            LockerType locker { Base::lockIfThreadSafe() };
+            currentCount = ++Base::m_operationCountSinceLastCleanup;
+        }
+        if (currentCount / 2 > set().size())
             const_cast<WeakHashSet&>(*this).removeNullReferences();
     }
-
-    WeakPtrImplSet m_set;
-    mutable unsigned m_operationCountSinceLastCleanup { 0 };
 };
 
 template<typename MapFunction, typename T, typename WeakMapImpl>
@@ -203,9 +306,13 @@ struct Mapper<MapFunction, const WeakHashSet<T, WeakMapImpl> &, void> {
     static Vector<DestinationItemType> map(const WeakHashSet<T, WeakMapImpl>& source, const MapFunction& mapFunction)
     {
         Vector<DestinationItemType> result;
-        result.reserveInitialCapacity(source.computeSize());
-        for (auto& item : source)
-            result.uncheckedAppend(mapFunction(item));
+        // FIXME: No need to allocate a vector here if it's not thread safe.
+        auto weakPtrs = source.weakPtrs();
+        result.reserveInitialCapacity(weakPtrs.size());
+        for (auto& weakPtr : weakPtrs) {
+            if (auto item = weakPtr.get())
+                result.uncheckedAppend(mapFunction(*item));
+        }
         return result;
     }
 };

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -146,7 +146,7 @@ public:
 
 private:
     template<typename, typename, typename> friend class WeakHashMap;
-    template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
+    template<typename, typename, typename> friend struct WeakHashSetBase;
     template<typename, typename> friend class WeakPtr;
     template<typename, typename> friend class WeakPtrFactory;
 
@@ -243,7 +243,7 @@ public:
     void setBitfield(uint16_t value) const { return m_impl.setType(value); }
 
 private:
-    template<typename, typename, EnableWeakPtrThreadingAssertions> friend class WeakHashSet;
+    template<typename, typename, typename> friend struct WeakHashSetBase;
     template<typename, typename, typename> friend class WeakHashMap;
     template<typename, typename> friend class WeakPtr;
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -186,7 +186,7 @@ private:
     FileSystem::Salt m_salt;
     bool m_closed { false };
     HashMap<WebCore::ClientOrigin, std::unique_ptr<OriginStorageManager>> m_originStorageManagers;
-    WeakHashSet<IPC::Connection> m_connections; // Main thread only.
+    WeakHashSet<IPC::Connection> m_connections;
     std::unique_ptr<FileSystemStorageHandleRegistry> m_fileSystemStorageHandleRegistry;
     std::unique_ptr<StorageAreaRegistry> m_storageAreaRegistry;
     std::unique_ptr<IDBStorageRegistry> m_idbStorageRegistry;

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -44,6 +44,7 @@
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RunLoop.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/CString.h>
@@ -126,7 +127,7 @@ class UnixMessage;
 class WorkQueueMessageReceiver;
 uint64_t nextAsyncReplyHandlerID();
 
-class Connection : public ThreadSafeRefCounted<Connection, WTF::DestructionThread::MainRunLoop>, public CanMakeWeakPtr<Connection> {
+class Connection : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Connection, WTF::DestructionThread::MainRunLoop> {
 public:
     enum SyncRequestIDType { };
     using SyncRequestID = ObjectIdentifier<SyncRequestIDType>;

--- a/Source/WebKit/UIProcess/Notifications/WebNotification.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotification.h
@@ -74,7 +74,7 @@ private:
     WebCore::NotificationData m_data;
     RefPtr<API::SecurityOrigin> m_origin;
     WebPageProxyIdentifier m_pageIdentifier;
-    WeakPtr<IPC::Connection> m_sourceConnection;
+    ThreadSafeWeakPtr<IPC::Connection> m_sourceConnection;
 };
 
 inline bool isNotificationIDValid(uint64_t id)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2125,6 +2125,11 @@ void WebProcessProxy::sendPermissionChanged(WebCore::PermissionName permissionNa
     send(Messages::WebPermissionController::permissionChanged(permissionName, topOrigin), 0);
 }
 
+unsigned WebProcessProxy::provisionalPageCount() const
+{
+    return m_provisionalPages.computeSize();
+}
+
 TextStream& operator<<(TextStream& ts, const WebProcessProxy& process)
 {
     auto appendCount = [&ts](unsigned value, ASCIILiteral description) {

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -205,7 +205,7 @@ public:
     
     typename WebPageProxyMap::ValuesConstIteratorRange pages() const { return m_pageMap.values(); }
     unsigned pageCount() const { return m_pageMap.size(); }
-    unsigned provisionalPageCount() const { return m_provisionalPages.computeSize(); }
+    unsigned provisionalPageCount() const;
     unsigned visiblePageCount() const { return m_visiblePageCounter.value(); }
 
     void activePagesDomainsForTesting(CompletionHandler<void(Vector<String>&&)>&&); // This is what is reported to ActivityMonitor.


### PR DESCRIPTION
#### 2e9c640f529a1f604d55b376a9a891c97854e79e
<pre>
Make WeakHashSet work with ThreadSafeWeakPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=248133">https://bugs.webkit.org/show_bug.cgi?id=248133</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::get const):
(WTF::ThreadSafeWeakPtr::get const):
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const): Deleted.
* Source/WTF/wtf/WeakHashSet.h:
(WTF::WeakHashSetBase::add):
(WTF::WeakHashSetBase::lockIfThreadSafe const):
(WTF::WeakHashSetBase::valueToImpl):
(WTF::WeakHashSetBase::implToWeakPtr):
* Source/WTF/wtf/WeakPtr.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/Notifications/WebNotification.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::provisionalPageCount const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::provisionalPageCount const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e9c640f529a1f604d55b376a9a891c97854e79e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97090 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6357 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30211 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106607 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166878 "Found 30 new test failures: accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-node-reparent.html, accessibility/win/document-role.html, accessibility/win/focus-events.html, animations/animation-controller-drt-api.html, animations/animation-direction-reverse-fill-mode.html, animations/font-variations/font-weight.html, contact-picker/contacts-select-invalid-properties-and-options.html, contact-picker/contacts-select-subframe.html ... (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6595 "Hash 2e9c640f for PR 6674 does not build (failure)") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35089 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89479 "Hash 2e9c640f for PR 6674 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103295 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102759 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/6595 "Hash 2e9c640f for PR 6674 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83707 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/89479 "Hash 2e9c640f for PR 6674 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/6595 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/30211 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/89479 "Hash 2e9c640f for PR 6674 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88015 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/380 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/30211 "Hash 2e9c640f for PR 6674 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83456 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/362 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/30211 "Hash 2e9c640f for PR 6674 does not build (failure)") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28440 "Passed tests") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5161 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44070 "Found 30 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/custom-elements/controls.html, accessibility/custom-elements/current.html, accessibility/custom-elements/describedby-shadow.html, accessibility/custom-elements/describedby.html ... (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86164 "Built successfully") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1603 "Hash 2e9c640f for PR 6674 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/30211 "Hash 2e9c640f for PR 6674 does not build (failure)") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19418 "Passed tests") | 
<!--EWS-Status-Bubble-End-->