### PR TITLE
Adopt GameController.framework's setThumbstickUserIntentHandler SPI

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -54,6 +54,16 @@ static void disableDefaultSystemAction(GCControllerButtonInput *button)
 void GameControllerGamepad::setupElements()
 {
     auto *profile = m_gcController.get().physicalInputProfile;
+
+    // The user can expose an already-connected game controller to a web page by expressing explicit intent.
+    // Examples include pressing a button, or wiggling the joystick with intent.
+    if ([profile respondsToSelector:@selector(setThumbstickUserIntentHandler:)]) {
+        [profile setThumbstickUserIntentHandler:^(__kindof GCPhysicalInputProfile*, GCControllerElement*) {
+            m_lastUpdateTime = MonotonicTime::now();
+            GameControllerGamepadProvider::singleton().gamepadHadInput(*this, true);
+        }];
+    }
+
     auto *homeButton = profile.buttons[GCInputButtonHome];
     m_buttonValues.resize(homeButton ? numberOfStandardGamepadButtonsWithHomeButton : numberOfStandardGamepadButtonsWithoutHomeButton);
 

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerSPI.h
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerSPI.h
@@ -27,6 +27,11 @@
 
 #import <GameController/GCController.h>
 
+typedef void (^GCPhysicalInputProfileThumbstickUserIntentHandler)(__kindof GCPhysicalInputProfile *profile, GCControllerElement *element);
+@interface GCPhysicalInputProfile ()
+-(void) setThumbstickUserIntentHandler:(GCPhysicalInputProfileThumbstickUserIntentHandler)handler;
+@end
+
 #if !HAVE(GCCONTROLLER_HID_DEVICE_CHECK)
 @class _GCCControllerHIDServiceInfo;
 #endif


### PR DESCRIPTION
#### 8b1081372e8c729a1c849724c1a09138cba9c771
<pre>
Adopt GameController.framework&apos;s setThumbstickUserIntentHandler SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=248247">https://bugs.webkit.org/show_bug.cgi?id=248247</a>
rdar://87368239

Reviewed by Tim Hatcher.

It would be great if users could &quot;wiggle the joystick&quot; to expose a gamepad to a web page,
instead of having to press a button.

Let&apos;s adopt new SPI to enable that.

* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
* Source/WebCore/platform/gamepad/cocoa/GameControllerSPI.h:

Canonical link: <a href="https://commits.webkit.org/256959@main">https://commits.webkit.org/256959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0356317823f9517205ec9668cacb420847cf104b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106866 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167130 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6916 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35349 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103544 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103012 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/83978 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32197 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87048 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/627 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/609 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5412 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41140 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->