### PR TITLE
[WPE] gamepad crashes on raspberry pi 4 (arm64)

### DIFF
--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -117,7 +117,7 @@ void GamepadProviderLibWPE::stopMonitoringGamepads(GamepadProviderClient& client
     m_lastActiveGamepad = nullptr;
 }
 
-void GamepadProviderLibWPE::gamepadConnected(unsigned id)
+void GamepadProviderLibWPE::gamepadConnected(uintptr_t id)
 {
     ASSERT(!m_gamepadMap.get(id));
     ASSERT(m_provider);
@@ -148,7 +148,7 @@ void GamepadProviderLibWPE::gamepadConnected(unsigned id)
         client->platformGamepadConnected(*m_gamepadVector[index], eventVisibility);
 }
 
-void GamepadProviderLibWPE::gamepadDisconnected(unsigned id)
+void GamepadProviderLibWPE::gamepadDisconnected(uintptr_t id)
 {
     LOG(Gamepad, "GamepadProviderLibWPE device %u removed", id);
 
@@ -171,7 +171,7 @@ unsigned GamepadProviderLibWPE::indexForNewlyConnectedDevice()
     return index;
 }
 
-std::unique_ptr<GamepadLibWPE> GamepadProviderLibWPE::removeGamepadForId(unsigned id)
+std::unique_ptr<GamepadLibWPE> GamepadProviderLibWPE::removeGamepadForId(uintptr_t id)
 {
     auto removedGamepad = m_gamepadMap.take(id);
     ASSERT(removedGamepad);

--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h
@@ -62,16 +62,16 @@ public:
 private:
     GamepadProviderLibWPE();
 
-    void gamepadConnected(unsigned);
-    void gamepadDisconnected(unsigned);
-    std::unique_ptr<GamepadLibWPE> removeGamepadForId(unsigned);
+    void gamepadConnected(uintptr_t);
+    void gamepadDisconnected(uintptr_t);
+    std::unique_ptr<GamepadLibWPE> removeGamepadForId(uintptr_t);
 
     unsigned indexForNewlyConnectedDevice();
     void initialGamepadsConnectedTimerFired();
     void inputNotificationTimerFired();
 
     Vector<PlatformGamepad*> m_gamepadVector;
-    HashMap<unsigned, std::unique_ptr<GamepadLibWPE>> m_gamepadMap;
+    HashMap<uintptr_t, std::unique_ptr<GamepadLibWPE>> m_gamepadMap;
     bool m_initialGamepadsConnected { false };
 
     std::unique_ptr<struct wpe_gamepad_provider, void (*)(struct wpe_gamepad_provider*)> m_provider;


### PR DESCRIPTION
#### a6099cec8ff21c0ea765f38feae3ecb899ba19b4
<pre>
[WPE] gamepad crashes on raspberry pi 4 (arm64)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248210">https://bugs.webkit.org/show_bug.cgi?id=248210</a>

Reviewed by Michael Catanzaro.

This is a breadcrumbs of the initial merge, because in libwpe uintptr_t is used for
gamepad id, while in webkit&apos;s platform code unsigned is used.

* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp:
(WebCore::GamepadProviderLibWPE::gamepadConnected):
(WebCore::GamepadProviderLibWPE::gamepadDisconnected):
(WebCore::GamepadProviderLibWPE::removeGamepadForId):
* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.h:

Canonical link: <a href="https://commits.webkit.org/256940@main">https://commits.webkit.org/256940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1235f845838f5ae4a0ddf42937e1226087c17356

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106806 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167072 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6847 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35286 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103487 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102950 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83915 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32126 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/86992 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75052 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/567 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/551 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4783 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5352 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41072 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->