### PR TITLE
Make ::backdrop renderers use background layers when possible

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -757,11 +757,6 @@ void RenderElement::propagateStyleToAnonymousChildren(StylePropagationType propa
         if (propagationType == PropagateToBlockChildrenOnly && !is<RenderBlock>(elementChild))
             continue;
 
-#if ENABLE(FULLSCREEN_API)
-        if (elementChild.isRenderFullScreen() || elementChild.isRenderFullScreenPlaceholder())
-            continue;
-#endif
-
         // RenderFragmentedFlows are updated through the RenderView::styleDidChange function.
         if (is<RenderFragmentedFlow>(elementChild))
             continue;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -263,10 +263,6 @@ public:
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual bool isAttachment() const { return false; }
 #endif
-#if ENABLE(FULLSCREEN_API)
-    virtual bool isRenderFullScreen() const { return false; }
-    virtual bool isRenderFullScreenPlaceholder() const { return false; }
-#endif
     virtual bool isRenderGrid() const { return false; }
 
     virtual bool isMultiColumnBlockFlow() const { return false; }
@@ -1157,10 +1153,6 @@ inline bool RenderObject::isAnonymousBlock() const
         && (style().display() == DisplayType::Block || style().display() == DisplayType::Box)
         && style().styleType() == PseudoId::None
         && isRenderBlock()
-#if ENABLE(FULLSCREEN_API)
-        && !isRenderFullScreen()
-        && !isRenderFullScreenPlaceholder()
-#endif
 #if ENABLE(MATHML)
         && !isRenderMathMLBlock()
 #endif


### PR DESCRIPTION
#### d9c26627b25a3f17b3237ce3b6705c4c67ab9445
<pre>
Make ::backdrop renderers use background layers when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=248148">https://bugs.webkit.org/show_bug.cgi?id=248148</a>
rdar://102566049

Reviewed by NOBODY (OOPS!).

Right now, when rotating in fullscreen on iPad, there are short white flashes. This was avoided by RenderFullscreen using
&quot;background layers&quot;. Now that RenderFullscreen is gone, we need to find an alternate solution. For this, we target ::backdrop
pseudo elements that have:

- No offset from the viewport edge (margin/inset properties being 0)
- No borders (since their color might mismatch with the background color)
- No transforms/clips/masks (since they intentionally do not cover the whole screen)

* LayoutTests/fullscreen/full-screen-layer-dump-expected.txt:
* LayoutTests/fullscreen/full-screen-layer-dump.html:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::propagateStyleToAnonymousChildren):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isAttachment const):
(WebCore::RenderObject::isAnonymousBlock const):
(WebCore::RenderObject::isRenderFullScreen const): Deleted.
(WebCore::RenderObject::isRenderFullScreenPlaceholder const): Deleted.
Cleanup functions that always return false after the RenderFullscreen removal.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9c26627b25a3f17b3237ce3b6705c4c67ab9445

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98429 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7634 "Hash d9c26627 for PR 6688 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31558 "Hash d9c26627 for PR 6688 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107855 "Hash d9c26627 for PR 6688 does not build (failure)") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/168121 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102368 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8148 "Hash d9c26627 for PR 6688 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36375 "Hash d9c26627 for PR 6688 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90975 "The change is no longer eligible for processing.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104512 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104095 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/8148 "Hash d9c26627 for PR 6688 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85014 "Hash d9c26627 for PR 6688 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90975 "The change is no longer eligible for processing.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/8148 "Hash d9c26627 for PR 6688 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/31558 "Hash d9c26627 for PR 6688 does not build (failure)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90975 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1578 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/31558 "Hash d9c26627 for PR 6688 does not build (failure)") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1500 "The change is no longer eligible for processing.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/31558 "Hash d9c26627 for PR 6688 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6424 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/85014 "Hash d9c26627 for PR 6688 does not build (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2876 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/31558 "Hash d9c26627 for PR 6688 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->