### PR TITLE
API::Object allocations leak in ObjC ARC due to internal strong wrapper reference.

### DIFF
--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -39,10 +39,6 @@
 
 #define DELEGATE_REF_COUNTING_TO_COCOA PLATFORM(COCOA)
 
-#if DELEGATE_REF_COUNTING_TO_COCOA
-OBJC_CLASS NSObject;
-#endif
-
 namespace API {
 
 class Object
@@ -231,14 +227,14 @@ public:
 #if DELEGATE_REF_COUNTING_TO_COCOA
 #ifdef __OBJC__
     template<typename T, typename... Args>
-    static void constructInWrapper(NSObject <WKObject> *wrapper, Args&&... args)
+    static void constructInWrapper(id <WKObject> wrapper, Args&&... args)
     {
         Object* object = new (&wrapper._apiObject) T(std::forward<Args>(args)...);
-        object->m_wrapper = wrapper;
+        object->m_wrapper = (__bridge CFTypeRef)wrapper;
     }
-#endif
 
-    NSObject *wrapper() const { return m_wrapper; }
+    id <WKObject> wrapper() const { return (__bridge id <WKObject>)m_wrapper; }
+#endif
 
     void ref() const;
     void deref() const;
@@ -261,7 +257,7 @@ private:
     // Derived classes must override operator new and call newObject().
     void* operator new(size_t) = delete;
 
-    NSObject *m_wrapper;
+    CFTypeRef m_wrapper;
 #endif // DELEGATE_REF_COUNTING_TO_COCOA
 };
 

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -119,12 +119,12 @@ namespace API {
 
 void Object::ref() const
 {
-    CFRetain((__bridge CFTypeRef)wrapper());
+    CFRetain(m_wrapper);
 }
 
 void Object::deref() const
 {
-    CFRelease((__bridge CFTypeRef)wrapper());
+    CFRelease(m_wrapper);
 }
 
 static id <WKObject> allocateWKObject(Class cls, size_t size)
@@ -475,7 +475,7 @@ void* Object::newObject(size_t size, Type type)
     }
 
     Object& object = wrapper._apiObject;
-    object.m_wrapper = wrapper;
+    object.m_wrapper = (__bridge CFTypeRef)wrapper;
 
     return &object;
 }

--- a/Source/WebKit/Shared/Cocoa/WKNSArray.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSArray.mm
@@ -52,7 +52,7 @@
 - (id)objectAtIndex:(NSUInteger)i
 {
     API::Object* object = _array->at(i);
-    return object ? object->wrapper() : [NSNull null];
+    return object ? (id)object->wrapper() : [NSNull null];
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -68,7 +68,7 @@ using namespace WebKit;
     if (!exists)
         return nil;
 
-    return value ? value->wrapper() : [NSNull null];
+    return value ? (id)value->wrapper() : [NSNull null];
 }
 
 - (NSEnumerator *)keyEnumerator

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -214,7 +214,9 @@ public:
 
     NSArray *errors();
 
+#ifdef __OBJC__
     _WKWebExtension *wrapper() const { return (_WKWebExtension *)API::ObjectImpl<API::Object::Type::WebExtension>::wrapper(); }
+#endif
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -193,7 +193,9 @@ public:
     void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
     void webViewWebContentProcessDidTerminate(WKWebView *);
 
+#ifdef __OBJC__
     _WKWebExtensionContext *wrapper() const { return (_WKWebExtensionContext *)API::ObjectImpl<API::Object::Type::WebExtensionContext>::wrapper(); }
+#endif
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -87,7 +87,9 @@ public:
     template<typename T, typename U>
     void sendToAllProcesses(const T& message, ObjectIdentifier<U> destinationID);
 
+#ifdef __OBJC__
     _WKWebExtensionController *wrapper() const { return (_WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }
+#endif
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -101,7 +101,9 @@ public:
 
     unsigned hash() const { return m_hash; }
 
+#ifdef __OBJC__
     _WKWebExtensionMatchPattern *wrapper() const { return (_WKWebExtensionMatchPattern *)API::ObjectImpl<API::Object::Type::WebExtensionMatchPattern>::wrapper(); }
+#endif
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -71,6 +71,7 @@ OBJC_CLASS AVPlayerViewController;
 OBJC_CLASS CALayer;
 OBJC_CLASS NSFileWrapper;
 OBJC_CLASS NSMenu;
+OBJC_CLASS NSObject;
 OBJC_CLASS NSSet;
 OBJC_CLASS NSTextAlternatives;
 OBJC_CLASS UIGestureRecognizer;


### PR DESCRIPTION
#### bbb9a28e95477f7f83bb0b2b822d5aebfecf6b44
<pre>
API::Object allocations leak in ObjC ARC due to internal strong wrapper reference.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248205">https://bugs.webkit.org/show_bug.cgi?id=248205</a>

Reviewed by Darin Adler and David Kilzer.

The m_wrapper in `API::Object` was counting as a strong reference in objects using ObjC ARC.
This was affecting all the new `_WKWebExtension*` API classes.

Changed `m_wrapper` in `API::Object` to be a `CFTypeRef` instead. This hides the references from
ARC and continues to let `API::Object` manage the ref counting with `CFRetain`/`CFRelease`.

Tested with automated WKWebExtension API tests and manual testing with Xcode&apos;s memory graph.

* Source/WebKit/Shared/API/APIObject.h:
(API::Object::constructInWrapper): Bridge cast to `CFTypeRef` when setting m_wrapper. Use `id &lt;WKObject&gt;`.
(API::Object::wrapper const): Changed to return `id &lt;WKObject&gt;` instead of NSObject *. This
better balances with `constructInWrapper()` taking `id &lt;WKObject&gt;`. wrapper() is now also limited
to ObjC contexts, like `constructInWrapper()`, which ObjC/ObjC++ files is the only place it is used.
The `WKObject` protocol conforms to the `NSObject` protocol, so `NSObject &lt;WKObject&gt; *` is redundant.
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::ref const): Use `m_wrapper` instead of `wrapper()` since the type is now `CFTypeRef`.
(API::Object::deref const): Ditto.
(API::Object::newObject): Bridge cast to `CFTypeRef` when setting m_wrapper.
* Source/WebKit/Shared/Cocoa/WKNSArray.mm:
(-[WKNSArray objectAtIndex:]): Cast `wrapper()` to id to avoid warning about NSNull not conforming to `WKObject`.
* Source/WebKit/Shared/Cocoa/WKNSDictionary.mm:
(-[WKNSDictionary objectForKey:]): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtension.h: Wrap `wrapper()` in `#if __OBJC__` to match `API::Object`.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h: Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h: Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h: Ditto.
* Source/WebKit/UIProcess/PageClient.h: Added `OBJC_CLASS NSObject;` to fix build.

Canonical link: <a href="https://commits.webkit.org/256954@main">https://commits.webkit.org/256954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69c25a7baa36e9f95aa7c897556aa0d55d2adaa3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106853 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6901 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35336 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103532 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102998 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83964 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32184 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87036 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/614 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/597 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2355 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41123 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->