### PR TITLE
Cache::put should not resolve/reject the promise if the context is stopped

### DIFF
--- a/LayoutTests/http/wpt/cache-storage/cache-in-stopped-context-expected.txt
+++ b/LayoutTests/http/wpt/cache-storage/cache-in-stopped-context-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Make sure cache.put promise does not resolve in detached context
+

--- a/LayoutTests/http/wpt/cache-storage/cache-in-stopped-context.html
+++ b/LayoutTests/http/wpt/cache-storage/cache-in-stopped-context.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Cache Storage in stopped context</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function load_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.src = url;
+        frame.onload = resolve;
+        document.body.appendChild(frame);
+    });
+}
+
+promise_test(async test => {
+    const frame = await load_iframe('resources/cache-in-stopped-context-iframe.html');
+    await new Promise(resolve => setTimeout(resolve, 50));
+}, "Make sure cache.put promise does not resolve in detached context");
+</script>
+</body>
+<script>
+</script>

--- a/LayoutTests/http/wpt/cache-storage/resources/cache-in-stopped-context-iframe.html
+++ b/LayoutTests/http/wpt/cache-storage/resources/cache-in-stopped-context-iframe.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script>
+async function test()
+{
+    const cache = await self.caches.open("cacheTest");
+    const blob = new Blob();
+    parent.document.getElementsByTagName('iframe')[0].remove();
+
+    cache.put(new Request("test"), new Response(blob)).then(() => {
+        assert_unreached('Promise was resolved');
+    }, () => {
+        assert_unreached('Promise was rejected');
+    });
+}
+
+window.onload = test;
+</script>

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -347,7 +347,7 @@ void DOMCache::putWithResponseData(DOMPromiseDeferred<void>&& promise, Ref<Fetch
 
 void DOMCache::put(RequestInfo&& info, Ref<FetchResponse>&& response, DOMPromiseDeferred<void>&& promise)
 {
-    if (UNLIKELY(!scriptExecutionContext()))
+    if (isContextStopped())
         return;
 
     bool ignoreMethod = false;


### PR DESCRIPTION
#### fe7a1d0561c899b77da4bf8ec9234620dd2c3fda
<pre>
Cache::put should not resolve/reject the promise if the context is stopped
<a href="https://bugs.webkit.org/show_bug.cgi?id=248231">https://bugs.webkit.org/show_bug.cgi?id=248231</a>
rdar://problem/102607428

Reviewed by Chris Dumez.

Return early if context is stopped.

* LayoutTests/http/wpt/cache-storage/cache-in-stopped-context-expected.txt: Added.
* LayoutTests/http/wpt/cache-storage/cache-in-stopped-context.html: Added.
* LayoutTests/http/wpt/cache-storage/resources/cache-in-stopped-context-iframe.html: Added.
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::put):

Canonical link: <a href="https://commits.webkit.org/257083@main">https://commits.webkit.org/257083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ee2005d2e5ae123145e04fc27a578ea0ca9fe52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106828 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167093 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6871 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35309 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103508 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5161 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83938 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75088 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/588 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20306 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/573 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21767 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44254 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41097 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->