### PR TITLE
Support timestamps on WI console

### DIFF
--- a/LayoutTests/inspector/console/console-api-expected.txt
+++ b/LayoutTests/inspector/console/console-api-expected.txt
@@ -37,7 +37,7 @@ STEP: console.log('console.log')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.warn('console.warn')
@@ -60,7 +60,7 @@ STEP: console.warn('console.warn')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.error('console.error')
@@ -83,7 +83,7 @@ STEP: console.error('console.error')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.debug('console.debug')
@@ -106,7 +106,7 @@ STEP: console.debug('console.debug')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.info('console.info')
@@ -129,7 +129,7 @@ STEP: console.info('console.info')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.assert(false, 'assertion message')
@@ -152,7 +152,7 @@ STEP: console.assert(false, 'assertion message')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.trace()
@@ -167,7 +167,7 @@ STEP: console.trace()
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.log('string message', string)
@@ -196,7 +196,7 @@ STEP: console.log('string message', string)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.log('message', object, object)
@@ -259,7 +259,7 @@ STEP: console.log('message', object, object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.error('message', object)
@@ -302,7 +302,7 @@ STEP: console.error('message', object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.warn('message', object)
@@ -345,7 +345,7 @@ STEP: console.warn('message', object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.debug('message', object)
@@ -388,7 +388,7 @@ STEP: console.debug('message', object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.info('message', object)
@@ -431,7 +431,7 @@ STEP: console.info('message', object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.dir(object)
@@ -468,7 +468,7 @@ STEP: console.dir(object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.dirxml(object)
@@ -505,7 +505,7 @@ STEP: console.dirxml(object)
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.group('groupName')
@@ -528,7 +528,7 @@ STEP: console.group('groupName')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.groupEnd('groupName')
@@ -551,7 +551,7 @@ STEP: console.groupEnd('groupName')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.groupCollapsed('collapsedGroupName')
@@ -574,7 +574,7 @@ STEP: console.groupCollapsed('collapsedGroupName')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.groupEnd('collapsedGroupName')
@@ -597,7 +597,7 @@ STEP: console.groupEnd('collapsedGroupName')
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count()
@@ -612,7 +612,7 @@ STEP: console.count()
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count()
@@ -627,7 +627,7 @@ STEP: console.count()
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count("default")
@@ -642,7 +642,7 @@ STEP: console.count("default")
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count('')
@@ -657,7 +657,7 @@ STEP: console.count('')
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count('    ')
@@ -672,7 +672,7 @@ STEP: console.count('    ')
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count('')
@@ -687,7 +687,7 @@ STEP: console.count('')
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count('    ')
@@ -702,7 +702,7 @@ STEP: console.count('    ')
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(string)
@@ -717,7 +717,7 @@ STEP: console.count(string)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(string)
@@ -732,7 +732,7 @@ STEP: console.count(string)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(object)
@@ -747,7 +747,7 @@ STEP: console.count(object)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(object)
@@ -762,7 +762,7 @@ STEP: console.count(object)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(otherObject)
@@ -777,7 +777,7 @@ STEP: console.count(otherObject)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(otherObject)
@@ -792,7 +792,7 @@ STEP: console.count(otherObject)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(number)
@@ -807,7 +807,7 @@ STEP: console.count(number)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.count(number)
@@ -822,6 +822,6 @@ STEP: console.count(number)
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 

--- a/LayoutTests/inspector/console/console-api.html
+++ b/LayoutTests/inspector/console/console-api.html
@@ -53,7 +53,7 @@ function test()
     {
         if (key === "_target" || key === "_listeners")
             return undefined;
-        if (key === "_objectId" || key === "_stackTrace")
+        if (key === "_objectId" || key === "_stackTrace" || key === "_timestamp")
             return "<filtered>";
         return value;
     }

--- a/LayoutTests/inspector/console/console-table-expected.txt
+++ b/LayoutTests/inspector/console/console-table-expected.txt
@@ -39,7 +39,7 @@ STEP: console.table([])
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table(['apple', 'orange', 'banana'])
@@ -90,7 +90,7 @@ STEP: console.table(['apple', 'orange', 'banana'])
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table({firstName: 'John', lastName: 'Smith'})
@@ -132,7 +132,7 @@ STEP: console.table({firstName: 'John', lastName: 'Smith'})
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table({f: function(){}, x: 10})
@@ -181,7 +181,7 @@ STEP: console.table({f: function(){}, x: 10})
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table([['John', 'Smith'], ['Jane', 'Doe'], ['Emily', 'Jones']])
@@ -295,7 +295,7 @@ STEP: console.table([['John', 'Smith'], ['Jane', 'Doe'], ['Emily', 'Jones']])
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table([john, jane, emily])
@@ -400,7 +400,7 @@ STEP: console.table([john, jane, emily])
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table([john, jane, emily], ['firstName'])
@@ -529,7 +529,7 @@ STEP: console.table([john, jane, emily], ['firstName'])
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 STEP: console.table([manyProperties, manyProperties], ['five', 'six'])
@@ -680,6 +680,6 @@ STEP: console.table([manyProperties, manyProperties], ['five', 'six'])
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 

--- a/LayoutTests/inspector/console/console-table.html
+++ b/LayoutTests/inspector/console/console-table.html
@@ -32,7 +32,7 @@ function test()
     {
         if (key === "_target" || key === "_listeners")
             return undefined;
-        if (key === "_objectId" || key === "_stackTrace")
+        if (key === "_objectId" || key === "_stackTrace" || key === "_timestamp")
             return "<filtered>";
         return value;
     }

--- a/LayoutTests/inspector/worker/console-basic-expected.txt
+++ b/LayoutTests/inspector/worker/console-basic-expected.txt
@@ -61,7 +61,7 @@ PASS: ConsoleMessage parameter RemoteObjects should be from the Worker target.
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 -- Running test case: Worker.Console.warn
@@ -84,7 +84,7 @@ PASS: ConsoleMessage parameter RemoteObjects should be from the Worker target.
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 -- Running test case: Worker.Console.error
@@ -107,7 +107,7 @@ PASS: ConsoleMessage parameter RemoteObjects should be from the Worker target.
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 -- Running test case: Worker.Console.assert
@@ -130,7 +130,7 @@ PASS: ConsoleMessage parameter RemoteObjects should be from the Worker target.
   ],
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 -- Running test case: Worker.Console.time
@@ -146,7 +146,7 @@ PASS: ConsoleMessage parameter RemoteObjects should be from the Worker target.
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 
 -- Running test case: Worker.Console.count
@@ -162,6 +162,6 @@ PASS: ConsoleMessage parameter RemoteObjects should be from the Worker target.
   "_repeatCount": 1,
   "_stackTrace": "<filtered>",
   "_request": null,
-  "_timestamp": null
+  "_timestamp": "<filtered>"
 }
 

--- a/LayoutTests/inspector/worker/console-basic.html
+++ b/LayoutTests/inspector/worker/console-basic.html
@@ -14,7 +14,7 @@ function test()
     function consoleMessageJSONFilter(key, value) {
         if (key === "_target" || key === "_hasChildren" || key === "_listeners")
             return undefined;
-        if (key === "_objectId" || key === "_stackTrace" || key === "_sourceCodeLocation")
+        if (key === "_objectId" || key === "_stackTrace" || key === "_sourceCodeLocation" || key === "_timestamp")
             return "<filtered>";
         if (key === "_url")
             return sanitizeURL(value);

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -49,8 +49,8 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
     , m_message(message)
     , m_url()
     , m_requestId(IdentifiersFactory::requestId(requestIdentifier))
-    , m_timestamp(timestamp)
 {
+    m_timestamp = timestamp ? timestamp : Seconds(MonotonicTime::now().secondsSinceEpoch());
 }
 
 ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLevel level, const String& message, const String& url, unsigned line, unsigned column, JSC::JSGlobalObject* globalObject, unsigned long requestIdentifier, Seconds timestamp)
@@ -62,8 +62,8 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
     , m_line(line)
     , m_column(column)
     , m_requestId(IdentifiersFactory::requestId(requestIdentifier))
-    , m_timestamp(timestamp)
 {
+    m_timestamp = timestamp ? timestamp : Seconds(MonotonicTime::now().secondsSinceEpoch());
     autogenerateMetadata(globalObject);
 }
 
@@ -75,8 +75,8 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
     , m_callStack(WTFMove(callStack))
     , m_url()
     , m_requestId(IdentifiersFactory::requestId(requestIdentifier))
-    , m_timestamp(timestamp)
 {
+    m_timestamp = timestamp ? timestamp : Seconds(MonotonicTime::now().secondsSinceEpoch());
     const ScriptCallFrame* frame = m_callStack ? m_callStack->firstNonNativeCallFrame() : nullptr;
     if (frame) {
         m_url = frame->sourceURL();
@@ -94,8 +94,8 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
     , m_callStack(WTFMove(callStack))
     , m_url()
     , m_requestId(IdentifiersFactory::requestId(requestIdentifier))
-    , m_timestamp(timestamp)
 {
+    m_timestamp = timestamp ? timestamp : Seconds(MonotonicTime::now().secondsSinceEpoch());
     const ScriptCallFrame* frame = m_callStack ? m_callStack->firstNonNativeCallFrame() : nullptr;
     if (frame) {
         m_url = frame->sourceURL();
@@ -112,8 +112,8 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
     , m_arguments(WTFMove(arguments))
     , m_url()
     , m_requestId(IdentifiersFactory::requestId(requestIdentifier))
-    , m_timestamp(timestamp)
 {
+    m_timestamp = timestamp ? timestamp : Seconds(MonotonicTime::now().secondsSinceEpoch());
     autogenerateMetadata(globalObject);
 }
 
@@ -123,8 +123,8 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
     , m_level(level)
     , m_url()
     , m_requestId(IdentifiersFactory::requestId(requestIdentifier))
-    , m_timestamp(timestamp)
 {
+    m_timestamp = timestamp ? timestamp : Seconds(MonotonicTime::now().secondsSinceEpoch());
     if (globalObject)
         m_globalObject = { globalObject->vm(), globalObject };
 
@@ -333,7 +333,8 @@ String ConsoleMessage::toString() const
 
 void ConsoleMessage::updateRepeatCountInConsole(ConsoleFrontendDispatcher& consoleFrontendDispatcher)
 {
-    consoleFrontendDispatcher.messageRepeatCountUpdated(m_repeatCount);
+    Seconds timestamp = MonotonicTime::now().secondsSinceEpoch();
+    consoleFrontendDispatcher.messageRepeatCountUpdated(m_repeatCount, timestamp.seconds());
 }
 
 bool ConsoleMessage::isEqual(ConsoleMessage* msg) const

--- a/Source/JavaScriptCore/inspector/protocol/Console.json
+++ b/Source/JavaScriptCore/inspector/protocol/Console.json
@@ -127,7 +127,8 @@
             "name": "messageRepeatCountUpdated",
             "description": "Issued when subsequent message(s) are equal to the previous one(s).",
             "parameters": [
-                { "name": "count", "type": "integer", "description": "New repeat count value." }
+                { "name": "count", "type": "integer", "description": "New repeat count value." },
+                { "name": "timestamp", "type": "number", "optional": true, "description": "Timestamp of the latest message." }
             ]
         },
         {

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1683,6 +1683,7 @@ localizedStrings["Timer Fired"] = "Timer Fired";
 localizedStrings["Timer Installed"] = "Timer Installed";
 localizedStrings["Timer Removed"] = "Timer Removed";
 localizedStrings["Timers:"] = "Timers:";
+localizedStrings["Timestamps"] = "Timestamps";
 localizedStrings["Timestamp \u2014 %s"] = "Timestamp \u2014 %s";
 localizedStrings["Timing"] = "Timing";
 /* Property value for `font-variant-capitals: titling-caps`. */

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -214,6 +214,7 @@ WI.settings = {
     searchRegularExpression: new WI.Setting("search-regular-expression", false),
     selectedNetworkDetailContentViewIdentifier: new WI.Setting("network-detail-content-view-identifier", "preview"),
     sourceMapsEnabled: new WI.Setting("source-maps-enabled", true),
+    showConsoleMessageTimestamps: new WI.Setting("show-console-message-timestamps", false),
     showCSSPropertySyntaxInDocumentationPopover: new WI.Setting("show-css-property-syntax-in-documentation-popover", false),
     showCanvasPath: new WI.Setting("show-canvas-path", false),
     showImageGrid: new WI.Setting("show-image-grid", true),

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -196,11 +196,11 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         }
     }
 
-    messageRepeatCountUpdated(count)
+    messageRepeatCountUpdated(count, timestamp)
     {
         this._incrementMessageLevelCount(this._lastMessageLevel, 1);
 
-        this.dispatchEventToListeners(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, {count});
+        this.dispatchEventToListeners(WI.ConsoleManager.Event.PreviousMessageRepeatCountUpdated, {count, timestamp});
     }
 
     requestClearMessages()

--- a/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
@@ -38,9 +38,9 @@ WI.ConsoleObserver = class ConsoleObserver extends InspectorBackend.Dispatcher
         WI.consoleManager.messageWasAdded(this._target, message.source, message.level, message.text, message.type, message.url, message.line, message.column || 0, message.repeatCount, message.parameters, message.stackTrace, message.networkRequestId, message.timestamp);
     }
 
-    messageRepeatCountUpdated(count)
+    messageRepeatCountUpdated(count, timestamp)
     {
-        WI.consoleManager.messageRepeatCountUpdated(count);
+        WI.consoleManager.messageRepeatCountUpdated(count, timestamp);
     }
 
     messagesCleared()

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -61,6 +61,7 @@
 
 .console-message-body {
     white-space: pre-wrap;
+    display: flex;
 }
 
 .console-message-body > span {
@@ -308,6 +309,16 @@
 
 .console-top-level-message .object-tree .object-tree {
     display: inline-block;
+}
+
+.console-message .timestamp {
+    color: var(--text-color-tertiary);
+    padding-inline-end: 5px;
+    display: block;
+}
+
+.console-session:not(.timestamps-visible) .console-message .timestamp {
+    display: none;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -514,7 +514,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
 
     _previousMessageRepeatCountUpdated(event)
     {
-        if (!this._logViewController.updatePreviousMessageRepeatCount(event.data.count))
+        if (!this._logViewController.updatePreviousMessageRepeatCount(event.data.count, event.data.timestamp))
             return;
 
         if (this._lastMessageView) {

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -354,6 +354,7 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         }
 
         consoleSettingsView.addSetting(WI.UIString("Traces:"), WI.settings.consoleAutoExpandTrace, WI.UIString("Auto-expand"));
+        consoleSettingsView.addSetting(WI.UIString("Show:"), WI.settings.showConsoleMessageTimestamps, WI.UIString("Timestamps"));
 
         if (WI.ConsoleManager.supportsLogChannels()) {
             consoleSettingsView.addSeparator();


### PR DESCRIPTION
#### d69d0f7bc8d83054032900f13091b03d9a724212
<pre>
Support timestamps on WI console
<a href="https://bugs.webkit.org/show_bug.cgi?id=248240">https://bugs.webkit.org/show_bug.cgi?id=248240</a>

Reviewed by Patrick Angle.

We want a toggle-able flag in web inspector&apos;s console for showing a timestamp per console message.
Send the timestamp from the backend and display per console message. For duplicate messages, keep the repeat count and update the timestamp to that of the latest console message.
Collapse/expand functionality for duplicate messages when toggling off/on timestamps will come in a future PR.

-LayoutTests/inspector/console/console-api-expected.txt
-LayoutTests/inspector/console/console-api.html
-LayoutTests/inspector/worker/console-basic-expected.txt
-LayoutTests/inspector/worker/console-basic.html
-LayoutTests/inspector/console/console-table-expected.txt
-LayoutTests/inspector/console/console-table.html
-Source/JavaScriptCore/inspector/ConsoleMessage.cpp
-Source/JavaScriptCore/inspector/protocol/Console.json
-Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
-Source/WebInspectorUI/UserInterface/Base/Setting.js
-Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
-Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
-Source/WebInspectorUI/UserInterface/Protocol/ConsoleObserver.js
-Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
-Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
-Source/WebInspectorUI/UserInterface/Views/LogContentView.js
-Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js

Canonical link: <a href="https://commits.webkit.org/258675@main">https://commits.webkit.org/258675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c59e867feb597e3189a8aaedbbc62617de1ea80a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/102422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/11556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/35474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/111711 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/171921 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/12621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/2468 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/94716 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/109429 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/108203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/9673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/92872 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/37311 "Build was cancelled. Recent messages:Failed to print configuration; Cleaned up git repository; Skipping applying patch since patch_id isn't provided; Checked out pull request; Updated gtk dependencies; Pull request contains relevant changes; Skipped layout-tests; 23 flakes 87 failures; 11 flakes 74 failures; Reverted pull request changes; Compiled WebKit (cancelled)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/91536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/24352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/79063 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/92696 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/5040 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/25775 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/88989 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/2718 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/5191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/2216 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29577 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/11216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/45268 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/91914 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5960 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/6933 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/20580 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->