### PR TITLE
[Cocoa] Add conversion functions from native modifier types to OptionSet<WebKit::WebEventModifier>

### DIFF
--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.h
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@ public:
     static WebKit::WebWheelEvent createWebWheelEvent(UIScrollEvent *, UIView *contentView, std::optional<WebKit::WebWheelEvent::Phase> overridePhase = std::nullopt);
 #endif
 
+    static OptionSet<WebKit::WebEventModifier> webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags);
     static UIKeyModifierFlags toUIKeyModifierFlags(OptionSet<WebKit::WebEventModifier>);
 };
 

--- a/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
+++ b/Source/WebKit/Shared/ios/WebIOSEventFactory.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,22 @@
 #import <WebCore/KeyEventCodesIOS.h>
 #import <WebCore/PlatformEventFactoryIOS.h>
 #import <WebCore/Scrollbar.h>
+
+OptionSet<WebKit::WebEventModifier> WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags modifierFlags)
+{
+    OptionSet<WebKit::WebEventModifier> modifiers;
+    if (modifierFlags & UIKeyModifierShift)
+        modifiers.add(WebKit::WebEventModifier::ShiftKey);
+    if (modifierFlags & UIKeyModifierControl)
+        modifiers.add(WebKit::WebEventModifier::ControlKey);
+    if (modifierFlags & UIKeyModifierAlternate)
+        modifiers.add(WebKit::WebEventModifier::AltKey);
+    if (modifierFlags & UIKeyModifierCommand)
+        modifiers.add(WebKit::WebEventModifier::MetaKey);
+    if (modifierFlags & UIKeyModifierAlphaShift)
+        modifiers.add(WebKit::WebEventModifier::CapsLockKey);
+    return modifiers;
+}
 
 UIKeyModifierFlags WebIOSEventFactory::toUIKeyModifierFlags(OptionSet<WebKit::WebEventModifier> modifiers)
 {

--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,6 +53,7 @@ public:
     static bool shouldBeHandledAsContextClick(const WebCore::PlatformMouseEvent&);
 
 #if defined(__OBJC__)
+    static OptionSet<WebKit::WebEventModifier> webEventModifiersForNSEventModifierFlags(NSEventModifierFlags);
     static NSEventModifierFlags toNSEventModifierFlags(OptionSet<WebKit::WebEventModifier>);
     static NSInteger toNSButtonNumber(WebKit::WebMouseEventButton);
 #endif

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,6 +30,7 @@
 
 #import "Logging.h"
 #import "WebAutomationSessionMacros.h"
+#import "WebEventFactory.h"
 #import "WebInspectorUIProxy.h"
 #import "WebPageProxy.h"
 #import "WKWebViewPrivate.h"
@@ -253,20 +254,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 
 OptionSet<WebEventModifier> WebAutomationSession::platformWebModifiersFromRaw(unsigned modifiers)
 {
-    OptionSet<WebEventModifier> webModifiers;
-
-    if (modifiers & NSEventModifierFlagCommand)
-        webModifiers.add(WebEventModifier::MetaKey);
-    if (modifiers & NSEventModifierFlagOption)
-        webModifiers.add(WebEventModifier::AltKey);
-    if (modifiers & NSEventModifierFlagControl)
-        webModifiers.add(WebEventModifier::ControlKey);
-    if (modifiers & NSEventModifierFlagShift)
-        webModifiers.add(WebEventModifier::ShiftKey);
-    if (modifiers & NSEventModifierFlagCapsLock)
-        webModifiers.add(WebEventModifier::CapsLockKey);
-
-    return webModifiers;
+    return WebEventFactory::webEventModifiersForNSEventModifierFlags(modifiers);
 }
 
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)

--- a/Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.mm
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2019 Apple Inc. All rights reserved.
+* Copyright (C) 2019-2022 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -29,25 +29,10 @@
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 
 #import "NativeWebMouseEvent.h"
+#import "WebIOSEventFactory.h"
 #import <pal/spi/ios/GraphicsServicesSPI.h>
 #import <wtf/Compiler.h>
 #import <wtf/MonotonicTime.h>
-
-static OptionSet<WebKit::WebEventModifier> webEventModifiersForUIKeyModifierFlags(UIKeyModifierFlags flags)
-{
-    OptionSet<WebKit::WebEventModifier> modifiers;
-    if (flags & UIKeyModifierShift)
-        modifiers.add(WebKit::WebEventModifier::ShiftKey);
-    if (flags & UIKeyModifierControl)
-        modifiers.add(WebKit::WebEventModifier::ControlKey);
-    if (flags & UIKeyModifierAlternate)
-        modifiers.add(WebKit::WebEventModifier::AltKey);
-    if (flags & UIKeyModifierCommand)
-        modifiers.add(WebKit::WebEventModifier::MetaKey);
-    if (flags & UIKeyModifierAlphaShift)
-        modifiers.add(WebKit::WebEventModifier::CapsLockKey);
-    return modifiers;
-}
 
 @implementation WKMouseGestureRecognizer {
     RetainPtr<UIEvent> _currentHoverEvent;
@@ -119,7 +104,7 @@ static String pointerTypeForUITouchType(UITouchType type)
 
 - (std::unique_ptr<WebKit::NativeWebMouseEvent>)createMouseEventWithType:(WebKit::WebEvent::Type)type wasCancelled:(BOOL)cancelled
 {
-    auto modifiers = webEventModifiersForUIKeyModifierFlags(self.modifierFlags);
+    auto modifiers = WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags(self.modifierFlags);
     BOOL isRightButton = modifiers.contains(WebKit::WebEventModifier::ControlKey) || (_pressedButtonMask && (*_pressedButtonMask & UIEventButtonMaskSecondary));
 
     auto button = [&] {


### PR DESCRIPTION
#### 8996a7f84e0fde0d7b15e727404daea7b8db8dc6
<pre>
[Cocoa] Add conversion functions from native modifier types to OptionSet&lt;WebKit::WebEventModifier&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=248162">https://bugs.webkit.org/show_bug.cgi?id=248162</a>
&lt;rdar://102571520&gt;

Reviewed by Darin Adler and Timothy Hatcher.

Define conversion functions from native modifier types to
OptionSet&lt;WebKit::WebEventModifier&gt; to make it easier to reuse
this code.

* Source/WebKit/Shared/ios/WebIOSEventFactory.h:
(WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags): Add.
* Source/WebKit/Shared/ios/WebIOSEventFactory.mm:
(WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags): Add.
- Move here from WKMouseGestureRecognizer.mm.

* Source/WebKit/Shared/mac/WebEventFactory.h:
(WebKit::WebEventFactory::webEventModifiersForNSEventModifierFlags): Add.
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::modifiersForEvent): Delete.
(WebKit::WebEventFactory::createWebMouseEvent):
(WebKit::WebEventFactory::createWebWheelEvent):
(WebKit::WebEventFactory::createWebKeyboardEvent):
- Switch to use webEventModifiersForNSEventModifierFlags().
(WebKit::WebEventFactory::webEventModifiersForNSEventModifierFlags): Add.
- Move and rename from modifiersForEvent().  Change argument
  type from native event to native modifier flags.

* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::platformWebModifiersFromRaw):
- Remove duplicate code by calling
  WebEventFactory::webEventModifiersForNSEventModifierFlags().
* Source/WebKit/UIProcess/ios/WKMouseGestureRecognizer.mm:
(webEventModifiersForUIKeyModifierFlags): Delete.
- Move to WebIOSEventFactory.mm.
(-[WKMouseGestureRecognizer createMouseEventWithType:wasCancelled:]):
- Switch to use
  WebIOSEventFactory::webEventModifiersForUIKeyModifierFlags().

Canonical link: <a href="https://commits.webkit.org/256942@main">https://commits.webkit.org/256942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc0076a62cceeac0779358c66bbb71753204b7b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106836 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6882 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35318 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89727 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102980 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83946 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/597 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/580 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5380 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2352 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41107 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->