### PR TITLE
Fix focus traversal for HTMLPluginElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
@@ -2,5 +2,5 @@ Pressing TAB twice should focus/highlight end checkbox
 
 start  end
 
-FAIL focus advances with tab key thorough object element assert_equals: object got focus expected Element node <object type="text/html" data="data:text/html," width="16... but got Element node <body><p>Pressing TAB twice should focus/highlight end ch...
+PASS focus advances with tab key thorough object element
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
@@ -1,0 +1,6 @@
+Pressing TAB twice should focus/highlight end checkbox
+
+start  end
+
+FAIL focus advances with tab key thorough object element assert_equals: object got focus expected Element node <object type="text/html" data="data:text/html," width="16... but got Element node <body><p>Pressing TAB twice should focus/highlight end ch...
+

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -176,9 +176,8 @@ void HTMLPlugInElement::defaultEventHandler(Event& event)
     // Don't keep the widget alive over the defaultEventHandler call, since that can do things like navigate.
     {
         RefPtr<Widget> widget = downcast<RenderWidget>(*renderer).widget();
-        if (!widget)
-            return;
-        widget->handleEvent(event);
+        if (widget)
+            widget->handleEvent(event);
         if (event.defaultHandled())
             return;
     }


### PR DESCRIPTION
#### 0989933dce571efb250060e4cc47d5c952fbf917
<pre>
Fix focus traversal for HTMLPluginElement

Fix focus traversal for HTMLPluginElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=248138">https://bugs.webkit.org/show_bug.cgi?id=248138</a>

Reviewed by Ryosuke Niwa.

This patch is to align Webkit behavior with Blink / Chrome and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/src/+/2d8d2b205c31e236b1ff896cc5530402ce858212">https://chromium.googlesource.com/chromium/src/+/2d8d2b205c31e236b1ff896cc5530402ce858212</a>

It is to remove early return when the widget / plugin is not present.

* Source/WebCore/html/HTMLPlugInElement.cpp:
(HTMLPlugInElement::defaultEventHandler): Fix early return
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt: Rebaselined
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt: Add platform specific expectation

Canonical link: <a href="https://commits.webkit.org/256900@main">https://commits.webkit.org/256900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5849caf249cc635cd87d1e4dc410c1a6a56460c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106656 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166928 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6668 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35139 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103346 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5010 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83761 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31999 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/427 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44120 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40929 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->