### PR TITLE
[Filters] Control applying the Filter by a new enum named FilterRenderingMode

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1763,6 +1763,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/filters/FilterImageVector.h
     platform/graphics/filters/FilterOperation.h
     platform/graphics/filters/FilterOperations.h
+    platform/graphics/filters/FilterRenderingMode.h
     platform/graphics/filters/FilterResults.h
     platform/graphics/filters/LightSource.h
     platform/graphics/filters/PointLightSource.h

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3828,13 +3828,14 @@ void Page::recomputeTextAutoSizingInAllFrames()
 
 #endif
 
-bool Page::acceleratedFiltersEnabled() const
+OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes() const
 {
+    OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
-    return settings().acceleratedFiltersEnabled();
-#else
-    return false;
+    if (settings().acceleratedFiltersEnabled())
+        modes = modes | FilterRenderingMode::Accelerated;
 #endif
+    return modes;
 }
 
 bool Page::shouldDisableCorsForRequestTo(const URL& url) const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -27,6 +27,7 @@
 #include "DisabledAdaptations.h"
 #include "Document.h"
 #include "EventTrackingRegions.h"
+#include "FilterRenderingMode.h"
 #include "FindOptions.h"
 #include "FrameLoaderTypes.h"
 #include "IntRectHash.h"
@@ -514,7 +515,7 @@ public:
     WEBCORE_EXPORT void recomputeTextAutoSizingInAllFrames();
 #endif
 
-    bool acceleratedFiltersEnabled() const;
+    OptionSet<FilterRenderingMode> preferredFilterRenderingModes() const;
 
     const FloatBoxExtent& fullscreenInsets() const { return m_fullscreenInsets; }
     WEBCORE_EXPORT void setFullscreenInsets(const FloatBoxExtent&);

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -110,13 +110,14 @@ bool FEColorMatrix::resultIsAlphaImage(const FilterImageVector&) const
     return m_type == FECOLORMATRIX_TYPE_LUMINANCETOALPHA;
 }
 
-bool FEColorMatrix::supportsAcceleratedRendering() const
+OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() const
 {
+    OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
-    return FEColorMatrixCoreImageApplier::supportsCoreImageRendering(*this);
-#else
-    return false;
+    if (FEColorMatrixCoreImageApplier::supportsCoreImageRendering(*this))
+        modes = modes | FilterRenderingMode::Accelerated;
 #endif
+    return modes;
 }
 
 std::unique_ptr<FilterEffectApplier> FEColorMatrix::createAcceleratedApplier() const

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -57,7 +57,7 @@ private:
 
     bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
 
-    bool supportsAcceleratedRendering() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -57,13 +57,14 @@ FEComponentTransfer::FEComponentTransfer(ComponentTransferFunctions&& functions)
 {
 }
 
-bool FEComponentTransfer::supportsAcceleratedRendering() const
+OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingModes() const
 {
+    OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
-    return FEComponentTransferCoreImageApplier::supportsCoreImageRendering(*this);
-#else
-    return false;
+    if (FEComponentTransferCoreImageApplier::supportsCoreImageRendering(*this))
+        modes = modes | FilterRenderingMode::Accelerated;
 #endif
+    return modes;
 }
 
 std::unique_ptr<FilterEffectApplier> FEComponentTransfer::createAcceleratedApplier() const

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -81,7 +81,7 @@ private:
     FEComponentTransfer(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc);
     FEComponentTransfer(ComponentTransferFunctions&&);
 
-    bool supportsAcceleratedRendering() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -41,9 +41,12 @@ class Filter : public FilterFunction {
 public:
     enum class ClipOperation { Intersect, Unite };
 
-    RenderingMode renderingMode() const { return m_renderingMode; }
-    void setRenderingMode(RenderingMode renderingMode) { m_renderingMode = renderingMode; }
-    
+    RenderingMode renderingMode() const;
+
+    FilterRenderingMode filterRenderingMode() const { return m_filterRenderingMode; }
+    void setFilterRenderingMode(FilterRenderingMode filterRenderingMode) { m_filterRenderingMode = filterRenderingMode; }
+    void setFilterRenderingMode(OptionSet<FilterRenderingMode> preferredFilterRenderingMode);
+
     FloatSize filterScale() const { return m_filterScale; }
     void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
 
@@ -72,10 +75,10 @@ public:
 
 protected:
     using FilterFunction::FilterFunction;
-    Filter(Filter::Type, RenderingMode, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion = { });
+    Filter(Filter::Type, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion = { });
 
 private:
-    RenderingMode m_renderingMode;
+    FilterRenderingMode m_filterRenderingMode { FilterRenderingMode::Software };
     FloatSize m_filterScale;
     ClipOperation m_clipOperation;
     FloatRect m_filterRegion;

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -28,6 +28,7 @@
 #include "FilterEffectGeometry.h"
 #include "FilterImage.h"
 #include "FilterImageVector.h"
+#include "FilterRenderingMode.h"
 #include "FloatRect.h"
 #include "LengthBox.h"
 #include <wtf/RefCounted.h>
@@ -93,7 +94,7 @@ public:
     static AtomString sourceGraphicName() { return filterName(Type::SourceGraphic); }
     AtomString filterName() const { return filterName(m_filterType); }
 
-    virtual bool supportsAcceleratedRendering() const { return false; }
+    virtual OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const { return FilterRenderingMode::Software; }
     virtual RefPtr<FilterImage> apply(const Filter&, FilterImage&, FilterResults&) { return nullptr; }
 
     virtual WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation = FilterRepresentation::TestOutput) const = 0;

--- a/Source/WebCore/platform/graphics/filters/FilterRenderingMode.h
+++ b/Source/WebCore/platform/graphics/filters/FilterRenderingMode.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/OptionSet.h>
+
+namespace WebCore {
+
+enum class FilterRenderingMode : uint8_t {
+    Software        = 1 << 0,
+    Accelerated     = 1 << 1,
+    GraphicsContext = 1 << 2
+};
+
+constexpr OptionSet<FilterRenderingMode> allFilterRenderingModes = {
+    FilterRenderingMode::Software,
+    FilterRenderingMode::Accelerated,
+    FilterRenderingMode::GraphicsContext
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::FilterRenderingMode> {
+    using values = EnumValues<
+        WebCore::FilterRenderingMode,
+
+        WebCore::FilterRenderingMode::Software,
+        WebCore::FilterRenderingMode::Accelerated,
+        WebCore::FilterRenderingMode::GraphicsContext
+    >;
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.cpp
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.cpp
@@ -41,13 +41,13 @@ SourceGraphic::SourceGraphic()
 {
 }
 
-bool SourceGraphic::supportsAcceleratedRendering() const
+OptionSet<FilterRenderingMode> SourceGraphic::supportedFilterRenderingModes() const
 {
+    OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
 #if USE(CORE_IMAGE)
-    return true;
-#else
-    return false;
+    modes = modes | FilterRenderingMode::Accelerated;
 #endif
+    return modes;
 }
 
 std::unique_ptr<FilterEffectApplier> SourceGraphic::createAcceleratedApplier() const

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.h
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.h
@@ -36,7 +36,7 @@ private:
 
     unsigned numberOfEffectInputs() const override { return 0; }
 
-    bool supportsAcceleratedRendering() const override;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -42,22 +42,21 @@
 
 namespace WebCore {
 
-RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperations& operations, RenderingMode renderingMode, const FloatSize& filterScale, ClipOperation clipOperation, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+RefPtr<CSSFilter> CSSFilter::create(RenderElement& renderer, const FilterOperations& operations, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, ClipOperation clipOperation, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
 {
     bool hasFilterThatMovesPixels = operations.hasFilterThatMovesPixels();
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin = operations.hasFilterThatShouldBeRestrictedBySecurityOrigin();
 
-    auto filter = adoptRef(*new CSSFilter(renderingMode, filterScale, clipOperation, hasFilterThatMovesPixels, hasFilterThatShouldBeRestrictedBySecurityOrigin));
-    if (!filter->buildFilterFunctions(renderer, operations, targetBoundingBox, destinationContext)) {
+    auto filter = adoptRef(*new CSSFilter(filterScale, clipOperation, hasFilterThatMovesPixels, hasFilterThatShouldBeRestrictedBySecurityOrigin));
+
+    if (!filter->buildFilterFunctions(renderer, operations, preferredFilterRenderingModes, targetBoundingBox, destinationContext)) {
         LOG_WITH_STREAM(Filters, stream << "CSSFilter::create: failed to build filters " << operations);
         return nullptr;
     }
 
     LOG_WITH_STREAM(Filters, stream << "CSSFilter::create built filter " << filter.get() << " for " << operations);
 
-    if (renderingMode == RenderingMode::Accelerated && !filter->supportsAcceleratedRendering())
-        filter->setRenderingMode(RenderingMode::Unaccelerated);
-
+    filter->setFilterRenderingMode(preferredFilterRenderingModes);
     return filter;
 }
 
@@ -66,8 +65,8 @@ RefPtr<CSSFilter> CSSFilter::create(Vector<Ref<FilterFunction>>&& functions)
     return adoptRef(new CSSFilter(WTFMove(functions)));
 }
 
-CSSFilter::CSSFilter(RenderingMode renderingMode, const FloatSize& filterScale, ClipOperation clipOperation, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin)
-    : Filter(Filter::Type::CSSFilter, renderingMode, filterScale, clipOperation)
+CSSFilter::CSSFilter(const FloatSize& filterScale, ClipOperation clipOperation, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin)
+    : Filter(Filter::Type::CSSFilter, filterScale, clipOperation)
     , m_hasFilterThatMovesPixels(hasFilterThatMovesPixels)
     , m_hasFilterThatShouldBeRestrictedBySecurityOrigin(hasFilterThatShouldBeRestrictedBySecurityOrigin)
 {
@@ -210,7 +209,7 @@ static IntOutsets calculateReferenceFilterOutsets(const ReferenceFilterOperation
     return SVGFilter::calculateOutsets(*filterElement, targetBoundingBox);
 }
 
-static RefPtr<SVGFilter> createReferenceFilter(CSSFilter& filter, const ReferenceFilterOperation& filterOperation, RenderElement& renderer, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+static RefPtr<SVGFilter> createReferenceFilter(CSSFilter& filter, const ReferenceFilterOperation& filterOperation, RenderElement& renderer, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
 {
     auto filterElement = referenceFilterElement(filterOperation, renderer);
     if (!filterElement)
@@ -218,10 +217,10 @@ static RefPtr<SVGFilter> createReferenceFilter(CSSFilter& filter, const Referenc
 
     auto filterRegion = SVGLengthContext::resolveRectangle<SVGFilterElement>(filterElement, filterElement->filterUnits(), targetBoundingBox);
 
-    return SVGFilter::create(*filterElement, filter.renderingMode(), filter.filterScale(), filter.clipOperation(), filterRegion, targetBoundingBox, destinationContext);
+    return SVGFilter::create(*filterElement, preferredFilterRenderingModes, filter.filterScale(), filter.clipOperation(), filterRegion, targetBoundingBox, destinationContext);
 }
 
-bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperations& operations, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperations& operations, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
 {
     RefPtr<FilterFunction> function;
 
@@ -272,7 +271,7 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
             break;
 
         case FilterOperation::REFERENCE:
-            function = createReferenceFilter(*this, downcast<ReferenceFilterOperation>(*operation), renderer, targetBoundingBox, destinationContext);
+            function = createReferenceFilter(*this, downcast<ReferenceFilterOperation>(*operation), renderer, preferredFilterRenderingModes, targetBoundingBox, destinationContext);
             break;
 
         default:
@@ -315,17 +314,15 @@ FilterEffectVector CSSFilter::effectsOfType(FilterFunction::Type filterType) con
     return effects;
 }
 
-bool CSSFilter::supportsAcceleratedRendering() const
+OptionSet<FilterRenderingMode> CSSFilter::supportedFilterRenderingModes() const
 {
-    if (renderingMode() == RenderingMode::Unaccelerated)
-        return false;
+    OptionSet<FilterRenderingMode> modes = allFilterRenderingModes;
 
-    for (auto& function : m_functions) {
-        if (!function->supportsAcceleratedRendering())
-            return false;
-    }
+    for (auto& function : m_functions)
+        modes = modes & function->supportedFilterRenderingModes();
 
-    return true;
+    ASSERT(modes);
+    return modes;
 }
 
 RefPtr<FilterImage> CSSFilter::apply(FilterImage* sourceImage, FilterResults& results)

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -33,12 +33,11 @@ namespace WebCore {
 class FilterOperations;
 class GraphicsContext;
 class RenderElement;
-class SourceGraphic;
 
 class CSSFilter final : public Filter {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static RefPtr<CSSFilter> create(RenderElement&, const FilterOperations&, RenderingMode, const FloatSize& filterScale, ClipOperation, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<CSSFilter> create(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, ClipOperation, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     WEBCORE_EXPORT static RefPtr<CSSFilter> create(Vector<Ref<FilterFunction>>&&);
 
     const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
@@ -56,12 +55,12 @@ public:
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);
 
 private:
-    CSSFilter(RenderingMode, const FloatSize& filterScale, ClipOperation, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
+    CSSFilter(const FloatSize& filterScale, ClipOperation, bool hasFilterThatMovesPixels, bool hasFilterThatShouldBeRestrictedBySecurityOrigin);
     CSSFilter(Vector<Ref<FilterFunction>>&&);
 
-    bool buildFilterFunctions(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    bool buildFilterFunctions(RenderElement&, const FilterOperations&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
 
-    bool supportsAcceleratedRendering() const final;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const final;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5482,7 +5482,7 @@ void RenderLayer::updateFilterPaintingStrategy()
     }
     
     ensureLayerFilters();
-    m_filters->setRenderingMode(renderer().page().acceleratedFiltersEnabled() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated);
+    m_filters->setPreferredFilterRenderingModes(renderer().page().preferredFilterRenderingModes());
     m_filters->setFilterScale({ page().deviceScaleFactor(), page().deviceScaleFactor() });
 }
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -160,7 +160,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     if (!m_filter || m_targetBoundingBox != targetBoundingBox) {
         m_targetBoundingBox = targetBoundingBox;
         // FIXME: This rebuilds the entire effects chain even if the filter style didn't change.
-        m_filter = CSSFilter::create(renderer, renderer.style().filter(), m_renderingMode, m_filterScale, Filter::ClipOperation::Unite, m_targetBoundingBox, context);
+        m_filter = CSSFilter::create(renderer, renderer.style().filter(), m_preferredFilterRenderingModes, m_filterScale, Filter::ClipOperation::Unite, m_targetBoundingBox, context);
     }
 
     if (!m_filter)

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -32,6 +32,7 @@
 
 #include "CachedResourceHandle.h"
 #include "CachedSVGDocumentClient.h"
+#include "FilterRenderingMode.h"
 #include "RenderLayer.h"
 
 namespace WebCore {
@@ -58,7 +59,7 @@ public:
     void updateReferenceFilterClients(const FilterOperations&);
     void removeReferenceFilterClients();
 
-    void setRenderingMode(RenderingMode renderingMode) { m_renderingMode = renderingMode; }
+    void setPreferredFilterRenderingModes(OptionSet<FilterRenderingMode> preferredFilterRenderingModes) { m_preferredFilterRenderingModes = preferredFilterRenderingModes; }
     void setFilterScale(const FloatSize& filterScale) { m_filterScale = filterScale; }
 
     static bool isIdentity(RenderElement&);
@@ -77,7 +78,7 @@ private:
     void allocateBackingStoreIfNeeded(GraphicsContext&);
 
     RenderLayer& m_layer;
-    RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
+    OptionSet<FilterRenderingMode> m_preferredFilterRenderingModes { FilterRenderingMode::Software };
     FloatSize m_filterScale { 1, 1 };
 
     Vector<RefPtr<Element>> m_internalSVGReferences;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -119,11 +119,10 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
     // Determine scale factor for filter. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
     ImageBuffer::sizeNeedsClamping(filterData->sourceImageRect.size(), filterScale);
 
-    // Set the rendering mode from the page's settings.
-    auto renderingMode = renderer.page().acceleratedFiltersEnabled() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
+    auto preferredFilterModes = renderer.page().preferredFilterRenderingModes();
 
     // Create the SVGFilter object.
-    filterData->filter = SVGFilter::create(filterElement(), renderingMode, filterScale, Filter::ClipOperation::Intersect, filterRegion, targetBoundingBox, *context);
+    filterData->filter = SVGFilter::create(filterElement(), preferredFilterModes, filterScale, Filter::ClipOperation::Intersect, filterRegion, targetBoundingBox, *context);
     if (!filterData->filter) {
         m_rendererFilterDataMap.remove(&renderer);
         return false;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -467,7 +467,7 @@ void writeSVGResourceContainer(TextStream& ts, const RenderSVGResourceContainer&
         // Creating a placeholder filter which is passed to the builder.
         FloatRect dummyRect;
         FloatSize dummyScale(1, 1);
-        auto dummyFilter = SVGFilter::create(filter.filterElement(), RenderingMode::Unaccelerated, dummyScale, Filter::ClipOperation::Intersect, dummyRect, dummyRect, NullGraphicsContext());
+        auto dummyFilter = SVGFilter::create(filter.filterElement(), FilterRenderingMode::Software, dummyScale, Filter::ClipOperation::Intersect, dummyRect, dummyRect, NullGraphicsContext());
         if (dummyFilter) {
             TextStream::IndentScope indentScope(ts);
             dummyFilter->externalRepresentation(ts, FilterRepresentation::TestOutput);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -36,7 +36,7 @@ class SVGFilterElement;
 
 class SVGFilter final : public Filter {
 public:
-    static RefPtr<SVGFilter> create(SVGFilterElement&, RenderingMode, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
+    static RefPtr<SVGFilter> create(SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
     WEBCORE_EXPORT static RefPtr<SVGFilter> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
 
     static bool isIdentity(SVGFilterElement&);
@@ -56,7 +56,7 @@ public:
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 
 private:
-    SVGFilter(RenderingMode, const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits);
+    SVGFilter(const FloatSize& filterScale, ClipOperation, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits);
     SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
 
     static std::optional<SVGFilterExpression> buildExpression(SVGFilterElement&, const SVGFilter&, const GraphicsContext& destinationContext);
@@ -65,7 +65,7 @@ private:
     FloatSize resolvedSize(const FloatSize&) const final;
     FloatPoint3D resolvedPoint3D(const FloatPoint3D&) const final;
 
-    bool supportsAcceleratedRendering() const final;
+    OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const final;
 
     RefPtr<FilterImage> apply(const Filter&, FilterImage& sourceImage, FilterResults&) final;
 

--- a/Source/WebKit/Platform/IPC/FilterReference.h
+++ b/Source/WebKit/Platform/IPC/FilterReference.h
@@ -448,7 +448,7 @@ template<class Encoder>
 void FilterReference::encodeFilter(const WebCore::Filter& filter, Encoder& encoder)
 {
     encoder << filter.filterType();
-    encoder << filter.renderingMode();
+    encoder << filter.filterRenderingMode();
     encoder << filter.filterScale();
     encoder << filter.clipOperation();
     encoder << filter.filterRegion();
@@ -462,9 +462,9 @@ void FilterReference::encodeFilter(const WebCore::Filter& filter, Encoder& encod
 template<class Decoder>
 RefPtr<WebCore::Filter> FilterReference::decodeFilter(Decoder& decoder, WebCore::FilterFunction::Type filterType)
 {
-    std::optional<WebCore::RenderingMode> renderingMode;
-    decoder >> renderingMode;
-    if (!renderingMode)
+    std::optional<WebCore::FilterRenderingMode> filterRenderingMode;
+    decoder >> filterRenderingMode;
+    if (!filterRenderingMode)
         return nullptr;
 
     std::optional<WebCore::FloatSize> filterScale;
@@ -490,7 +490,7 @@ RefPtr<WebCore::Filter> FilterReference::decodeFilter(Decoder& decoder, WebCore:
         filter = decodeSVGFilter(decoder);
     
     if (filter) {
-        filter->setRenderingMode(*renderingMode);
+        filter->setFilterRenderingMode(*filterRenderingMode);
         filter->setFilterScale(*filterScale);
         filter->setClipOperation(*clipOperation);
         filter->setFilterRegion(*filterRegion);


### PR DESCRIPTION
#### ccb8d41a1adb174e09b49b63d2e91b46d2769e21
<pre>
[Filters] Control applying the Filter by a new enum named FilterRenderingMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248193">https://bugs.webkit.org/show_bug.cgi?id=248193</a>
rdar://102590236

Reviewed by Cameron McCormack.

RenderingMode has been used to control whether the Filter should use accelerated
or unaccelerated ImageBuffers. To support extended CoreGraphics filters, we need
even a new way to apply the filter which does not require creating temporary
ImageBuffers.

FilterRenderingMode will be used for this purpose. FilterEffect and Filter will
now provide OptionSet&lt;FilterRenderingMode&gt; telling which modes they support.
The Settings will provide preferred OptionSet&lt;FilterRenderingMode&gt;. Filter will
decide which FilterRenderingMode to use based on the preferred and the supported
FilterRenderingModes.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::preferredFilterRenderingModes const):
(WebCore::Page::acceleratedFiltersEnabled const): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::supportedFilterRenderingModes const):
(WebCore::FEColorMatrix::supportsAcceleratedRendering const): Deleted.
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::supportedFilterRenderingModes const):
(WebCore::FEComponentTransfer::supportsAcceleratedRendering const): Deleted.
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::Filter):
(WebCore::Filter::renderingMode const):
(WebCore::Filter::setFilterRenderingMode):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::filterRenderingMode const):
(WebCore::Filter::setFilterRenderingMode):
(WebCore::Filter::Filter):
(WebCore::Filter::renderingMode const): Deleted.
(WebCore::Filter::setRenderingMode): Deleted.
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::createApplier const):
(WebCore::FilterEffect::apply):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
(WebCore::FilterFunction::supportedFilterRenderingModes const):
(WebCore::FilterFunction::supportsAcceleratedRendering const): Deleted.
* Source/WebCore/platform/graphics/filters/FilterRenderingMode.h: Added.
* Source/WebCore/platform/graphics/filters/SourceGraphic.cpp:
(WebCore::SourceGraphic::supportedFilterRenderingModes const):
(WebCore::SourceGraphic::supportsAcceleratedRendering const): Deleted.
* Source/WebCore/platform/graphics/filters/SourceGraphic.h:
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::create):
(WebCore::CSSFilter::CSSFilter):
(WebCore::createReferenceFilter):
(WebCore::CSSFilter::buildFilterFunctions):
(WebCore::CSSFilter::supportedFilterRenderingModes const):
(WebCore::CSSFilter::supportsAcceleratedRendering const): Deleted.
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGResourceContainer):
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::create):
(WebCore::SVGFilter::SVGFilter):
(WebCore::SVGFilter::supportedFilterRenderingModes const):
(WebCore::SVGFilter::supportsAcceleratedRendering const): Deleted.
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebKit/Platform/IPC/FilterReference.h:
(IPC::FilterReference::encodeFilter):
(IPC::FilterReference::decodeFilter):

Canonical link: <a href="https://commits.webkit.org/256985@main">https://commits.webkit.org/256985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd12326e2c7bfa1349d7d5c1ef91d3ec393fce2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106997 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7078 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35500 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103668 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103148 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84121 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32309 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75235 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/752 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21910 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4816 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5549 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41277 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->