### PR TITLE
[webkitpy] Remove vestigle skipped feature support

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py
@@ -48,7 +48,7 @@ class FakePort(object):
         self.host.ports_parsed.append(self.name)
         return {self.path: ''}
 
-    def skipped_layout_tests(self, _, **kwargs):
+    def skipped_layout_tests(self, **kwargs):
         return set([])
 
     def all_test_configurations(self):

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
@@ -1093,8 +1093,7 @@ class TestExpectations(object):
         self.parse_default_port_expectations()
         self.parse_override_expectations()
 
-        # FIXME: move ignore_tests into port.skipped_layout_tests()
-        self.add_skipped_tests(self._port.skipped_layout_tests(self._full_test_list, device_type=self._device_type).union(set(self._port.get_option('ignore_tests', []))))
+        self.add_skipped_tests(self._port.skipped_layout_tests(device_type=self._device_type))
 
         self._report_warnings()
         self._process_tests_without_expectations()

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py
@@ -290,7 +290,7 @@ class SkippedTests(Base):
         if overrides:
             expectations_dict['overrides'] = overrides
         port.expectations_dict = lambda **kwargs: expectations_dict
-        port.skipped_layout_tests = lambda tests, **kwargs: set(skips)
+        port.skipped_layout_tests = lambda **kwargs: set(skips)
         expectations_to_lint = expectations_dict if lint else None
         exp = TestExpectations(port, ['failures/expected/text.html'], expectations_to_lint=expectations_to_lint)
         exp.parse_all_expectations()
@@ -327,7 +327,7 @@ class SkippedTests(Base):
         expectations_dict = OrderedDict()
         expectations_dict['expectations'] = ''
         port.expectations_dict = lambda **kwargs: expectations_dict
-        port.skipped_layout_tests = lambda tests, **kwargs: {'foo/bar/baz.html'}
+        port.skipped_layout_tests = lambda **kwargs: {'foo/bar/baz.html'}
         with OutputCapture() as captured:
             exp = TestExpectations(port)
             exp.parse_all_expectations()

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -675,9 +675,11 @@ class Port(object):
     def perf_tests_dir(self):
         return self._webkit_finder.perf_tests_dir()
 
-    def skipped_layout_tests(self, test_list, device_type=None):
+    def skipped_layout_tests(self, device_type=None):
         """Returns tests skipped outside of the TestExpectations files."""
-        return set(self._tests_for_other_platforms(device_type=device_type)).union(self._skipped_tests_for_unsupported_features(test_list))
+        return set(self._tests_for_other_platforms(device_type=device_type)) | set(
+            self.get_option("ignore_tests", [])
+        )
 
     @memoized
     def skipped_perf_tests(self):
@@ -1489,9 +1491,6 @@ class Port(object):
                 basename = self._filesystem.basename(entry)
                 dirs_to_skip.append('platform/%s' % basename)
         return dirs_to_skip
-
-    def _skipped_tests_for_unsupported_features(self, test_list):
-        return []
 
     def _wk2_port_name(self):
         # By current convention, the WebKit2 name is always mac-wk2, win-wk2, not mac-leopard-wk2, etc,

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -545,7 +545,7 @@ class PortTestCase(unittest.TestCase):
         self.assertEqual(port.path_to_test_expectations_file(), '/mock-checkout/LayoutTests/platform/testwebkitport/TestExpectations')
 
     def test_skipped_layout_tests(self):
-        self.assertEqual(TestWebKitPort().skipped_layout_tests(test_list=[]), set(['media']))
+        self.assertEqual(TestWebKitPort().skipped_layout_tests(), set(['media']))
 
     def test_expectations_files(self):
         port = TestWebKitPort()

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -476,9 +476,11 @@ class TestPort(Port):
     def webkit_base(self):
         return '/test.checkout'
 
-    def _skipped_tests_for_unsupported_features(self, test_list):
-        return set(['failures/expected/skip_text.html',
-                    'failures/unexpected/skip_pass.html'])
+    def skipped_layout_tests(self, device_type):
+        return super(TestPort, self).skipped_layout_tests(device_type=device_type) | {
+            "failures/expected/skip_text.html",
+            "failures/unexpected/skip_pass.html",
+        }
 
     def name(self):
         return self._name

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -212,6 +212,7 @@ class WinPort(ApplePort):
         return {binary.split('.')[0]: self._build_path(binary) for binary in self.API_TEST_BINARY_NAMES}
 
     def test_search_path(self, **kwargs):
+        # This is similar to baseline_search_path, but excludes mac paths.
         test_fallback_names = [path for path in self.baseline_search_path() if not path.startswith(self._webkit_baseline_path('mac'))]
         return list(map(self._webkit_baseline_path, test_fallback_names))
 


### PR DESCRIPTION
#### c7a31322c9a0f4177b1f469b88f5a60967273e4b
<pre>
[webkitpy] Remove vestigle skipped feature support
<a href="https://bugs.webkit.org/show_bug.cgi?id=248234">https://bugs.webkit.org/show_bug.cgi?id=248234</a>

Reviewed by Jonathan Bedard.

This removes Port._skipped_tests_for_unsupported_features and
simplifies Port.skipped_layout_tests, along with addressing an old
FIXME saying to move code from TestExpectations.parse_all_expectations
to Port.skipped_layout_tests.

* Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py:
(FakePort.skipped_layout_tests):
* Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py:
(TestExpectations.parse_all_expectations): Fix the FIXME.
* Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py:
(SkippedTests.check):
(SkippedTests.test_skipped_entry_dont_exist):
* Tools/Scripts/webkitpy/port/base.py:
(Port.skipped_layout_tests):
(Port._tests_for_other_platforms):
(Port._skipped_tests_for_unsupported_features): Deleted.
* Tools/Scripts/webkitpy/port/port_testcase.py:
(PortTestCase.test_skipped_layout_tests):
* Tools/Scripts/webkitpy/port/test.py:
* Tools/Scripts/webkitpy/port/win.py:
(WinPort.test_search_path): Add a comment, to keep me sane in future.

Canonical link: <a href="https://commits.webkit.org/257099@main">https://commits.webkit.org/257099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e75ce9a126bc55b185d7f5c1a34d1593637f3a72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106843 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167106 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6890 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35325 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89734 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103522 "Hash e75ce9a1 for PR 6741 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5177 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83953 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32174 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/100901 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75101 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/604 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20318 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/587 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44639 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41115 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->