### PR TITLE
Use raw Quad in CSSBorderImageSliceValue and CSSBorderImageWidthValue

### DIFF
--- a/Source/WebCore/css/CSSBorderImageSliceValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-CSSBorderImageSliceValue::CSSBorderImageSliceValue(RefPtr<CSSPrimitiveValue>&& slices, bool fill)
+CSSBorderImageSliceValue::CSSBorderImageSliceValue(Ref<Quad>&& slices, bool fill)
     : CSSValue(BorderImageSliceClass)
     , m_slices(WTFMove(slices))
     , m_fill(fill)
@@ -51,7 +51,7 @@ String CSSBorderImageSliceValue::customCSSText() const
 
 bool CSSBorderImageSliceValue::equals(const CSSBorderImageSliceValue& other) const
 {
-    return m_fill == other.m_fill && compareCSSValuePtr(m_slices, other.m_slices);
+    return m_fill == other.m_fill && m_slices->equals(other.m_slices);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSBorderImageSliceValue.h
+++ b/Source/WebCore/css/CSSBorderImageSliceValue.h
@@ -34,24 +34,24 @@ class Rect;
 
 class CSSBorderImageSliceValue final : public CSSValue {
 public:
-    static Ref<CSSBorderImageSliceValue> create(RefPtr<CSSPrimitiveValue>&& slices, bool fill)
+    static Ref<CSSBorderImageSliceValue> create(Ref<Quad>&& slices, bool fill)
     {
         return adoptRef(*new CSSBorderImageSliceValue(WTFMove(slices), fill));
     }
 
     String customCSSText() const;
 
-    Quad* slices() const { return m_slices ? m_slices->quadValue() : nullptr; }
+    Quad& slices() const { return m_slices.get(); }
 
     bool equals(const CSSBorderImageSliceValue&) const;
 
     // These four values are used to make "cuts" in the border image. They can be numbers
     // or percentages.
-    RefPtr<CSSPrimitiveValue> m_slices;
+    Ref<Quad> m_slices;
     bool m_fill;
 
 private:
-    CSSBorderImageSliceValue(RefPtr<CSSPrimitiveValue>&& slices, bool fill);
+    CSSBorderImageSliceValue(Ref<Quad>&& slices, bool fill);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSBorderImageWidthValue.cpp
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-CSSBorderImageWidthValue::CSSBorderImageWidthValue(RefPtr<CSSPrimitiveValue>&& widths, bool overridesBorderWidths)
+CSSBorderImageWidthValue::CSSBorderImageWidthValue(Ref<Quad>&& widths, bool overridesBorderWidths)
     : CSSValue(BorderImageWidthClass)
     , m_widths(WTFMove(widths))
     , m_overridesBorderWidths(overridesBorderWidths)
@@ -50,7 +50,7 @@ String CSSBorderImageWidthValue::customCSSText() const
 
 bool CSSBorderImageWidthValue::equals(const CSSBorderImageWidthValue& other) const
 {
-    return m_overridesBorderWidths == other.m_overridesBorderWidths && compareCSSValuePtr(m_widths, other.m_widths);
+    return m_overridesBorderWidths == other.m_overridesBorderWidths && m_widths->equals(other.m_widths);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSBorderImageWidthValue.h
+++ b/Source/WebCore/css/CSSBorderImageWidthValue.h
@@ -34,22 +34,22 @@ class Rect;
 
 class CSSBorderImageWidthValue final : public CSSValue {
 public:
-    static Ref<CSSBorderImageWidthValue> create(RefPtr<CSSPrimitiveValue>&& widths, bool overridesBorderWidths)
+    static Ref<CSSBorderImageWidthValue> create(Ref<Quad>&& widths, bool overridesBorderWidths)
     {
         return adoptRef(*new CSSBorderImageWidthValue(WTFMove(widths), overridesBorderWidths));
     }
 
     String customCSSText() const;
 
-    Quad* widths() const { return m_widths ? m_widths->quadValue() : nullptr; }
+    Quad& widths() const { return m_widths.get(); }
 
     bool equals(const CSSBorderImageWidthValue&) const;
 
-    RefPtr<CSSPrimitiveValue> m_widths;
+    Ref<Quad> m_widths;
     bool m_overridesBorderWidths;
 
 private:
-    CSSBorderImageWidthValue(RefPtr<CSSPrimitiveValue>&& widths, bool overridesBorderWidths);
+    CSSBorderImageWidthValue(Ref<Quad>&& widths, bool overridesBorderWidths);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -507,23 +507,23 @@ void CSSToStyleMap::mapNinePieceImageSlice(CSSBorderImageSliceValue& value, Nine
 {
     // Set up a length box to represent our image slices.
     LengthBox box;
-    Quad* slices = value.slices();
-    if (slices->top()->isPercentage())
-        box.top() = Length(slices->top()->doubleValue(), LengthType::Percent);
+    Quad& slices = value.slices();
+    if (slices.top()->isPercentage())
+        box.top() = Length(slices.top()->doubleValue(), LengthType::Percent);
     else
-        box.top() = Length(slices->top()->intValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
-    if (slices->bottom()->isPercentage())
-        box.bottom() = Length(slices->bottom()->doubleValue(), LengthType::Percent);
+        box.top() = Length(slices.top()->intValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
+    if (slices.bottom()->isPercentage())
+        box.bottom() = Length(slices.bottom()->doubleValue(), LengthType::Percent);
     else
-        box.bottom() = Length((int)slices->bottom()->floatValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
-    if (slices->left()->isPercentage())
-        box.left() = Length(slices->left()->doubleValue(), LengthType::Percent);
+        box.bottom() = Length((int)slices.bottom()->floatValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
+    if (slices.left()->isPercentage())
+        box.left() = Length(slices.left()->doubleValue(), LengthType::Percent);
     else
-        box.left() = Length(slices->left()->intValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
-    if (slices->right()->isPercentage())
-        box.right() = Length(slices->right()->doubleValue(), LengthType::Percent);
+        box.left() = Length(slices.left()->intValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
+    if (slices.right()->isPercentage())
+        box.right() = Length(slices.right()->doubleValue(), LengthType::Percent);
     else
-        box.right() = Length(slices->right()->intValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
+        box.right() = Length(slices.right()->intValue(CSSUnitType::CSS_NUMBER), LengthType::Fixed);
     image.setImageSlices(box);
 
     // Set our fill mode.
@@ -555,51 +555,51 @@ LengthBox CSSToStyleMap::mapNinePieceImageQuad(CSSValue& value)
     // Retrieve the primitive value.
     auto& borderWidths = downcast<CSSPrimitiveValue>(value);
 
-    return mapNinePieceImageQuad(borderWidths.quadValue());
+    return mapNinePieceImageQuad(*borderWidths.quadValue());
 }
 
-LengthBox CSSToStyleMap::mapNinePieceImageQuad(Quad* quad)
+LengthBox CSSToStyleMap::mapNinePieceImageQuad(Quad& quad)
 {
     // Get our zoom value.
     CSSToLengthConversionData conversionData = useSVGZoomRules() ? m_builderState.cssToLengthConversionData().copyWithAdjustedZoom(1.0f) : m_builderState.cssToLengthConversionData();
 
     // Set up a length box to represent our image slices.
     LengthBox box; // Defaults to 'auto' so we don't have to handle that explicitly below.
-    if (quad->top()->isNumber())
-        box.top() = Length(quad->top()->floatValue(), LengthType::Relative);
-    else if (quad->top()->isPercentage())
-        box.top() = Length(quad->top()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
-    else if (quad->top()->isCalculatedPercentageWithLength())
-        box.top() = Length(quad->top()->cssCalcValue()->createCalculationValue(conversionData));
-    else if (quad->top()->valueID() != CSSValueAuto)
-        box.top() = quad->top()->computeLength<Length>(conversionData);
+    if (quad.top()->isNumber())
+        box.top() = Length(quad.top()->floatValue(), LengthType::Relative);
+    else if (quad.top()->isPercentage())
+        box.top() = Length(quad.top()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
+    else if (quad.top()->isCalculatedPercentageWithLength())
+        box.top() = Length(quad.top()->cssCalcValue()->createCalculationValue(conversionData));
+    else if (quad.top()->valueID() != CSSValueAuto)
+        box.top() = quad.top()->computeLength<Length>(conversionData);
 
-    if (quad->right()->isNumber())
-        box.right() = Length(quad->right()->floatValue(), LengthType::Relative);
-    else if (quad->right()->isPercentage())
-        box.right() = Length(quad->right()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
-    else if (quad->right()->isCalculatedPercentageWithLength())
-        box.right() = Length(quad->right()->cssCalcValue()->createCalculationValue(conversionData));
-    else if (quad->right()->valueID() != CSSValueAuto)
-        box.right() = quad->right()->computeLength<Length>(conversionData);
+    if (quad.right()->isNumber())
+        box.right() = Length(quad.right()->floatValue(), LengthType::Relative);
+    else if (quad.right()->isPercentage())
+        box.right() = Length(quad.right()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
+    else if (quad.right()->isCalculatedPercentageWithLength())
+        box.right() = Length(quad.right()->cssCalcValue()->createCalculationValue(conversionData));
+    else if (quad.right()->valueID() != CSSValueAuto)
+        box.right() = quad.right()->computeLength<Length>(conversionData);
 
-    if (quad->bottom()->isNumber())
-        box.bottom() = Length(quad->bottom()->floatValue(), LengthType::Relative);
-    else if (quad->bottom()->isPercentage())
-        box.bottom() = Length(quad->bottom()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
-    else if (quad->bottom()->isCalculatedPercentageWithLength())
-        box.bottom() = Length(quad->bottom()->cssCalcValue()->createCalculationValue(conversionData));
-    else if (quad->bottom()->valueID() != CSSValueAuto)
-        box.bottom() = quad->bottom()->computeLength<Length>(conversionData);
+    if (quad.bottom()->isNumber())
+        box.bottom() = Length(quad.bottom()->floatValue(), LengthType::Relative);
+    else if (quad.bottom()->isPercentage())
+        box.bottom() = Length(quad.bottom()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
+    else if (quad.bottom()->isCalculatedPercentageWithLength())
+        box.bottom() = Length(quad.bottom()->cssCalcValue()->createCalculationValue(conversionData));
+    else if (quad.bottom()->valueID() != CSSValueAuto)
+        box.bottom() = quad.bottom()->computeLength<Length>(conversionData);
 
-    if (quad->left()->isNumber())
-        box.left() = Length(quad->left()->floatValue(), LengthType::Relative);
-    else if (quad->left()->isPercentage())
-        box.left() = Length(quad->left()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
-    else if (quad->left()->isCalculatedPercentageWithLength())
-        box.left() = Length(quad->left()->cssCalcValue()->createCalculationValue(conversionData));
-    else if (quad->left()->valueID() != CSSValueAuto)
-        box.left() = quad->left()->computeLength<Length>(conversionData);
+    if (quad.left()->isNumber())
+        box.left() = Length(quad.left()->floatValue(), LengthType::Relative);
+    else if (quad.left()->isPercentage())
+        box.left() = Length(quad.left()->doubleValue(CSSUnitType::CSS_PERCENTAGE), LengthType::Percent);
+    else if (quad.left()->isCalculatedPercentageWithLength())
+        box.left() = Length(quad.left()->cssCalcValue()->createCalculationValue(conversionData));
+    else if (quad.left()->valueID() != CSSValueAuto)
+        box.left() = quad.left()->computeLength<Length>(conversionData);
 
     return box;
 }

--- a/Source/WebCore/css/CSSToStyleMap.h
+++ b/Source/WebCore/css/CSSToStyleMap.h
@@ -86,7 +86,7 @@ private:
     RenderStyle* style() const;
     bool useSVGZoomRules() const;
     RefPtr<StyleImage> styleImage(CSSValue&);
-    LengthBox mapNinePieceImageQuad(Quad*);
+    LengthBox mapNinePieceImageQuad(Quad&);
 
     // FIXME: This type can merge into BuilderState.
     Style::BuilderState& m_builderState;

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -275,7 +275,7 @@ static inline Ref<CSSBorderImageSliceValue> valueForNinePieceImageSlice(const Ni
     quad->setBottom(WTFMove(bottom));
     quad->setLeft(WTFMove(left));
 
-    return CSSBorderImageSliceValue::create(CSSValuePool::singleton().createValue(WTFMove(quad)), image.fill());
+    return CSSBorderImageSliceValue::create(WTFMove(quad), image.fill());
 }
 
 static Ref<CSSPrimitiveValue> valueForNinePieceImageQuad(const LengthBox& box, const RenderStyle& style)

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -1249,18 +1249,20 @@ String StyleProperties::borderImagePropertyValue(CSSPropertyID propertyID) const
         if (omittedSlice && (longhand == CSSPropertyBorderImageWidth || longhand == CSSPropertyBorderImageOutset))
             return String();
 
+        String valueText;
+
         // -webkit-border-image has a legacy behavior that makes fixed border slices also set the border widths.
         if (is<CSSBorderImageWidthValue>(value.get())) {
             auto* borderImageWidth = downcast<CSSBorderImageWidthValue>(value.get());
-            Quad* widths = borderImageWidth->widths();
-            bool overridesBorderWidths = propertyID == CSSPropertyWebkitBorderImage && widths && (widths->top()->isLength() || widths->right()->isLength() || widths->bottom()->isLength() || widths->left()->isLength());
+            Quad& widths = borderImageWidth->widths();
+            bool overridesBorderWidths = propertyID == CSSPropertyWebkitBorderImage && (widths.top()->isLength() || widths.right()->isLength() || widths.bottom()->isLength() || widths.left()->isLength());
             if (overridesBorderWidths != borderImageWidth->m_overridesBorderWidths)
                 return String();
-            value = borderImageWidth->m_widths;
-        }
+            valueText = widths.cssText();
+        } else
+            valueText = value->cssText();
 
         // If a longhand is set to a css-wide keyword, the others should be the same.
-        String valueText = value->cssText();
         if (isCSSWideValueKeyword(valueText)) {
             if (!i)
                 commonWideValueText = valueText;

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -7429,7 +7429,7 @@ RefPtr<CSSValue> consumeBorderImageSlice(CSSPropertyID property, CSSParserTokenR
     quad->setLeft(slices[3].releaseNonNull());
     
     // Make our new border image value now.
-    return CSSBorderImageSliceValue::create(CSSValuePool::singleton().createValue(WTFMove(quad)), fill);
+    return CSSBorderImageSliceValue::create(WTFMove(quad), fill);
 }
 
 RefPtr<CSSValue> consumeBorderImageOutset(CSSParserTokenRange& range)
@@ -7488,7 +7488,7 @@ RefPtr<CSSValue> consumeBorderImageWidth(CSSPropertyID property, CSSParserTokenR
     quad->setBottom(widths[2].releaseNonNull());
     quad->setLeft(widths[3].releaseNonNull());
 
-    return CSSBorderImageWidthValue::create(CSSValuePool::singleton().createValue(WTFMove(quad)), overridesBorderWidths);
+    return CSSBorderImageWidthValue::create(WTFMove(quad), overridesBorderWidths);
 }
 
 bool consumeBorderImageComponents(CSSPropertyID property, CSSParserTokenRange& range, const CSSParserContext& context, RefPtr<CSSValue>& source,


### PR DESCRIPTION
#### bfb21d18f6471f5984b601fc6939009d1da709ca
<pre>
Use raw Quad in CSSBorderImageSliceValue and CSSBorderImageWidthValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=248252">https://bugs.webkit.org/show_bug.cgi?id=248252</a>

Reviewed by Darin Adler.

These classes were using a CSSPrimitiveValue wrapper for a Quad.
They can just use the Quad directly.
No test since there should be no observable change in behavior.

* Source/WebCore/css/CSSBorderImageSliceValue.cpp:
(WebCore::CSSBorderImageSliceValue::CSSBorderImageSliceValue):
(WebCore::CSSBorderImageSliceValue::equals const):
* Source/WebCore/css/CSSBorderImageSliceValue.h:
* Source/WebCore/css/CSSBorderImageWidthValue.cpp:
(WebCore::CSSBorderImageWidthValue::CSSBorderImageWidthValue):
(WebCore::CSSBorderImageWidthValue::equals const):
* Source/WebCore/css/CSSBorderImageWidthValue.h:
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapNinePieceImageSlice):
(WebCore::CSSToStyleMap::mapNinePieceImageQuad):
* Source/WebCore/css/CSSToStyleMap.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForNinePieceImageSlice):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::borderImagePropertyValue const):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeBorderImageSlice):
(WebCore::CSSPropertyParserHelpers::consumeBorderImageWidth):

Canonical link: <a href="https://commits.webkit.org/256968@main">https://commits.webkit.org/256968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e53e7787682d5659e9d170c9f4dde4b2f167656

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106896 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167162 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6953 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35383 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103573 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103041 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84009 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32220 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87080 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75145 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/655 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/637 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21821 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4805 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5443 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41170 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->