### PR TITLE
Support rendering non-native <progress> in vertical writing mode

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4199,10 +4199,6 @@ webkit.org/b/230080 imported/w3c/web-platform-tests/css/css-transforms/transform
 webkit.org/b/166941 imported/w3c/web-platform-tests/css/css-writing-modes/logical-physical-mapping-001.html [ ImageOnlyFailure ]
 
 # Vertical form controls support.
-webkit.org/b/247754 imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-horizontal.optional.html [ ImageOnlyFailure ]
-webkit.org/b/247754 imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-vertical.optional.html [ ImageOnlyFailure ]
-webkit.org/b/247754 imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-none-horizontal.optional.html [ ImageOnlyFailure ]
-webkit.org/b/247754 imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-none-vertical.optional.html [ ImageOnlyFailure ]
 webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-horizontal.optional.html [ ImageOnlyFailure ]
 webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-vlr.optional.html [ ImageOnlyFailure ]
 webkit.org/b/248262 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-appearance-native-vrl.optional.html [ ImageOnlyFailure ]

--- a/LayoutTests/editing/style/apply-style-atomic-expected.txt
+++ b/LayoutTests/editing/style/apply-style-atomic-expected.txt
@@ -15,6 +15,6 @@ Test that WebKit does not crash when we apply style to atomic elements and that 
 |           shadow:pseudoId="-webkit-progress-bar"
 |           <div>
 |             pseudo="-webkit-progress-value"
-|             style="width: -100%;"
+|             style="inline-size: -100%;"
 |             shadow:pseudoId="-webkit-progress-value"
 |   <#selection-focus>

--- a/LayoutTests/editing/style/apply-style-atomic-live-range-expected.txt
+++ b/LayoutTests/editing/style/apply-style-atomic-live-range-expected.txt
@@ -15,6 +15,6 @@ Test that WebKit does not crash when we apply style to atomic elements and that 
 |           shadow:pseudoId="-webkit-progress-bar"
 |           <div>
 |             pseudo="-webkit-progress-value"
-|             style="width: -100%;"
+|             style="inline-size: -100%;"
 |             shadow:pseudoId="-webkit-progress-value"
 |   <#selection-focus>

--- a/LayoutTests/fast/dom/HTMLProgressElement/progress-clone-expected.txt
+++ b/LayoutTests/fast/dom/HTMLProgressElement/progress-clone-expected.txt
@@ -1,8 +1,8 @@
 PASS cloned.value is target.value
 PASS internals.shadowPseudoId(clonedShadowRoot.firstChild.firstChild) is internals.shadowPseudoId(targetShadowRoot.firstChild.firstChild)
 PASS internals.shadowPseudoId(clonedShadowRoot.firstChild.firstChild.firstChild) is internals.shadowPseudoId(targetShadowRoot.firstChild.firstChild.firstChild)
-PASS clonedShadowRoot.firstChild.firstChild.firstChild.style.width is "70%"
-PASS targetShadowRoot.firstChild.firstChild.firstChild.style.width is "50%"
+PASS clonedShadowRoot.firstChild.firstChild.firstChild.style.inlineSize is "70%"
+PASS targetShadowRoot.firstChild.firstChild.firstChild.style.inlineSize is "50%"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/HTMLProgressElement/progress-clone.html
+++ b/LayoutTests/fast/dom/HTMLProgressElement/progress-clone.html
@@ -3,13 +3,13 @@
 <script src="../../../resources/js-test-pre.js"></script>
 </head>
 <body>
-<progress id="target" min="0" max="100" value="50" style="-webkit-appearance: none;" ></progress>
+<progress id="target" min="0" max="100" value="50" style="appearance: none;" ></progress>
 <script>
 (function() {
     target = document.getElementById("target");
     cloned = target.cloneNode();
     document.body.insertBefore(cloned, target.nextSibling);
-    
+
     if (!window.internals) {
         debug("You need internals to run this test.");
         return;
@@ -21,11 +21,10 @@
     shouldBe("cloned.value", "target.value");
     shouldBe("internals.shadowPseudoId(clonedShadowRoot.firstChild.firstChild)", "internals.shadowPseudoId(targetShadowRoot.firstChild.firstChild)");
     shouldBe("internals.shadowPseudoId(clonedShadowRoot.firstChild.firstChild.firstChild)", "internals.shadowPseudoId(targetShadowRoot.firstChild.firstChild.firstChild)");
-    
+
     cloned.value = 70;
-    shouldBe("clonedShadowRoot.firstChild.firstChild.firstChild.style.width", '"70%"');
-    shouldBe("targetShadowRoot.firstChild.firstChild.firstChild.style.width", '"50%"');
-    
+    shouldBe("clonedShadowRoot.firstChild.firstChild.firstChild.style.inlineSize", '"70%"');
+    shouldBe("targetShadowRoot.firstChild.firstChild.firstChild.style.inlineSize", '"50%"');
 })();
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/dom/HTMLProgressElement/progress-element-markup-expected.txt
+++ b/LayoutTests/fast/dom/HTMLProgressElement/progress-element-markup-expected.txt
@@ -2,7 +2,7 @@
 A progress element should have a nested shadow box with a width specified:
 | <progress>
 |   max="100"
-|   style="-webkit-appearance: none;"
+|   style="appearance: none;"
 |   value="70"
 |   <shadow:root>
 |     <div>
@@ -13,5 +13,5 @@ A progress element should have a nested shadow box with a width specified:
 |         shadow:pseudoId="-webkit-progress-bar"
 |         <div>
 |           pseudo="-webkit-progress-value"
-|           style="width: 70%;"
+|           style="inline-size: 70%;"
 |           shadow:pseudoId="-webkit-progress-value"

--- a/LayoutTests/fast/dom/HTMLProgressElement/progress-element-markup.html
+++ b/LayoutTests/fast/dom/HTMLProgressElement/progress-element-markup.html
@@ -4,7 +4,7 @@
 <script src="../../../resources/dump-as-markup.js"></script>
 </head>
 <body>
-  <div id="target"><progress style="-webkit-appearance: none;" value=70 max=100></progress></div>
+  <div id="target"><progress style="appearance: none;" value=70 max=100></progress></div>
 <script>
 Markup.dump(document.getElementById("target"), "A progress element should have a nested shadow box with a width specified");
 </script>

--- a/LayoutTests/fast/dom/HTMLProgressElement/progress-writing-mode-expected.html
+++ b/LayoutTests/fast/dom/HTMLProgressElement/progress-writing-mode-expected.html
@@ -4,14 +4,14 @@
 progress {
   width: 50px;
   height: 50px;
-  -webkit-appearance: none;
+  appearance: none;
 }
 </style>
 </head>
 <body>
 <progress min=0 value=30 max=100></progress>
 <progress min=0 value=30 max=100></progress>
-<progress min=0 value=30 max=100></progress>
-<progress min=0 value=30 max=100></progress>
+<progress min=0 value=30 max=100 style="writing-mode: vertical-rl;"></progress>
+<progress min=0 value=30 max=100 style="writing-mode: vertical-lr;"></progress>
 </body>
 </html>

--- a/LayoutTests/fast/dom/HTMLProgressElement/progress-writing-mode.html
+++ b/LayoutTests/fast/dom/HTMLProgressElement/progress-writing-mode.html
@@ -4,15 +4,16 @@
 progress {
   width: 50px;
   height: 50px;
-  -webkit-appearance: none;
+  appearance: none;
   background-color: red; /* should not be visible */
 }
 </style>
 </head>
 <body>
-<progress min=0 value=30 max=100 style="-webkit-writing-mode: vertical-lr;"></progress>
-<progress min=0 value=30 max=100 style="-webkit-writing-mode: vertical-rl;"></progress>
-<progress min=0 value=30 max=100 style="-webkit-writing-mode: horizontal-tb;"></progress>
-<progress min=0 value=30 max=100 style="-webkit-writing-mode: horizontal-bt;"></progress>
+<progress min=0 value=30 max=100 style="writing-mode: horizontal-tb;"></progress>
+<progress min=0 value=30 max=100 style="writing-mode: horizontal-bt;"></progress>
+<!-- vertical-lr should match vertical-rl -->
+<progress min=0 value=30 max=100 style="writing-mode: vertical-lr;"></progress>
+<progress min=0 value=30 max=100 style="writing-mode: vertical-rl;"></progress>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
@@ -1,6 +1,6 @@
 
 
 FAIL progress[style="writing-mode: horizontal-tb"] block size should match height and inline should match width assert_equals: expected "16px" but got "21px"
-FAIL progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width assert_equals: expected "16px" but got "21px"
-FAIL progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width assert_equals: expected "16px" but got "21px"
+PASS progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width
+PASS progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS progress[style="writing-mode: horizontal-tb"] block size should match height and inline should match width
-FAIL progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width assert_equals: expected "160px" but got "16px"
-FAIL progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width assert_equals: expected "160px" but got "16px"
+PASS progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width
+PASS progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width
 

--- a/Source/WebCore/css/horizontalFormControls.css
+++ b/Source/WebCore/css/horizontalFormControls.css
@@ -25,6 +25,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* Every time a new control is supported in vertical writing mode, it should be added here and removed from the html.css rule */
-textarea, input:not([type="button"], [type="submit"], [type="reset"], [type="file"]) {
+textarea, progress, input:not([type="button"], [type="submit"], [type="reset"], [type="file"]) {
     writing-mode: horizontal-tb !important;
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -400,7 +400,7 @@ button {
 }
 
 /* Every time a new control is supported in vertical writing mode, it should be removed from here and added in the horizontalFormControls.css rule */
-select, button, meter, progress, input:is([type="button"], [type="submit"], [type="reset"], [type="file"]) {
+select, button, meter, input:is([type="button"], [type="submit"], [type="reset"], [type="file"]) {
     writing-mode: horizontal-tb !important;
 }
 
@@ -1203,8 +1203,8 @@ progress {
     appearance: auto;
     box-sizing: border-box;
     display: inline-block;
-    height: 1em;
-    width: 10em;
+    block-size: 1em;
+    inline-size: 10em;
     vertical-align: -0.2em;
 }
 
@@ -1223,8 +1223,8 @@ progress::-webkit-progress-bar {
 
 progress::-webkit-progress-value {
     background-color: green;
-    height: 100%;
-    width: 50%; /* should be removed later */
+    block-size: 100%;
+    inline-size: 50%; /* should be removed later */
     box-sizing: border-box;
 }
 

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -135,7 +135,7 @@ void HTMLProgressElement::updateDeterminateState()
 
 void HTMLProgressElement::didElementStateChange()
 {
-    m_value->setWidthPercentage(position() * 100);
+    m_value->setInlineSizePercentage(position() * 100);
     if (RenderProgress* renderer = renderProgress())
         renderer->updateFromElement();
 
@@ -153,7 +153,7 @@ void HTMLProgressElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     auto bar = ProgressBarElement::create(document());
     auto value = ProgressValueElement::create(document());
     m_value = value.ptr();
-    m_value->setWidthPercentage(HTMLProgressElement::IndeterminatePosition * 100);
+    m_value->setInlineSizePercentage(HTMLProgressElement::IndeterminatePosition * 100);
     bar->appendChild(value);
 
     inner->appendChild(bar);

--- a/Source/WebCore/html/shadow/ProgressShadowElement.cpp
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.cpp
@@ -85,9 +85,9 @@ ProgressValueElement::ProgressValueElement(Document& document)
 {
 }
 
-void ProgressValueElement::setWidthPercentage(double width)
+void ProgressValueElement::setInlineSizePercentage(double size)
 {
-    setInlineStyleProperty(CSSPropertyWidth, width, CSSUnitType::CSS_PERCENTAGE);
+    setInlineStyleProperty(CSSPropertyInlineSize, size, CSSUnitType::CSS_PERCENTAGE);
 }
 
 Ref<ProgressInnerElement> ProgressInnerElement::create(Document& document)

--- a/Source/WebCore/html/shadow/ProgressShadowElement.h
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.h
@@ -77,7 +77,7 @@ static_assert(sizeof(ProgressBarElement) == sizeof(ProgressShadowElement));
 class ProgressValueElement final : public ProgressShadowElement {
 public:
     static Ref<ProgressValueElement> create(Document&);
-    void setWidthPercentage(double);
+    void setInlineSizePercentage(double);
 
 private:
     ProgressValueElement(Document&);


### PR DESCRIPTION
#### fd4ac798e708eb677e85f3f9b847c29898eb584e
<pre>
Support rendering non-native &lt;progress&gt; in vertical writing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=247754">https://bugs.webkit.org/show_bug.cgi?id=247754</a>
rdar://102477867

Reviewed by Aditya Keerthi.

Update relevant rules to use logical properties.

Enable &lt;progress&gt; in vertical writing mode behind the VerticalFormControlsEnabled setting.

Native &lt;progress&gt; appearance will also need to be painted vertically, but that will be done in a separate commit.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt:
* LayoutTests/editing/style/apply-style-atomic-expected.txt:
* LayoutTests/editing/style/apply-style-atomic-live-range-expected.txt:
* LayoutTests/fast/dom/HTMLProgressElement/progress-clone-expected.txt:
* LayoutTests/fast/dom/HTMLProgressElement/progress-clone.html:
* LayoutTests/fast/dom/HTMLProgressElement/progress-element-markup-expected.txt:
* LayoutTests/fast/dom/HTMLProgressElement/progress-element-markup.html:
* LayoutTests/fast/dom/HTMLProgressElement/progress-writing-mode-expected.html:
* LayoutTests/fast/dom/HTMLProgressElement/progress-writing-mode.html:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt:
* Source/WebCore/css/horizontalFormControls.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/html.css:
(select, button, meter, input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;], [type=&quot;file&quot;])):
(progress):
(progress::-webkit-progress-value):
(select, button, meter, progress, input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;], [type=&quot;file&quot;])): Deleted.
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::didElementStateChange):
(WebCore::HTMLProgressElement::didAddUserAgentShadowRoot):
* Source/WebCore/html/shadow/ProgressShadowElement.cpp:
(WebCore::ProgressValueElement::setInlineSizePercentage):
(WebCore::ProgressValueElement::setWidthPercentage): Deleted.
* Source/WebCore/html/shadow/ProgressShadowElement.h:

Canonical link: <a href="https://commits.webkit.org/262336@main">https://commits.webkit.org/262336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092583cf54f06c96523c8a052bbd7464c6a16dfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/1210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/1243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/1282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/1973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/1079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/1294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/1312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/1245 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/1219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/1136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/1119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/1842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/1154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/1112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/1099 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/1060 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/1103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/1143 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/2213 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/1184 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/1153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/1060 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/1242 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/1089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/1122 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/251 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/321 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/1179 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/1245 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/245 "Passed tests") | 
<!--EWS-Status-Bubble-End-->