### PR TITLE
AlternativeTextType as enum class with EnumTraits and serialization

### DIFF
--- a/LayoutTests/ipc/webpageproxy-correctionpanel-no-crash-expected.txt
+++ b/LayoutTests/ipc/webpageproxy-correctionpanel-no-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/webpageproxy-correctionpanel-no-crash.html
+++ b/LayoutTests/ipc/webpageproxy-correctionpanel-no-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+if (window.IPC)
+    IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_ShowCorrectionPanel.name,[{type: 'uint8_t',value: 120},{type: 'float',value: 134.3630587066791},{type: 'float',value: 659.5882936421311},{type: 'float',value: 249},{type: 'uint8_t',value: 3},{type: 'String',value: ""},{type: 'String',value: ""},{type: 'Vector',value: [[{type: 'String',value: "cancelOperation"}],[{type: 'String',value: ""}],[{type: 'String',value: "page-9"}],[{type: 'String',value: ""}],[{type: 'String',value: "cancelOperation"}],[{type: 'String',value: "file:///tmp/ipcfuzz"}],[{type: 'String',value: ""}],[{type: 'String',value: "com.apple.pasteboard.clipboard"}]]}]);
+</script>
+This test passes if it does not crash.
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3320,7 +3320,7 @@ void Editor::addTextToKillRing(const String& text, KillRingInsertionMode mode)
 
 void Editor::startAlternativeTextUITimer()
 {
-    m_alternativeTextController->startAlternativeTextUITimer(AlternativeTextTypeCorrection);
+    m_alternativeTextController->startAlternativeTextUITimer(AlternativeTextType::Correction);
 }
 
 void Editor::handleAlternativeTextUIResult(const String& correction)

--- a/Source/WebCore/page/AlternativeTextClient.h
+++ b/Source/WebCore/page/AlternativeTextClient.h
@@ -38,11 +38,11 @@ enum ReasonForDismissingAlternativeText {
     ReasonForDismissingAlternativeTextAccepted
 };
 
-enum AlternativeTextType {
-    AlternativeTextTypeCorrection = 0,
-    AlternativeTextTypeReversion,
-    AlternativeTextTypeSpellingSuggestions,
-    AlternativeTextTypeDictationAlternatives
+enum class AlternativeTextType : uint8_t {
+    Correction = 0,
+    Reversion,
+    SpellingSuggestions,
+    DictationAlternatives
 };
 
 enum class AutocorrectionResponse {
@@ -68,3 +68,16 @@ public:
 };
     
 } // namespace WebCore
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::AlternativeTextType> {
+    using values = EnumValues<
+        WebCore::AlternativeTextType,
+        WebCore::AlternativeTextType::Correction,
+        WebCore::AlternativeTextType::Reversion,
+        WebCore::AlternativeTextType::SpellingSuggestions,
+        WebCore::AlternativeTextType::DictationAlternatives
+    >;
+};
+
+}

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -660,6 +660,7 @@ def headers_for_type(type):
         'WebCore::BezierCurveData': ['<WebCore/InlinePathData.h>'],
         'WebCore::BlendMode': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::BrowsingContextGroupSwitchDecision': ['<WebCore/FrameLoaderTypes.h>'],
+        'WebCore::AlternativeTextType': ['<WebCore/AlternativeTextClient.h>'],
         'WebCore::COEPDisposition': ['<WebCore/CrossOriginEmbedderPolicy.h>'],
         'WebCore::COOPDisposition': ['<WebCore/CrossOriginOpenerPolicy.h>'],
         'WebCore::ColorSchemePreference': ['<WebCore/DocumentLoader.h>'],

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -149,6 +149,7 @@
 #include "WebViewDidMoveToWindowObserver.h"
 #include "WebWheelEventCoalescer.h"
 #include "WebsiteDataStore.h"
+#include <WebCore/AlternativeTextClient.h>
 #include <WebCore/AppHighlight.h>
 #include <WebCore/BitmapImage.h>
 #include <WebCore/CompositionHighlight.h>
@@ -9683,10 +9684,9 @@ void WebPageProxy::substitutionsPanelIsShowing(CompletionHandler<void(bool)>&& c
     completionHandler(TextChecker::substitutionsPanelIsShowing());
 }
 
-void WebPageProxy::showCorrectionPanel(int32_t panelType, const FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings)
+void WebPageProxy::showCorrectionPanel(AlternativeTextType panelType, const FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings)
 {
-    // FIXME: Make AlternativeTextType an enum class with EnumTraits and serialize it instead of casting to/from an int32_t.
-    pageClient().showCorrectionPanel((AlternativeTextType)panelType, boundingBoxOfReplacedString, replacedString, replacementString, alternativeReplacementStrings);
+    pageClient().showCorrectionPanel(panelType, boundingBoxOfReplacedString, replacedString, replacementString, alternativeReplacementStrings);
 }
 
 void WebPageProxy::dismissCorrectionPanel(int32_t reason)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -81,7 +81,7 @@
 #include "WebUndoStepID.h"
 #include "WebsitePoliciesData.h"
 #include "WindowKind.h"
-#include <WebCore/ActivityState.h>
+#include <WebCore/AlternativeTextClient.h>
 #include <WebCore/AutoplayEvent.h>
 #include <WebCore/Color.h>
 #include <WebCore/DiagnosticLoggingClient.h>
@@ -2514,7 +2514,7 @@ private:
 
 #if PLATFORM(MAC)
     void substitutionsPanelIsShowing(CompletionHandler<void(bool)>&&);
-    void showCorrectionPanel(int32_t panelType, const WebCore::FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings);
+    void showCorrectionPanel(WebCore::AlternativeTextType panelType, const WebCore::FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings);
     void dismissCorrectionPanel(int32_t reason);
     void dismissCorrectionPanelSoon(int32_t reason, CompletionHandler<void(String)>&&);
     void recordAutocorrectionResponse(int32_t responseType, const String& replacedString, const String& replacementString);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -361,7 +361,7 @@ messages -> WebPageProxy {
 #endif
 #if PLATFORM(MAC)
     # Autocorrection messages
-    ShowCorrectionPanel(int32_t panelType, WebCore::FloatRect boundingBoxOfReplacedString, String replacedString, String replacementString, Vector<String> alternativeReplacementStrings)
+    ShowCorrectionPanel(enum:uint8_t WebCore::AlternativeTextType panelType, WebCore::FloatRect boundingBoxOfReplacedString, String replacedString, String replacementString, Vector<String> alternativeReplacementStrings)
     DismissCorrectionPanel(int32_t reason)
     DismissCorrectionPanelSoon(int32_t reason) -> (String result) Synchronous
     RecordAutocorrectionResponse(int32_t response, String replacedString, String replacementString);

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -35,18 +35,16 @@
 static inline NSCorrectionIndicatorType correctionIndicatorType(WebCore::AlternativeTextType alternativeTextType)
 {
     switch (alternativeTextType) {
-    case WebCore::AlternativeTextTypeCorrection:
+    case WebCore::AlternativeTextType::Correction:
         return NSCorrectionIndicatorTypeDefault;
-    case WebCore::AlternativeTextTypeReversion:
+    case WebCore::AlternativeTextType::Reversion:
         return NSCorrectionIndicatorTypeReversion;
-    case WebCore::AlternativeTextTypeSpellingSuggestions:
+    case WebCore::AlternativeTextType::SpellingSuggestions:
         return NSCorrectionIndicatorTypeGuesses;
-    case WebCore::AlternativeTextTypeDictationAlternatives:
+    case WebCore::AlternativeTextType::DictationAlternatives:
         ASSERT_NOT_REACHED();
-        break;
+        return NSCorrectionIndicatorTypeDefault;
     }
-    ASSERT_NOT_REACHED();
-    return NSCorrectionIndicatorTypeDefault;
 }
 
 namespace WebKit {
@@ -78,7 +76,7 @@ void CorrectionPanel::show(NSView *view, WebViewImpl& webViewImpl, AlternativeTe
     m_view = view;
     m_spellCheckerDocumentTag = spellCheckerDocumentTag;
     NSCorrectionIndicatorType indicatorType = correctionIndicatorType(type);
-    
+
     RetainPtr<NSArray> alternativeStrings;
     if (!alternativeReplacementStrings.isEmpty())
         alternativeStrings = createNSArray(alternativeReplacementStrings);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.mm
@@ -35,18 +35,17 @@ using namespace WebCore;
 static inline NSCorrectionIndicatorType correctionIndicatorType(AlternativeTextType alternativeTextType)
 {
     switch (alternativeTextType) {
-    case AlternativeTextTypeCorrection:
+    case AlternativeTextType::Correction:
         return NSCorrectionIndicatorTypeDefault;
-    case AlternativeTextTypeReversion:
+    case AlternativeTextType::Reversion:
         return NSCorrectionIndicatorTypeReversion;
-    case AlternativeTextTypeSpellingSuggestions:
+    case AlternativeTextType::SpellingSuggestions:
         return NSCorrectionIndicatorTypeGuesses;
-    case AlternativeTextTypeDictationAlternatives:
+    case AlternativeTextType::DictationAlternatives:
         ASSERT_NOT_REACHED();
-        break;
+        return NSCorrectionIndicatorTypeDefault;
     }
-    ASSERT_NOT_REACHED();
-    return NSCorrectionIndicatorTypeDefault;
+    
 }
 
 CorrectionPanel::CorrectionPanel()


### PR DESCRIPTION
#### d84ac58bd76d15e40b36f215e7c8ecae110686d2
<pre>
AlternativeTextType as enum class with EnumTraits and serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=248174">https://bugs.webkit.org/show_bug.cgi?id=248174</a>
rdar://102309622

Making AlternativeTextType an enum class with EnumTraits and serialize it instead of casting to/from an int32_t. Prevents from assertion failure in void _NSWindowSetFrameIvar

Reviewed by Youenn Fablet

Canonical link: <a href="https://commits.webkit.org/257360@main">https://commits.webkit.org/257360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebad6030560c521efafc3e0361b384eae04b48a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107737 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168007 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85015 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104323 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33101 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101833 "webkitpy-tests (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76045 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1454 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22521 "Found 1 new test failure: streams/readable-stream-default-controller-error.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1398 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45136 "Found 30 new test failures: accessibility/aria-keyshortcuts.html, css3/supports-dom-api.html, fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html, fast/rendering/render-style-null-optgroup-crash.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-property-parsing.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, http/wpt/service-workers/fetch-service-worker-preload-download.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html ... (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6292 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41942 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->