### PR TITLE
Reset selection between different editing behaviors in editing/selection/user-select-all-with-shift.html

### DIFF
--- a/LayoutTests/editing/selection/user-select-all-with-shift-expected.txt
+++ b/LayoutTests/editing/selection/user-select-all-with-shift-expected.txt
@@ -58,12 +58,12 @@ After clicking on the first element (windows):
 | <div>
 |   class="select-all"
 |   id="first"
-|   "<#selection-focus>First element"
+|   "<#selection-anchor>First element<#selection-focus>"
 | "\nSome other text.\n"
 | <div>
 |   class="select-all"
 |   id="second"
-|   "Second element<#selection-anchor>"
+|   "Second element"
 | "\n"
 
 After shift clicking on the second element (windows):
@@ -71,12 +71,12 @@ After shift clicking on the second element (windows):
 | <div>
 |   class="select-all"
 |   id="first"
-|   "First element"
+|   "<#selection-anchor>First element"
 | "\nSome other text.\n"
 | <div>
 |   class="select-all"
 |   id="second"
-|   "<#selection-focus>Second element<#selection-anchor>"
+|   "Second element<#selection-focus>"
 | "\n"
 
 After clicking on the second element (windows):
@@ -110,12 +110,12 @@ After clicking on the first element (unix):
 | <div>
 |   class="select-all"
 |   id="first"
-|   "<#selection-focus>First element"
+|   "<#selection-anchor>First element<#selection-focus>"
 | "\nSome other text.\n"
 | <div>
 |   class="select-all"
 |   id="second"
-|   "Second<#selection-anchor> element"
+|   "Second element"
 | "\n"
 
 After shift clicking on the second element (unix):
@@ -123,12 +123,12 @@ After shift clicking on the second element (unix):
 | <div>
 |   class="select-all"
 |   id="first"
-|   "First element"
+|   "<#selection-anchor>First element"
 | "\nSome other text.\n"
 | <div>
 |   class="select-all"
 |   id="second"
-|   "<#selection-anchor>Second element<#selection-focus>"
+|   "Second element<#selection-focus>"
 | "\n"
 
 After clicking on the second element (unix):

--- a/LayoutTests/editing/selection/user-select-all-with-shift.html
+++ b/LayoutTests/editing/selection/user-select-all-with-shift.html
@@ -31,6 +31,8 @@ function clickOnElement(element, keys) {
 function runTest(editingBehavior) {
     internals.settings.setEditingBehavior(editingBehavior);
 
+    getSelection().removeAllRanges();
+
     var postfix = ' (' + editingBehavior + ')';
 
     clickOnElement(document.getElementById('first'));


### PR DESCRIPTION
#### 932c64772f3f93d3199f1f357463e405fc1718aa
<pre>
Reset selection between different editing behaviors in editing/selection/user-select-all-with-shift.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=248153">https://bugs.webkit.org/show_bug.cgi?id=248153</a>
Reviewed by Darin Adler.

Clear selection at the beginning of each test so that all editing behaviors are tested as intended.

* LayoutTests/editing/selection/user-select-all-with-shift-expected.txt:
* LayoutTests/editing/selection/user-select-all-with-shift.html:

Canonical link: <a href="https://commits.webkit.org/256911@main">https://commits.webkit.org/256911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce3b5cb09c52f71b216cdacd95c7da9af9181a13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106659 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/166931 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6671 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35142 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103349 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5013 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83764 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32000 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/74888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/430 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20170 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/414 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21613 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5212 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44121 "Found 2 new test failures: fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html (failure)") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2337 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40928 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->