### PR TITLE
[SVG] Default for x1, y1 and y2 is 0% for LinearGradient

### DIFF
--- a/LayoutTests/svg/gradients/linear-gradient-default-length-expected.txt
+++ b/LayoutTests/svg/gradients/linear-gradient-default-length-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Testing SVGLinearGradientElement coordinate defaults x1
+PASS Testing SVGLinearGradientElement coordinate defaults x2
+PASS Testing SVGLinearGradientElement coordinate defaults y1
+PASS Testing SVGLinearGradientElement coordinate defaults y2
+

--- a/LayoutTests/svg/gradients/linear-gradient-default-length.html
+++ b/LayoutTests/svg/gradients/linear-gradient-default-length.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html> 
+<title>SVGLinearGradientElement coordinate defaults</title>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<svg>
+    <linearGradient id="lg"/>
+</svg>
+<script>
+function testLengthValue(result, expected, testcase) {
+    test(function() {
+        assert_equals(result, expected);
+    }, "Testing " + document.title + " " + testcase);
+}
+var linearGradient = document.querySelector("#lg");
+testLengthValue(linearGradient.x1.baseVal.valueAsString, "0%", "x1");
+testLengthValue(linearGradient.x2.baseVal.valueAsString, "100%", "x2");
+testLengthValue(linearGradient.y1.baseVal.valueAsString, "0%", "y1");
+testLengthValue(linearGradient.y2.baseVal.valueAsString, "0%", "y2");
+</script>

--- a/LayoutTests/svg/gradients/linear-gradient-x1-default-length-expected.svg
+++ b/LayoutTests/svg/gradients/linear-gradient-x1-default-length-expected.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="g0">
+    <stop offset="5%" stop-color="black" />
+    <stop offset="50%" stop-color="red" />
+    <stop offset="95%" stop-color="black" />
+  </linearGradient>
+
+  <rect x="1" y="1" width="8" height="8" fill="url(#g0)" />
+</svg>

--- a/LayoutTests/svg/gradients/linear-gradient-x1-default-length.svg
+++ b/LayoutTests/svg/gradients/linear-gradient-x1-default-length.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient x1="0%" id="g0">
+    <stop offset="5%" stop-color="black" />
+    <stop offset="50%" stop-color="red" />
+    <stop offset="95%" stop-color="black" />
+  </linearGradient>
+
+  <rect x="1" y="1" width="8" height="8" fill="url(#g0)" />
+</svg>

--- a/LayoutTests/svg/gradients/linear-gradient-y1-default-length-expected.svg
+++ b/LayoutTests/svg/gradients/linear-gradient-y1-default-length-expected.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="g0">
+    <stop offset="5%" stop-color="black" />
+    <stop offset="50%" stop-color="red" />
+    <stop offset="95%" stop-color="black" />
+  </linearGradient>
+
+  <rect x="1" y="1" width="8" height="8" fill="url(#g0)" />
+</svg>

--- a/LayoutTests/svg/gradients/linear-gradient-y1-default-length.svg
+++ b/LayoutTests/svg/gradients/linear-gradient-y1-default-length.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient y1="0%" id="g0">
+    <stop offset="5%" stop-color="black" />
+    <stop offset="50%" stop-color="red" />
+    <stop offset="95%" stop-color="black" />
+  </linearGradient>
+
+  <rect x="1" y="1" width="8" height="8" fill="url(#g0)" />
+</svg>

--- a/LayoutTests/svg/gradients/linear-gradient-y2-default-length-expected.svg
+++ b/LayoutTests/svg/gradients/linear-gradient-y2-default-length-expected.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient id="g0">
+    <stop offset="5%" stop-color="black" />
+    <stop offset="50%" stop-color="red" />
+    <stop offset="95%" stop-color="black" />
+  </linearGradient>
+
+  <rect x="1" y="1" width="8" height="8" fill="url(#g0)" />
+</svg>

--- a/LayoutTests/svg/gradients/linear-gradient-y2-default-length.svg
+++ b/LayoutTests/svg/gradients/linear-gradient-y2-default-length.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+  <linearGradient y2="0%" id="g0">
+    <stop offset="5%" stop-color="black" />
+    <stop offset="50%" stop-color="red" />
+    <stop offset="95%" stop-color="black" />
+  </linearGradient>
+
+  <rect x="1" y="1" width="8" height="8" fill="url(#g0)" />
+</svg>

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -57,10 +57,10 @@ private:
 
     bool selfHasRelativeLengths() const override;
 
-    Ref<SVGAnimatedLength> m_x1 { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
-    Ref<SVGAnimatedLength> m_y1 { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
+    Ref<SVGAnimatedLength> m_x1 { SVGAnimatedLength::create(this, SVGLengthMode::Width, "0%"_s) };
+    Ref<SVGAnimatedLength> m_y1 { SVGAnimatedLength::create(this, SVGLengthMode::Height, "0%"_s) };
     Ref<SVGAnimatedLength> m_x2 { SVGAnimatedLength::create(this, SVGLengthMode::Width, "100%"_s) };
-    Ref<SVGAnimatedLength> m_y2 { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
+    Ref<SVGAnimatedLength> m_y2 { SVGAnimatedLength::create(this, SVGLengthMode::Height, "0%"_s) };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7a2abd482abc992a55a58f3a3b7957229775ac2c
<pre>
[SVG] Default for x1, y1 and y2 is 0% for LinearGradient

[SVG] Default for x1, y1 and y2 is 0% for LinearGradient
<a href="https://bugs.webkit.org/show_bug.cgi?id=248212">https://bugs.webkit.org/show_bug.cgi?id=248212</a>

Reviewed by Nikolas Zimmermann.

This patch is to align Webkit with Blink / Chrome and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/219dff463987f53c22f5f96f35a794246a13538d">https://chromium.googlesource.com/chromium/blink/+/219dff463987f53c22f5f96f35a794246a13538d</a>

As per the spec, if the x1|y1|y2 attribute is not specified,
the effect is as if a value of &quot;0%&quot; were specified.

* Source/WebCore/svg/SVGLinearGradientElement.h: Update default values for x1, y1 and y2
* LayoutTests/svg/gradient/linear-gradient-default-length.html: Add Test Case
* LayoutTests/svg/gradient/linear-gradient-default-length-expected.txt: Add Test Case Expectations
* LayoutTests/svg/gradient/linear-gradient-y2-default-length.svg: Added Test Case
* LayoutTests/svg/gradient/linear-gradient-y2-default-length-expected.svg: Added Test Case Expectations
* LayoutTests/svg/gradient/linear-gradient-y1-default-length.svg: Added Test Case
* LayoutTests/svg/gradient/linear-gradient-y1-default-length-expected.svg: Added Test Case Expectations
* LayoutTests/svg/gradient/linear-gradient-x1-default-length.svg: Added Test Case
* LayoutTests/svg/gradient/linear-gradient-x1-default-length-expected.svg: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/257032@main">https://commits.webkit.org/257032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a757bd59dbcedaab57db3f6f99a6931c3c67211c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106846 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167109 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6893 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35328 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103525 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5179 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83956 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32176 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75103 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/607 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/590 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44269 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41303 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->