### PR TITLE
Add browser.test interface for Web Extension API testing.

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -303,6 +303,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIExtension.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIRuntime.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/WebExtensionContextProxy.messages.in
 $(PROJECT_DIR)/WebProcess/Extensions/WebExtensionControllerProxy.messages.in
 $(PROJECT_DIR)/WebProcess/FullScreen/WebFullScreenManager.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -70,6 +70,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPINamespace.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIRuntime.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIRuntime.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPITest.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/LegacyCustomProtocolManagerMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/LegacyCustomProtocolManagerMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/LegacyCustomProtocolManagerMessagesReplies.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -589,6 +589,7 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIExtension \
     WebExtensionAPINamespace \
     WebExtensionAPIRuntime \
+    WebExtensionAPITest \
 #
 
 JS%.h JS%.mm : %.idl $(BINDINGS_SCRIPTS) $(IDL_ATTRIBUTES_FILE) $(FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES)

--- a/Source/WebKit/Shared/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.h
@@ -44,6 +44,7 @@ struct WebExtensionContextParameters {
     String uniqueIdentifier;
     RetainPtr<NSDictionary> manifest;
     double manifestVersion;
+    bool testingMode;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
@@ -32,6 +32,7 @@ struct WebKit::WebExtensionContextParameters {
     String uniqueIdentifier;
     RetainPtr<NSDictionary> manifest;
     double manifestVersion;
+    bool testingMode;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -455,6 +455,16 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     _webExtensionContext->cancelUserGesture(tab);
 }
 
+- (BOOL)_inTestingMode
+{
+    return _webExtensionContext->inTestingMode();
+}
+
+- (void)_setTestingMode:(BOOL)testingMode
+{
+    _webExtensionContext->setTestingMode(testingMode);
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -661,6 +671,15 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 }
 
 - (void)cancelUserGestureForTab:(id<_WKWebExtensionTab>)tab
+{
+}
+
+- (BOOL)_inTestingMode
+{
+    return NO;
+}
+
+- (void)_setTestingMode:(BOOL)testingMode
 {
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h
@@ -29,6 +29,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKWebExtensionContext ()
 
+/*!
+ @abstract Enables extra `browser.test` JavaScript APIs for unit testing.
+ @discussion Defaults to `YES` in debug builds.
+ */
+@property (nonatomic, getter=_inTestingMode, setter=_setTestingMode:) BOOL _testingMode;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegatePrivate.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <WebKit/_WKWebExtensionControllerDelegate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+@protocol _WKWebExtensionControllerDelegatePrivate <_WKWebExtensionControllerDelegate>
+@optional
+
+/*!
+ @abstract Delegate for the `browser.test.assertTrue()`, `browser.test.assertFalse()`, `browser.test.assertThrows()`, and `browser.test.assertRejects()`  JavaScript testing APIs.
+ @discussion Default implementation logs a message to the system console when `result` is `NO`.
+ */
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Delegate for the `browser.test.assertEq()` and `browser.test.assertDeepEq()` JavaScript testing APIs.
+ @discussion Default implementation logs a message to the system console when `result` is `NO`.
+ */
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Delegate for the `browser.test.log()` JavaScript testing API.
+ @discussion Default implementation always logs the message to the system console.
+ */
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Delegate for the `browser.test.yield()` JavaScript testing API.
+ @discussion Default implementation always logs the message to the system console. Test harnesses should use this to exit the run loop to preform other work before resuming extension execution.
+ */
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+
+/*!
+ @abstract Delegate for the `browser.test.notifyPass()` and `browser.test.notifyFail()` JavaScript testing APIs.
+ @discussion Default implementation logs a message to the system console when `result` is `NO`. Test harnesses should use this to exit the run loop and record a test pass or failure.
+ */
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionController.h"
+#import "_WKWebExtensionControllerDelegatePrivate.h"
+#import "_WKWebExtensionControllerInternal.h"
+
+namespace WebKit {
+
+void WebExtensionContext::testResult(bool result, String message, String sourceURL, unsigned lineNumber)
+{
+    if (!isLoaded())
+        return;
+
+    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
+        [delegate _webExtensionController:extensionController()->wrapper() recordTestAssertionResult:result withMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+        return;
+    }
+
+    if (result)
+        return;
+
+    if (message.isEmpty())
+        message = "(no message)"_s;
+
+    NSLog(@"EXTENSION TEST ASSERTION FAILED: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionContext::testEqual(bool result, String expectedValue, String actualValue, String message, String sourceURL, unsigned lineNumber)
+{
+    if (!isLoaded())
+        return;
+
+    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
+        [delegate _webExtensionController:extensionController()->wrapper() recordTestEqualityResult:result expectedValue:expectedValue actualValue:actualValue withMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+        return;
+    }
+
+    if (result)
+        return;
+
+    if (message.isEmpty())
+        message = "Expected equality of these values"_s;
+
+    NSLog(@"EXTENSION TEST EQUALITY FAILED: %@: %@ !== %@ (%@:%u)", (NSString *)message, (NSString *)expectedValue, (NSString *)actualValue, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionContext::testMessage(String message, String sourceURL, unsigned lineNumber)
+{
+    if (!isLoaded())
+        return;
+
+    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
+        [delegate _webExtensionController:extensionController()->wrapper() recordTestMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+        return;
+    }
+
+    if (message.isEmpty())
+        message = "(no message)"_s;
+
+    NSLog(@"EXTENSION TEST MESSAGE: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionContext::testYielded(String message, String sourceURL, unsigned lineNumber)
+{
+    if (!isLoaded())
+        return;
+
+    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestYieldedWithMessage:andSourceURL:lineNumber:forExtensionContext:)]) {
+        [delegate _webExtensionController:extensionController()->wrapper() recordTestYieldedWithMessage:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+        return;
+    }
+
+    if (message.isEmpty())
+        message = "(no message)"_s;
+
+    NSLog(@"EXTENSION TEST YIELDED: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionContext::testFinished(bool result, String message, String sourceURL, unsigned lineNumber)
+{
+    if (!isLoaded())
+        return;
+
+    auto delegate = (id<_WKWebExtensionControllerDelegatePrivate>)extensionController()->wrapper().delegate;
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:forExtensionContext:)]) {
+        [delegate _webExtensionController:extensionController()->wrapper() recordTestFinishedWithResult:result message:message andSourceURL:sourceURL lineNumber:lineNumber forExtensionContext:wrapper()];
+        return;
+    }
+
+    if (result)
+        return;
+
+    if (message.isEmpty())
+        message = "(no message)"_s;
+
+    NSLog(@"EXTENSION TEST FAILED: %@ (%@:%u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -986,6 +986,15 @@ void WebExtensionContext::cancelUserGesture(_WKWebExtensionTab *tab)
     [m_temporaryTabPermissionMatchPatterns removeObjectForKey:tab];
 }
 
+void WebExtensionContext::setTestingMode(bool testingMode)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    m_testingMode = testingMode;
+}
+
 WKWebViewConfiguration *WebExtensionContext::webViewConfiguration()
 {
     ASSERT(isLoaded());

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -66,6 +66,7 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
     parameters.uniqueIdentifier = uniqueIdentifier();
     parameters.manifest = extension().manifest();
     parameters.manifestVersion = extension().manifestVersion();
+    parameters.testingMode = inTestingMode();
 #endif
 
     return parameters;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -185,6 +185,9 @@ public:
     bool hasActiveUserGesture(_WKWebExtensionTab *) const;
     void cancelUserGesture(_WKWebExtensionTab *);
 
+    bool inTestingMode() const { return m_testingMode; }
+    void setTestingMode(bool);
+
     bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);
     void didFinishNavigation(WKWebView *, WKNavigation *);
     void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
@@ -215,6 +218,13 @@ private:
     void unloadBackgroundWebView();
 
     void performTasksAfterBackgroundContentLoads();
+
+    // Test APIs
+    void testResult(bool result, String message, String sourceURL, unsigned lineNumber);
+    void testEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
+    void testMessage(String message, String sourceURL, unsigned lineNumber);
+    void testYielded(String message, String sourceURL, unsigned lineNumber);
+    void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 #endif
 
     // IPC::MessageReceiver.
@@ -242,7 +252,12 @@ private:
 
     RetainPtr<NSMapTable> m_temporaryTabPermissionMatchPatterns;
 
-    bool m_requestedOptionalAccessToAllHosts = false;
+    bool m_requestedOptionalAccessToAllHosts { false };
+#ifdef NDEBUG
+    bool m_testingMode { false };
+#else
+    bool m_testingMode { true };
+#endif
 
     RetainPtr<WKWebView> m_backgroundWebView;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -26,7 +26,12 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 messages -> WebExtensionContext {
-
+    // Test APIs
+    TestResult(bool result, String message, String sourceURL, unsigned lineNumber);
+    TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
+    TestMessage(String message, String sourceURL, unsigned lineNumber);
+    TestYielded(String message, String sourceURL, unsigned lineNumber);
+    TestFinished(bool result, String message, String sourceURL, unsigned lineNumber);
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -394,6 +394,11 @@
 		1C0A19571C90068F00FE0EBB /* WebAutomationSessionMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C0A19551C90068F00FE0EBB /* WebAutomationSessionMessageReceiver.cpp */; };
 		1C0A19581C90068F00FE0EBB /* WebAutomationSessionMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A19561C90068F00FE0EBB /* WebAutomationSessionMessages.h */; };
 		1C0A195C1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C0A195B1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h */; };
+		1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */; };
+		1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		1C1549842926F091001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1CE972288DF5030098D3A1 /* _WKWebExtensionMatchPattern.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C1CE973288DF5030098D3A1 /* _WKWebExtensionMatchPatternInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C1CE96F288DF5020098D3A1 /* _WKWebExtensionMatchPatternInternal.h */; };
@@ -3567,6 +3572,12 @@
 		1C0A19591C9006EA00FE0EBB /* WebAutomationSession.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebAutomationSession.messages.in; sourceTree = "<group>"; };
 		1C0A195A1C91669500FE0EBB /* WebAutomationSessionProxy.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = WebAutomationSessionProxy.js; sourceTree = "<group>"; };
 		1C0A195B1C916E1B00FE0EBB /* WebAutomationSessionProxyScriptSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAutomationSessionProxyScriptSource.h; path = DerivedSources/WebKit/WebAutomationSessionProxyScriptSource.h; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPITestCocoa.mm; sourceTree = "<group>"; };
+		1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPITest.h; sourceTree = "<group>"; };
+		1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPITest.h; sourceTree = "<group>"; };
+		1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPITest.mm; sourceTree = "<group>"; };
+		1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPITestCocoa.mm; sourceTree = "<group>"; };
+		1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionControllerDelegatePrivate.h; sourceTree = "<group>"; };
 		1C1CE96A288DF31E0098D3A1 /* WebExtensionMatchPattern.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionMatchPattern.h; sourceTree = "<group>"; };
 		1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionMatchPatternCocoa.mm; sourceTree = "<group>"; };
 		1C1CE96E288DF5020098D3A1 /* _WKWebExtensionMatchPattern.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionMatchPattern.mm; sourceTree = "<group>"; };
@@ -3980,6 +3991,7 @@
 		1CC23B20288732F600D0A65A /* WebExtensionControllerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionControllerProxy.h; sourceTree = "<group>"; };
 		1CC23B21288732F600D0A65A /* WebExtensionControllerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebExtensionControllerProxy.cpp; sourceTree = "<group>"; };
 		1CC54AFD270F9654005BF8BE /* QualifiedRenderingResourceIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QualifiedRenderingResourceIdentifier.h; sourceTree = "<group>"; };
+		1CDA62A02925DA3700D90390 /* WebExtensionAPITest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPITest.idl; sourceTree = "<group>"; };
 		1CDDFC7B2755860000C93C62 /* RemoteGPUProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteGPUProxy.messages.in; sourceTree = "<group>"; };
 		1CDDFC7C2755866D00C93C62 /* RemoteGPUProxyMessagesReplies.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGPUProxyMessagesReplies.h; sourceTree = "<group>"; };
 		1CDDFC7D2755866D00C93C62 /* RemoteGPUProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGPUProxyMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -8829,6 +8841,14 @@
 			path = Automation;
 			sourceTree = "<group>";
 		};
+		1C1549802926E7CC001B9E5B /* API */ = {
+			isa = PBXGroup;
+			children = (
+				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
 		1C3D0ABF291AE6200093F67E /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
@@ -8845,6 +8865,7 @@
 				1C5DC44F290888140061EC62 /* WebExtensionAPINamespace.h */,
 				1C5DC44E29087E7F0061EC62 /* WebExtensionAPIObject.h */,
 				1C5DC469290B239C0061EC62 /* WebExtensionAPIRuntime.h */,
+				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -8855,6 +8876,7 @@
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
 				1C5DC464290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm */,
+				1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */,
 			);
 			path = Cocoa;
 			sourceTree = "<group>";
@@ -8891,6 +8913,7 @@
 		1C627476288A1DDE00CED3A2 /* Cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				1C1549802926E7CC001B9E5B /* API */,
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
@@ -8987,6 +9010,7 @@
 				1C9DD99028FA19A30093BDB0 /* WebExtensionAPIExtension.idl */,
 				1C9DD9A428FA19A30093BDB0 /* WebExtensionAPINamespace.idl */,
 				1C9DD99C28FA19A30093BDB0 /* WebExtensionAPIRuntime.idl */,
+				1CDA62A02925DA3700D90390 /* WebExtensionAPITest.idl */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -10275,6 +10299,7 @@
 				1C3BEB5728875CE400E66E38 /* _WKWebExtensionController.h */,
 				1C3BEB5528875CE400E66E38 /* _WKWebExtensionController.mm */,
 				1C04983B289AFF9B0010308B /* _WKWebExtensionControllerDelegate.h */,
+				1C1549832926F04E001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h */,
 				1C3BEB5628875CE400E66E38 /* _WKWebExtensionControllerInternal.h */,
 				1C3BEB5828875CE500E66E38 /* _WKWebExtensionControllerPrivate.h */,
 				1C3BEB6D288883E200E66E38 /* _WKWebExtensionInternal.h */,
@@ -13456,6 +13481,8 @@
 				1C5DC4542908AC260061EC62 /* JSWebExtensionAPINamespace.mm */,
 				1C5DC461290B1C470061EC62 /* JSWebExtensionAPIRuntime.h */,
 				1C5DC463290B1C470061EC62 /* JSWebExtensionAPIRuntime.mm */,
+				1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */,
+				1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */,
 				2984F586164BA095004BC0C6 /* LegacyCustomProtocolManagerMessageReceiver.cpp */,
 				2984F587164BA095004BC0C6 /* LegacyCustomProtocolManagerMessages.h */,
 				2984F57A164B915F004BC0C6 /* LegacyCustomProtocolManagerProxyMessageReceiver.cpp */,
@@ -14605,6 +14632,7 @@
 				1C0234D728A013D900AC1E5B /* _WKWebExtensionContextPrivate.h in Headers */,
 				1C3BEB5B28875CE500E66E38 /* _WKWebExtensionController.h in Headers */,
 				1C04983F289AFF9B0010308B /* _WKWebExtensionControllerDelegate.h in Headers */,
+				1C1549842926F091001B9E5B /* _WKWebExtensionControllerDelegatePrivate.h in Headers */,
 				1C3BEB5A28875CE500E66E38 /* _WKWebExtensionControllerInternal.h in Headers */,
 				1C3BEB5C28875CE500E66E38 /* _WKWebExtensionControllerPrivate.h in Headers */,
 				1C3BEB722888842F00E66E38 /* _WKWebExtensionInternal.h in Headers */,
@@ -15518,6 +15546,7 @@
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,
 				1C5DC46B290B271E0061EC62 /* WebExtensionAPIObject.h in Headers */,
 				1C5DC46A290B271A0061EC62 /* WebExtensionAPIRuntime.h in Headers */,
+				1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */,
 				1C0234D928A01B1C00AC1E5B /* WebExtensionContextIdentifier.h in Headers */,
 				1C0234D228A00FF000AC1E5B /* WebExtensionContextMessages.h in Headers */,
 				1C0234CF28A00FF000AC1E5B /* WebExtensionContextMessagesReplies.h in Headers */,
@@ -17894,6 +17923,7 @@
 				1C5DC471290B33A20061EC62 /* JSWebExtensionAPIExtension.mm in Sources */,
 				1C5DC4552908AC900061EC62 /* JSWebExtensionAPINamespace.mm in Sources */,
 				1C5DC472290B33A60061EC62 /* JSWebExtensionAPIRuntime.mm in Sources */,
+				1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */,
 				1C5DC45F2909B05A0061EC62 /* JSWebExtensionWrapperCocoa.mm in Sources */,
 				C14D37FE24ACE086007FF014 /* LaunchServicesDatabaseManager.mm in Sources */,
 				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
@@ -18214,7 +18244,9 @@
 				1C5DC467290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm in Sources */,
 				1C5DC4522908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm in Sources */,
 				1C5DC466290B23890061EC62 /* WebExtensionAPIRuntimeCocoa.mm in Sources */,
+				1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,
+				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
 				1C0234DC28A0268C00AC1E5B /* WebExtensionContextCocoa.mm in Sources */,
 				1C0234CD28A00FE400AC1E5B /* WebExtensionContextMessageReceiver.cpp in Sources */,
 				1C0234CE28A00FE600AC1E5B /* WebExtensionContextProxyMessageReceiver.cpp in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -34,6 +34,16 @@
 
 namespace WebKit {
 
+bool WebExtensionAPINamespace::isPropertyAllowed(String name, WebPage*)
+{
+    // This property is only allowed in testing contexts.
+    if (name == "test"_s)
+        return extensionContext().inTestingMode();
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 WebExtensionAPIExtension& WebExtensionAPINamespace::extension()
 {
     if (!m_extension)
@@ -46,6 +56,13 @@ WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime()
     if (!m_runtime)
         m_runtime = WebExtensionAPIRuntime::create(forMainWorld(), extensionContext());
     return *m_runtime;
+}
+
+WebExtensionAPITest& WebExtensionAPINamespace::test()
+{
+    if (!m_test)
+        m_test = WebExtensionAPITest::create(forMainWorld(), runtime(), extensionContext());
+    return *m_test;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPITest.h"
+
+#import "WebExtensionContextMessages.h"
+#import "WebProcess.h"
+#import <JavaScriptCore/APICast.h>
+#import <JavaScriptCore/ScriptCallStack.h>
+#import <JavaScriptCore/ScriptCallStackFactory.h>
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+static std::pair<String, unsigned> scriptLocation(JSContextRef context)
+{
+    auto callStack = Inspector::createScriptCallStack(toJS(context));
+    if (const Inspector::ScriptCallFrame* frame = callStack->firstNonNativeCallFrame()) {
+        auto sourceURL = frame->sourceURL();
+        if (sourceURL.isEmpty())
+            sourceURL = "global code"_s;
+        return { sourceURL, frame->lineNumber() };
+    }
+
+    return { "unknown"_s, 0 };
+}
+
+void WebExtensionAPITest::notifyFail(JSContextRef context, NSString *message)
+{
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestFinished(false, message, location.first, location.second), extensionContext().identifier());
+}
+
+void WebExtensionAPITest::notifyPass(JSContextRef context, NSString *message)
+{
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestFinished(true, message, location.first, location.second), extensionContext().identifier());
+}
+
+void WebExtensionAPITest::yield(JSContextRef context, NSString *message)
+{
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestYielded(message, location.first, location.second), extensionContext().identifier());
+}
+
+void WebExtensionAPITest::log(JSContextRef context, NSString *message)
+{
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestMessage(message, location.first, location.second), extensionContext().identifier());
+}
+
+void WebExtensionAPITest::fail(JSContextRef context, NSString *message)
+{
+    assertTrue(context, false, message);
+}
+
+void WebExtensionAPITest::succeed(JSContextRef context, NSString *message)
+{
+    assertTrue(context, true, message);
+}
+
+void WebExtensionAPITest::assertTrue(JSContextRef context, bool actualValue, NSString *message)
+{
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestResult(actualValue, message, location.first, location.second), extensionContext().identifier());
+}
+
+void WebExtensionAPITest::assertFalse(JSContextRef context, bool actualValue, NSString *message)
+{
+    assertTrue(context, !actualValue, message);
+}
+
+inline NSString *debugString(JSValue *value)
+{
+    if (value._regularExpression)
+        return value.toString;
+    return value._toSortedJSONString ?: @"undefined";
+}
+
+void WebExtensionAPITest::assertDeepEq(JSContextRef context, JSValue *expectedValue, JSValue *actualValue, NSString *message)
+{
+    NSString *expectedJSONValue = debugString(expectedValue);
+    NSString *actualJSONValue = debugString(actualValue);
+
+    // FIXME: Comparing JSON is a quick attempt that works, but can still fail due to any non-JSON values.
+    // See Firefox's implementation: https://searchfox.org/mozilla-central/source/toolkit/components/extensions/child/ext-test.js#78
+    BOOL strictEqual = [expectedValue isEqualToObject:actualValue];
+    BOOL deepEqual = strictEqual || [expectedJSONValue isEqualToString:actualJSONValue];
+
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestEqual(deepEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), extensionContext().identifier());
+}
+
+void WebExtensionAPITest::assertEq(JSContextRef context, JSValue *expectedValue, JSValue *actualValue, NSString *message)
+{
+    NSString *expectedJSONValue = debugString(expectedValue);
+    NSString *actualJSONValue = debugString(actualValue);
+
+    BOOL strictEqual = [expectedValue isEqualToObject:actualValue];
+    if (!strictEqual && [expectedJSONValue isEqualToString:actualJSONValue])
+        actualJSONValue = [actualJSONValue stringByAppendingString:@" (different)"];
+
+    auto location = scriptLocation(context);
+    WebProcess::singleton().send(Messages::WebExtensionContext::TestEqual(strictEqual, expectedJSONValue, actualJSONValue, message, location.first, location.second), extensionContext().identifier());
+}
+
+JSValue *WebExtensionAPITest::assertRejects(JSContextRef context, JSValue *promise, JSValue *expectedError, NSString *message)
+{
+    // Wrap in a native promise for consistency.
+    promise = [JSValue valueWithNewPromiseResolvedWithResult:promise inContext:promise.context];
+
+    [promise _awaitThenableResolutionWithCompletionHandler:^(JSValue *result, JSValue *error) {
+        if (result || !error) {
+            assertTrue(context, false, [NSString stringWithFormat:@"Promise resolved with a result (%@); expected an error (%@).", debugString(result), debugString(expectedError)]);
+            return;
+        }
+
+        if (!expectedError)
+            return;
+
+        JSValue *errorMessageValue = error.isObject && [error hasProperty:@"message"] ? error[@"message"] : error;
+
+        if (expectedError._regularExpression) {
+            JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ errorMessageValue ]];
+            assertTrue(context, testResult.toBool, [NSString stringWithFormat:@"Promise rejected with an error (%@) that didn't match %@.", debugString(errorMessageValue), debugString(expectedError)]);
+            return;
+        }
+
+        assertTrue(context, [expectedError isEqualWithTypeCoercionToObject:errorMessageValue], [NSString stringWithFormat:@"Promise rejected with an error (%@) that didn't equal %@.", debugString(errorMessageValue), debugString(expectedError)]);
+    }];
+
+    return promise;
+}
+
+void WebExtensionAPITest::assertThrows(JSContextRef context, JSValue *function, JSValue *expectedError, NSString *message)
+{
+    [function callWithArguments:@[ ]];
+
+    JSValue *exceptionValue = function.context.exception;
+    if (!exceptionValue) {
+        assertTrue(context, false, [NSString stringWithFormat:@"Function did not throw an exception; expected an error (%@).", debugString(expectedError)]);
+        return;
+    }
+
+    if (!expectedError)
+        return;
+
+    JSValue *exceptionMessageValue = exceptionValue.isObject && [exceptionValue hasProperty:@"message"] ? exceptionValue[@"message"] : exceptionValue;
+
+    if (expectedError._regularExpression) {
+        JSValue *testResult = [expectedError invokeMethod:@"test" withArguments:@[ exceptionMessageValue ]];
+        assertTrue(context, testResult.toBool, [NSString stringWithFormat:@"Function throw an exception (%@) that didn't match %@.", debugString(exceptionMessageValue), debugString(expectedError)]);
+        return;
+    }
+
+    assertTrue(context, [expectedError isEqualWithTypeCoercionToObject:exceptionMessageValue], [NSString stringWithFormat:@"Function throw an exception (%@) that didn't equal %@.", debugString(exceptionMessageValue), debugString(expectedError)]);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -27,33 +27,39 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#include "JSWebExtensionAPINamespace.h"
-#include "WebExtensionAPIExtension.h"
+#include "JSWebExtensionAPITest.h"
 #include "WebExtensionAPIObject.h"
-#include "WebExtensionAPIRuntime.h"
-#include "WebExtensionAPITest.h"
+
+OBJC_CLASS NSString;
 
 namespace WebKit {
 
-class WebExtensionAPIExtension;
-class WebExtensionAPIRuntime;
+class WebPage;
 
-class WebExtensionAPINamespace : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINamespace, namespace);
+class WebExtensionAPITest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITest, test);
 
 public:
 #if PLATFORM(COCOA)
-    bool isPropertyAllowed(String propertyName, WebPage*);
+    void notifyFail(JSContextRef, NSString *message);
+    void notifyPass(JSContextRef, NSString *message);
 
-    WebExtensionAPIExtension& extension();
-    WebExtensionAPIRuntime& runtime() final;
-    WebExtensionAPITest& test();
+    void yield(JSContextRef, NSString *message);
+
+    void log(JSContextRef, NSString *message);
+
+    void fail(JSContextRef, NSString *message);
+    void succeed(JSContextRef, NSString *message);
+
+    void assertTrue(JSContextRef, bool testValue, NSString *message);
+    void assertFalse(JSContextRef, bool testValue, NSString *message);
+
+    void assertDeepEq(JSContextRef, JSValue *expectedValue, JSValue *actualValue, NSString *message);
+    void assertEq(JSContextRef, JSValue *expectedValue, JSValue *actualValue, NSString *message);
+
+    JSValue *assertRejects(JSContextRef, JSValue *promise, JSValue *expectedError, NSString *message);
+    void assertThrows(JSContextRef, JSValue *function, JSValue *expectedError, NSString *message);
 #endif
-
-private:
-    RefPtr<WebExtensionAPIExtension> m_extension;
-    RefPtr<WebExtensionAPIRuntime> m_runtime;
-    RefPtr<WebExtensionAPITest> m_test;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -196,9 +196,15 @@ NSString *serializeJSObject(JSContextRef, JSValueRef, JSValueRef* exception);
 
 #ifdef __OBJC__
 
-@interface JSValue (ThenableExtras)
+@interface JSValue (WebKitExtras)
+- (NSString *)_toJSONString;
+- (NSString *)_toSortedJSONString;
+
+@property (nonatomic, readonly, getter=_isFunction) BOOL _function;
+@property (nonatomic, readonly, getter=_isRegularExpression) BOOL _regularExpression;
 @property (nonatomic, readonly, getter=_isThenable) BOOL _thenable;
-- (void)_awaitThenableResolutionWithCompletionHandler:(void (^)(id result, id error))completionHandler;
+
+- (void)_awaitThenableResolutionWithCompletionHandler:(void (^)(JSValue *result, JSValue *error))completionHandler;
 @end
 
 #endif // __OBJC__

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -989,7 +989,7 @@ EOF
 EOF
     }
 
-    if ($signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"}) {
+    if ($signature->type->name eq "any" && !($signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"Serialization"}) && !$signature->extendedAttributes->{"Optional"} && !$signature->extendedAttributes->{"ValuesAllowed"}) {
         $hasExceptions = 1;
 
         push(@$contents, <<EOF);
@@ -1141,7 +1141,7 @@ sub _javaScriptTypeCondition
 
     return "(JSValueIsObject(context, ${argument}) && !JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr))) || JSValueIsString(context, ${argument}) || ${nullOrUndefined}" if $idlTypeName eq "any" && $signature->extendedAttributes->{"NSObject"} && $signature->extendedAttributes->{"DOMString"};
     return "(JSValueIsObject(context, ${argument}) && !JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr))) || ${nullOrUndefined}" if $idlTypeName eq "any" && ($signature->extendedAttributes->{"NSObject"} || $signature->extendedAttributes->{"NSArray"} || $signature->extendedAttributes->{"NSDictionary"} || $signature->extendedAttributes->{"Serialization"});
-    return "JSValueIsObject(context, ${argument}) || ${nullOrUndefined}" if $idlTypeName eq "any";
+    return "JSValueIsObject(context, ${argument}) || ${nullOrUndefined}" if $idlTypeName eq "any" && !$signature->extendedAttributes->{"ValuesAllowed"};
     return "(JSValueIsObject(context, ${argument}) && JSObjectIsFunction(context, JSValueToObject(context, ${argument}, nullptr))) || ${nullOrUndefined}" if $idlTypeName eq "function";
     return "JSValueIsBoolean(context, ${argument}) || ${nullOrUndefined}" if $idlTypeName eq "boolean";
     return "JSValueIsArray(context, ${argument}) || ${nullOrUndefined}" if $idlTypeName eq "array";

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json
@@ -121,6 +121,9 @@
         },
         "URL": {
             "contextsAllowed": ["argument", "attribute", "operation"]
+        },
+        "ValuesAllowed": {
+            "contextsAllowed": ["argument"]
         }
     }
 }

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -32,4 +32,6 @@
 
     readonly attribute WebExtensionAPIRuntime runtime;
 
+    [Dynamic] readonly attribute WebExtensionAPITest test;
+
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WK_WEB_EXTENSIONS,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPITest {
+
+    // Notifies that test failed.
+    [NeedsScriptContext] void notifyFail([Optional] DOMString message);
+
+    // Notifies that test passed.
+    [NeedsScriptContext] void notifyPass([Optional] DOMString message);
+
+    // Yields the running of the extension for external testing.
+    [NeedsScriptContext] void yield([Optional] DOMString message);
+
+    // Logs a message during testing.
+    [NeedsScriptContext] void log(DOMString message);
+
+    // Alias for `assertTrue(false, message)`.
+    [NeedsScriptContext] void fail([Optional] DOMString message);
+
+    // Alias for `assertTrue(true, message)`.
+    [NeedsScriptContext] void succeed([Optional] DOMString message);
+
+    // Asserts the test value is `true`.
+    [NeedsScriptContext] void assertTrue(boolean actualValue, [Optional] DOMString message);
+
+    // Asserts the test value is `false`.
+    [NeedsScriptContext] void assertFalse(boolean actualValue, [Optional] DOMString message);
+
+    // Asserts the test value is deeply equal to the expected value.
+    [NeedsScriptContext] void assertDeepEq([ValuesAllowed] any expectedValue, [ValuesAllowed] any actualValue, [Optional] DOMString message);
+
+    // Asserts the test value is equal to the expected value.
+    [NeedsScriptContext] void assertEq([ValuesAllowed] any expectedValue, [ValuesAllowed] any actualValue, [Optional] DOMString message);
+
+    // Asserts the promise is rejected.
+    [NeedsScriptContext, ProcessArgumentsLeftToRight] any assertRejects(any promise, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
+
+    // Asserts the function throws an exception.
+    [NeedsScriptContext, ProcessArgumentsLeftToRight] void assertThrows(any function, [Optional, ValuesAllowed] any expectedError, [Optional] DOMString message);
+
+};

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -55,6 +55,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(WebExtension
         context.m_uniqueIdentifier = parameters.uniqueIdentifier;
         context.m_manifest = parameters.manifest;
         context.m_manifestVersion = parameters.manifestVersion;
+        context.m_testingMode = parameters.testingMode;
     };
 
     if (auto context = webExtensionContextProxies().get(parameters.identifier)) {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -56,6 +56,8 @@ public:
     double manifestVersion() { return m_manifestVersion; }
     bool usesManifestVersion(double version) { return manifestVersion() >= version; }
 
+    bool inTestingMode() { return m_testingMode; }
+
     WebCore::DOMWrapperWorld* contentScriptWorld() { return m_contentScriptWorld.get(); }
     void setContentScriptWorld(WebCore::DOMWrapperWorld* world) { m_contentScriptWorld = world; }
 #endif
@@ -72,7 +74,8 @@ private:
     URL m_baseURL;
     String m_uniqueIdentifier;
     RetainPtr<NSDictionary> m_manifest;
-    double m_manifestVersion;
+    double m_manifestVersion { 0 };
+    bool m_testingMode { false };
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
 #endif
 };

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -281,6 +281,8 @@ Tests/WebKitCocoa/WKRequestActivatedElementInfo.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
 Tests/WebKitCocoa/WKURLSchemeHandler-leaks.mm
 Tests/WebKitCocoa/WKWebExtension.mm
+Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
 Tests/WebKitCocoa/WKWebExtensionContext.mm
 Tests/WebKitCocoa/WKWebExtensionController.mm
 Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		1ADBEFE3130C6AA100D61D19 /* simple-accelerated-compositing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1ADBEFBC130C6A0100D61D19 /* simple-accelerated-compositing.html */; };
 		1AEDE22613E5E7E700E62FE8 /* InjectedBundleControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */; };
 		1AF7B21F1D6CD14D008C126C /* EnumTraits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7B21D1D6CD12E008C126C /* EnumTraits.cpp */; };
+		1C15499A2928475C001B9E5B /* WebExtensionUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C24DEED263001DE00450D07 /* TextStyleFontSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C24DEEC263001DE00450D07 /* TextStyleFontSize.mm */; };
 		1C2B81831C891F0900A5529F /* CancelFontSubresourcePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */; };
 		1C2B81861C89259D00A5529F /* webfont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C2B81841C8924A200A5529F /* webfont.html */; };
@@ -1996,6 +1997,10 @@
 		1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = InjectedBundleControllerMac.mm; sourceTree = "<group>"; };
 		1AEF994817A09F5300998EF0 /* GetPIDAfterAbortedProcessLaunch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GetPIDAfterAbortedProcessLaunch.cpp; sourceTree = "<group>"; };
 		1AF7B21D1D6CD12E008C126C /* EnumTraits.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnumTraits.cpp; sourceTree = "<group>"; };
+		1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIRuntime.mm; sourceTree = "<group>"; };
+		1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WebExtensionUtilities.mm; path = cocoa/WebExtensionUtilities.mm; sourceTree = "<group>"; };
+		1C15498F2926F944001B9E5B /* WebExtensionUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebExtensionUtilities.h; path = cocoa/WebExtensionUtilities.h; sourceTree = "<group>"; };
+		1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIExtension.mm; sourceTree = "<group>"; };
 		1C24DEEC263001DE00450D07 /* TextStyleFontSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextStyleFontSize.mm; sourceTree = "<group>"; };
 		1C2B817E1C891E4200A5529F /* CancelFontSubresource.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresource.mm; sourceTree = "<group>"; };
 		1C2B81811C891EFA00A5529F /* CancelFontSubresourcePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CancelFontSubresourcePlugIn.mm; sourceTree = "<group>"; };
@@ -3695,6 +3700,8 @@
 				41733D7A25DE96DA00A136E5 /* UserMediaCaptureUIDelegate.h */,
 				41733D7B25DE96DA00A136E5 /* UserMediaCaptureUIDelegate.mm */,
 				7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */,
+				1C15498F2926F944001B9E5B /* WebExtensionUtilities.h */,
+				1C15498E2926F701001B9E5B /* WebExtensionUtilities.mm */,
 				A14FC5841B89739100D107EB /* WKWebViewConfigurationExtras.h */,
 				A14FC5831B89739100D107EB /* WKWebViewConfigurationExtras.mm */,
 			);
@@ -4061,6 +4068,8 @@
 				51C683DD1EA134DB00650183 /* WKURLSchemeHandler-1.mm */,
 				5182C22D1F2BCB410059BA7C /* WKURLSchemeHandler-leaks.mm */,
 				1CFAA40828947999009F894D /* WKWebExtension.mm */,
+				1C1549A2292ADB64001B9E5B /* WKWebExtensionAPIExtension.mm */,
+				1C1549852926F4CA001B9E5B /* WKWebExtensionAPIRuntime.mm */,
 				1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */,
 				1CAB9B7128F5E08900E6C77E /* WKWebExtensionController.mm */,
 				1CFAA40928974405009F894D /* WKWebExtensionMatchPattern.mm */,
@@ -6504,6 +6513,7 @@
 				0F139E771A423A5B00F590F5 /* WeakObjCPtr.mm in Sources */,
 				7CCE7F191A411AE600447C4C /* WebArchive.cpp in Sources */,
 				7C83E04C1D0A641800FEBCF3 /* WebCoreNSURLSession.mm in Sources */,
+				1C15499A2928475C001B9E5B /* WebExtensionUtilities.mm in Sources */,
 				C1FF9EDB244644F000839AE4 /* WebFilter.mm in Sources */,
 				7B7D096A2519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm in Sources */,
 				31E9BDA1247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionUtilities.h"
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionAPIExtension, GetURL)
+{
+    auto *baseURLString = @"test-extension://76C788B8-3374-400D-8259-40E5B9DF79D3";
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Variable Setup
+        [NSString stringWithFormat:@"const baseURL = '%@'", baseURLString],
+
+        // Error Cases
+        @"browser.test.assertThrows(() => browser.extension.getURL(), /A required argument is missing./)",
+        @"browser.test.assertThrows(() => browser.extension.getURL(null), /Expected a string./)",
+        @"browser.test.assertThrows(() => browser.extension.getURL(undefined), /Expected a string./)",
+
+        // Normal Cases
+        @"browser.test.assertEq(browser.extension.getURL(''), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.extension.getURL('test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.extension.getURL('/test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.extension.getURL('../../test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.extension.getURL('./test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.extension.getURL('././/example'), `${baseURL}//example`)",
+        @"browser.test.assertEq(browser.extension.getURL('../../example/..//test/'), `${baseURL}//test/`)",
+        @"browser.test.assertEq(browser.extension.getURL('.'), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.extension.getURL('..//../'), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.extension.getURL('.././..'), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.extension.getURL('/.././.'), `${baseURL}/`)",
+
+        // Unexpected Cases
+        // FIXME: <https://webkit.org/b/248154> browser.extension.getURL() has some edge cases that should be failures or return different results
+        @"browser.test.assertEq(browser.extension.getURL(42), `${baseURL}/42`)",
+        @"browser.test.assertEq(browser.extension.getURL(/test/), `${baseURL}/test/`)",
+        @"browser.test.assertEq(browser.extension.getURL('//'), 'test-extension://')",
+        @"browser.test.assertEq(browser.extension.getURL('//example'), `test-extension://example`)",
+        @"browser.test.assertEq(browser.extension.getURL('///'), 'test-extension:///')",
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *manifest = @{ @"manifest_version": @2, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+
+    // Set a base URL so it is a known value and not the default random one.
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+
+    // Manifest v3 deprecates getURL(), so it should be an udefined property.
+
+    backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(typeof browser.extension.getURL, 'undefined')",
+        @"browser.test.assertEq(browser.extension.getURL, undefined)",
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    manifest = @{ @"manifest_version": @3, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
+
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionUtilities.h"
+
+namespace TestWebKitAPI {
+
+static auto *manifest = @{ @"manifest_version": @3, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
+
+TEST(WKWebExtensionAPIRuntime, GetURL)
+{
+    auto *baseURLString = @"test-extension://76C788B8-3374-400D-8259-40E5B9DF79D3";
+
+    auto *backgroundScript = Util::constructScript(@[
+        // Variable Setup
+        [NSString stringWithFormat:@"const baseURL = '%@'", baseURLString],
+
+        // Error Cases
+        @"browser.test.assertThrows(() => browser.runtime.getURL(), /A required argument is missing./)",
+        @"browser.test.assertThrows(() => browser.runtime.getURL(null), /Expected a string./)",
+        @"browser.test.assertThrows(() => browser.runtime.getURL(undefined), /Expected a string./)",
+
+        // Normal Cases
+        @"browser.test.assertEq(browser.runtime.getURL(''), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.runtime.getURL('test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.runtime.getURL('/test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.runtime.getURL('../../test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.runtime.getURL('./test.js'), `${baseURL}/test.js`)",
+        @"browser.test.assertEq(browser.runtime.getURL('././/example'), `${baseURL}//example`)",
+        @"browser.test.assertEq(browser.runtime.getURL('../../example/..//test/'), `${baseURL}//test/`)",
+        @"browser.test.assertEq(browser.runtime.getURL('.'), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.runtime.getURL('..//../'), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.runtime.getURL('.././..'), `${baseURL}/`)",
+        @"browser.test.assertEq(browser.runtime.getURL('/.././.'), `${baseURL}/`)",
+
+        // Unexpected Cases
+        // FIXME: <https://webkit.org/b/248154> browser.runtime.getURL() has some edge cases that should be failures or return different results
+        @"browser.test.assertEq(browser.runtime.getURL(42), `${baseURL}/42`)",
+        @"browser.test.assertEq(browser.runtime.getURL(/test/), `${baseURL}/test/`)",
+        @"browser.test.assertEq(browser.runtime.getURL('//'), 'test-extension://')",
+        @"browser.test.assertEq(browser.runtime.getURL('//example'), `test-extension://example`)",
+        @"browser.test.assertEq(browser.runtime.getURL('///'), 'test-extension:///')",
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+
+    // Set a base URL so it is a known value and not the default random one.
+    manager.get().context.baseURL = [NSURL URLWithString:baseURLString];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIRuntime, Id)
+{
+    auto *uniqueIdentifier = @"org.webkit.test.extension (76C788B8)";
+
+    auto *backgroundScript = Util::constructScript(@[
+        [NSString stringWithFormat:@"browser.test.assertEq(browser.runtime.id, '%@')", uniqueIdentifier],
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension.get()]);
+
+    // Set an uniqueIdentifier so it is a known value and not the default random one.
+    manager.get().context.uniqueIdentifier = uniqueIdentifier;
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIRuntime, GetManifest)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // FIXME: <https://webkit.org/b/248154> browser.runtime.getManifest() returns 1/0 instead true/false for background.persistent
+        @"browser.test.assertDeepEq(browser.runtime.getManifest(), { manifest_version: 3, background: { persistent: 0, scripts: [ 'background.js' ], type: 'module' } })",
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIRuntime, GetPlatformInfo)
+{
+#if PLATFORM(MAC) && (CPU(ARM) || CPU(ARM64))
+    auto *expectedInfo = @"{ os: 'mac', arch: 'arm' }";
+#elif PLATFORM(MAC) && (CPU(X86_64))
+    auto *expectedInfo = @"{ os: 'mac', arch: 'x86-64' }";
+#elif PLATFORM(IOS_FAMILY) && (CPU(ARM) || CPU(ARM64))
+    auto *expectedInfo = @"{ os: 'ios', arch: 'arm' }";
+#elif PLATFORM(IOS_FAMILY) && (CPU(X86_64))
+    auto *expectedInfo = @"{ os: 'ios', arch: 'x86-64' }";
+#else
+    auto *expectedInfo = @"{ os: 'unknown', arch: 'unknown' }";
+#endif
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertTrue(browser.runtime.getPlatformInfo() instanceof Promise)",
+        [NSString stringWithFormat:@"browser.test.assertDeepEq(await browser.runtime.getPlatformInfo(), %@)", expectedInfo],
+        [NSString stringWithFormat:@"browser.test.assertEq(browser.runtime.getPlatformInfo((info) => browser.test.assertDeepEq(info, %@)), undefined)", expectedInfo],
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIRuntime, LastError)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(typeof browser.runtime.lastError, 'object')",
+        @"browser.test.assertEq(browser.runtime.lastError, null)",
+
+        // FIXME: <https://webkit.org/b/248156> Need test cases for lastError
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TestCocoa.h"
+#include "Utilities.h"
+#include "WTFTestUtilities.h"
+#include <WebKit/_WKWebExtensionContextPrivate.h>
+#include <WebKit/_WKWebExtensionControllerDelegatePrivate.h>
+#include <WebKit/_WKWebExtensionControllerPrivate.h>
+#include <WebKit/_WKWebExtensionPrivate.h>
+
+#ifdef __OBJC__
+
+@interface TestWebExtensionManager : NSObject
+
+- (instancetype)initWithExtension:(_WKWebExtension *)extension;
+
+@property (nonatomic, strong) _WKWebExtension *extension;
+@property (nonatomic, strong) _WKWebExtensionContext *context;
+@property (nonatomic, strong) _WKWebExtensionController *controller;
+@property (nonatomic, weak) id <_WKWebExtensionControllerDelegate> controllerDelegate;
+
+@property (nonatomic, readonly, strong) NSString *yieldMessage;
+
+- (void)load;
+- (void)run;
+- (void)loadAndRun;
+
+@end
+
+#else // not __OBJC__
+
+OBJC_CLASS TestWebExtensionManager;
+
+#endif // __OBJC__
+
+namespace TestWebKitAPI::Util {
+
+#ifdef __OBJC__
+
+inline NSString *constructScript(NSArray *lines) { return [lines componentsJoinedByString:@";\n"]; }
+
+#endif
+
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources);
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL);
+
+} // namespace TestWebKitAPI::Util

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionUtilities.h"
+
+@interface TestWebExtensionManager () <_WKWebExtensionControllerDelegatePrivate>
+@end
+
+@implementation TestWebExtensionManager {
+    bool _done;
+}
+
+- (instancetype)initWithExtension:(_WKWebExtension *)extension
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _extension = extension;
+    _context = [[_WKWebExtensionContext alloc] initWithExtension:extension];
+    _controller = [[_WKWebExtensionController alloc] init];
+
+    _context._testingMode = YES;
+
+    // This should always be self. If you need the delegate, use the controllerDelegate property.
+    // Delegate method calls will be forwarded to the controllerDelegate.
+    _controller.delegate = self;
+
+    return self;
+}
+
+- (BOOL)respondsToSelector:(SEL)selector
+{
+    return [_controllerDelegate respondsToSelector:selector] || [super respondsToSelector:selector];
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector
+{
+    return [_controllerDelegate respondsToSelector:selector] ? _controllerDelegate : [super forwardingTargetForSelector:selector];
+}
+
+- (void)load
+{
+    NSError *error;
+    EXPECT_TRUE([_controller loadExtensionContext:_context error:&error]);
+    EXPECT_NULL(error);
+}
+
+- (void)run
+{
+    _done = false;
+    TestWebKitAPI::Util::run(&_done);
+}
+
+- (void)loadAndRun
+{
+    [self load];
+    [self run];
+}
+
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+{
+    if (result)
+        return;
+
+    if (!message.length)
+        message = @"Assertion failed with no message.";
+
+    ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, message.UTF8String) = ::testing::Message();
+}
+
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+{
+    if (result)
+        return;
+
+    if (!message.length)
+        message = @"Expected equality of these values";
+
+    ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, "") = ::testing::Message()
+        << message.UTF8String << ":\n"
+        << "  " << actualValue.UTF8String << "\n"
+        << "  " << expectedValue.UTF8String;
+}
+
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+{
+    printf("\n%s:%u\n%s\n\n", sourceURL.UTF8String, lineNumber, message.UTF8String);
+}
+
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestYieldedWithMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+{
+    _done = true;
+    _yieldMessage = [message copy];
+}
+
+- (void)_webExtensionController:(_WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber forExtensionContext:(_WKWebExtensionContext *)context
+{
+    _done = true;
+
+    if (result)
+        return;
+
+    if (!message.length)
+        message = @"Test failed with no message.";
+
+    ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, message.UTF8String) = ::testing::Message();
+}
+
+@end
+
+namespace TestWebKitAPI {
+namespace Util {
+
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(_WKWebExtension *extension)
+{
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initWithExtension:extension]);
+    [manager loadAndRun];
+    return manager;
+}
+
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources)
+{
+    return loadAndRunExtension([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+}
+
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSDictionary *resources)
+{
+    return loadAndRunExtension([[_WKWebExtension alloc] _initWithResources:resources]);
+}
+
+RetainPtr<TestWebExtensionManager> loadAndRunExtension(NSURL *baseURL)
+{
+    return loadAndRunExtension([[_WKWebExtension alloc] initWithResourceBaseURL:baseURL]);
+}
+
+} // namespace Util
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8f7a6bbb4ad4d9fd9a99bc158ade012bbf1a2c64
<pre>
Add browser.test interface for Web Extension API testing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248157">https://bugs.webkit.org/show_bug.cgi?id=248157</a>

Reviewed by Darin Adler.

This adds the `browser.test` APIs uses by Firefox and Chrome for extension unit tests.

The various assertion methods have default implementations that log to the system console
for testing in any client. However, a test harness like TestWebKitAPI can implement the
private delegate methods that allows it to tie into the gtest infrastructure. This allows
easy unit testing on the JavaScript extension APIs directly in TestWebKitAPI tests.

This change adds some unit tests for the existing `browser.runtime` and `browser.extension` APIs.

* Source/WebKit/DerivedSources-input.xcfilelist: Updated with the build.
* Source/WebKit/DerivedSources-output.xcfilelist: Ditto.
* Source/WebKit/DerivedSources.make: Added
* Source/WebKit/Shared/WebExtensionContextParameters.h: Added testingMode.
* Source/WebKit/Shared/WebExtensionContextParameters.serialization.in: Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext _inTestingMode]): Added.
(-[_WKWebExtensionContext _setTestingMode:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContextPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegatePrivate.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITestCocoa.mm: Added.
(WebKit::WebExtensionContext::testResult): Added.
(WebKit::WebExtensionContext::testEqual): Added.
(WebKit::WebExtensionContext::testMessage): Added.
(WebKit::WebExtensionContext::testYielded): Added.
(WebKit::WebExtensionContext::testFinished): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setTestingMode): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const): Set testingMode.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::inTestingMode const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in: Added test messages.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added new files.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Added. Don&apos;t allow test unless in testing mode.
(WebKit::WebExtensionAPINamespace::test): Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm: Added.
(WebKit::scriptLocation):
(WebKit::WebExtensionAPITest::notifyFail):
(WebKit::WebExtensionAPITest::notifyPass):
(WebKit::WebExtensionAPITest::yield):
(WebKit::WebExtensionAPITest::log):
(WebKit::WebExtensionAPITest::fail):
(WebKit::WebExtensionAPITest::succeed):
(WebKit::WebExtensionAPITest::assertTrue):
(WebKit::WebExtensionAPITest::assertFalse):
(WebKit::debugString):
(WebKit::WebExtensionAPITest::assertDeepEq):
(WebKit::WebExtensionAPITest::assertEq):
(WebKit::WebExtensionAPITest::assertRejects):
(WebKit::WebExtensionAPITest::assertThrows):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h: Added.
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::serializeJSObject): Use value instead of object for clarity.
(functionObjectByName): Removed.
(-[JSValue _toJSONString]): Added.
(-[JSValue _toSortedJSONString]): Added.
(-[JSValue _isFunction]): Added.
(-[JSValue _isRegularExpression]): Added.
(-[JSValue _isThenable]): Simplified by using JSValue instead of functionObjectByName().
(-[JSValue _awaitThenableResolutionWithCompletionHandler:]): Use better JSValue type for parameters.
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_installAutomaticExceptions): Check for ValuesAllowed attribute to about isObject check.
(_javaScriptTypeCondition): Ditto.
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/IDLAttributes.json: Added ValuesAllowed.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl: Added test attribute.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl: Added.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::getOrCreate): Set testingMode.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm: Added.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h: Added.
(TestWebKitAPI::Util::constructScript):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm: Added.
(-[TestWebExtensionManager initWithExtension:]):
(-[TestWebExtensionManager respondsToSelector:]):
(-[TestWebExtensionManager forwardingTargetForSelector:]):
(-[TestWebExtensionManager load]):
(-[TestWebExtensionManager run]):
(-[TestWebExtensionManager loadAndRun]):
(-[TestWebExtensionManager _webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:forExtensionContext:]):
(-[TestWebExtensionManager _webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:forExtensionContext:]):
(-[TestWebExtensionManager _webExtensionController:recordTestMessage:andSourceURL:lineNumber:forExtensionContext:]):
(-[TestWebExtensionManager _webExtensionController:recordTestYieldedWithMessage:andSourceURL:lineNumber:forExtensionContext:]):
(-[TestWebExtensionManager _webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:forExtensionContext:]):
(TestWebKitAPI::Util::loadAndRunExtension):

Canonical link: <a href="https://commits.webkit.org/256923@main">https://commits.webkit.org/256923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a52354aced5282f253d952b2ba79064671c069

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106777 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6814 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35256 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89651 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103463 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102921 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83886 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/86974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/543 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/527 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5326 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2345 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1767 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->