### PR TITLE
Type getter is not needed for internal ReadableStream sources

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-stream-source-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-stream-source-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Only JS streams should check type
+

--- a/LayoutTests/http/wpt/fetch/fetch-stream-source.html
+++ b/LayoutTests/http/wpt/fetch/fetch-stream-source.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch and source</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+promise_test(async () => {
+    let counter = 0;
+    Object.prototype.__defineGetter__("type", function() {
+        counter++;
+    });
+
+    const response = await fetch('/');
+    const fetchReadableStream = response.body;
+    const [r1, r2] = fetchReadableStream.tee();
+    assert_equals(counter, 0);
+}, "Only JS streams should check type");
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/streams/ReadableStream.js
+++ b/Source/WebCore/Modules/streams/ReadableStream.js
@@ -48,10 +48,10 @@ function initializeReadableStream(underlyingSource, strategy)
 
     // FIXME: We should introduce https://streams.spec.whatwg.org/#create-readable-stream.
     // For now, we emulate this with underlyingSource with private properties.
-    if (@getByIdDirectPrivate(underlyingSource, "pull") !== @undefined) {
+    if (underlyingSource.@pull !== @undefined) {
         const size = @getByIdDirectPrivate(strategy, "size");
         const highWaterMark = @getByIdDirectPrivate(strategy, "highWaterMark");
-        @setupReadableStreamDefaultController(this, underlyingSource, size, highWaterMark !== @undefined ? highWaterMark : 1, @getByIdDirectPrivate(underlyingSource, "start"), @getByIdDirectPrivate(underlyingSource, "pull"), @getByIdDirectPrivate(underlyingSource, "cancel"));
+        @setupReadableStreamDefaultController(this, underlyingSource, size, highWaterMark !== @undefined ? highWaterMark : 1, underlyingSource.@start, underlyingSource.@pull, underlyingSource.@cancel);
         return this;
     }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.idl
@@ -30,10 +30,10 @@
     LegacyNoInterfaceObject,
     SkipVTableValidation
 ] interface ReadableStreamSource {
-    [Custom] Promise<undefined> start(ReadableStreamDefaultController controller);
-    [Custom] Promise<undefined> pull(ReadableStreamDefaultController controller);
-    undefined cancel(any reason);
+    [Custom, PrivateIdentifier] Promise<undefined> start(ReadableStreamDefaultController controller);
+    [Custom, PrivateIdentifier] Promise<undefined> pull(ReadableStreamDefaultController controller);
+    [PrivateIdentifier] undefined cancel(any reason);
 
     // Place holder to keep the controller linked to the source.
-    [CachedAttribute, CustomGetter] readonly attribute any controller;
+    [CachedAttribute, CustomGetter, PrivateIdentifier] readonly attribute any controller;
 };

--- a/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h
@@ -43,8 +43,10 @@ public:
             if constexpr (shouldThrow != CastedThisErrorBehavior::Assert) {
                 if (UNLIKELY(!thisObject))
                     return rejectPromiseWithThisTypeError(promise.get(), JSClass::info()->className, operationName);
-            } else
+            } else {
+                UNUSED_PARAM(operationName);
                 ASSERT(thisObject);
+            }
 
             ASSERT_GC_OBJECT_INHERITS(thisObject, JSClass::info());
             


### PR DESCRIPTION
#### f44648f07471b6c34f61993baa8997f7519a18a1
<pre>
Type getter is not needed for internal ReadableStream sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=248268">https://bugs.webkit.org/show_bug.cgi?id=248268</a>
rdar://102338913

Reviewed by Eric Carlson.

Make ReadableStreamSource method privates.
In ReadableStream, use @getters instead of private getters to allow getting private values from prototype.
Covered by added test.

* LayoutTests/http/wpt/fetch/fetch-stream-source-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-stream-source.html: Added.
* Source/WebCore/Modules/streams/ReadableStream.js:
(initializeReadableStream):
* Source/WebCore/Modules/streams/ReadableStreamSource.idl:
* Source/WebCore/bindings/js/JSDOMOperationReturningPromise.h:
(WebCore::IDLOperationReturningPromise::call):

Canonical link: <a href="https://commits.webkit.org/257063@main">https://commits.webkit.org/257063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2be9dc4cf956967ccc5d85f2502c949b67a6baa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106909 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167175 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6967 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35398 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103585 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103053 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5230 "Found 1 new test failure: fast/forms/ios/focus-button.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84022 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32231 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75156 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/667 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20367 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21835 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4851 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5456 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44315 "Found 2 new test failures: fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41186 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->