### PR TITLE
Update the GPU process' override languages list each time WKContextConfigurationSetOverrideLanguages is called

### DIFF
--- a/LayoutTests/fast/text/international/system-language/han-text-style.html
+++ b/LayoutTests/fast/text/international/system-language/han-text-style.html
@@ -7,7 +7,7 @@
 This test makes sure that the correct glyphs are drawn for text-style fonts when app-specific languages are specified.
 The test passes if this text you're reading right now is the only text on this page.
 <div style="position: relative;">
-<div style="font: -apple-system-tall-body; font-size: 48px;"><span id="target">[][][]</target></div>
+<div style="font: -apple-system-tall-body; font-size: 48px;"><span id="target">[][][]</span></div>
 <div id="overlay" style="position: absolute; top: 0px; left: 0px; width: 100px; height: 100px; background: white;"></div>
 </div>
 <script>

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -569,6 +569,12 @@ void GPUProcess::requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier pro
     completion(iterator->value->remoteMediaPlayerManagerProxy().bitmapImageForCurrentTime(playerIdentifier));
 }
 
+void GPUProcess::userPreferredLanguagesChanged(const Vector<String>& languages)
+{
+    LOG_WITH_STREAM(Language, stream << "The GPU process's userPreferredLanguagesChanged: " << languages);
+    overrideUserPreferredLanguages(languages);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -187,6 +187,8 @@ private:
     void enablePowerLogging(SandboxExtension::Handle&&);
 #endif
 
+    void userPreferredLanguagesChanged(const Vector<String>&);
+
     // Connections to WebProcesses.
     HashMap<WebCore::ProcessIdentifier, Ref<GPUConnectionToWebProcess>> m_webProcessConnections;
     MonotonicTime m_creationTime { MonotonicTime::now() };

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -80,6 +80,8 @@ messages -> GPUProcess LegacyReceiver {
 #endif
 
     WebProcessConnectionCountForTesting() -> (uint64_t count)
+
+    UserPreferredLanguagesChanged(Vector<String> languages)
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp
@@ -158,6 +158,12 @@ void WKContextConfigurationSetOverrideLanguages(WKContextConfigurationRef, WKArr
     // However, playwright automation tests rely on it.
     // See https://bugs.webkit.org/show_bug.cgi?id=242827 for details.
     WebKit::setOverrideLanguages(toImpl(overrideLanguages)->toStringVector());
+
+#if ENABLE(GPU_PROCESS)
+    // Assume we don't have multiple WebProcessPools operational that need to
+    // have distinct override languages, which is true for WebKitTestRunner.
+    WebProcessPool::updateOverrideLanguagesInGPUProcessIfCreated();
+#endif
 }
 
 bool WKContextConfigurationProcessSwapsOnNavigation(WKContextConfigurationRef configuration)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -375,6 +375,14 @@ void WebProcessPool::setOverrideLanguages(Vector<String>&& languages)
 #endif
 }
 
+#if ENABLE(GPU_PROCESS)
+void WebProcessPool::updateOverrideLanguagesInGPUProcessIfCreated()
+{
+    if (auto* gpuProcess = GPUProcessProxy::singletonIfCreated())
+        gpuProcess->send(Messages::GPUProcess::UserPreferredLanguagesChanged(overrideLanguages()), 0);
+}
+#endif
+
 void WebProcessPool::fullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled)
 {
     sendToAllProcesses(Messages::WebProcess::FullKeyboardAccessModeChanged(fullKeyboardAccessEnabled));

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -371,7 +371,10 @@ public:
 
     GPUProcessProxy& ensureGPUProcess();
     GPUProcessProxy* gpuProcess() const { return m_gpuProcess.get(); }
+
+    static void updateOverrideLanguagesInGPUProcessIfCreated();
 #endif
+
     // Network Process Management
     void networkProcessDidTerminate(NetworkProcessProxy&, ProcessTerminationReason);
 


### PR DESCRIPTION
#### e3a858aa3f8e3beec1bb8855a7657a2c80db2b32
<pre>
Update the GPU process&apos; override languages list each time WKContextConfigurationSetOverrideLanguages is called
<a href="https://bugs.webkit.org/show_bug.cgi?id=248194">https://bugs.webkit.org/show_bug.cgi?id=248194</a>
rdar://102588345

Reviewed by NOBODY (OOPS!).

As part of making the &lt;!-- webkit-test-runner [ language=...] --&gt; test option
work with the GPU process, <a href="https://bugs.webkit.org/show_bug.cgi?id=242581">https://bugs.webkit.org/show_bug.cgi?id=242581</a> and
<a href="https://bugs.webkit.org/show_bug.cgi?id=242584">https://bugs.webkit.org/show_bug.cgi?id=242584</a> changed the way
WKContextConfigurationSetOverrideLanguages works, so that when the GPU
process is created, it gets its override languages through
through AuxiliaryProcessProxy::populateOverrideLanguagesLaunchOptions,
which reads the UI process global override languages state.

This change was done under the assumption that we only have a single
WebProcessPool whose override languages we care about at one time,
because WebKitTestRunner will create a new WebProcessPool when it
encounters a test with a different language TestOption value. While this
is correct (apart from third party uses of
WKContextConfigurationSetOverrideLanguages found in
<a href="https://bugs.webkit.org/show_bug.cgi?id=242827)">https://bugs.webkit.org/show_bug.cgi?id=242827)</a>, it&apos;s not sufficient,
because the GPU process is a singleton created once for the entire
WebKitTestRunner session (barring crashes), which means that when a
subsequent test that uses a different language TestOption is run, the
GPU process will not be using a matching override langauges list.

Until <a href="https://bugs.webkit.org/show_bug.cgi?id=242827">https://bugs.webkit.org/show_bug.cgi?id=242827</a> is addressed in a
way that doesn&apos;t require the GPU process to know what the override languages
list is, continue assuming that we don&apos;t have multiple WebProcessPools running
with different override languages, and update the GPU process&apos; override
languages list with the value most recently passed in to
WKContextConfigurationSetOverrideLanguages.

* LayoutTests/fast/text/international/system-language/han-text-style.html:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::userPreferredLanguagesChanged):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/UIProcess/API/C/WKContextConfigurationRef.cpp:
(WKContextConfigurationSetOverrideLanguages):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::updateOverrideLanguagesInGPUProcessIfCreated):
* Source/WebKit/UIProcess/WebProcessPool.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3a858aa3f8e3beec1bb8855a7657a2c80db2b32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106751 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167021 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6786 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35232 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103438 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5105 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83860 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32144 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/520 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21704 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5303 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44199 "Found 2 new test failures: fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41026 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->