### PR TITLE
Don't paint focus ring for anonymous block continuations

### DIFF
--- a/LayoutTests/fast/css/focus-ring-continuations-expected.txt
+++ b/LayoutTests/fast/css/focus-ring-continuations-expected.txt
@@ -1,0 +1,21 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x70
+  RenderBlock {HTML} at (0,0) size 800x70
+    RenderBody {BODY} at (8,8) size 784x54
+      RenderBlock (anonymous) at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 688x17
+          text run at (0,0) width 688: "Tests focus ring around an inline element containing block continuations. There should be a single focus ring."
+      RenderBlock {DIV} at (0,18) size 200x36
+        RenderBlock (anonymous) at (0,0) size 200x18
+          RenderInline {SPAN} at (0,0) size 100x17
+            RenderText {#text} at (0,0) size 100x17
+              text run at (0,0) width 100: "INLINE TEXT"
+        RenderBlock (anonymous) at (0,18) size 200x18
+        RenderBlock (anonymous) at (0,36) size 200x0
+          RenderInline {SPAN} at (0,0) size 0x0
+          RenderText {#text} at (0,0) size 0x0
+layer at (8,41) size 200x18
+  RenderBlock (relative positioned) {DIV} at (0,0) size 200x18
+    RenderText {#text} at (0,0) size 146x17
+      text run at (0,0) width 146: "BLOCK CONTENTS"

--- a/LayoutTests/fast/css/focus-ring-continuations.html
+++ b/LayoutTests/fast/css/focus-ring-continuations.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+#focus {
+  outline: -webkit-focus-ring-color auto 5px;
+}
+#container {
+  width: 200px;
+}
+#inner {
+  position: relative;
+  top: -3px;
+}
+</style>
+Tests focus ring around an inline element containing block continuations.
+There should be a single focus ring.
+<div id="container">
+  <span id="focus">
+    INLINE TEXT
+    <div id="inner">BLOCK CONTENTS</div>
+  </span>
+</div>

--- a/LayoutTests/platform/ios/fast/css/focus-ring-continuations-expected.txt
+++ b/LayoutTests/platform/ios/fast/css/focus-ring-continuations-expected.txt
@@ -1,0 +1,21 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x76
+  RenderBlock {HTML} at (0,0) size 800x76
+    RenderBody {BODY} at (8,8) size 784x60
+      RenderBlock (anonymous) at (0,0) size 784x20
+        RenderText {#text} at (0,0) size 702x19
+          text run at (0,0) width 702: "Tests focus ring around an inline element containing block continuations. There should be a single focus ring."
+      RenderBlock {DIV} at (0,20) size 200x40
+        RenderBlock (anonymous) at (0,0) size 200x20
+          RenderInline {SPAN} at (0,0) size 99x19
+            RenderText {#text} at (0,0) size 99x19
+              text run at (0,0) width 99: "INLINE TEXT"
+        RenderBlock (anonymous) at (0,20) size 200x20
+        RenderBlock (anonymous) at (0,40) size 200x0
+          RenderInline {SPAN} at (0,0) size 0x0
+          RenderText {#text} at (0,0) size 0x0
+layer at (8,45) size 200x20
+  RenderBlock (relative positioned) {DIV} at (0,0) size 200x20
+    RenderText {#text} at (0,0) size 142x19
+      text run at (0,0) width 142: "BLOCK CONTENTS"

--- a/LayoutTests/platform/mac/fast/css/focus-ring-continuations-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/focus-ring-continuations-expected.txt
@@ -1,0 +1,21 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x70
+  RenderBlock {HTML} at (0,0) size 800x70
+    RenderBody {BODY} at (8,8) size 784x54
+      RenderBlock (anonymous) at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 702x18
+          text run at (0,0) width 702: "Tests focus ring around an inline element containing block continuations. There should be a single focus ring."
+      RenderBlock {DIV} at (0,18) size 200x36
+        RenderBlock (anonymous) at (0,0) size 200x18
+          RenderInline {SPAN} at (0,0) size 99x18
+            RenderText {#text} at (0,0) size 99x18
+              text run at (0,0) width 99: "INLINE TEXT"
+        RenderBlock (anonymous) at (0,18) size 200x18
+        RenderBlock (anonymous) at (0,36) size 200x0
+          RenderInline {SPAN} at (0,0) size 0x0
+          RenderText {#text} at (0,0) size 0x0
+layer at (8,41) size 200x18
+  RenderBlock (relative positioned) {DIV} at (0,0) size 200x18
+    RenderText {#text} at (0,0) size 142x18
+      text run at (0,0) width 142: "BLOCK CONTENTS"

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1331,8 +1331,13 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
         paintFloats(paintInfo, scrolledOffset, paintPhase == PaintPhase::Selection || paintPhase == PaintPhase::TextClip || paintPhase == PaintPhase::EventRegion);
 
     // 5. paint outline.
-    if ((paintPhase == PaintPhase::Outline || paintPhase == PaintPhase::SelfOutline) && hasOutline() && style().visibility() == Visibility::Visible)
-        paintOutline(paintInfo, LayoutRect(paintOffset, size()));
+    if ((paintPhase == PaintPhase::Outline || paintPhase == PaintPhase::SelfOutline) && hasOutline() && style().visibility() == Visibility::Visible) {
+        // Don't paint focus ring for anonymous block continuation because the
+        // inline element having outline-style:auto paints the whole focus ring.
+        bool hasOutlineStyleAuto = style().outlineStyleIsAuto() == OutlineIsAuto::On;
+        if (!hasOutlineStyleAuto || !isContinuation())
+            paintOutline(paintInfo, LayoutRect(paintOffset, size()));
+    }
 
     // 6. paint continuation outlines.
     if ((paintPhase == PaintPhase::Outline || paintPhase == PaintPhase::ChildOutlines)) {


### PR DESCRIPTION
#### 3a868b086d4bd0dc4a322dfa6499df20e8369364
<pre>
Don&apos;t paint focus ring for anonymous block continuations

Don&apos;t paint focus ring for anonymous block continuations
<a href="https://bugs.webkit.org/show_bug.cgi?id=248187">https://bugs.webkit.org/show_bug.cgi?id=248187</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=180748

Now we push outline style to anonymous block continuations when the
containing inline style changes. As the inline paints the whole
focus ring, the anonymous block continuation should not paint focus
ring again.

* Source/WebCore/rendering/RenderBlock.cpp:
(RenderBlock::paintObject): Add logic to not paint &quot;anonymous block continuations&quot;
* LayoutTests/fast/css/focus-ring-continuations.html: Add Test Case
* LayoutTests/fast/css/focus-ring-continuations-expected.txt: Add Test Case Expectations
* LayoutTests/platform/ios/fast/css/focus-ring-continuations-expected.txt: Add Test Case Expectations (Platform Specific)
* LayoutTests/platform/mac/fast/css/focus-ring-continuations-expected.txt: Add Test Case Expectations (Platform Specific)

Canonical link: <a href="https://commits.webkit.org/257199@main">https://commits.webkit.org/257199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88f6366adc29daf93f7baf4bd7d959327d1ac6e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107627 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167889 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7874 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36145 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103819 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84763 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87795 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1344 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1303 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6177 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2474 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41850 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->