### PR TITLE
[Filters] Introduce GraphicsStyle and add it to GraphicsContext and GraphicsContextState

### DIFF
--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -330,6 +330,26 @@ TextStream& operator<<(TextStream& ts, const OptionSet<Option>& options)
     return ts << "]";
 }
 
+template<typename T, size_t size>
+TextStream& operator<<(TextStream& ts, const std::array<T, size>& array)
+{
+    ts << "[";
+
+    unsigned count = 0;
+    for (const auto& value : array) {
+        if (count)
+            ts << ", ";
+        ts << value;
+        if (++count == ts.containerSizeLimit())
+            break;
+    }
+
+    if (count != array.size())
+        ts << ", ...";
+
+    return ts << "]";
+}
+
 template<typename, typename = void, typename = void, typename = void, typename = void, size_t = 0>
 struct supports_text_stream_insertion : std::false_type { };
 
@@ -362,6 +382,9 @@ struct supports_text_stream_insertion<RefPtr<T>> : supports_text_stream_insertio
 
 template<typename T>
 struct supports_text_stream_insertion<Ref<T>> : supports_text_stream_insertion<T> { };
+
+template<typename T, size_t size>
+struct supports_text_stream_insertion<std::array<T, size>> : supports_text_stream_insertion<T> { };
 
 template<typename T>
 struct ValueOrEllipsis {

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1614,6 +1614,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/GraphicsLayerFactory.h
     platform/graphics/GraphicsLayerTransform.h
     platform/graphics/GraphicsLayerUpdater.h
+    platform/graphics/GraphicsStyle.h
     platform/graphics/GraphicsTypes.h
     platform/graphics/GraphicsTypesGL.h
     platform/graphics/Icon.h

--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -190,9 +190,29 @@ struct CGShadowStyle {
 };
 typedef struct CGShadowStyle CGShadowStyle;
 
+#if HAVE(CORE_GRAPHICS_STYLES)
+struct CGGaussianBlurStyle {
+    unsigned version;
+    CGFloat radius;
+};
+typedef struct CGGaussianBlurStyle CGGaussianBlurStyle;
+
+struct CGColorMatrixStyle {
+    unsigned version;
+    CGFloat matrix[20];
+};
+typedef struct CGColorMatrixStyle CGColorMatrixStyle;
+#endif
+
 typedef CF_ENUM (int32_t, CGStyleType)
 {
+    kCGStyleUnknown = 0,
     kCGStyleShadow = 1,
+    kCGStyleFocusRing = 2,
+#if HAVE(CORE_GRAPHICS_STYLES)
+    kCGStyleGaussianBlur = 3,
+    kCGStyleColorMatrix = 4,
+#endif
 };
 
 #if PLATFORM(MAC)
@@ -344,6 +364,12 @@ CGGradientRef CGGradientCreateWithColorsAndOptions(CGColorSpaceRef, CFArrayRef, 
 
 #if HAVE(CORE_GRAPHICS_PREMULTIPLIED_INTERPOLATION_GRADIENT)
 extern const CFStringRef kCGGradientInterpolatesPremultiplied;
+#endif
+
+#if HAVE(CORE_GRAPHICS_STYLES)
+CGStyleRef CGStyleCreateShadow2(CGSize offset, CGFloat radius, CGColorRef);
+CGStyleRef CGStyleCreateGaussianBlur(const CGGaussianBlurStyle*);
+CGStyleRef CGStyleCreateColorMatrix(const CGColorMatrixStyle*);
 #endif
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2139,6 +2139,7 @@ platform/graphics/GraphicsLayer.cpp
 platform/graphics/GraphicsLayerContentsDisplayDelegate.cpp
 platform/graphics/GraphicsLayerTransform.cpp
 platform/graphics/GraphicsLayerUpdater.cpp
+platform/graphics/GraphicsStyle.cpp
 platform/graphics/GraphicsTypes.cpp
 platform/graphics/HEVCUtilities.cpp
 platform/graphics/Icon.cpp

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -207,6 +207,9 @@ static const char* stateChangeName(GraphicsContextState::Change change)
     case GraphicsContextState::Change::DropShadow:
         return "drop-shadow";
 
+    case GraphicsContextState::Change::Style:
+        return "style";
+
     case GraphicsContextState::Change::Alpha:
         return "alpha";
 
@@ -258,6 +261,7 @@ TextStream& GraphicsContextState::dump(TextStream& ts) const
 
     dump(Change::CompositeMode,                 &GraphicsContextState::m_compositeMode);
     dump(Change::DropShadow,                    &GraphicsContextState::m_dropShadow);
+    dump(Change::Style,                         &GraphicsContextState::m_style);
 
     dump(Change::Alpha,                         &GraphicsContextState::m_alpha);
     dump(Change::ImageInterpolationQuality,     &GraphicsContextState::m_imageInterpolationQuality);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GraphicsStyle.h"
 #include "GraphicsTypes.h"
 #include "SourceBrush.h"
 #include "WindRule.h"
@@ -45,18 +46,19 @@ public:
 
         CompositeMode               = 1 << 5,
         DropShadow                  = 1 << 6,
+        Style                       = 1 << 7,
 
-        Alpha                       = 1 << 7,
-        TextDrawingMode             = 1 << 8,
-        ImageInterpolationQuality   = 1 << 9,
+        Alpha                       = 1 << 8,
+        TextDrawingMode             = 1 << 9,
+        ImageInterpolationQuality   = 1 << 10,
 
-        ShouldAntialias             = 1 << 10,
-        ShouldSmoothFonts           = 1 << 11,
-        ShouldSubpixelQuantizeFonts = 1 << 12,
-        ShadowsIgnoreTransforms     = 1 << 13,
-        DrawLuminanceMask           = 1 << 14,
+        ShouldAntialias             = 1 << 11,
+        ShouldSmoothFonts           = 1 << 12,
+        ShouldSubpixelQuantizeFonts = 1 << 13,
+        ShadowsIgnoreTransforms     = 1 << 14,
+        DrawLuminanceMask           = 1 << 15,
 #if HAVE(OS_DARK_MODE_SUPPORT)
-        UseDarkAppearance           = 1 << 15,
+        UseDarkAppearance           = 1 << 16,
 #endif
     };
     using ChangeFlags = OptionSet<Change>;
@@ -96,6 +98,9 @@ public:
 
     const DropShadow& dropShadow() const { return m_dropShadow; }
     void setDropShadow(const DropShadow& dropShadow) { setProperty(Change::DropShadow, &GraphicsContextState::m_dropShadow, dropShadow); }
+
+    const std::optional<GraphicsStyle>& style() const { return m_style; }
+    void setStyle(const std::optional<GraphicsStyle>& style) { setProperty(Change::Style, &GraphicsContextState::m_style, style); }
 
     float alpha() const { return m_alpha; }
     void setAlpha(float alpha) { setProperty(Change::Alpha, &GraphicsContextState::m_alpha, alpha); }
@@ -165,14 +170,15 @@ private:
 
     SourceBrush m_fillBrush { Color::black };
     WindRule m_fillRule { WindRule::NonZero };
-    
+
     SourceBrush m_strokeBrush { Color::black };
     float m_strokeThickness { 0 };
     StrokeStyle m_strokeStyle { SolidStroke };
-    
+
     CompositeMode m_compositeMode { CompositeOperator::SourceOver, BlendMode::Normal };
     DropShadow m_dropShadow;
-    
+    std::optional<GraphicsStyle> m_style;
+
     float m_alpha { 1 };
     InterpolationQuality m_imageInterpolationQuality { InterpolationQuality::Default };
     TextDrawingModeFlags m_textDrawingMode { TextDrawingMode::Fill };
@@ -206,6 +212,7 @@ void GraphicsContextState::encode(Encoder& encoder) const
 
     encode(Change::CompositeMode,                   &GraphicsContextState::m_compositeMode);
     encode(Change::DropShadow,                      &GraphicsContextState::m_dropShadow);
+    encode(Change::Style,                           &GraphicsContextState::m_style);
 
     encode(Change::Alpha,                           &GraphicsContextState::m_alpha);
     encode(Change::ImageInterpolationQuality,       &GraphicsContextState::m_imageInterpolationQuality);
@@ -261,6 +268,8 @@ std::optional<GraphicsContextState> GraphicsContextState::decode(Decoder& decode
         return std::nullopt;
     if (!decode(state, Change::DropShadow,                  &GraphicsContextState::m_dropShadow))
         return std::nullopt;
+    if (!decode(state, Change::Style,                       &GraphicsContextState::m_style))
+        return std::nullopt;
 
     if (!decode(state, Change::Alpha,                       &GraphicsContextState::m_alpha))
         return std::nullopt;
@@ -306,6 +315,7 @@ template<> struct EnumTraits<WebCore::GraphicsContextState::Change> {
 
         WebCore::GraphicsContextState::Change::CompositeMode,
         WebCore::GraphicsContextState::Change::DropShadow,
+        WebCore::GraphicsContextState::Change::Style,
 
         WebCore::GraphicsContextState::Change::Alpha,
         WebCore::GraphicsContextState::Change::TextDrawingMode,

--- a/Source/WebCore/platform/graphics/GraphicsStyle.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GraphicsStyle.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, const GraphicsDropShadow& dropShadow)
+{
+    ts.dumpProperty("offset", dropShadow.offset);
+    ts.dumpProperty("radius", dropShadow.radius);
+    ts.dumpProperty("color", dropShadow.color);
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const GraphicsGaussianBlur& gaussianBlur)
+{
+    ts.dumpProperty("radius", gaussianBlur.radius);
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const GraphicsColorMatrix& colorMatrix)
+{
+    ts.dumpProperty("values", colorMatrix.values);
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const GraphicsStyle& style)
+{
+    WTF::switchOn(style,
+        [&] (const GraphicsDropShadow& dropShadow) {
+            ts << dropShadow;
+        },
+        [&] (const GraphicsGaussianBlur& gaussianBlur) {
+            ts << gaussianBlur;
+        },
+        [&] (const GraphicsColorMatrix& colorMatrix) {
+            ts << colorMatrix;
+        }
+    );
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "FloatSize.h"
+#include <wtf/Vector.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+struct GraphicsDropShadow {
+    FloatSize offset;
+    FloatSize radius;
+    Color color;
+    
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<GraphicsDropShadow> decode(Decoder&);
+};
+
+inline bool operator==(const GraphicsDropShadow& a, const GraphicsDropShadow& b)
+{
+    return a.offset == b.offset && a.radius == b.radius && a.color == b.color;
+}
+
+struct GraphicsGaussianBlur {
+    FloatSize radius;
+
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<GraphicsGaussianBlur> decode(Decoder&);
+};
+
+inline bool operator==(const GraphicsGaussianBlur& a, const GraphicsGaussianBlur& b)
+{
+    return a.radius == b.radius;
+}
+
+struct GraphicsColorMatrix {
+    std::array<float, 20> values;
+
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<GraphicsColorMatrix> decode(Decoder&);
+};
+
+inline bool operator==(const GraphicsColorMatrix& a, const GraphicsColorMatrix& b)
+{
+    return a.values == b.values;
+}
+
+using GraphicsStyle = std::variant<
+    GraphicsDropShadow,
+    GraphicsGaussianBlur,
+    GraphicsColorMatrix
+>;
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsDropShadow&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsGaussianBlur&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsColorMatrix&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const GraphicsStyle&);
+
+template<class Encoder>
+void GraphicsDropShadow::encode(Encoder& encoder) const
+{
+    encoder << offset;
+    encoder << radius;
+    encoder << color;
+}
+
+template<class Decoder>
+std::optional<GraphicsDropShadow> GraphicsDropShadow::decode(Decoder& decoder)
+{
+    std::optional<FloatSize> offset;
+    decoder >> offset;
+    if (!offset)
+        return std::nullopt;
+
+    std::optional<FloatSize> radius;
+    decoder >> radius;
+    if (!radius)
+        return std::nullopt;
+
+    std::optional<Color> color;
+    decoder >> color;
+    if (!color)
+        return std::nullopt;
+
+    return GraphicsDropShadow { *offset, *radius, *color };
+}
+
+template<class Encoder>
+void GraphicsGaussianBlur::encode(Encoder& encoder) const
+{
+    encoder << radius;
+}
+
+template<class Decoder>
+std::optional<GraphicsGaussianBlur> GraphicsGaussianBlur::decode(Decoder& decoder)
+{
+    std::optional<FloatSize> radius;
+    decoder >> radius;
+    if (!radius)
+        return std::nullopt;
+
+    return GraphicsGaussianBlur { *radius };
+}
+
+template<class Encoder>
+void GraphicsColorMatrix::encode(Encoder& encoder) const
+{
+    encoder << values;
+}
+
+template<class Decoder>
+std::optional<GraphicsColorMatrix> GraphicsColorMatrix::decode(Decoder& decoder)
+{
+    std::optional<std::array<float, 20>> values;
+    decoder >> values;
+    if (!values)
+        return std::nullopt;
+
+    return GraphicsColorMatrix { WTFMove(*values) };
+}
+
+} // namespace WebCore


### PR DESCRIPTION
#### d6bd013ec6badee83d7af668ae1f5535714507f1
<pre>
[Filters] Introduce GraphicsStyle and add it to GraphicsContext and GraphicsContextState
<a href="https://bugs.webkit.org/show_bug.cgi?id=248197">https://bugs.webkit.org/show_bug.cgi?id=248197</a>
rdar://102591759

Reviewed by Cameron McCormack.

This will allow applying a GraphicsStyle to all the following drawing commands.
Some of FilterEffects can be expressed as GraphicsStyles. Applying a FilterEffect
using CoreGraphics will be done by setting GraphicsStyle to the GraphicsContext
before drawing the sourceImage of the Filter.

The plan is use transparency layers to control beginning, ending and nesting
GraphicsStyles.

* Source/WTF/wtf/text/TextStream.h:
(WTF::operator&lt;&lt;):
* Source/WebCore/Headers.cmake:
* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::stateChangeName):
(WebCore::GraphicsContextState::dump const):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::style const):
(WebCore::GraphicsContextState::setStyle):
(WebCore::GraphicsContextState::encode const):
(WebCore::GraphicsContextState::decode):
* Source/WebCore/platform/graphics/GraphicsStyle.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsStyle.h: Added.
(WebCore::operator==):
(WebCore::GraphicsDropShadow::encode const):
(WebCore::GraphicsDropShadow::decode):
(WebCore::GraphicsGaussianBlur::encode const):
(WebCore::GraphicsGaussianBlur::decode):
(WebCore::GraphicsColorMatrix::encode const):
(WebCore::GraphicsColorMatrix::decode):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::setCGStyle):
(WebCore::GraphicsContextCG::didUpdateState):

Canonical link: <a href="https://commits.webkit.org/256980@main">https://commits.webkit.org/256980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e48b9fdd026f154f230e1ba47cc438b1b88693b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106940 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167206 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7007 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35434 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103614 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103086 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5262 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84056 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32261 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75186 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88334 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/694 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/83995 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21865 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28487 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5487 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44342 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86821 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2372 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41218 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19509 "Passed tests") | 
<!--EWS-Status-Bubble-End-->