### PR TITLE
[web-animations] filter values containing a url() should animate discretely

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5176,8 +5176,6 @@ webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/selection-tex
 
 
 # css/filter-effects
-webkit.org/b/235000 [ Debug ] imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003.html [ Skip ]
-
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-basic-background-color.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-basic-opacity-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-basic.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt
@@ -199,34 +199,34 @@ PASS Web Animations: property <filter> from [none] to [sepia(1)] at (0) should b
 PASS Web Animations: property <filter> from [none] to [sepia(1)] at (0.5) should be [sepia(0.5)]
 PASS Web Animations: property <filter> from [none] to [sepia(1)] at (1) should be [sepia(1)]
 PASS Web Animations: property <filter> from [none] to [sepia(1)] at (1.5) should be [sepia(1)]
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (-0.3) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0.3) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (-0.3) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0.3) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "( ) "
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (-0.3) should be [none]
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0) should be [none]
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0.3) should be [none]
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none]
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none]
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none]
+PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (-0.3) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0.3) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none]
+PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (-0.3) should be [url("#svgfilter")]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (0) should be [url("#svgfilter")]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (0.3) should be [url("#svgfilter")]
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "( ) "
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none]
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none]
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none]
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none]
 PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (-0.3) should be [url("#svgfilter")]
 PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (0) should be [url("#svgfilter")]
 PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (0.3) should be [url("#svgfilter")]
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none] assert_equals: expected "none " but got "url ( \" # svgfilter \" ) "
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none] assert_equals: expected "none " but got "( ) "
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "( ) "
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (0.5) should be [none]
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (0.6) should be [none]
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (1) should be [none]
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [none] at (1.5) should be [none]
 PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [blur(5px)] at (-0.3) should be [blur(5px)]
 PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0) should be [blur(5px)]
 PASS CSS Transitions: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.3) should be [blur(5px)]

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -248,7 +248,7 @@ FAIL filter: interpolate different length of filter-function-list with function 
 FAIL filter: interpolate different length of filter-function-list with function which lacuna value is 0 assert_equals: The value should be opacity(0.5) grayscale(0.5) invert(0.5) sepia(0.5) blur(5px) at 500ms expected "opacity(0.5) grayscale(0.5) invert(0.5) sepia(0.5) blur(5px)" but got "opacity(0) grayscale(1) invert(1) sepia(1) blur(10px)"
 FAIL filter: interpolate different length of filter-function-list with drop-shadow function assert_equals: The value should be blur(5px) drop-shadow(rgba(0, 0, 255, 0.4) 5px 5px 5px) at 500ms expected "blur(5px) drop-shadow(rgba(0, 0, 255, 0.4) 5px 5px 5px)" but got "blur(10px) drop-shadow(rgba(0, 0, 255, 0.8) 10px 10px 10px)"
 PASS filter: interpolate from none
-FAIL filter: url function (interpoalte as discrete) assert_equals: The value should be blur(0px) url("#f1") at 499ms expected "blur(0px) url(\"#f1\")" but got "blur(4.99px) url(\"#f1\")"
+PASS filter: url function (interpoalte as discrete)
 PASS flex-basis (type: lengthPercentageOrCalc) has testInterpolation function
 PASS flex-basis supports animating as a length
 PASS flex-basis supports animating as a length of rem


### PR DESCRIPTION
#### 582bdb346c12768580df6f09484c5601789aa4ce
<pre>
[web-animations] filter values containing a url() should animate discretely
<a href="https://bugs.webkit.org/show_bug.cgi?id=248263">https://bugs.webkit.org/show_bug.cgi?id=248263</a>

Reviewed by Tim Nguyen.

We determine when a filter list contains url() and animate discretely in that case.
We also simply return either the &quot;from&quot; or &quot;to&quot; value when animating discretely.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFilterOperations):

Canonical link: <a href="https://commits.webkit.org/256970@main">https://commits.webkit.org/256970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fedb5cd56d8c927df16d0cc4fbfc3cb18aba6fb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106923 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6984 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35412 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103597 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103066 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84036 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/678 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/661 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2364 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1907 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->