### PR TITLE
Creation of remote audio rendering internal unit is needlessly complex

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
@@ -51,9 +51,13 @@ namespace WebCore {
 class LocalAudioMediaStreamTrackRendererInternalUnit final : public AudioMediaStreamTrackRendererInternalUnit {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    LocalAudioMediaStreamTrackRendererInternalUnit(RenderCallback&&, ResetCallback&&);
+    static UniqueRef<AudioMediaStreamTrackRendererInternalUnit> create(Client& client)
+    {
+        return UniqueRef<LocalAudioMediaStreamTrackRendererInternalUnit> { *new LocalAudioMediaStreamTrackRendererInternalUnit { client } };
+    }
 
 private:
+    explicit LocalAudioMediaStreamTrackRendererInternalUnit(Client&);
     void createAudioUnitIfNeeded();
 
     // AudioMediaStreamTrackRendererInternalUnit API.
@@ -65,8 +69,7 @@ private:
     OSStatus render(AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32 sampleCount, AudioBufferList*);
     static OSStatus renderingCallback(void*, AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32 inBusNumber, UInt32 sampleCount, AudioBufferList*);
 
-    RenderCallback m_renderCallback;
-    ResetCallback m_resetCallback;
+    Client& m_client;
     std::optional<CAAudioStreamDescription> m_outputDescription;
     AudioComponentInstance m_remoteIOUnit { nullptr };
     bool m_isStarted { false };
@@ -76,14 +79,9 @@ private:
 #endif
 };
 
-UniqueRef<AudioMediaStreamTrackRendererInternalUnit> AudioMediaStreamTrackRendererInternalUnit::createLocalInternalUnit(RenderCallback&& renderCallback, ResetCallback&& resetCallback)
-{
-    return makeUniqueRef<LocalAudioMediaStreamTrackRendererInternalUnit>(WTFMove(renderCallback), WTFMove(resetCallback));
-}
 
-LocalAudioMediaStreamTrackRendererInternalUnit::LocalAudioMediaStreamTrackRendererInternalUnit(RenderCallback&& renderCallback, ResetCallback&& resetCallback)
-    : m_renderCallback(WTFMove(renderCallback))
-    , m_resetCallback(WTFMove(resetCallback))
+LocalAudioMediaStreamTrackRendererInternalUnit::LocalAudioMediaStreamTrackRendererInternalUnit(Client& client)
+    : m_client(client)
 {
 }
 
@@ -276,10 +274,10 @@ OSStatus LocalAudioMediaStreamTrackRendererInternalUnit::render(AudioUnitRenderA
     auto sampleTime = timeStamp->mSampleTime;
     // If we observe an irregularity in the timeline, we trigger a reset.
     if (m_sampleTime && (m_sampleTime + 2 * sampleCount < sampleTime || sampleTime <= m_sampleTime))
-        m_resetCallback();
+        m_client.reset();
     m_sampleTime = sampleTime < std::numeric_limits<Float64>::max() - sampleCount ? sampleTime : 0;
 
-    auto result = m_renderCallback(sampleCount, *ioData, sampleTime, timeStamp->mHostTime, *actionFlags);
+    auto result = m_client.render(sampleCount, *ioData, sampleTime, timeStamp->mHostTime, *actionFlags);
     // FIXME: We should probably introduce a limiter to limit the amount of clipping.
     clipAudioBufferList(*ioData, m_outputDescription->format());
     return result;
@@ -288,6 +286,19 @@ OSStatus LocalAudioMediaStreamTrackRendererInternalUnit::render(AudioUnitRenderA
 OSStatus LocalAudioMediaStreamTrackRendererInternalUnit::renderingCallback(void* processor, AudioUnitRenderActionFlags* actionFlags, const AudioTimeStamp* timeStamp, UInt32, UInt32 sampleCount, AudioBufferList* ioData)
 {
     return static_cast<LocalAudioMediaStreamTrackRendererInternalUnit*>(processor)->render(actionFlags, timeStamp, sampleCount, ioData);
+}
+
+static auto createInternalUnit = LocalAudioMediaStreamTrackRendererInternalUnit::create;
+
+void AudioMediaStreamTrackRendererInternalUnit::setCreateFunction(CreateFunction function)
+{
+    ASSERT(function);
+    createInternalUnit = function;
+}
+
+UniqueRef<AudioMediaStreamTrackRendererInternalUnit> AudioMediaStreamTrackRendererInternalUnit::create(Client& client)
+{
+    return createInternalUnit(client);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -38,11 +38,16 @@ class CAAudioStreamDescription;
 class AudioMediaStreamTrackRendererInternalUnit {
 public:
     virtual ~AudioMediaStreamTrackRendererInternalUnit() = default;
+    class Client {
+    public:
+        virtual ~Client() = default;
+        virtual OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) = 0;
+        virtual void reset() = 0;
+    };
+    WEBCORE_EXPORT static UniqueRef<AudioMediaStreamTrackRendererInternalUnit> create(Client&);
 
-    using RenderCallback = Function<OSStatus(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&)>;
-    using ResetCallback = Function<void()>;
-    WEBCORE_EXPORT static UniqueRef<AudioMediaStreamTrackRendererInternalUnit> createLocalInternalUnit(RenderCallback&&, ResetCallback&&);
-
+    using CreateFunction = UniqueRef<AudioMediaStreamTrackRendererInternalUnit>(*)(AudioMediaStreamTrackRendererInternalUnit::Client&);
+    WEBCORE_EXPORT static void setCreateFunction(CreateFunction);
     virtual void start() = 0;
     virtual void stop() = 0;
     virtual void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&) = 0;

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -33,32 +33,6 @@
 
 namespace WebCore {
 
-static AudioMediaStreamTrackRendererUnit::CreateInternalUnitFunction& getCreateInternalUnitFunction()
-{
-    static NeverDestroyed<AudioMediaStreamTrackRendererUnit::CreateInternalUnitFunction> function;
-    return function;
-}
-
-void AudioMediaStreamTrackRendererUnit::setCreateInternalUnitFunction(CreateInternalUnitFunction&& function)
-{
-    getCreateInternalUnitFunction() = WTFMove(function);
-}
-
-static UniqueRef<AudioMediaStreamTrackRendererInternalUnit> createInternalUnit(AudioMediaStreamTrackRendererUnit& unit)
-{
-    AudioMediaStreamTrackRendererInternalUnit::RenderCallback renderCallback = [&unit](auto sampleCount, auto& list, auto sampleTime, auto hostTime, auto& flags) {
-        unit.render(sampleCount, list, sampleTime, hostTime, flags);
-        return 0;
-    };
-    AudioMediaStreamTrackRendererInternalUnit::ResetCallback resetCallback = [&unit]() { unit.reset(); };
-
-    auto& function = getCreateInternalUnitFunction();
-    if (function)
-        return function(WTFMove(renderCallback), WTFMove(resetCallback));
-
-    return AudioMediaStreamTrackRendererInternalUnit::createLocalInternalUnit(WTFMove(renderCallback), WTFMove(resetCallback));
-}
-
 AudioMediaStreamTrackRendererUnit& AudioMediaStreamTrackRendererUnit::singleton()
 {
     static NeverDestroyed<AudioMediaStreamTrackRendererUnit> registry;
@@ -66,7 +40,7 @@ AudioMediaStreamTrackRendererUnit& AudioMediaStreamTrackRendererUnit::singleton(
 }
 
 AudioMediaStreamTrackRendererUnit::AudioMediaStreamTrackRendererUnit()
-    : m_internalUnit(createInternalUnit(*this))
+    : m_internalUnit(AudioMediaStreamTrackRendererInternalUnit::create(*this))
 {
 }
 
@@ -174,7 +148,7 @@ void AudioMediaStreamTrackRendererUnit::updateRenderSourcesIfNecessary()
     m_hasPendingRenderSources = false;
 }
 
-void AudioMediaStreamTrackRendererUnit::render(size_t sampleCount, AudioBufferList& ioData, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags& actionFlags)
+OSStatus AudioMediaStreamTrackRendererUnit::render(size_t sampleCount, AudioBufferList& ioData, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags& actionFlags)
 {
     // For performance reasons, we forbid heap allocations while doing rendering on the audio thread.
     ForbidMallocUseForCurrentThreadScope forbidMallocUse;
@@ -191,6 +165,7 @@ void AudioMediaStreamTrackRendererUnit::render(size_t sampleCount, AudioBufferLi
     }
     if (!hasCopiedData)
         actionFlags = kAudioUnitRenderAction_OutputIsSilence;
+    return 0;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h
@@ -40,20 +40,17 @@ namespace WebCore {
 class AudioSampleDataSource;
 class AudioSampleBufferList;
 class CAAudioStreamDescription;
-class AudioMediaStreamTrackRendererInternalUnit;
 
-class AudioMediaStreamTrackRendererUnit : public BaseAudioMediaStreamTrackRendererUnit, public CanMakeWeakPtr<AudioMediaStreamTrackRendererUnit, WeakPtrFactoryInitialization::Eager> {
+class AudioMediaStreamTrackRendererUnit : public BaseAudioMediaStreamTrackRendererUnit, public CanMakeWeakPtr<AudioMediaStreamTrackRendererUnit, WeakPtrFactoryInitialization::Eager>, AudioMediaStreamTrackRendererInternalUnit::Client {
 public:
     WEBCORE_EXPORT static AudioMediaStreamTrackRendererUnit& singleton();
 
     AudioMediaStreamTrackRendererUnit();
     ~AudioMediaStreamTrackRendererUnit();
 
-    using CreateInternalUnitFunction = Function<UniqueRef<AudioMediaStreamTrackRendererInternalUnit>(AudioMediaStreamTrackRendererInternalUnit::RenderCallback&&, AudioMediaStreamTrackRendererInternalUnit::ResetCallback&&)>;
-    WEBCORE_EXPORT static void setCreateInternalUnitFunction(CreateInternalUnitFunction&&);
-
-    WEBCORE_EXPORT void render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&);
-    void reset();
+    // AudioMediaStreamTrackRendererInternalUnit
+    OSStatus render(size_t sampleCount, AudioBufferList&, uint64_t sampleTime, double hostTime, AudioUnitRenderActionFlags&) final;
+    void reset() final;
 
     void retrieveFormatDescription(CompletionHandler<void(std::optional<CAAudioStreamDescription>)>&&);
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h
@@ -47,8 +47,6 @@ class AudioMediaStreamTrackRendererInternalUnitManager {
 public:
     AudioMediaStreamTrackRendererInternalUnitManager() = default;
 
-    UniqueRef<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteInternalUnit(WebCore::AudioMediaStreamTrackRendererInternalUnit::RenderCallback&&, WebCore::AudioMediaStreamTrackRendererInternalUnit::ResetCallback&&);
-
     class Proxy;
     void add(Proxy&);
     void remove(Proxy&);
@@ -59,6 +57,8 @@ public:
 private:
     HashMap<AudioMediaStreamTrackRendererInternalUnitIdentifier, WeakPtr<Proxy>> m_proxies;
 };
+
+UniqueRef<WebCore::AudioMediaStreamTrackRendererInternalUnit> createRemoteAudioMediaStreamTrackRendererInternalUnitProxy(WebCore::AudioMediaStreamTrackRendererInternalUnit::Client&);
 
 }
 

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -82,11 +82,8 @@ void UserMediaCaptureManager::setupCaptureProcesses(bool shouldCaptureAudioInUIP
     m_videoFactory.setShouldCaptureInGPUProcess(shouldCaptureVideoInGPUProcess);
     m_displayFactory.setShouldCaptureInGPUProcess(shouldCaptureDisplayInGPUProcess);
 
-    if (shouldCaptureAudioInGPUProcess) {
-        WebCore::AudioMediaStreamTrackRendererUnit::setCreateInternalUnitFunction([](auto&& renderCallback, auto&& resetCallback) {
-            return WebProcess::singleton().audioMediaStreamTrackRendererInternalUnitManager().createRemoteInternalUnit(WTFMove(renderCallback), WTFMove(resetCallback));
-        });
-    }
+    if (shouldCaptureAudioInGPUProcess)
+        WebCore::AudioMediaStreamTrackRendererInternalUnit::setCreateFunction(createRemoteAudioMediaStreamTrackRendererInternalUnitProxy);
 
     if (shouldCaptureAudioInUIProcess || shouldCaptureAudioInGPUProcess)
         RealtimeMediaSourceCenter::singleton().setAudioCaptureFactory(m_audioFactory);


### PR DESCRIPTION
#### 6dc0b32040a92f08d8a14b620c19fbd629d6ea12
<pre>
Creation of remote audio rendering internal unit is needlessly complex
<a href="https://bugs.webkit.org/show_bug.cgi?id=248168">https://bugs.webkit.org/show_bug.cgi?id=248168</a>
rdar://problem/102577160

Reviewed by Darin Adler.

It takes two Functions that capture the same creator instance.
The creation is configured with a third Function.

Replace the two Functions with just a normal Client interface.

Replace the global factory Function with a normal function pointer.

Rename the creating functions to be just normal Class::create(...).

* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererInternalUnit::setCreateFunction):
(WebCore::AudioMediaStreamTrackRendererInternalUnit::create):
(WebCore::AudioMediaStreamTrackRendererInternalUnit::createLocalInternalUnit): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::LocalAudioMediaStreamTrackRendererInternalUnit): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::retrieveFormatDescription): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::setAudioOutputDevice): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::start): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::stop): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded): Deleted.
(WebCore::clipAudioBuffer): Deleted.
(WebCore::clipAudioBufferList): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::render): Deleted.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::renderingCallback): Deleted.
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::AudioMediaStreamTrackRendererUnit):
(WebCore::AudioMediaStreamTrackRendererUnit::render):
(WebCore::getCreateInternalUnitFunction): Deleted.
(WebCore::AudioMediaStreamTrackRendererUnit::setCreateInternalUnitFunction): Deleted.
(WebCore::createInternalUnit): Deleted.
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::Unit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::reset):
(WebKit::renderCallback): Deleted.
(WebKit::resetCallback): Deleted.
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::notifyReset): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::createRemoteAudioMediaStreamTrackRendererInternalUnitProxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::Proxy):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::startThread):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::Proxy::reset):
(WebKit::AudioMediaStreamTrackRendererInternalUnitManager::createRemoteInternalUnit): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/AudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::setupCaptureProcesses):

Canonical link: <a href="https://commits.webkit.org/256969@main">https://commits.webkit.org/256969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02791ca566e1245d14fcad8d294cde41c5accd3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106906 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167172 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6963 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35394 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103582 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103050 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84019 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32229 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87090 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75154 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/664 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/647 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21831 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4804 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5453 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41180 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->