### PR TITLE
[WKTR] Fix warnings about duplicate NSString category methods

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,7 +30,7 @@
  */
 
 #import "config.h"
-#import "AccessibilityCommonMac.h"
+#import "AccessibilityCommonCocoa.h"
 
 #import "JSWrapper.h"
 #import "StringFunctions.h"

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "AccessibilityCommonMac.h"
+#import "AccessibilityCommonCocoa.h"
 #import "AccessibilityController.h"
 #import "AccessibilityNotificationHandler.h"
 #import "InjectedBundle.h"

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "AccessibilityUIElement.h"
 
-#import "AccessibilityCommonMac.h"
+#import "AccessibilityCommonCocoa.h"
 #import "AccessibilityNotificationHandler.h"
 #import "InjectedBundle.h"
 #import "InjectedBundlePage.h"
@@ -148,23 +148,6 @@ typedef void (*AXPostedNotificationCallback)(id element, NSString* notification,
 @interface NSObject (WebAccessibilityObjectWrapperPrivate)
 - (NSString *)accessibilityDOMIdentifier;
 - (CGPathRef)_accessibilityPath;
-@end
-
-@implementation NSString (JSStringRefAdditions)
-
-+ (NSString *)stringWithJSStringRef:(JSStringRef)jsStringRef
-{
-    if (!jsStringRef)
-        return nil;
-    
-    return adoptCF(JSStringCopyCFString(kCFAllocatorDefault, jsStringRef)).bridgingAutorelease();
-}
-
-- (JSRetainPtr<JSStringRef>)createJSStringRef
-{
-    return adopt(JSStringCreateWithCFString((__bridge CFStringRef)self));
-}
-
 @end
 
 namespace WTR {

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -31,7 +31,7 @@
 #import "config.h"
 #import "AccessibilityController.h"
 
-#import "AccessibilityCommonMac.h"
+#import "AccessibilityCommonCocoa.h"
 #import "AccessibilityNotificationHandler.h"
 #import "InjectedBundle.h"
 #import "InjectedBundlePage.h"

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm
@@ -31,7 +31,7 @@
 #import "config.h"
 #import "AccessibilityNotificationHandler.h"
 
-#import "AccessibilityCommonMac.h"
+#import "AccessibilityCommonCocoa.h"
 #import "AccessibilityUIElement.h"
 #import "InjectedBundle.h"
 #import "InjectedBundlePage.h"

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -24,7 +24,7 @@
  */
 
 #import "config.h"
-#import "AccessibilityCommonMac.h"
+#import "AccessibilityCommonCocoa.h"
 
 #if ENABLE(ACCESSIBILITY)
 

--- a/Tools/WebKitTestRunner/PlatformMac.cmake
+++ b/Tools/WebKitTestRunner/PlatformMac.cmake
@@ -32,6 +32,7 @@ list(APPEND WebKitTestRunner_INCLUDE_DIRECTORIES
 )
 
 list(APPEND WebKitTestRunnerInjectedBundle_SOURCES
+    ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/ActivateFontsCocoa.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/cocoa/InjectedBundlePageCocoa.mm
 
@@ -39,7 +40,6 @@ list(APPEND WebKitTestRunnerInjectedBundle_SOURCES
     ${WebKitTestRunner_DIR}/InjectedBundle/mac/AccessibilityNotificationHandler.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/mac/AccessibilityTextMarkerRangeMac.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/mac/InjectedBundleMac.mm
-    ${WebKitTestRunner_DIR}/InjectedBundle/mac/AccessibilityCommonMac.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/mac/AccessibilityTextMarkerMac.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/mac/AccessibilityUIElementMac.mm
     ${WebKitTestRunner_DIR}/InjectedBundle/mac/TestRunnerMac.mm

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -73,7 +73,7 @@
 		29210EB4144CACD500835BB5 /* AccessibilityTextMarker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29210EB1144CACD400835BB5 /* AccessibilityTextMarker.cpp */; };
 		29210EB5144CACD500835BB5 /* AccessibilityTextMarkerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EB3144CACD400835BB5 /* AccessibilityTextMarkerMac.mm */; };
 		29210EDA144CC3EA00835BB5 /* AccessibilityUIElementMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EAB144CACB200835BB5 /* AccessibilityUIElementMac.mm */; };
-		29210EDA144CC3EA00835BB6 /* AccessibilityCommonMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EAB144CACB200835BB6 /* AccessibilityCommonMac.mm */; };
+		29210EDA144CC3EA00835BB6 /* AccessibilityCommonCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EAB144CACB200835BB6 /* AccessibilityCommonCocoa.mm */; };
 		29210EDB144CD47900835BB5 /* JSAccessibilityController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 583913D014335E95008307E5 /* JSAccessibilityController.cpp */; };
 		29210EE1144CDB2600835BB5 /* JSAccessibilityUIElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29210EDB146727E711835BB5 /* JSAccessibilityUIElement.cpp */; };
 		29A8FCCB145EF02E009045A6 /* JSAccessibilityTextMarker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29210EE1144CDE6789815EE5 /* JSAccessibilityTextMarker.cpp */; };
@@ -273,7 +273,7 @@
 		29210EA9144CACB200835BB5 /* AccessibilityUIElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccessibilityUIElement.cpp; sourceTree = "<group>"; };
 		29210EAA144CACB200835BB5 /* AccessibilityUIElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityUIElement.h; sourceTree = "<group>"; };
 		29210EAB144CACB200835BB5 /* AccessibilityUIElementMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityUIElementMac.mm; sourceTree = "<group>"; };
-		29210EAB144CACB200835BB6 /* AccessibilityCommonMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityCommonMac.mm; sourceTree = "<group>"; };
+		29210EAB144CACB200835BB6 /* AccessibilityCommonCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityCommonCocoa.mm; sourceTree = "<group>"; };
 		29210EB1144CACD400835BB5 /* AccessibilityTextMarker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccessibilityTextMarker.cpp; sourceTree = "<group>"; };
 		29210EB2144CACD400835BB5 /* AccessibilityTextMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityTextMarker.h; sourceTree = "<group>"; };
 		29210EB3144CACD400835BB5 /* AccessibilityTextMarkerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AccessibilityTextMarkerMac.mm; path = mac/AccessibilityTextMarkerMac.mm; sourceTree = "<group>"; };
@@ -282,7 +282,7 @@
 		29210EDC144CD56E00835BB5 /* AccessibilityUIElement.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AccessibilityUIElement.idl; sourceTree = "<group>"; };
 		29210EE1144CDE6789815EE5 /* JSAccessibilityTextMarker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSAccessibilityTextMarker.cpp; sourceTree = "<group>"; };
 		29210EE1145CDE6789815EE5 /* JSAccessibilityTextMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSAccessibilityTextMarker.h; sourceTree = "<group>"; };
-		299E2AA41E3DEE140065DC30 /* AccessibilityCommonMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityCommonMac.h; sourceTree = "<group>"; };
+		299E2AA41E3DEE140065DC30 /* AccessibilityCommonCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityCommonCocoa.h; sourceTree = "<group>"; };
 		29A8FCC5145B93C6009045A6 /* AccessibilityTextMarker.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AccessibilityTextMarker.idl; sourceTree = "<group>"; };
 		29A8FCD2145EF8F2009045A6 /* AccessibilityTextMarkerRange.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = AccessibilityTextMarkerRange.idl; sourceTree = "<group>"; };
 		29A8FCDF145F0358009045A6 /* AccessibilityTextMarkerRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityTextMarkerRange.h; sourceTree = "<group>"; };
@@ -627,6 +627,8 @@
 		0FEB909D1905A75D000FDBF3 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				299E2AA41E3DEE140065DC30 /* AccessibilityCommonCocoa.h */,
+				29210EAB144CACB200835BB6 /* AccessibilityCommonCocoa.mm */,
 				65EB859F11EC67CC0034D300 /* ActivateFontsCocoa.mm */,
 				0FEB909E1905A776000FDBF3 /* InjectedBundlePageCocoa.mm */,
 			);
@@ -761,8 +763,6 @@
 		65EB859E11EC67CC0034D300 /* mac */ = {
 			isa = PBXGroup;
 			children = (
-				299E2AA41E3DEE140065DC30 /* AccessibilityCommonMac.h */,
-				29210EAB144CACB200835BB6 /* AccessibilityCommonMac.mm */,
 				8034C6611487636400AC32E9 /* AccessibilityControllerMac.mm */,
 				29A8FCE4145F0464009045A6 /* AccessibilityTextMarkerRangeMac.mm */,
 				29210EAB144CACB200835BB5 /* AccessibilityUIElementMac.mm */,
@@ -1295,7 +1295,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				29210EDA144CC3EA00835BB6 /* AccessibilityCommonMac.mm in Sources */,
+				29210EDA144CC3EA00835BB6 /* AccessibilityCommonCocoa.mm in Sources */,
 				29210EB0144CACBD00835BB5 /* AccessibilityController.cpp in Sources */,
 				2E63ED8A1891AD7E002A7AFC /* AccessibilityControllerIOS.mm in Sources */,
 				8034C6621487636400AC32E9 /* AccessibilityControllerMac.mm in Sources */,


### PR DESCRIPTION
#### d685f7a65d20f2ee8650660518d7ff8543bd05ff
<pre>
[WKTR] Fix warnings about duplicate NSString category methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=248239">https://bugs.webkit.org/show_bug.cgi?id=248239</a>
&lt;rdar://102609414&gt;

Reviewed by Darin Adler.

Remove duplciate methods from AccessibilityUIElementIOS.mm since
they already exist in AccessibilityCommonMac.mm.  Also take this
opportunity to rename AccessibilityCommonMac.{h,mm} to
AccessibilityCommonCocoa.{h,mm} and move them to the cocoa/
folder since they are used on both iOS and Mac platforms.

* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.h: Rename from Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityCommonMac.h.
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm: Rename from Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityCommonMac.mm.

* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityControllerIOS.mm:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(+[NSString stringWithJSStringRef:]): Delete.
(-[NSString createJSStringRef]): Delete.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityNotificationHandler.mm:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
- Update #import statements for AccessibilityCommonMac.h rename.

* Tools/WebKitTestRunner/PlatformMac.cmake:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
- Update project for header and source file renames.

Canonical link: <a href="https://commits.webkit.org/256958@main">https://commits.webkit.org/256958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35dcb29b7fa1c39a009902c3904c605776580883

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106845 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167108 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6892 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35327 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103524 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/102989 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83955 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87030 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/606 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21783 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2359 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41117 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->