### PR TITLE
Use an effect iteration test method for various KeyframeEffectStack methods iterating over effects

### DIFF
--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -68,31 +68,34 @@ void KeyframeEffectStack::removeEffect(KeyframeEffect& effect)
         startAcceleratedAnimationsIfPossible();
 }
 
-bool KeyframeEffectStack::requiresPseudoElement() const
+bool KeyframeEffectStack::hasMatchingEffect(const Function<bool(const KeyframeEffect&)>& function) const
 {
     for (auto& effect : m_effects) {
-        if (effect->requiresPseudoElement())
+        if (function(*effect))
             return true;
     }
     return false;
+}
+
+bool KeyframeEffectStack::requiresPseudoElement() const
+{
+    return hasMatchingEffect([] (const KeyframeEffect& effect) {
+        return effect.requiresPseudoElement();
+    });
 }
 
 bool KeyframeEffectStack::hasEffectWithImplicitKeyframes() const
 {
-    for (auto& effect : m_effects) {
-        if (effect->hasImplicitKeyframes())
-            return true;
-    }
-    return false;
+    return hasMatchingEffect([] (const KeyframeEffect& effect) {
+        return effect.hasImplicitKeyframes();
+    });
 }
 
 bool KeyframeEffectStack::isCurrentlyAffectingProperty(CSSPropertyID property) const
 {
-    for (auto& effect : m_effects) {
-        if (effect->isCurrentlyAffectingProperty(property) || effect->isRunningAcceleratedAnimationForProperty(property))
-            return true;
-    }
-    return false;
+    return hasMatchingEffect([property] (const KeyframeEffect& effect) {
+        return effect.isCurrentlyAffectingProperty(property) || effect.isRunningAcceleratedAnimationForProperty(property);
+    });
 }
 
 Vector<WeakPtr<KeyframeEffect>> KeyframeEffectStack::sortedEffects()
@@ -224,11 +227,9 @@ bool KeyframeEffectStack::allowsAcceleration() const
     // as well not run any at all since we'll be updating effects for this stack
     // for each animation frame. So for now, we simply return false if any effect in the
     // stack is unable to be accelerated.
-    for (auto& effect : m_effects) {
-        if (effect->preventsAcceleration())
-            return false;
-    }
-    return true;
+    return !hasMatchingEffect([] (const KeyframeEffect& effect) {
+        return effect.preventsAcceleration();
+    });
 }
 
 void KeyframeEffectStack::startAcceleratedAnimationsIfPossible()

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -69,7 +69,7 @@ public:
 
 private:
     void ensureEffectsAreSorted();
-
+    bool hasMatchingEffect(const Function<bool(const KeyframeEffect&)>&) const;
     void startAcceleratedAnimationsIfPossible();
     void stopAcceleratedAnimations();
 


### PR DESCRIPTION
#### 3caac1b06ad4606f2a1aa1a045d6a299b677429a
<pre>
Use an effect iteration test method for various KeyframeEffectStack methods iterating over effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=248141">https://bugs.webkit.org/show_bug.cgi?id=248141</a>

Reviewed by Alexey Shvayka.

Add the hasMatchingEffect() method which takes a function parameter expecting a `const KeyframeEffect`
to test for an effect matching a given condition.

* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::hasMatchingEffect const):
(WebCore::KeyframeEffectStack::containsProperty const):
(WebCore::KeyframeEffectStack::requiresPseudoElement const):
(WebCore::KeyframeEffectStack::hasEffectWithImplicitKeyframes const):
(WebCore::KeyframeEffectStack::allowsAcceleration const):
* Source/WebCore/animation/KeyframeEffectStack.h:

Canonical link: <a href="https://commits.webkit.org/256888@main">https://commits.webkit.org/256888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edaed7d0ac1d0ef2c5a9c4ba2e93e4831c4faa40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106644 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166916 "Failed to checkout and rebase branch from PR 6681") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6651 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35127 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89516 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103334 "Failed to checkout and rebase branch from PR 6681") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102795 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/4996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83747 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/31989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/415 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/399 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5197 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2329 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1639 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/40916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->