### PR TITLE
Remove version requirement in git-webkit for bugzilla and github

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -434,13 +434,13 @@ class Tracker(GenericTracker):
         if component not in self.projects[project]['components']:
             raise ValueError("'{}' is not a recognized component in '{}'".format(component, project))
 
-        if not version and len(self.projects[project]['versions']) == 1:
-            version = self.projects[project]['versions'][0]
-        elif not version:
-            version = webkitcorepy.Terminal.choose(
-                "What version of '{}' should the bug be associated with?".format(project),
-                options=self.projects[project]['versions'], numbered=True,
-            )
+        if not version:
+            # This is the default option, aligned to webkit-patch behavior.
+            # FIXME: We should make this class project agnostic by specifying this in trackers.json.
+            version = "WebKit Nightly Build"
+            if version not in self.projects[project]['versions']:
+                # If the default option does not exist on the list, we pick the last one from versions.
+                version = self.projects[project]['versions'][-1]
         if version not in self.projects[project]['versions']:
             raise ValueError("'{}' is not a recognized version for '{}'".format(version, project))
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -523,15 +523,9 @@ with 'repo' and 'workflow' access and appropriate 'Expiration' for your {host} u
             if component not in self.projects[project]['components']:
                 raise ValueError("'{}' is not a recognized component in '{}'".format(component, project))
 
-            if not version and len(self.projects[project]['versions']) == 1:
-                version = self.projects[project]['versions'][0]
-            elif not version:
-                version = webkitcorepy.Terminal.choose(
-                    "What version of '{}' should the bug be associated with?".format(project),
-                    options=self.projects[project]['versions'], numbered=True,
-                )
-            if version not in self.projects[project]['versions']:
-                raise ValueError("'{}' is not a recognized version for '{}'".format(version, project))
+            if version:
+                if version not in self.projects[project]['versions']:
+                    raise ValueError("'{}' is not a recognized version for '{}'".format(version, project))
 
         else:
             if project:

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -335,7 +335,6 @@ class TestBugzilla(unittest.TestCase):
 
             self.assertEqual(created.project, 'WebKit')
             self.assertEqual(created.component, 'SVG')
-            self.assertEqual(created.version, 'Safari 15')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -348,12 +347,6 @@ What component in 'WebKit' should the bug be associated with?:
     2) Scrolling
     3) Tables
     4) Text
-: 
-What version of 'WebKit' should the bug be associated with?:
-    1) Other
-    2) Safari 15
-    3) Safari Technology Preview
-    4) WebKit Local Build
 : 
 ''',
         )

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py
@@ -338,7 +338,6 @@ class TestGitHub(unittest.TestCase):
 
             self.assertEqual(created.project, 'WebKit')
             self.assertEqual(created.component, 'SVG')
-            self.assertEqual(created.version, 'Other')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -349,13 +348,6 @@ class TestGitHub(unittest.TestCase):
     4) Scrolling
     5) Tables
     6) Text
-: 
-What version of 'WebKit' should the bug be associated with?:
-    1) All
-    2) Other
-    3) Safari 15
-    4) Safari Technology Preview
-    5) WebKit Local Build
 : 
 ''',
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -251,7 +251,6 @@ class TestBranch(testing.PathTestCase):
             self.assertEqual(issue.description, 'Issue created via command line prompts.')
             self.assertEqual(issue.project, 'WebKit')
             self.assertEqual(issue.component, 'SVG')
-            self.assertEqual(issue.version, 'Safari 15')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -266,12 +265,6 @@ What component in 'WebKit' should the bug be associated with?:
     2) Scrolling
     3) Tables
     4) Text
-: 
-What version of 'WebKit' should the bug be associated with?:
-    1) Other
-    2) Safari 15
-    3) Safari Technology Preview
-    4) WebKit Local Build
 : 
 Created 'https://bugs.example.com/show_bug.cgi?id=4 [Area] New Issue'
 Created the local development branch 'eng/Area-New-Issue'


### PR DESCRIPTION
#### 1bbc66231a675bdb963ee6c1d7e1179869c8eda8
<pre>
Remove version requirement in git-webkit for bugzilla and github
<a href="https://bugs.webkit.org/show_bug.cgi?id=248163">https://bugs.webkit.org/show_bug.cgi?id=248163</a>
rdar://102571648

Reviewed by Darin Adler.

This patch removes asking version when creating a bugzilla entry from git-webkit since this was not happening in webkit-patch.
Since we do not have consensus on this addition, we should do the same thing to webkit-patch to reduce engineering burden.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_create_prompt):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_create_projects):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_create_bug):

Canonical link: <a href="https://commits.webkit.org/256961@main">https://commits.webkit.org/256961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8208017b4162f203ac3c8febaea5b8091ea3894d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106883 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6935 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35366 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89774 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/103029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83995 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100941 "Found 1 webkitpy python3 test failure: webkitcorepy.tests.file_lock_unittest.FileLockTestCase.test_locked_timeout") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/643 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/96301 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/625 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5429 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2360 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1871 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->