### PR TITLE
Percent-width blocks cannot form a re-layout boundary

### DIFF
--- a/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden-expected.txt
+++ b/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden-expected.txt
@@ -1,0 +1,5 @@
+There should be a blue square below.
+
+
+PASS #root 1
+

--- a/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden.html
+++ b/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<p>There should be a blue square below.</p>
+<div id="root" style="width:fit-content;" data-expected-width="100">
+    <div style="width:100%; height:10em; overflow:hidden;" data-expected-width="100">
+        <div id="child" style="width:20px; height:100px; background:blue;"></div>
+    </div>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/check-layout-th.js"></script>
+<script>
+    document.body.offsetTop;
+    document.getElementById("child").style.width = "100px";
+    checkLayout("#root");
+</script>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -4,7 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  *           (C) 2004 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
- * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * This library is free software; you can redistribute it and/or
@@ -527,8 +527,13 @@ static inline bool objectIsRelayoutBoundary(const RenderElement* object)
     if (object->document().settings().layerBasedSVGEngineEnabled() && object->isSVGLayerAwareRenderer())
         return false;
 #endif
-
-    if (object->style().width().isIntrinsicOrAuto() || object->style().height().isIntrinsicOrAuto() || object->style().height().isPercentOrCalculated())
+    
+    // If either dimension is percent-based, intrinsic, or anything but fixed
+    // this object cannot form a re-layout boundary. A non-fixed computed logical
+    // height will allow the object to grow and shrink based on the content
+    // inside. The same goes for for logical width, if this objects is inside a
+    // shrink-to-fit container, for instance.
+    if (!object->style().width().isFixed() || !object->style().height().isFixed())
         return false;
 
     // Table parts can't be relayout roots since the table is responsible for layouting all the parts.


### PR DESCRIPTION
#### b42824bb6c99acd8ddbbb241711aa5182fea912f
<pre>
Percent-width blocks cannot form a re-layout boundary

Percent-width blocks cannot form a re-layout boundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=247913">https://bugs.webkit.org/show_bug.cgi?id=247913</a>

Reviewed by Alan Baradlay.

This patch is to align Webkit behavior with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/da179e152dff0ab3e3dabc72299bd4fb586881c9">https://chromium.googlesource.com/chromium/src.git/+/da179e152dff0ab3e3dabc72299bd4fb586881c9</a>

A block with non-visible overflow can only form a re-layout boundary if both
width and height are fixed.

The block may be inside a shrink-to-fit container (there&apos;s no cheap and
reliable way to detect that), so that changes inside it may affect its width.

* Source/WebCore/rendering/RenderObject.cpp:
(objectIsRelayoutBoundary): Add comment and update logic
of relayout for non-fixed container
* LayoutTests/fast/css-intrinsic-dimension/resize-inside-percent-width-overflow-hidden.html: Added Test Case
* LayoutTests/fast/css-intrinsic-dimension/resize-inside-percent-width-overflow-hidden-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/256901@main">https://commits.webkit.org/256901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d69d8d902b8c15e67dfb30b8d5ce6c32c15b5fd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106672 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166944 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6688 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35155 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103362 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5023 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83778 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32012 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86872 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74902 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/443 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/427 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21625 "Found 1 new test failure: media/video-seek-have-nothing.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44130 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40941 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->