### PR TITLE
[GTK][WPE] Move WebKitWebView::context-menu signal declaration to platform specific files

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -745,6 +745,21 @@ list(APPEND WebKit_DEPENDENCIES
      WebKit-forwarding-headers
 )
 
+set(WEBKITGTK_SOURCES_FOR_INTROSPECTION
+    UIProcess/API/gtk/WebKitColorChooserRequest.cpp
+    UIProcess/API/gtk/WebKitInputMethodContextGtk.cpp
+    UIProcess/API/gtk/WebKitPrintCustomWidget.cpp
+    UIProcess/API/gtk/WebKitPrintOperation.cpp
+    UIProcess/API/gtk/WebKitWebInspector.cpp
+    UIProcess/API/gtk/WebKitWebViewGtk.cpp
+)
+
+if (USE_GTK4)
+    list(APPEND WEBKITGTK_SOURCES_FOR_INTROSPECTION UIProcess/API/gtk/WebKitWebViewGtk4.cpp)
+else ()
+    list(APPEND WEBKITGTK_SOURCES_FOR_INTROSPECTION UIProcess/API/gtk/WebKitWebViewGtk3.cpp)
+endif ()
+
 GI_INTROSPECT(WebKit${WEBKITGTK_API_INFIX} ${WEBKITGTK_API_VERSION} webkit${WEBKITGTK_API_INFIX}/webkit${WEBKITGTK_API_INFIX}.h
     TARGET WebKit
     PACKAGE webkit${WEBKITGTK_API_INFIX}gtk
@@ -756,9 +771,9 @@ GI_INTROSPECT(WebKit${WEBKITGTK_API_INFIX} ${WEBKITGTK_API_VERSION} webkit${WEBK
         Soup-${SOUP_API_VERSION}:libsoup-${SOUP_API_VERSION}
     SOURCES
         ${WebKitGTK_INSTALLED_HEADERS}
+        ${WEBKITGTK_SOURCES_FOR_INTROSPECTION}
         Shared/API/glib
         UIProcess/API/glib
-        UIProcess/API/gtk
     NO_IMPLICIT_SOURCES
 )
 GI_DOCGEN(WebKit${WEBKITGTK_API_INFIX} gtk/webkitgtk.toml.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -216,6 +216,8 @@ UIProcess/API/gtk/WebKitWebInspector.cpp @no-unify
 UIProcess/API/gtk/WebKitWebViewBase.cpp @no-unify
 UIProcess/API/gtk/WebKitWebViewDialog.cpp @no-unify
 UIProcess/API/gtk/WebKitWebViewGtk.cpp @no-unify
+UIProcess/API/gtk/WebKitWebViewGtk3.cpp @no-unify
+UIProcess/API/gtk/WebKitWebViewGtk4.cpp @no-unify
 
 UIProcess/API/soup/HTTPCookieStoreSoup.cpp
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -2011,76 +2011,7 @@ static void webkit_web_view_class_init(WebKitWebViewClass* webViewClass)
         G_TYPE_BOOLEAN, 1, /* number of parameters */
         WEBKIT_TYPE_FILE_CHOOSER_REQUEST);
 
-    // FIXME: We need a solution to split the documentation that doesn't break introspection.
-    /**
-     * WebKitWebView::context-menu:
-     * @web_view: the #WebKitWebView on which the signal is emitted
-     * @context_menu: the proposed #WebKitContextMenu
-     * @event: the #GdkEvent that triggered the context menu. Deprecated 2.40.
-     * @hit_test_result: a #WebKitHitTestResult
-     *
-     * Emitted when a context menu is about to be displayed to give the application
-     * a chance to customize the proposed menu, prevent the menu from being displayed,
-     * or build its own context menu.
-     * <itemizedlist>
-     * <listitem><para>
-     *  To customize the proposed menu you can use webkit_context_menu_prepend(),
-     *  webkit_context_menu_append() or webkit_context_menu_insert() to add new
-     *  #WebKitContextMenuItem<!-- -->s to @context_menu, webkit_context_menu_move_item()
-     *  to reorder existing items, or webkit_context_menu_remove() to remove an
-     *  existing item. The signal handler should return %FALSE, and the menu represented
-     *  by @context_menu will be shown.
-     * </para></listitem>
-     * <listitem><para>
-     *  To prevent the menu from being displayed you can just connect to this signal
-     *  and return %TRUE so that the proposed menu will not be shown.
-     * </para></listitem>
-     * <listitem><para>
-     *  To build your own menu, you can remove all items from the proposed menu with
-     *  webkit_context_menu_remove_all(), add your own items and return %FALSE so
-     *  that the menu will be shown. You can also ignore the proposed #WebKitContextMenu,
-     *  build your own #GtkMenu and return %TRUE to prevent the proposed menu from being shown.
-     * </para></listitem>
-     * <listitem><para>
-     *  If you just want the default menu to be shown always, simply don't connect to this
-     *  signal because showing the proposed context menu is the default behaviour.
-     * </para></listitem>
-     * </itemizedlist>
-     *
-     * The @event parameter is now deprecated, use webkit_context_menu_get_event() to get the
-     * #GdkEvent that triggered the context menu.
-     *
-     * If the signal handler returns %FALSE the context menu represented by @context_menu
-     * will be shown, if it return %TRUE the context menu will not be shown.
-     *
-     * The proposed #WebKitContextMenu passed in @context_menu argument is only valid
-     * during the signal emission.
-     *
-     * Returns: %TRUE to stop other handlers from being invoked for the event.
-     *    %FALSE to propagate the event further.
-     */
-    signals[CONTEXT_MENU] = g_signal_new(
-        "context-menu",
-        G_TYPE_FROM_CLASS(webViewClass),
-        G_SIGNAL_RUN_LAST,
-        G_STRUCT_OFFSET(WebKitWebViewClass, context_menu),
-        g_signal_accumulator_true_handled, nullptr,
-        g_cclosure_marshal_generic,
-        G_TYPE_BOOLEAN,
-#if ENABLE(2022_GLIB_API)
-        2,
-#else
-        3,
-#endif
-        WEBKIT_TYPE_CONTEXT_MENU,
-#if !ENABLE(2022_GLIB_API)
-#if PLATFORM(GTK)
-        GDK_TYPE_EVENT | G_SIGNAL_TYPE_STATIC_SCOPE,
-#elif PLATFORM(WPE)
-        G_TYPE_POINTER,
-#endif
-#endif
-        WEBKIT_TYPE_HIT_TEST_RESULT);
+    signals[CONTEXT_MENU] = createContextMenuSignal(webViewClass);
 
     /**
      * WebKitWebView::context-menu-dismissed:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -325,17 +325,16 @@ struct _WebKitWebViewClass {
     gboolean   (* run_file_chooser)            (WebKitWebView               *web_view,
                                                 WebKitFileChooserRequest    *request);
 
+    gboolean   (* context_menu)                (WebKitWebView               *web_view,
+                                                WebKitContextMenu           *context_menu,
+#if !ENABLE(2022_GLIB_API)
 #if PLATFORM(GTK)
-    gboolean   (* context_menu)                (WebKitWebView               *web_view,
-                                                WebKitContextMenu           *context_menu,
                                                 GdkEvent                    *event,
-                                                WebKitHitTestResult         *hit_test_result);
 #elif PLATFORM(WPE)
-    gboolean   (* context_menu)                (WebKitWebView               *web_view,
-                                                WebKitContextMenu           *context_menu,
-                                                void                        *event, /* FIXME: Use a wpe thing here. I'm not sure we want to expose libwpe in the API. */
-                                                WebKitHitTestResult         *hit_test_result);
+                                                void                        *event,
 #endif
+#endif
+                                                WebKitHitTestResult         *hit_test_result);
 
     void       (* context_menu_dismissed)      (WebKitWebView               *web_view);
     void       (* submit_form)                 (WebKitWebView               *web_view,

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -128,3 +128,4 @@ void webkitWebViewDeleteSurrounding(WebKitWebView*, int offset, unsigned charact
 void webkitWebViewSetIsWebProcessResponsive(WebKitWebView*, bool);
 
 guint createShowOptionMenuSignal(WebKitWebViewClass*);
+guint createContextMenuSignal(WebKitWebViewClass*);

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk3.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitWebView.h"
+
+#include <gtk/gtk.h>
+
+#if !USE(GTK4)
+guint createContextMenuSignal(WebKitWebViewClass* webViewClass)
+{
+    /**
+     * WebKitWebView::context-menu:
+     * @web_view: the #WebKitWebView on which the signal is emitted
+     * @context_menu: the proposed #WebKitContextMenu
+     * @event: the #GdkEvent that triggered the context menu. Deprecated 2.40.
+     * @hit_test_result: a #WebKitHitTestResult
+     *
+     * Emitted when a context menu is about to be displayed to give the application
+     * a chance to customize the proposed menu, prevent the menu from being displayed,
+     * or build its own context menu.
+     * <itemizedlist>
+     * <listitem><para>
+     *  To customize the proposed menu you can use webkit_context_menu_prepend(),
+     *  webkit_context_menu_append() or webkit_context_menu_insert() to add new
+     *  #WebKitContextMenuItem<!-- -->s to @context_menu, webkit_context_menu_move_item()
+     *  to reorder existing items, or webkit_context_menu_remove() to remove an
+     *  existing item. The signal handler should return %FALSE, and the menu represented
+     *  by @context_menu will be shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  To prevent the menu from being displayed you can just connect to this signal
+     *  and return %TRUE so that the proposed menu will not be shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  To build your own menu, you can remove all items from the proposed menu with
+     *  webkit_context_menu_remove_all(), add your own items and return %FALSE so
+     *  that the menu will be shown. You can also ignore the proposed #WebKitContextMenu,
+     *  build your own #GtkMenu and return %TRUE to prevent the proposed menu from being shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  If you just want the default menu to be shown always, simply don't connect to this
+     *  signal because showing the proposed context menu is the default behaviour.
+     * </para></listitem>
+     * </itemizedlist>
+     *
+     * The @event parameter is now deprecated. Use webkit_context_menu_get_event() to get the
+     * #GdkEvent that triggered the context menu.
+     *
+     * If the signal handler returns %FALSE the context menu represented by @context_menu
+     * will be shown, if it return %TRUE the context menu will not be shown.
+     *
+     * The proposed #WebKitContextMenu passed in @context_menu argument is only valid
+     * during the signal emission.
+     *
+     * Returns: %TRUE to stop other handlers from being invoked for the event.
+     *    %FALSE to propagate the event further.
+     */
+    return g_signal_new(
+        "context-menu",
+        G_TYPE_FROM_CLASS(webViewClass),
+        G_SIGNAL_RUN_LAST,
+        G_STRUCT_OFFSET(WebKitWebViewClass, context_menu),
+        g_signal_accumulator_true_handled, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_BOOLEAN,
+        3,
+        WEBKIT_TYPE_CONTEXT_MENU,
+        GDK_TYPE_EVENT | G_SIGNAL_TYPE_STATIC_SCOPE,
+        WEBKIT_TYPE_HIT_TEST_RESULT);
+}
+#endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk4.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitWebView.h"
+
+#include <gtk/gtk.h>
+
+#if USE(GTK4)
+guint createContextMenuSignal(WebKitWebViewClass* webViewClass)
+{
+    /**
+     * WebKitWebView::context-menu:
+     * @web_view: the #WebKitWebView on which the signal is emitted
+     * @context_menu: the proposed #WebKitContextMenu
+     * @hit_test_result: a #WebKitHitTestResult
+     *
+     * Emitted when a context menu is about to be displayed to give the application
+     * a chance to customize the proposed menu, prevent the menu from being displayed,
+     * or build its own context menu.
+     * <itemizedlist>
+     * <listitem><para>
+     *  To customize the proposed menu you can use webkit_context_menu_prepend(),
+     *  webkit_context_menu_append() or webkit_context_menu_insert() to add new
+     *  #WebKitContextMenuItem<!-- -->s to @context_menu, webkit_context_menu_move_item()
+     *  to reorder existing items, or webkit_context_menu_remove() to remove an
+     *  existing item. The signal handler should return %FALSE, and the menu represented
+     *  by @context_menu will be shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  To prevent the menu from being displayed you can just connect to this signal
+     *  and return %TRUE so that the proposed menu will not be shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  To build your own menu, you can remove all items from the proposed menu with
+     *  webkit_context_menu_remove_all(), add your own items and return %FALSE so
+     *  that the menu will be shown. You can also ignore the proposed #WebKitContextMenu,
+     *  build your own #GtkMenu and return %TRUE to prevent the proposed menu from being shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  If you just want the default menu to be shown always, simply don't connect to this
+     *  signal because showing the proposed context menu is the default behaviour.
+     * </para></listitem>
+     * </itemizedlist>
+     *
+     * If the signal handler returns %FALSE the context menu represented by @context_menu
+     * will be shown, if it return %TRUE the context menu will not be shown.
+     *
+     * The proposed #WebKitContextMenu passed in @context_menu argument is only valid
+     * during the signal emission.
+     *
+     * Returns: %TRUE to stop other handlers from being invoked for the event.
+     *    %FALSE to propagate the event further.
+     */
+    return g_signal_new(
+        "context-menu",
+        G_TYPE_FROM_CLASS(webViewClass),
+        G_SIGNAL_RUN_LAST,
+        G_STRUCT_OFFSET(WebKitWebViewClass, context_menu),
+        g_signal_accumulator_true_handled, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_BOOLEAN,
+        2,
+        WEBKIT_TYPE_CONTEXT_MENU,
+        WEBKIT_TYPE_HIT_TEST_RESULT);
+}
+#endif

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp
@@ -238,6 +238,64 @@ void webkit_web_view_get_background_color(WebKitWebView* webView, WebKitColor* c
     webkitColorFillFromWebCoreColor(webCoreColor.value_or(WebCore::Color::white), color);
 }
 
+guint createContextMenuSignal(WebKitWebViewClass* webViewClass)
+{
+    /**
+     * WebKitWebView::context-menu:
+     * @web_view: the #WebKitWebView on which the signal is emitted
+     * @context_menu: the proposed #WebKitContextMenu
+     * @hit_test_result: a #WebKitHitTestResult
+     *
+     * Emitted when a context menu is about to be displayed to give the application
+     * a chance to customize the proposed menu, prevent the menu from being displayed,
+     * or build its own context menu.
+     * <itemizedlist>
+     * <listitem><para>
+     *  To customize the proposed menu you can use webkit_context_menu_prepend(),
+     *  webkit_context_menu_append() or webkit_context_menu_insert() to add new
+     *  #WebKitContextMenuItem<!-- -->s to @context_menu, webkit_context_menu_move_item()
+     *  to reorder existing items, or webkit_context_menu_remove() to remove an
+     *  existing item. The signal handler should return %FALSE, and the menu represented
+     *  by @context_menu will be shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  To prevent the menu from being displayed you can just connect to this signal
+     *  and return %TRUE so that the proposed menu will not be shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  To build your own menu, you can remove all items from the proposed menu with
+     *  webkit_context_menu_remove_all(), add your own items and return %FALSE so
+     *  that the menu will be shown. You can also ignore the proposed #WebKitContextMenu,
+     *  build your own menu and return %TRUE to prevent the proposed menu from being shown.
+     * </para></listitem>
+     * <listitem><para>
+     *  If you just want the default menu to be shown always, simply don't connect to this
+     *  signal because showing the proposed context menu is the default behaviour.
+     * </para></listitem>
+     * </itemizedlist>
+     *
+     * If the signal handler returns %FALSE the context menu represented by @context_menu
+     * will be shown, if it return %TRUE the context menu will not be shown.
+     *
+     * The proposed #WebKitContextMenu passed in @context_menu argument is only valid
+     * during the signal emission.
+     *
+     * Returns: %TRUE to stop other handlers from being invoked for the event.
+     *    %FALSE to propagate the event further.
+     */
+    return g_signal_new(
+        "context-menu",
+        G_TYPE_FROM_CLASS(webViewClass),
+        G_SIGNAL_RUN_LAST,
+        G_STRUCT_OFFSET(WebKitWebViewClass, context_menu),
+        g_signal_accumulator_true_handled, nullptr,
+        g_cclosure_marshal_generic,
+        G_TYPE_BOOLEAN,
+        2,
+        WEBKIT_TYPE_CONTEXT_MENU,
+        WEBKIT_TYPE_HIT_TEST_RESULT);
+}
+
 guint createShowOptionMenuSignal(WebKitWebViewClass* webViewClass)
 {
     /**


### PR DESCRIPTION
#### da67032774ee7d7d35ad2746bb374d2f1ef2fc0d
<pre>
[GTK][WPE] Move WebKitWebView::context-menu signal declaration to platform specific files
<a href="https://bugs.webkit.org/show_bug.cgi?id=248142">https://bugs.webkit.org/show_bug.cgi?id=248142</a>

Reviewed by Žan Doberšek.

Similar to what we did for option-menu signal we need to move the
context-menu signal declaration to WebKitWebViewWPE.cpp,
WebKitWebViewGtk3.cpp and WebKitWebViewGtk4.cpp to not confuse
introspection.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk3.cpp: Added.
(createContextMenuSignal):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewGtk4.cpp: Added.
(createContextMenuSignal):
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewWPE.cpp:
(createContextMenuSignal):

Canonical link: <a href="https://commits.webkit.org/256902@main">https://commits.webkit.org/256902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1361c0d8e065b31cdf8a21b261fe66b6f18a44a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106688 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6711 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35171 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103378 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102837 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83796 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86892 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/74929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/459 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/443 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21646 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5241 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2334 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/40962 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->