### PR TITLE
[webkitpy] WPT server startup is racy

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py
@@ -140,6 +140,12 @@ class WebPlatformTestServer(http_server_base.HttpServerBase):
     def ports_to_forward(self):
         return [mapping['port'] for mapping in self._mappings]
 
+    def first_port(self, port_obj):
+        config = wpt_config_json(port_obj)
+        if not config:
+            return None
+        return config["ports"]["http"][0]
+
     def _prepare_config(self):
         self._filesystem.maybe_make_directory(self._output_dir)
         self._output_log_path = self._filesystem.join(self._output_dir, self._log_file_name)


### PR DESCRIPTION
#### a4f3bf81be81c1676af4f63abd87e6ed3d117909
<pre>
[webkitpy] WPT server startup is racy
<a href="https://bugs.webkit.org/show_bug.cgi?id=248146">https://bugs.webkit.org/show_bug.cgi?id=248146</a>

Reviewed by Darin Adler.

Wait until a 5 seconds timeout happens or the HTTP server has actually finally started before
running any test, otherwise one or a few of the first tests would fail to connect to the HTTP server.

* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server.py:
(WebPlatformTestServer.first_port):
* Tools/Scripts/webkitpy/port/base.py:
(Port.start_web_platform_test_server):

Canonical link: <a href="https://commits.webkit.org/256945@main">https://commits.webkit.org/256945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7f467bad9ab5098083f6aa76d4c35f71802418

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106830 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167094 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6875 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35311 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103509 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102973 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83941 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32162 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100889 "Passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/591 "Built successfully") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK1-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/575 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-BigSur-Release-WK2-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4786 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5374 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Big-Sur-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41101 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->