### PR TITLE
Use dump-as-markup.js in editing/selection/extend-after-mouse-selection.html

### DIFF
--- a/LayoutTests/editing/selection/extend-after-mouse-selection-expected.txt
+++ b/LayoutTests/editing/selection/extend-after-mouse-selection-expected.txt
@@ -1,22 +1,287 @@
-a bc
-d ef
-ghi
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 2 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](ef) anchorOffset: 2 focusNode: [object Text](a ) focusOffset: 1 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](ef) anchorOffset: 2 focusNode: [object Text](bc) focusOffset: 0 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text]( ) anchorOffset: 1 focusNode: [object Text](bc) focusOffset: 0 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text]( ) anchorOffset: 1 focusNode: [object Text](a ) focusOffset: 0 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 2 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 1 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 2 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text]( ) focusOffset: 1 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object HTMLSpanElement](null) focusOffset: 4 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 2 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 1 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text](ef) focusOffset: 2 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object Text]( ) focusOffset: 1 isCollapsed: false]
-PASS Selection is [anchorNode: [object Text](bc) anchorOffset: 0 focusNode: [object HTMLSpanElement](null) focusOffset: 4 isCollapsed: false]
-PASS successfullyParsed is true
 
-TEST COMPLETE
+Selecting from start to end with mac editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-focus>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
 
+Extending selection backward by one character with mac editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a<#selection-focus> "
+|   <span>
+|     id="start"
+|     "bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-anchor>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection forward by one character with mac editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-focus>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-anchor>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection forward by line boundary with mac editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-focus>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef"
+|   " <#selection-anchor>"
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection backward by line boundary with mac editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "<#selection-focus>a "
+|   <span>
+|     id="start"
+|     "bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef"
+|   " <#selection-anchor>"
+|   <br>
+|   "ghi"
+| "\n"
+
+Selecting from start to end with windows editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-focus>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection backward by one character with windows editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "e<#selection-focus>f"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection forward by one character with windows editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-focus>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection forward by line boundary with windows editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef"
+|   " <#selection-focus>"
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection backward by line boundary with windows editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   <#selection-focus>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Selecting from start to end with unix editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-focus>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection backward by one character with unix editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "e<#selection-focus>f"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection forward by one character with unix editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef<#selection-focus>"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection forward by line boundary with unix editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef"
+|   " <#selection-focus>"
+|   <br>
+|   "ghi"
+| "\n"
+
+Extending selection backward by line boundary with unix editing behavior:
+| "\n    "
+| <span>
+|   id="test"
+|   "a "
+|   <span>
+|     id="start"
+|     "<#selection-anchor>bc"
+|   " "
+|   <br>
+|   <#selection-focus>
+|   "d "
+|   <span>
+|     id="end"
+|     "ef"
+|   " "
+|   <br>
+|   "ghi"
+| "\n"

--- a/LayoutTests/editing/selection/extend-after-mouse-selection.html
+++ b/LayoutTests/editing/selection/extend-after-mouse-selection.html
@@ -8,8 +8,7 @@
 }
 </style>
 <script src="../editing.js"></script>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="resources/js-test-selection-shared.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
 
 <script>
 
@@ -30,36 +29,22 @@ function editingTest(editingBehavior) {
     eventSender.mouseMoveTo(endTarget.offsetLeft, endTarget.offsetTop + 10);
     eventSender.mouseUp();
 
-    assertSelectionAt(startTarget.firstChild, 0, endTarget.firstChild, 2);
+    Markup.dump(root, `Selecting from start to end with ${editingBehavior} editing behavior`);
 
     extendSelectionBackwardByCharacterCommand();
 
     // On Win/Linux the anchor is be fixed after the mouse-selection and never changes.
     // On Mac, the first character-granularity selection after a mouse-selection resets the anchor/focus.
-    if (editingBehavior == "mac")
-        assertSelectionAt(endTarget.firstChild, 2, startTarget.previousSibling, 1);
-    else
-        assertSelectionAt(startTarget.firstChild, 0, endTarget.firstChild, 1);
+    Markup.dump(root, `Extending selection backward by one character with ${editingBehavior} editing behavior`);
 
     extendSelectionForwardByCharacterCommand();
-    if (editingBehavior == "mac")
-        assertSelectionAt(endTarget.firstChild, 2, startTarget.firstChild, 0);
-    else
-        assertSelectionAt(startTarget.firstChild, 0, endTarget.firstChild, 2);
+    Markup.dump(root, `Extending selection forward by one character with ${editingBehavior} editing behavior`);
 
     extendSelectionForwardByLineBoundaryCommand();
-
-    if (editingBehavior == "mac")
-        assertSelectionAt(endTarget.nextSibling, 1, startTarget.firstChild, 0);
-    else
-        assertSelectionAt(startTarget.firstChild, 0, endTarget.nextSibling, 1);
+    Markup.dump(root, `Extending selection forward by line boundary with ${editingBehavior} editing behavior`);
 
     extendSelectionBackwardByLineBoundaryCommand();
-
-    if (editingBehavior == "mac")
-        assertSelectionAt(endTarget.nextSibling, 1, startTarget.previousSibling, 0);
-    else
-        assertSelectionAt(startTarget.firstChild, 0, document.getElementById('test'), 4);
+    Markup.dump(root, `Extending selection backward by line boundary with ${editingBehavior} editing behavior`);
 }
 
 </script>
@@ -78,7 +63,6 @@ editingTest("mac");
 editingTest("windows");
 editingTest("unix");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
#### 37ec2f1960f8e30e1c891ea0ee79578799e374f1
<pre>
Use dump-as-markup.js in editing/selection/extend-after-mouse-selection.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=248151">https://bugs.webkit.org/show_bug.cgi?id=248151</a>

Reviewed by Darin Adler.

Modernize the test using dump-as-markup.js and make it easier to rebaseline.

* LayoutTests/editing/selection/extend-after-mouse-selection-expected.txt:
* LayoutTests/editing/selection/extend-after-mouse-selection.html:

Canonical link: <a href="https://commits.webkit.org/256910@main">https://commits.webkit.org/256910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/119b4198688df663f132b98f90036558baa72f1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106655 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166927 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6666 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35138 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89527 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103345 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5007 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83759 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/31998 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86856 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74886 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/426 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21610 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44115 "Passed tests") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2336 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40925 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->