### PR TITLE
[WPE] built-product-archive not longer includes cog in the release.zip archive

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -290,10 +290,12 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
         cogDirectory = os.path.join('Tools', 'cog-prefix', 'src', 'cog-build')
         absoluteCogDirectory = os.path.join(_configurationBuildDirectory, cogDirectory)
         if platform == 'wpe' and os.path.isdir(absoluteCogDirectory):
-            contents.extend([os.path.join(cogDirectory, filename_or_directory) for filename_or_directory in ['cog', 'cogctl', 'modules']])
-            for filename in os.listdir(absoluteCogDirectory):
-                if filename.startswith('libcogcore'):
-                    contents.append(os.path.join(cogDirectory, filename))
+            for cog_root, cog_dirs, cog_files in os.walk(absoluteCogDirectory):
+                for cog_file in cog_files:
+                    if cog_file in ['cog', 'cogctl'] or '.so' in cog_file:
+                        realAbsolutePath = os.path.join(cog_root, cog_file)
+                        realRelativePath = realAbsolutePath[len(_configurationBuildDirectory)+1:]
+                        contents.append(realRelativePath)
 
         if platform == 'gtk':
             contents.extend([os.path.join('install', directory) for directory in ['include', os.path.join('lib', 'pkgconfig')]])


### PR DESCRIPTION
#### fce087ef681d6ea15d6a73fa453395e72e950d41
<pre>
[WPE] built-product-archive not longer includes cog in the release.zip archive
<a href="https://bugs.webkit.org/show_bug.cgi?id=248233">https://bugs.webkit.org/show_bug.cgi?id=248233</a>

Reviewed by Michael Catanzaro.

Since cog moved to Meson build system, the paths it uses for storing the built
products on the disk have changed. Instead of using a predefined names for
the paths just add to the product-archive the files (binaries) &apos;cog&apos;, &apos;cogctl&apos;
as well as any library.

* Tools/CISupport/built-product-archive:

Canonical link: <a href="https://commits.webkit.org/256941@main">https://commits.webkit.org/256941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6053a7223f75299d04b85fde65c4b89b6c05f30a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106835 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6881 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35317 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89726 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102979 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83945 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/596 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/579 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5379 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41106 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->