### PR TITLE
Serialize and deserialize resizable ArrayBuffer

### DIFF
--- a/LayoutTests/js/dom/resizable-array-buffer-serialization-expected.txt
+++ b/LayoutTests/js/dom/resizable-array-buffer-serialization-expected.txt
@@ -1,0 +1,19 @@
+Resizable ArrayBuffers should be serializable
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.resizable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS cloned.resizable is true
+PASS cloned.byteLength is 36
+PASS cloned.maxByteLength is 128
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS cloned.byteLength is 128
+PASS cloned.maxByteLength is 128
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/resizable-array-buffer-serialization.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-serialization.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Resizable ArrayBuffers serialization</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Resizable ArrayBuffers should be serializable");
+var arrayBuffer = new ArrayBuffer(36, { maxByteLength: 128 });
+shouldBeTrue(`arrayBuffer.resizable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+var cloned = structuredClone(arrayBuffer);
+shouldBeTrue(`cloned.resizable`);
+shouldBe(`cloned.byteLength`, `36`);
+shouldBe(`cloned.maxByteLength`, `128`);
+cloned.resize(128);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+shouldBe(`cloned.byteLength`, `128`);
+shouldBe(`cloned.maxByteLength`, `128`);
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-expected.txt
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-expected.txt
@@ -1,0 +1,22 @@
+Resizable ArrayBuffers should be serializable
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.resizable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS int32AutoArray.length is 8
+PASS int32AutoArray.byteOffset is 4
+PASS cloned.buffer.resizable is true
+PASS cloned.buffer.byteLength is 36
+PASS cloned.buffer.maxByteLength is 128
+PASS cloned.length is 8
+PASS cloned.byteOffset is 4
+PASS cloned.buffer.byteLength is 128
+PASS cloned.buffer.maxByteLength is 128
+PASS cloned.length is 31
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-expected.txt
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-expected.txt
@@ -1,0 +1,24 @@
+Resizable ArrayBuffers should be serializable OOB
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.resizable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS int32AutoArray.length is 8
+PASS int32AutoArray.byteOffset is 4
+PASS cloned.buffer.resizable is true
+PASS cloned.buffer.byteLength is 0
+PASS cloned.buffer.maxByteLength is 128
+PASS cloned.length is 0
+PASS cloned.byteOffset is 0
+PASS cloned[0] is undefined
+PASS cloned.buffer.byteLength is 128
+PASS cloned.buffer.maxByteLength is 128
+PASS cloned.length is 31
+PASS cloned.byteOffset is 4
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length-expected.txt
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length-expected.txt
@@ -1,0 +1,24 @@
+Resizable ArrayBuffers should be serializable OOB explicit length
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.resizable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS int32Array.length is 4
+PASS int32Array.byteOffset is 4
+PASS cloned.buffer.resizable is true
+PASS cloned.buffer.byteLength is 0
+PASS cloned.buffer.maxByteLength is 128
+PASS cloned.length is 0
+PASS cloned.byteOffset is 0
+PASS cloned[0] is undefined
+PASS cloned.buffer.byteLength is 128
+PASS cloned.buffer.maxByteLength is 128
+PASS cloned.length is 4
+PASS cloned.byteOffset is 4
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds-explicit-length.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Resizable ArrayBuffers serialization</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Resizable ArrayBuffers should be serializable OOB explicit length");
+var arrayBuffer = new ArrayBuffer(36, { maxByteLength: 128 });
+var int32Array = new Int32Array(arrayBuffer, 4, 4);
+shouldBeTrue(`arrayBuffer.resizable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+shouldBe(`int32Array.length`, `4`);
+shouldBe(`int32Array.byteOffset`, `4`);
+arrayBuffer.resize(0);
+var cloned = structuredClone(int32Array);
+shouldBeTrue(`cloned.buffer.resizable`);
+shouldBe(`cloned.buffer.byteLength`, `0`);
+shouldBe(`cloned.buffer.maxByteLength`, `128`);
+shouldBe(`cloned.length`, `0`);
+shouldBe(`cloned.byteOffset`, `0`);
+shouldBe(`cloned[0]`, `undefined`);
+cloned.buffer.resize(128);
+shouldBe(`cloned.buffer.byteLength`, `128`);
+shouldBe(`cloned.buffer.maxByteLength`, `128`);
+shouldBe(`cloned.length`, `4`);
+shouldBe(`cloned.byteOffset`, `4`);
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization-out-of-bounds.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Resizable ArrayBuffers serialization</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Resizable ArrayBuffers should be serializable OOB");
+var arrayBuffer = new ArrayBuffer(36, { maxByteLength: 128 });
+var int32AutoArray = new Int32Array(arrayBuffer, 4);
+shouldBeTrue(`arrayBuffer.resizable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+shouldBe(`int32AutoArray.length`, `8`);
+shouldBe(`int32AutoArray.byteOffset`, `4`);
+arrayBuffer.resize(0);
+var cloned = structuredClone(int32AutoArray);
+shouldBeTrue(`cloned.buffer.resizable`);
+shouldBe(`cloned.buffer.byteLength`, `0`);
+shouldBe(`cloned.buffer.maxByteLength`, `128`);
+shouldBe(`cloned.length`, `0`);
+shouldBe(`cloned.byteOffset`, `0`);
+shouldBe(`cloned[0]`, `undefined`);
+cloned.buffer.resize(128);
+shouldBe(`cloned.buffer.byteLength`, `128`);
+shouldBe(`cloned.buffer.maxByteLength`, `128`);
+shouldBe(`cloned.length`, `31`);
+shouldBe(`cloned.byteOffset`, `4`);
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/js/dom/resizable-array-buffer-view-serialization.html
+++ b/LayoutTests/js/dom/resizable-array-buffer-view-serialization.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Resizable ArrayBuffers serialization</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Resizable ArrayBuffers should be serializable");
+var arrayBuffer = new ArrayBuffer(36, { maxByteLength: 128 });
+var int32AutoArray = new Int32Array(arrayBuffer, 4);
+shouldBeTrue(`arrayBuffer.resizable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+shouldBe(`int32AutoArray.length`, `8`);
+shouldBe(`int32AutoArray.byteOffset`, `4`);
+var cloned = structuredClone(int32AutoArray);
+shouldBeTrue(`cloned.buffer.resizable`);
+shouldBe(`cloned.buffer.byteLength`, `36`);
+shouldBe(`cloned.buffer.maxByteLength`, `128`);
+shouldBe(`cloned.length`, `8`);
+shouldBe(`cloned.byteOffset`, `4`);
+cloned.buffer.resize(128);
+shouldBe(`cloned.buffer.byteLength`, `128`);
+shouldBe(`cloned.buffer.maxByteLength`, `128`);
+shouldBe(`cloned.length`, `31`);
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-serialization-expected.txt
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-serialization-expected.txt
@@ -1,0 +1,21 @@
+Growable SharedArrayBuffers should be serializable
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.growable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS result.growable is true
+PASS result.byteLength is 36
+PASS result.maxByteLength is 128
+PASS result.growable is true
+PASS result.byteLength is 128
+PASS result.maxByteLength is 128
+PASS arrayBuffer.growable is true
+PASS arrayBuffer.byteLength is 128
+PASS arrayBuffer.maxByteLength is 128
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-serialization.html
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-serialization.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Growable SharedArrayBuffers should be serializable</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Growable SharedArrayBuffers should be serializable");
+window.jsTestIsAsync = true;
+
+var arrayBuffer = new SharedArrayBuffer(36, { maxByteLength: 128 });
+
+shouldBeTrue(`arrayBuffer.growable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(URL.createObjectURL(blob));
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+(async () => {
+    const worker = await createWorker(`
+        self.onmessage = (event) => {
+            let data = event.data;
+            self.postMessage(data);
+        }
+    `);
+
+    const promise = new Promise(resolve => worker.onmessage = event => resolve(event.data));
+    worker.postMessage(arrayBuffer);
+
+    globalThis.result = await promise;
+    shouldBeTrue(`result.growable`);
+    shouldBe(`result.byteLength`, `36`);
+    shouldBe(`result.maxByteLength`, `128`);
+    result.grow(128);
+    shouldBeTrue(`result.growable`);
+    shouldBe(`result.byteLength`, `128`);
+    shouldBe(`result.maxByteLength`, `128`);
+    shouldBeTrue(`arrayBuffer.growable`);
+    shouldBe(`arrayBuffer.byteLength`, `128`);
+    shouldBe(`arrayBuffer.maxByteLength`, `128`);
+    finishJSTest();
+})();
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-expected.txt
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-expected.txt
@@ -1,0 +1,26 @@
+Growable SharedArrayBuffers typed array should be serializable
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.growable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS int32AutoArray.length is 8
+PASS int32AutoArray.byteOffset is 4
+PASS result.buffer.growable is true
+PASS result.buffer.byteLength is 36
+PASS result.buffer.maxByteLength is 128
+PASS result.length is 8
+PASS result.byteOffset is 4
+PASS int32AutoArray[0] is 42
+PASS result.buffer.byteLength is 128
+PASS result.buffer.maxByteLength is 128
+PASS int32AutoArray.length is 31
+PASS int32AutoArray.byteOffset is 4
+PASS result.length is 31
+PASS result.byteOffset is 4
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length-expected.txt
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length-expected.txt
@@ -1,0 +1,26 @@
+Growable SharedArrayBuffers typed array should be serializable explicit length
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS arrayBuffer.growable is true
+PASS arrayBuffer.byteLength is 36
+PASS arrayBuffer.maxByteLength is 128
+PASS int32AutoArray.length is 4
+PASS int32AutoArray.byteOffset is 4
+PASS result.buffer.growable is true
+PASS result.buffer.byteLength is 36
+PASS result.buffer.maxByteLength is 128
+PASS result.length is 4
+PASS result.byteOffset is 4
+PASS int32AutoArray[0] is 42
+PASS result.buffer.byteLength is 128
+PASS result.buffer.maxByteLength is 128
+PASS int32AutoArray.length is 4
+PASS int32AutoArray.byteOffset is 4
+PASS result.length is 4
+PASS result.byteOffset is 4
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization-explicit-length.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Growable SharedArrayBuffers typed array should be serializable explicit length</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Growable SharedArrayBuffers typed array should be serializable explicit length");
+window.jsTestIsAsync = true;
+
+var arrayBuffer = new SharedArrayBuffer(36, { maxByteLength: 128 });
+var int32AutoArray = new Int32Array(arrayBuffer, 4, 4);
+
+shouldBeTrue(`arrayBuffer.growable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+shouldBe(`int32AutoArray.length`, `4`);
+shouldBe(`int32AutoArray.byteOffset`, `4`);
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(URL.createObjectURL(blob));
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+(async () => {
+    const worker = await createWorker(`
+        self.onmessage = (event) => {
+            let data = event.data;
+            self.postMessage(data);
+        }
+    `);
+
+    const promise = new Promise(resolve => worker.onmessage = event => resolve(event.data));
+    worker.postMessage(int32AutoArray);
+
+    globalThis.result = await promise;
+    shouldBeTrue(`result.buffer.growable`);
+    shouldBe(`result.buffer.byteLength`, `36`);
+    shouldBe(`result.buffer.maxByteLength`, `128`);
+    shouldBe(`result.length`, `4`);
+    shouldBe(`result.byteOffset`, `4`);
+    result[0] = 42;
+    shouldBe(`int32AutoArray[0]`, `42`);
+    arrayBuffer.grow(128);
+    shouldBe(`result.buffer.byteLength`, `128`);
+    shouldBe(`result.buffer.maxByteLength`, `128`);
+    shouldBe(`int32AutoArray.length`, `4`);
+    shouldBe(`int32AutoArray.byteOffset`, `4`);
+    shouldBe(`result.length`, `4`);
+    shouldBe(`result.byteOffset`, `4`);
+    finishJSTest();
+})();
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization.html
+++ b/LayoutTests/workers/sab/growable-shared-array-buffer-view-serialization.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<title>Growable SharedArrayBuffers typed array should be serializable</title>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Growable SharedArrayBuffers typed array should be serializable");
+window.jsTestIsAsync = true;
+
+var arrayBuffer = new SharedArrayBuffer(36, { maxByteLength: 128 });
+var int32AutoArray = new Int32Array(arrayBuffer, 4);
+
+shouldBeTrue(`arrayBuffer.growable`);
+shouldBe(`arrayBuffer.byteLength`, `36`);
+shouldBe(`arrayBuffer.maxByteLength`, `128`);
+shouldBe(`int32AutoArray.length`, `8`);
+shouldBe(`int32AutoArray.byteOffset`, `4`);
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(URL.createObjectURL(blob));
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+(async () => {
+    const worker = await createWorker(`
+        self.onmessage = (event) => {
+            let data = event.data;
+            self.postMessage(data);
+        }
+    `);
+
+    const promise = new Promise(resolve => worker.onmessage = event => resolve(event.data));
+    worker.postMessage(int32AutoArray);
+
+    globalThis.result = await promise;
+    shouldBeTrue(`result.buffer.growable`);
+    shouldBe(`result.buffer.byteLength`, `36`);
+    shouldBe(`result.buffer.maxByteLength`, `128`);
+    shouldBe(`result.length`, `8`);
+    shouldBe(`result.byteOffset`, `4`);
+    result[0] = 42;
+    shouldBe(`int32AutoArray[0]`, `42`);
+    arrayBuffer.grow(128);
+    shouldBe(`result.buffer.byteLength`, `128`);
+    shouldBe(`result.buffer.maxByteLength`, `128`);
+    shouldBe(`int32AutoArray.length`, `31`);
+    shouldBe(`int32AutoArray.byteOffset`, `4`);
+    shouldBe(`result.length`, `31`);
+    shouldBe(`result.byteOffset`, `4`);
+    finishJSTest();
+})();
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/workers/sab/postMessage-clones-growable-expected.txt
+++ b/LayoutTests/workers/sab/postMessage-clones-growable-expected.txt
@@ -1,0 +1,19 @@
+Checks that window.postMessage clones growable SharedArrayBuffers
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS memory[0] is 42
+PASS otherMemory[0] is 0
+PASS memory[0] is 42
+PASS otherMemory[0] is 43
+PASS memory.length is 1
+PASS otherMemory.length is 1
+PASS memory.length is 256
+PASS otherMemory.length is 1
+PASS memory.length is 256
+PASS otherMemory.length is 256
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/workers/sab/postMessage-clones-growable.html
+++ b/LayoutTests/workers/sab/postMessage-clones-growable.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useResizableArrayBuffer=true,--useSharedArrayBuffer=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Checks that window.postMessage clones growable SharedArrayBuffers");
+
+jsTestIsAsync = true;
+
+var sab = new SharedArrayBuffer(4, { maxByteLength: 1024 });
+var memory = new Int32Array(sab);
+var otherMemory;
+
+window.addEventListener("message", function (event) {
+    otherMemory = event.data;
+    memory[0] = 42;
+    shouldBe("memory[0]", "42");
+    shouldBe("otherMemory[0]", "0");
+    otherMemory[0] = 43;
+    shouldBe("memory[0]", "42");
+    shouldBe("otherMemory[0]", "43");
+    shouldBe("memory.length", "1");
+    shouldBe("otherMemory.length", "1");
+    sab.grow(1024);
+    shouldBe("memory.length", "256");
+    shouldBe("otherMemory.length", "1");
+    otherMemory.buffer.resize(1024); // Cloning it as resizable ArrayBuffer.
+    shouldBe("memory.length", "256");
+    shouldBe("otherMemory.length", "256");
+    finishJSTest();
+});
+
+window.postMessage(memory, "*");
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.cpp
@@ -41,9 +41,12 @@ ArrayBufferView::ArrayBufferView(TypedArrayType type, RefPtr<ArrayBuffer>&& buff
     , m_buffer(WTFMove(buffer))
 {
     if (byteLength) {
-        Checked<size_t, CrashOnOverflow> length(byteOffset);
-        length += byteLength.value();
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(length <= m_buffer->byteLength());
+        // If it is resizable, then it can be possible that length exceeds byteLength, and this is fine since it just becomes OOB array.
+        if (!isResizableOrGrowableShared()) {
+            Checked<size_t, CrashOnOverflow> length(byteOffset);
+            length += byteLength.value();
+            RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(length <= m_buffer->byteLength());
+        }
     } else
         ASSERT(isAutoLength());
 

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -78,25 +78,29 @@ public:
 
     void* data() const { return baseAddress(); }
 
+    size_t byteOffsetRaw() const { return m_byteOffset; }
+
     size_t byteOffset() const
     {
         if (UNLIKELY(isDetached()))
             return 0;
 
         if (LIKELY(!isResizableOrGrowableShared()))
-            return m_byteOffset;
+            return byteOffsetRaw();
 
         size_t bufferByteLength = m_buffer->byteLength(std::memory_order_seq_cst);
-        size_t byteOffsetStart = m_byteOffset;
+        size_t byteOffsetStart = byteOffsetRaw();
         size_t byteOffsetEnd = 0;
         if (isAutoLength())
             byteOffsetEnd = bufferByteLength;
         else
-            byteOffsetEnd = byteOffsetStart + m_byteLength;
+            byteOffsetEnd = byteOffsetStart + byteLengthRaw();
         if (UNLIKELY(!(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength)))
             return 0;
-        return m_byteOffset;
+        return byteOffsetRaw();
     }
+
+    size_t byteLengthRaw() const { return m_byteLength; }
 
     size_t byteLength() const
     {
@@ -104,19 +108,19 @@ public:
             return 0;
 
         if (LIKELY(!isResizableOrGrowableShared()))
-            return m_byteLength;
+            return byteLengthRaw();
 
         size_t bufferByteLength = m_buffer->byteLength(std::memory_order_seq_cst);
-        size_t byteOffsetStart = m_byteOffset;
+        size_t byteOffsetStart = byteOffsetRaw();
         size_t byteOffsetEnd = 0;
         if (isAutoLength())
             byteOffsetEnd = bufferByteLength;
         else
-            byteOffsetEnd = byteOffsetStart + m_byteLength;
+            byteOffsetEnd = byteOffsetStart + byteLengthRaw();
         if (UNLIKELY(!(byteOffsetStart > bufferByteLength || byteOffsetEnd > bufferByteLength)))
             return 0;
         if (!isAutoLength())
-            return m_byteLength;
+            return byteLengthRaw();
         return roundDownToMultipleOf(JSC::elementSize(m_type), bufferByteLength - byteOffsetStart);
     }
 

--- a/Source/JavaScriptCore/runtime/DataView.h
+++ b/Source/JavaScriptCore/runtime/DataView.h
@@ -77,6 +77,8 @@ public:
             flipBytesIfLittleEndian(value, littleEndian);
     }
 
+    JS_EXPORT_PRIVATE static RefPtr<DataView> wrappedAs(Ref<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);
+
 private:
     DataView(RefPtr<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> byteLength);
 };

--- a/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
@@ -70,6 +70,11 @@ public:
         return byteLength() / sizeof(typename Adaptor::Type);
     }
 
+    size_t lengthRaw() const
+    {
+        return byteLengthRaw() / sizeof(typename Adaptor::Type);
+    }
+
     typename Adaptor::Type item(size_t index) const
     {
         ASSERT_WITH_SECURITY_IMPLICATION(index < this->length());
@@ -102,6 +107,8 @@ public:
     }
 
     JSArrayBufferView* wrapImpl(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject);
+
+    static RefPtr<GenericTypedArrayView<Adaptor>> wrappedAs(Ref<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);
 
 private:
     GenericTypedArrayView(RefPtr<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -338,16 +338,16 @@ RefPtr<ArrayBufferView> JSArrayBufferView::possiblySharedImpl()
     ArrayBuffer* buffer = possiblySharedBuffer();
     if (!buffer)
         return nullptr;
-    size_t byteOffset = this->byteOffset();
-    size_t length = this->length();
+    size_t byteOffset = this->byteOffsetRaw();
+    size_t length = this->lengthRaw();
     switch (type()) {
 #define FACTORY(type) \
     case type ## ArrayType: \
-        return type ## Array::tryCreate(buffer, byteOffset, isAutoLength() ? std::nullopt : std::optional { length });
+        return type ## Array::wrappedAs(*buffer, byteOffset, isAutoLength() ? std::nullopt : std::optional { length });
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(FACTORY)
 #undef FACTORY
     case DataViewType:
-        return DataView::create(buffer, byteOffset, isAutoLength() ? std::nullopt : std::optional { length });
+        return DataView::wrappedAs(*buffer, byteOffset, isAutoLength() ? std::nullopt : std::optional { length });
     default:
         RELEASE_ASSERT_NOT_REACHED();
         return nullptr;

--- a/Source/JavaScriptCore/runtime/JSDataView.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataView.cpp
@@ -106,12 +106,12 @@ bool JSDataView::setIndex(JSGlobalObject*, size_t, JSValue)
 
 RefPtr<DataView> JSDataView::possiblySharedTypedImpl()
 {
-    return DataView::create(possiblySharedBuffer(), byteOffset(), isAutoLength() ? std::nullopt : std::optional { length() });
+    return DataView::create(possiblySharedBuffer(), byteOffsetRaw(), isAutoLength() ? std::nullopt : std::optional { lengthRaw() });
 }
 
 RefPtr<DataView> JSDataView::unsharedTypedImpl()
 {
-    return DataView::create(unsharedBuffer(), byteOffset(), isAutoLength() ? std::nullopt : std::optional { length() });
+    return DataView::create(unsharedBuffer(), byteOffsetRaw(), isAutoLength() ? std::nullopt : std::optional { lengthRaw() });
 }
 
 Structure* JSDataView::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -132,7 +132,7 @@ JSGenericTypedArrayView<Adaptor>* JSGenericTypedArrayView<Adaptor>::create(JSGlo
 template<typename Adaptor>
 JSGenericTypedArrayView<Adaptor>* JSGenericTypedArrayView<Adaptor>::create(VM& vm, Structure* structure, RefPtr<typename Adaptor::ViewType>&& impl)
 {
-    ConstructionContext context(vm, structure, impl->possiblySharedBuffer(), impl->byteOffset(), impl->isAutoLength() ? std::nullopt : std::optional { impl->length() });
+    ConstructionContext context(vm, structure, impl->possiblySharedBuffer(), impl->byteOffsetRaw(), impl->isAutoLength() ? std::nullopt : std::optional { impl->lengthRaw() });
     ASSERT(context);
     JSGenericTypedArrayView* result =
         new (NotNull, allocateCell<JSGenericTypedArrayView>(vm))
@@ -419,13 +419,13 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
 template<typename Adaptor>
 RefPtr<typename Adaptor::ViewType> JSGenericTypedArrayView<Adaptor>::possiblySharedTypedImpl()
 {
-    return Adaptor::ViewType::tryCreate(possiblySharedBuffer(), byteOffset(), isAutoLength() ? std::nullopt : std::optional { length() });
+    return Adaptor::ViewType::tryCreate(possiblySharedBuffer(), byteOffsetRaw(), isAutoLength() ? std::nullopt : std::optional { lengthRaw() });
 }
 
 template<typename Adaptor>
 RefPtr<typename Adaptor::ViewType> JSGenericTypedArrayView<Adaptor>::unsharedTypedImpl()
 {
-    return Adaptor::ViewType::tryCreate(unsharedBuffer(), byteOffset(), isAutoLength() ? std::nullopt : std::optional { length() });
+    return Adaptor::ViewType::tryCreate(unsharedBuffer(), byteOffsetRaw(), isAutoLength() ? std::nullopt : std::optional { lengthRaw() });
 }
 
 template<typename Adaptor>


### PR DESCRIPTION
#### a9510aedf5179f92aa036b67aea7f5f9e8b0a24f
<pre>
Serialize and deserialize resizable ArrayBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=248209">https://bugs.webkit.org/show_bug.cgi?id=248209</a>
rdar://102601423

Reviewed by Ross Kirsling.

This patch adds serializing and deserializing of resizable ArrayBuffer and TypedArrays.
We add ResizableArrayBufferTag and add a feature serializing resizable ArrayBuffer.
But for growable SharedArrayBuffer, nothing is necessary since information is carried via
SharedArrayBufferContents already. For TypedArrays, we use UINT64_MAX byteLength marker
as a auto-length case. This works since byteLength cannot be UINT64_MAX since it exceeds
MAX_ARRAY_BUFFER_SIZE. The other things in TypedArrays are not changed much since these
TypedArrays should be resizable / growable ones when the subsequent backing serialized
ArrayBuffer is resizable.

We also add wrappedAs methods since normal tryCreate has more additional checks for construction.
But these checks can fail if the serialized TypedArrays are having ArrayBuffers which is resized
to be smaller after the construction. But this is OK since it just makes TypedArrays OOB. wrappedAs
methods do not have this check.

* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::byteOffsetRaw const):
(JSC::ArrayBufferView::byteOffset const):
(JSC::ArrayBufferView::byteLengthRaw const):
(JSC::ArrayBufferView::byteLength const):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpArrayBufferView):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readResizableNonSharedArrayBuffer):
(WebCore::CloneDeserializer::readArrayBufferViewImpl):
(WebCore::CloneDeserializer::readTerminal):

Canonical link: <a href="https://commits.webkit.org/256998@main">https://commits.webkit.org/256998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a195e21dd66fc96d8494e198a864d2ac66d57590

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107015 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167278 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7100 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35521 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89905 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103684 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5320 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84141 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32326 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75251 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88417 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/768 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84083 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21922 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4821 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44396 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/86910 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41296 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19515 "Passed tests") | 
<!--EWS-Status-Bubble-End-->