### PR TITLE
[WebXR] Disarm GCGLOwned object destructors when GraphicsContextGL is NULL

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -77,6 +77,16 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
         m_multisampleColorBuffer.release(*gl);
         m_resolvedFBO.release(*gl);
         m_context.deleteFramebuffer(m_framebuffer.ptr());
+    } else {
+        // The GraphicsContextGL is gone, so disarm the GCGLOwned objects so
+        // their destructors don't assert.
+#if USE(IOSURFACE_FOR_XR_LAYER_DATA)
+        m_opaqueTexture.leakObject();
+#endif
+        m_stencilBuffer.leakObject();
+        m_depthStencilBuffer.leakObject();
+        m_multisampleColorBuffer.leakObject();
+        m_resolvedFBO.leakObject();
     }
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -78,6 +78,8 @@ struct GCGLOwned {
 
     operator PlatformGLObject() const { return m_object; }
 
+    PlatformGLObject leakObject() { return std::exchange(m_object, 0); }
+
 protected:
     PlatformGLObject m_object = 0;
 };


### PR DESCRIPTION
#### d2dc5ce72fbec3933f37ca2c8be868dfab98e28c
<pre>
[WebXR] Disarm GCGLOwned object destructors when GraphicsContextGL is NULL
<a href="https://bugs.webkit.org/show_bug.cgi?id=248264">https://bugs.webkit.org/show_bug.cgi?id=248264</a>
rdar://102173321

Reviewed by Simon Fraser.

It&apos;s possible to destroy the underlying GraphicsContextGL before
WebXROpaqueFramebuffer&apos;s destructor runs. For example, when creating too WebGL
contexts, the context associated with a WebXROpaqueFramebuffer will be lost.

The GCGLOwned objects exist to catch when the user forgets to clean up. In this
case, where the GraphicsContextGL is NULL at destruction time, there&apos;s nothing
to do but reset the GCGLOwned objects, preventing their destructors from
asserting in debug builds.

Canonical link: <a href="https://commits.webkit.org/256981@main">https://commits.webkit.org/256981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85f2c7054fba209a860bf1ed5c686d87db3a9f24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106980 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7054 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35479 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/89878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103652 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103126 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84099 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32296 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87163 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75222 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/733 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/720 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5529 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1968 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41261 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->