### PR TITLE
Fix various leaks and reference cycles in Web Extension classes.

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -65,6 +65,7 @@ Ref<PageConfiguration> PageConfiguration::copy() const
     copy->m_userContentController = this->m_userContentController;
 #if ENABLE(WK_WEB_EXTENSIONS)
     copy->m_webExtensionController = this->m_webExtensionController;
+    copy->m_weakWebExtensionController = this->m_weakWebExtensionController;
 #endif
     copy->m_pageGroup = this->m_pageGroup;
     copy->m_preferences = this->m_preferences;
@@ -146,6 +147,16 @@ WebExtensionController* PageConfiguration::webExtensionController()
 void PageConfiguration::setWebExtensionController(WebExtensionController* webExtensionController)
 {
     m_webExtensionController = webExtensionController;
+}
+
+WebExtensionController* PageConfiguration::weakWebExtensionController()
+{
+    return m_weakWebExtensionController.get();
+}
+
+void PageConfiguration::setWeakWebExtensionController(WebExtensionController* webExtensionController)
+{
+    m_weakWebExtensionController = webExtensionController;
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS)
 

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -89,6 +89,9 @@ public:
 #if ENABLE(WK_WEB_EXTENSIONS)
     WebKit::WebExtensionController* webExtensionController();
     void setWebExtensionController(WebKit::WebExtensionController*);
+
+    WebKit::WebExtensionController* weakWebExtensionController();
+    void setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
     WebKit::WebPageGroup* pageGroup();
@@ -214,6 +217,7 @@ private:
     RefPtr<WebKit::WebUserContentControllerProxy> m_userContentController;
 #if ENABLE(WK_WEB_EXTENSIONS)
     RefPtr<WebKit::WebExtensionController> m_webExtensionController;
+    WeakPtr<WebKit::WebExtensionController> m_weakWebExtensionController;
 #endif
     RefPtr<WebKit::WebPageGroup> m_pageGroup;
     RefPtr<WebKit::WebPreferences> m_preferences;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -461,8 +461,11 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     pageConfiguration->setDefaultWebsitePolicies([_configuration defaultWebpagePreferences]->_websitePolicies.get());
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    if (auto *controller = _configuration.get()._webExtensionControllerIfExists)
+    if (auto *controller = _configuration.get()._strongWebExtensionController)
         pageConfiguration->setWebExtensionController(&controller._webExtensionController);
+
+    if (auto *controller = _configuration.get()._weakWebExtensionController)
+        pageConfiguration->setWeakWebExtensionController(&controller._webExtensionController);
 #endif
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -122,6 +122,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     LazyInitialized<RetainPtr<WKUserContentController>> _userContentController;
 #if ENABLE(WK_WEB_EXTENSIONS)
     LazyInitialized<RetainPtr<_WKWebExtensionController>> _webExtensionController;
+    WeakObjCPtr<_WKWebExtensionController> _weakWebExtensionController;
 #endif
     LazyInitialized<RetainPtr<_WKVisitedLinkStore>> _visitedLinkStore;
     LazyInitialized<RetainPtr<WKWebsiteDataStore>> _websiteDataStore;
@@ -300,11 +301,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     [coder encodeObject:self.userContentController forKey:@"userContentController"];
     [coder encodeObject:self.websiteDataStore forKey:@"websiteDataStore"];
 
-#if ENABLE(WK_WEB_EXTENSIONS)
-    if (auto *controller = self._webExtensionControllerIfExists)
-        [coder encodeObject:controller forKey:@"webExtensionController"];
-#endif
-
     [coder encodeBool:self.suppressesIncrementalRendering forKey:@"suppressesIncrementalRendering"];
 
     if (_applicationNameForUserAgent)
@@ -343,11 +339,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     self.preferences = [coder decodeObjectOfClass:[WKPreferences class] forKey:@"preferences"];
     self.userContentController = [coder decodeObjectOfClass:[WKUserContentController class] forKey:@"userContentController"];
     self.websiteDataStore = [coder decodeObjectOfClass:[WKWebsiteDataStore class] forKey:@"websiteDataStore"];
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-    if ([coder containsValueForKey:@"webExtensionController"])
-        self._webExtensionController = [coder decodeObjectOfClass:[_WKWebExtensionController class] forKey:@"webExtensionController"];
-#endif
 
     self.suppressesIncrementalRendering = [coder decodeBoolForKey:@"suppressesIncrementalRendering"];
 
@@ -402,8 +393,11 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    if (auto *controller = self._webExtensionControllerIfExists)
+    if (auto *controller = self->_webExtensionController.peek())
         configuration._webExtensionController = controller;
+
+    if (auto controller = self->_weakWebExtensionController.get())
+        configuration->_weakWebExtensionController = controller.get();
 #endif
 
     configuration->_suppressesIncrementalRendering = self->_suppressesIncrementalRendering;
@@ -509,7 +503,7 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     _userContentController.set(userContentController);
 }
 
-- (_WKWebExtensionController *)_webExtensionControllerIfExists
+- (_WKWebExtensionController *)_strongWebExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
     return _webExtensionController.peek();
@@ -521,7 +515,9 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 - (_WKWebExtensionController *)_webExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return _webExtensionController.get([] { return adoptNS([[_WKWebExtensionController alloc] init]); });
+    return self._weakWebExtensionController ?: _webExtensionController.get([] {
+        return adoptNS([[_WKWebExtensionController alloc] init]);
+    });
 #else
     return nullptr;
 #endif
@@ -531,6 +527,22 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
     _webExtensionController.set(webExtensionController);
+#endif
+}
+
+- (_WKWebExtensionController *)_weakWebExtensionController
+{
+#if ENABLE(WK_WEB_EXTENSIONS)
+    return _weakWebExtensionController.getAutoreleased();
+#else
+    return nullptr;
+#endif
+}
+
+- (void)_setWeakWebExtensionController:(_WKWebExtensionController *)webExtensionController
+{
+#if ENABLE(WK_WEB_EXTENSIONS)
+    _weakWebExtensionController = webExtensionController;
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -60,7 +60,8 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, strong, setter=_setVisitedLinkStore:) _WKVisitedLinkStore *_visitedLinkStore;
 
-@property (nonatomic, readonly) _WKWebExtensionController *_webExtensionControllerIfExists;
+@property (nonatomic, strong, readonly) _WKWebExtensionController *_strongWebExtensionController;
+@property (nonatomic, weak, setter=_setWeakWebExtensionController:) _WKWebExtensionController *_weakWebExtensionController;
 @property (nonatomic, strong, setter=_setWebExtensionController:) _WKWebExtensionController *_webExtensionController;
 
 @property (nonatomic, weak, setter=_setAlternateWebViewForNavigationGestures:) WKWebView *_alternateWebViewForNavigationGestures;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  A controller is associated with @link WKWebView @/link via the `webExtensionController` property on @link WKWebViewConfiguration @/link.
  */
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
-@interface _WKWebExtensionController : NSObject <NSSecureCoding>
+@interface _WKWebExtensionController : NSObject
 
 /*! @abstract The extension controller delegate. */
 @property (nonatomic, weak) id <_WKWebExtensionControllerDelegate> delegate;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm
@@ -37,21 +37,6 @@
 
 @implementation _WKWebExtensionController
 
-+ (BOOL)supportsSecureCoding
-{
-    return YES;
-}
-
-- (instancetype)initWithCoder:(NSCoder *)coder
-{
-    return [self init];
-}
-
-- (void)encodeWithCoder:(NSCoder *)coder
-{
-    // Nothing to meaningfully encode.
-}
-
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 - (instancetype)init
@@ -74,26 +59,36 @@
 
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext
 {
+    NSParameterAssert(extensionContext);
+
     return [self loadExtensionContext:extensionContext error:nullptr];
 }
 
 - (BOOL)loadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
+    NSParameterAssert(extensionContext);
+
     return _webExtensionController->load(extensionContext._webExtensionContext, outError);
 }
 
 - (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext
 {
+    NSParameterAssert(extensionContext);
+
     return [self unloadExtensionContext:extensionContext error:nullptr];
 }
 
 - (BOOL)unloadExtensionContext:(_WKWebExtensionContext *)extensionContext error:(NSError **)outError
 {
+    NSParameterAssert(extensionContext);
+
     return _webExtensionController->unload(extensionContext._webExtensionContext, outError);
 }
 
 - (_WKWebExtensionContext *)extensionContextForExtension:(_WKWebExtension *)extension
 {
+    NSParameterAssert(extension);
+
     if (auto extensionContext = _webExtensionController->extensionContext(extension._webExtension))
         return extensionContext->wrapper();
     return nil;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1001,7 +1001,9 @@ WKWebViewConfiguration *WebExtensionContext::webViewConfiguration()
 
     WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
 
-    configuration._webExtensionController = m_extensionController->wrapper();
+    // Use the weak property to avoid a reference cycle while an extension web view is being held by the context.
+    configuration._weakWebExtensionController = m_extensionController->wrapper();
+
     configuration._processDisplayName = extension().webProcessDisplayName();
 
     WKPreferences *preferences = configuration.preferences;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -62,6 +62,11 @@ void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLS
         URL frameDocumentURL = task.frameInfo().request().url().isEmpty() ? task.request().firstPartyForCookies() : task.frameInfo().request().url();
         URL requestURL = task.request().url();
 
+        if (!m_webExtensionController) {
+            task.didComplete([NSError errorWithDomain:NSURLErrorDomain code:noPermissionErrorCode userInfo:nil]);
+            return;
+        }
+
         auto extensionContext = m_webExtensionController->extensionContext(requestURL);
         if (!extensionContext) {
             // We need to return the same error here, as we do below for URLs that don't match web_accessible_resources.
@@ -113,6 +118,11 @@ void WebExtensionURLSchemeHandler::platformStopTask(WebPageProxy& page, WebURLSc
 {
     auto operation = m_operations.take(task);
     [operation cancel];
+}
+
+void WebExtensionURLSchemeHandler::platformTaskCompleted(WebURLSchemeTask& task)
+{
+    m_operations.remove(task);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -55,6 +55,13 @@ WebExtensionController::WebExtensionController()
     webExtensionControllers().add(m_identifier, this);
 }
 
+WebExtensionController::~WebExtensionController()
+{
+#if PLATFORM(COCOA)
+    unloadAll();
+#endif
+}
+
 WebExtensionControllerParameters WebExtensionController::parameters() const
 {
     WebExtensionControllerParameters parameters;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -60,6 +60,7 @@ public:
     static WebExtensionController* get(WebExtensionControllerIdentifier);
 
     explicit WebExtensionController();
+    ~WebExtensionController();
 
     using WebExtensionContextSet = HashSet<Ref<WebExtensionContext>>;
     using WebExtensionSet = HashSet<Ref<WebExtension>>;
@@ -74,6 +75,8 @@ public:
 #if PLATFORM(COCOA)
     bool load(WebExtensionContext&, NSError ** = nullptr);
     bool unload(WebExtensionContext&, NSError ** = nullptr);
+
+    void unloadAll();
 
     void addPage(WebPageProxy&);
     void removePage(WebPageProxy&);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h
@@ -50,6 +50,7 @@ private:
 
     void platformStartTask(WebPageProxy&, WebURLSchemeTask&) final;
     void platformStopTask(WebPageProxy&, WebURLSchemeTask&) final;
+    void platformTaskCompleted(WebURLSchemeTask&) final;
 
     WeakPtr<WebExtensionController> m_webExtensionController;
     HashMap<Ref<WebURLSchemeTask>, RetainPtr<NSBlockOperation>> m_operations;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -495,6 +495,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     , m_userContentController(*m_configuration->userContentController())
 #if ENABLE(WK_WEB_EXTENSIONS)
     , m_webExtensionController(m_configuration->webExtensionController())
+    , m_weakWebExtensionController(m_configuration->weakWebExtensionController())
 #endif
     , m_visitedLinkStore(*m_configuration->visitedLinkStore())
     , m_websiteDataStore(*m_configuration->websiteDataStore())
@@ -564,6 +565,8 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #if ENABLE(WK_WEB_EXTENSIONS)
     if (m_webExtensionController)
         m_webExtensionController->addPage(*this);
+    if (m_weakWebExtensionController)
+        m_weakWebExtensionController->addPage(*this);
 #endif
 
     m_inspector = WebInspectorUIProxy::create(*this);
@@ -1221,6 +1224,8 @@ void WebPageProxy::close()
 #if ENABLE(WK_WEB_EXTENSIONS)
     if (m_webExtensionController)
         m_webExtensionController->removePage(*this);
+    if (m_weakWebExtensionController)
+        m_weakWebExtensionController->removePage(*this);
 #endif
 
 #if ENABLE(CONTEXT_MENUS)
@@ -8743,6 +8748,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #if ENABLE(WK_WEB_EXTENSIONS)
     if (m_webExtensionController)
         parameters.webExtensionControllerParameters = m_webExtensionController->parameters();
+    if (m_weakWebExtensionController)
+        parameters.webExtensionControllerParameters = m_weakWebExtensionController->parameters();
 #endif
 
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2779,6 +2779,7 @@ private:
 
 #if ENABLE(WK_WEB_EXTENSIONS)
     RefPtr<WebExtensionController> m_webExtensionController;
+    WeakPtr<WebExtensionController> m_weakWebExtensionController;
 #endif
 
     Ref<VisitedLinkStore> m_visitedLinkStore;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -77,6 +77,11 @@ WebExtensionContextProxy::WebExtensionContextProxy(WebExtensionContextParameters
     WebProcess::singleton().addMessageReceiver(Messages::WebExtensionContextProxy::messageReceiverName(), m_identifier, *this);
 }
 
+WebExtensionContextProxy::~WebExtensionContextProxy()
+{
+    WebProcess::singleton().removeMessageReceiver(Messages::WebExtensionContextProxy::messageReceiverName(), m_identifier);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -42,6 +42,8 @@ public:
     static RefPtr<WebExtensionContextProxy> get(WebExtensionContextIdentifier);
     static Ref<WebExtensionContextProxy> getOrCreate(WebExtensionContextParameters);
 
+    ~WebExtensionContextProxy();
+
     WebExtensionContextIdentifier identifier() { return m_identifier; }
 
     bool operator==(const WebExtensionContextProxy& other) const { return (this == &other); }

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -85,6 +85,11 @@ WebExtensionControllerProxy::WebExtensionControllerProxy(WebExtensionControllerP
     WebProcess::singleton().addMessageReceiver(Messages::WebExtensionControllerProxy::messageReceiverName(), m_identifier, *this);
 }
 
+WebExtensionControllerProxy::~WebExtensionControllerProxy()
+{
+    WebProcess::singleton().removeMessageReceiver(Messages::WebExtensionControllerProxy::messageReceiverName(), m_identifier);
+}
+
 void WebExtensionControllerProxy::load(const WebExtensionContextParameters& contextParameters)
 {
     auto context = WebExtensionContextProxy::getOrCreate(contextParameters);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -50,6 +50,8 @@ public:
     static RefPtr<WebExtensionControllerProxy> get(WebExtensionControllerIdentifier);
     static Ref<WebExtensionControllerProxy> getOrCreate(WebExtensionControllerParameters);
 
+    ~WebExtensionControllerProxy();
+
     using WebExtensionContextProxySet = HashSet<Ref<WebExtensionContextProxy>>;
     using WebExtensionContextProxyBaseURLMap = HashMap<URL, Ref<WebExtensionContextProxy>>;
 


### PR DESCRIPTION
#### 01ba8487b4464ec9fe00767613438148240e234f
<pre>
Fix various leaks and reference cycles in Web Extension classes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248207">https://bugs.webkit.org/show_bug.cgi?id=248207</a>

Reviewed by Darin Adler.

Issues this fixes:
* WKWebViewConfiguration holds a references to _WKWebExtensionController, and that strong references
  was causing a retain cycle when WebExtensionContext made a configuration and loaded a WKWebView.
  To solve this, add a new _weakWebExtensionController property to the configuration and page proxy
  that can be used internally when making extension WKWebViews.
* WebExtensionController was not unloading contexts on destruct, and that was causing some world leaks.
* WebProcess proxy objects were not removing themselves from the MessageReceiverMap, causing an ASSERT.
  This wasn&apos;t fatal, since the MessageReceiverMap uses WeakPtr now and the count is just a debug tool.
  Maybe we should remove the MessageReceiverMap counting now that WeakPtr makes it moot?
* Removed empty NSSecureCoding support from _WKWebExtensionController since it did nothing and really
  would need a complex implementation make it work correctly. This was conflicting with the WeakPtr changes.

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::copy const): Added weakWebExtensionController.
(API::PageConfiguration::weakWebExtensionController): Added.
(API::PageConfiguration::setWeakWebExtensionController): Added.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setupPageConfiguration:]): Setup weakWebExtensionController.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration encodeWithCoder:]): Removed webExtensionController.
(-[WKWebViewConfiguration initWithCoder:]): Ditto.
(-[WKWebViewConfiguration copyWithZone:]): Ditto.
(-[WKWebViewConfiguration _strongWebExtensionController]): Added.
(-[WKWebViewConfiguration _webExtensionController]): Support returning _weakWebExtensionController.
(-[WKWebViewConfiguration _weakWebExtensionController]): Added.
(-[WKWebViewConfiguration _setWeakWebExtensionController:]): Added.
(-[WKWebViewConfiguration _webExtensionControllerIfExists]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.mm:
(-[_WKWebExtensionController loadExtensionContext:]): Drive-by add of NSParameterAssert to match other methods.
(-[_WKWebExtensionController loadExtensionContext:error:]): Ditto.
(-[_WKWebExtensionController unloadExtensionContext:]): Ditto.
(-[_WKWebExtensionController unloadExtensionContext:error:]): Ditto.
(-[_WKWebExtensionController extensionContextForExtension:]): Ditto.
(+[_WKWebExtensionController supportsSecureCoding]): Deleted.
(-[_WKWebExtensionController initWithCoder:]): Deleted.
(-[_WKWebExtensionController encodeWithCoder:]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::webViewConfiguration): Set _weakWebExtensionController property.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::unload): Change unload order and protect context.
(WebKit::WebExtensionController::unloadAll): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask): Early return if weak WebExtensionController is null.
(WebKit::WebExtensionURLSchemeHandler::platformTaskCompleted): Added. Tasks were not being removed from map.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::~WebExtensionController): Added. Call unloadAll().
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionURLSchemeHandler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::WebPageProxy): Added m_weakWebExtensionController.
(WebKit::WebPageProxy::close): Use m_weakWebExtensionController too.
(WebKit::WebPageProxy::creationParameters): Ditto.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::~WebExtensionContextProxy): Added. Call removeMessageReceiver().
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::WebExtensionControllerProxy::~WebExtensionControllerProxy): Added. Call removeMessageReceiver().
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:

Canonical link: <a href="https://commits.webkit.org/256956@main">https://commits.webkit.org/256956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4de372021708137360995782a248349c3da8464

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106867 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6918 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35351 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/89758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103545 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103013 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83979 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/89758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/89758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/628 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/610 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5414 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2357 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1855 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->