### PR TITLE
Multicol: Min-height should have no effect if content is taller and height is auto

### DIFF
--- a/LayoutTests/fast/multicol/min-height-greater-than-content-expected.txt
+++ b/LayoutTests/fast/multicol/min-height-greater-than-content-expected.txt
@@ -1,0 +1,5 @@
+Min-height should make the multicol container taller if min-height is greater than the content height, but it should not affect column balancing. We specify column-fill:auto here, but the columns should still be balanced, because height is auto. Note that in this test, the balanced content is shorter than min-height, which is what matters. The height of the uncolumnized content (i.e. the flowthread), on the other hand, is actually greater than min-height (but that shouldn't make any difference).
+
+Below there should be a blue square above a yellow square.
+
+PASS

--- a/LayoutTests/fast/multicol/min-height-greater-than-content.html
+++ b/LayoutTests/fast/multicol/min-height-greater-than-content.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../../resources/check-layout.js"></script>
+<style>
+    .box { width:20px; height:80px; -webkit-column-break-inside:avoid; background:blue; }
+</style>
+<p>Min-height should make the multicol container taller if min-height is greater than the content
+    height, but it should not affect column balancing. We specify column-fill:auto here, but the
+    columns should still be balanced, because height is auto. Note that in this test, the balanced
+    content is shorter than min-height, which is what matters. The height of the uncolumnized
+    content (i.e. the flowthread), on the other hand, is actually greater than min-height (but that
+    shouldn't make any difference).</p>
+<p>Below there should be a blue square above a yellow square.</p>
+<div id="test" style="position:relative; -webkit-columns:4; -webkit-column-gap:0; column-fill:auto; width:80px; min-height:160px; background:yellow;">
+    <div class="box" data-offset-y="0"></div>
+    <div class="box" data-offset-y="0"></div>
+    <div class="box" data-offset-y="0"></div>
+    <div class="box" data-offset-y="0"></div>
+</div>
+<script>
+    checkLayout("#test");
+</script>

--- a/LayoutTests/fast/multicol/min-height-greater-than-height-expected.txt
+++ b/LayoutTests/fast/multicol/min-height-greater-than-height-expected.txt
@@ -1,0 +1,5 @@
+If min-height is larger than height, the final height will be set according to min-height. Content should fill columns to their full height (the same as the height of the multicol container), since we request column-fill:auto, and height is non-auto, so we won't balance.
+
+Below there should be a blue square to the left of a hotpink square.
+
+PASS

--- a/LayoutTests/fast/multicol/min-height-greater-than-height.html
+++ b/LayoutTests/fast/multicol/min-height-greater-than-height.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../../resources/check-layout.js"></script>
+<style>
+    .box { height:40px; background:blue; }
+</style>
+<p>If min-height is larger than height, the final height will be set according to
+    min-height. Content should fill columns to their full height (the same as the height of the
+    multicol container), since we request column-fill:auto, and height is non-auto, so we won't
+    balance.</p>
+<p>Below there should be a blue square to the left of a hotpink square.</p>
+<div id="test" style="position:relative; -webkit-columns:4; -webkit-column-gap:0; column-fill:auto; width:160px; height:40px; min-height:80px; background:hotpink;">
+    <div data-offset-y="0" class="box"></div>
+    <div data-offset-y="40" class="box"></div>
+    <div data-offset-y="0" class="box"></div>
+    <div data-offset-y="40" class="box"></div>
+</div>
+<script>
+    checkLayout("#test");
+</script>

--- a/LayoutTests/fast/multicol/min-height-less-than-content-expected.txt
+++ b/LayoutTests/fast/multicol/min-height-less-than-content-expected.txt
@@ -1,0 +1,17 @@
+Min-height has no effect if it is less than the height of the content, and height is auto.
+
+The word "OKAY" should be seen below.
+
+
+
+O
+
+
+K
+
+
+A
+
+
+Y
+PASS

--- a/LayoutTests/fast/multicol/min-height-less-than-content.html
+++ b/LayoutTests/fast/multicol/min-height-less-than-content.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../../resources/check-layout.js"></script>
+<p>Min-height has no effect if it is less than the height of the content, and height is auto.</p>
+<p>The word "OKAY" should be seen below.</p>
+<div id="test" style="position:relative; -webkit-columns:4; width:4em; -webkit-column-gap:0; column-fill:auto; overflow:hidden; min-height:10px; line-height:20px;">
+    <br>
+    <br>
+    <div data-offset-y="40">O</div>
+    <br>
+    <br>
+    <div data-offset-y="40">K</div>
+    <br>
+    <br>
+    <div data-offset-y="40">A</div>
+    <br>
+    <br>
+    <div data-offset-y="40">Y</div>
+</div>
+<script>
+    checkLayout("#test");
+</script>

--- a/LayoutTests/fast/multicol/min-height-less-than-height-expected.txt
+++ b/LayoutTests/fast/multicol/min-height-less-than-height-expected.txt
@@ -1,0 +1,5 @@
+If min-height is less than height, it has no effect.
+
+Below there should be a blue square to the left of a hotpink square.
+
+PASS

--- a/LayoutTests/fast/multicol/min-height-less-than-height.html
+++ b/LayoutTests/fast/multicol/min-height-less-than-height.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../../resources/check-layout.js"></script>
+<style>
+    .box { height:40px; background:blue; }
+</style>
+<p>If min-height is less than height, it has no effect.</p>
+<p>Below there should be a blue square to the left of a hotpink square.</p>
+<div id="test" style="position:relative; -webkit-columns:4; -webkit-column-gap:0; column-fill:auto; width:160px; height:80px; min-height:40px; background:hotpink;">
+    <div data-offset-y="0" class="box"></div>
+    <div data-offset-y="40" class="box"></div>
+    <div data-offset-y="0" class="box"></div>
+    <div data-offset-y="40" class="box"></div>
+</div>
+<script>
+    checkLayout("#test");
+</script>

--- a/LayoutTests/fast/multicol/min-height-much-greater-than-content-expected.txt
+++ b/LayoutTests/fast/multicol/min-height-much-greater-than-content-expected.txt
@@ -1,0 +1,9 @@
+Min-height should make the multicol container taller if min-height is greater than the content height, but it should not affect column balancing. We specify column-fill:auto here, but the columns should still be balanced, because height is auto.
+
+Below there should be a yellow square with the word "OKAY" inside - from left to right, with large letter spacing.
+
+O
+K
+A
+Y
+PASS

--- a/LayoutTests/fast/multicol/min-height-much-greater-than-content.html
+++ b/LayoutTests/fast/multicol/min-height-much-greater-than-content.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../../resources/check-layout.js"></script>
+<p>Min-height should make the multicol container taller if min-height is greater than the content
+    height, but it should not affect column balancing. We specify column-fill:auto here, but the
+    columns should still be balanced, because height is auto.</p>
+<p>Below there should be a yellow square with the word "OKAY" inside - from left to right, with large letter spacing.</p>
+<div id="test" style="position:relative; -webkit-columns:8; -webkit-column-gap:0; column-fill:auto; width:160px; min-height:160px; line-height:20px; background:yellow;">
+    <div data-offset-y="0">O</div>
+    <div data-offset-y="0">K</div>
+    <div data-offset-y="0">A</div>
+    <div data-offset-y="0">Y</div>
+</div>
+<script>
+    checkLayout("#test");
+</script>


### PR DESCRIPTION
<pre>
Multicol: Min-height should have no effect if content is taller and height is auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=55740">https://bugs.webkit.org/show_bug.cgi?id=55740</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=202162">https://src.chromium.org/viewvc/blink?view=revision&revision=202162</a>

Calling computeLogicalHeight() before layout is somewhat problematic, since we don't know the content/intrinsic height at that point. Specifying that height as 0 would return the value of min-height (if specified) and make the multicol code believe that height is constrained, and prevent columns from getting any taller than that. In other words, min-height was more or less treated as max-height in multicol.

Since we only want to know if we have a non-auto height that could constrain the column heights, we can just skip computeLogicalHeight() if height is indefinite.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::checkForPaginationLogicalHeightChange): Update to add "isRenderView" and also add maximum condition for ColumnHeight
* LayoutTests/fast/multicol/min-height-much-greater-than-content.html: Add Test Case
LayoutTests/fast/multicol/min-height-much-greater-than-content-expected.txt: Add Test Case Expectation
* LayoutTests/fast/multicol/min-height-less-than-height.html: Add Test Case
* LayoutTests/fast/multicol/min-height-less-than-height-expected.txt: Add Test Case Expectations
* LayoutTests/fast/multicol/min-height-less-than-content.html: Add Test Case
* LayoutTests/fast/multicol/min-height-less-than-content-expected.txt: Add Test Case Expectations
* LayoutTests/fast/multicol/min-height-greater-than-height.html: Add Test Case
* LayoutTests/fast/multicol/min-height-greater-than-height-expected.txt: Add Test Case Expectations
* LayoutTests/fast/multicol/min-height-greater-than-content.html: Add Test Case
* LayoutTests/fast/multicol/min-height-greater-than-content-expected.txt: Add Test Case Expectation

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5690c4cc695d5e067208fd30af4ff1315cf3352

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106746 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167015 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6780 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35227 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103433 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5100 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83854 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/515 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20247 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/498 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21699 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44193 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41021 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->