### PR TITLE
[web-animations] keyframes should be recomputed if used CSS variable changes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-in-keyframe-adjusted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-in-keyframe-adjusted-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Animations reflect changes to variables on element
+PASS Animations reflect changes to variables on parent element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-in-keyframe-adjusted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-in-keyframe-adjusted.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Animations: adjust value of CSS variable used in keyframes</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+
+@keyframes anim {
+    from { margin-left: var(--margin-left) }
+    to   { margin-left: calc(var(--margin-left) * 2) }
+}
+
+</style>
+<div id="log"></div>
+<script>
+
+test(t => {
+  const div = addDiv(t);
+  div.style.setProperty('--margin-left', '100px');
+
+  div.style.animation = 'anim 1s linear';
+  const animation = div.getAnimations()[0];
+  animation.currentTime = 500;
+
+  assert_equals(
+    getComputedStyle(div).marginLeft,
+    '150px',
+    'Animated value before updating variable'
+  );
+
+  div.style.setProperty('--margin-left', '200px');
+
+  assert_equals(
+    getComputedStyle(div).marginLeft,
+    '300px',
+    'Animated value after updating variable'
+  );
+}, 'Animations reflect changes to variables on element');
+
+test(t => {
+  const parentDiv = addDiv(t);
+  const div = addDiv(t);
+  parentDiv.appendChild(div);
+  parentDiv.style.setProperty('--margin-left', '100px');
+
+  div.style.animation = 'anim 1s linear';
+  const animation = div.getAnimations()[0];
+  animation.currentTime = 500;
+
+  assert_equals(
+    getComputedStyle(div).marginLeft,
+    '150px',
+    'Animated value before updating variable'
+  );
+
+  parentDiv.style.setProperty('--margin-left', '200px');
+
+  assert_equals(
+    getComputedStyle(div).marginLeft,
+    '300px',
+    'Animated value after updating variable'
+  );
+}, 'Animations reflect changes to variables on parent element');
+
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-filling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-filling-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Filling effect values reflect changes to font-size on element
 PASS Filling effect values reflect changes to font-size on parent element
-FAIL Filling effect values reflect changes to variables on element assert_equals: Effect value after updating variable expected "200px" but got "100px"
-FAIL Filling effect values reflect changes to variables on parent element assert_equals: Effect value after updating variable expected "400px" but got "200px"
+PASS Filling effect values reflect changes to variables on element
+PASS Filling effect values reflect changes to variables on parent element
 PASS Filling effect values reflect changes to the the animation's keyframes
 PASS Filling effect values reflect changes to the the animation's composite mode
 PASS Filling effect values reflect changes to the the animation's iteration composite mode

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -189,6 +189,8 @@ public:
 
     static String CSSPropertyIDToIDLAttributeName(CSSPropertyID);
 
+    bool containsCSSVariableReferences() const { return m_containsCSSVariableReferences; }
+
 private:
     KeyframeEffect(Element*, PseudoId);
 
@@ -282,6 +284,7 @@ private:
     bool m_someKeyframesUseStepsTimingFunction { false };
     bool m_hasImplicitKeyframeForAcceleratedProperty { false };
     bool m_hasKeyframeComposingAcceleratedProperty { false };
+    bool m_containsCSSVariableReferences { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -171,8 +171,21 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
             return false;
         };
 
+        auto cssVariableChanged = [&]() {
+            auto customPropertyValueMapDidChange = [](const CustomPropertyValueMap& a, const CustomPropertyValueMap& b) {
+                return &a != &b && a != b;
+            };
+
+            if (previousLastStyleChangeEventStyle && effect->containsCSSVariableReferences()) {
+                if (customPropertyValueMapDidChange(previousLastStyleChangeEventStyle->inheritedCustomProperties(), targetStyle.inheritedCustomProperties())
+                    || customPropertyValueMapDidChange(previousLastStyleChangeEventStyle->nonInheritedCustomProperties(), targetStyle.nonInheritedCustomProperties()))
+                    return true;
+            }
+            return false;
+        };
+
         auto logicalPropertyDidChange = propertyAffectingLogicalPropertiesChanged && effect->animatesDirectionAwareProperty();
-        if (logicalPropertyDidChange || fontSizeChanged || inheritedPropertyChanged())
+        if (logicalPropertyDidChange || fontSizeChanged || inheritedPropertyChanged() || cssVariableChanged())
             effect->propertyAffectingKeyframeResolutionDidChange(unanimatedStyle, resolutionContext);
 
         animation->resolve(targetStyle, resolutionContext);

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -94,6 +94,17 @@ String StyleRuleKeyframe::cssText() const
     return makeString(keyText(), " { }");
 }
 
+bool StyleRuleKeyframe::containsCSSVariableReferences() const
+{
+    for (unsigned i = 0; i < m_properties->propertyCount(); ++i) {
+        if (auto* cssValue = m_properties->propertyAt(i).value()) {
+            if (cssValue->hasVariableReferences())
+                return true;
+        }
+    }
+    return false;
+}
+
 CSSKeyframeRule::CSSKeyframeRule(StyleRuleKeyframe& keyframe, CSSKeyframesRule* parent)
     : CSSRule(nullptr)
     , m_keyframe(keyframe)

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -59,6 +59,8 @@ public:
 
     String cssText() const;
 
+    bool containsCSSVariableReferences() const;
+
 private:
     explicit StyleRuleKeyframe(Ref<StyleProperties>&&);
     StyleRuleKeyframe(Vector<double>&&, Ref<StyleProperties>&&);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -412,7 +412,7 @@ Vector<Ref<StyleRuleKeyframe>> Resolver::keyframeRulesForName(const AtomString& 
     return deduplicatedKeyframes;
 }
 
-void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list)
+void Resolver::keyframeStylesForAnimation(const Element& element, const RenderStyle& elementStyle, const ResolutionContext& context, KeyframeList& list, bool& containsCSSVariableReferences)
 {
     list.clear();
 
@@ -420,6 +420,7 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
     if (keyframeRules.isEmpty())
         return;
 
+    containsCSSVariableReferences = false;
     // Construct and populate the style for each keyframe.
     for (auto& keyframeRule : keyframeRules) {
         // Add this keyframe style to all the indicated key times
@@ -427,6 +428,8 @@ void Resolver::keyframeStylesForAnimation(const Element& element, const RenderSt
             KeyframeValue keyframeValue(0, nullptr);
             keyframeValue.setStyle(styleForKeyframe(element, elementStyle, context, keyframeRule.get(), keyframeValue));
             keyframeValue.setKey(key);
+            if (!containsCSSVariableReferences)
+                containsCSSVariableReferences = keyframeRule->containsCSSVariableReferences();
             if (auto timingFunctionCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationTimingFunction))
                 keyframeValue.setTimingFunction(TimingFunction::createFromCSSValue(*timingFunctionCSSValue.get()));
             if (auto compositeOperationCSSValue = keyframeRule->properties().getPropertyCSSValue(CSSPropertyAnimationComposition)) {

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -98,7 +98,7 @@ public:
 
     ElementStyle styleForElement(const Element&, const ResolutionContext&, RuleMatchingBehavior = RuleMatchingBehavior::MatchAllRules);
 
-    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&);
+    void keyframeStylesForAnimation(const Element&, const RenderStyle& elementStyle, const ResolutionContext&, KeyframeList&, bool& containsCSSVariableReferences);
 
     WEBCORE_EXPORT std::unique_ptr<RenderStyle> pseudoStyleForElement(const Element&, const PseudoElementRequest&, const ResolutionContext&);
 


### PR DESCRIPTION
#### 5c0b3cb4b2450bcc60e21f512306aaaa56e3e9b3
<pre>
[web-animations] keyframes should be recomputed if used CSS variable changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=248145">https://bugs.webkit.org/show_bug.cgi?id=248145</a>

Reviewed by Antti Koivisto.

When the value for a CSS variable changes, we must ensure that any set of keyframes that use that CSS variable
are recomputed, whether the animation is a CSS Animation of a script-originated animation. This does not apply
to CSS Transitions which would operate on resolved values in RenderStyle.

To do this we add a StyleRuleKeyframe::containsCSSVariableReferences() method which indicates whether a keyframe
rule contains CSS variables. Then, we add a similar method on KeyframeEffect returning the boolean flag computed
resolving keyframes in KeyframeEffect::computeCSSAnimationBlendingKeyframes(), for the CSS Animations case, and
KeyframeEffect::updateBlendingKeyframes(), for the script-originated animation case.

Then in KeyframeEffectStack::applyKeyframeEffects(), much like we do for detecting changes made to font-size, we
check whether any CSS variable (or custom property in WebCore parlance) has changed and recompute keyframes if that
is the case.

We now pass the final two subtests in web-animations/animation-model/keyframe-effects/effect-value-context-filling.html
and since those tests only test the script-originated animation case, we also add a new test in css/css-animations
to test the CSS Animations case.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-in-keyframe-adjusted-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/animation-css-variable-in-keyframe-adjusted.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-context-filling-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateBlendingKeyframes):
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
* Source/WebCore/animation/KeyframeEffect.h:
(WebCore::KeyframeEffect::containsCSSVariableReferences const):
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::containsCSSVariableReferences const):
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::keyframeStylesForAnimation):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/256893@main">https://commits.webkit.org/256893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56e65947539a1151fb99fca0c78d0169e7b8dd84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106651 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166923 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101105 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6662 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35134 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103341 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102802 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83755 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31995 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86852 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74883 "Found 1 new API test failure: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/save-from-file (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/422 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/406 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21606 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2332 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40921 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->