### PR TITLE
[build.webkit.org] Add WebDriver post-commit bot for WPE

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -136,7 +136,9 @@
                     { "name": "wpe-linux-bot-9", "platform": "wpe" },
                     { "name": "wpe-linux-bot-10", "platform": "wpe" },
                     { "name": "wpe-linux-bot-11", "platform": "wpe" },
-                    { "name": "wpe-linux-bot-12", "platform": "wpe" }
+                    { "name": "wpe-linux-bot-12", "platform": "wpe" },
+                    { "name": "wpe-linux-bot-13", "platform": "wpe" },
+                    { "name": "wpe-linux-bot-14", "platform": "wpe" }
                   ],
 
     "builders":   [
@@ -596,7 +598,7 @@
                     {
                       "name": "WPE-Linux-64-bit-Release-Build", "factory": "BuildFactory",
                       "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
-                      "triggers": ["wpe-linux-64-release-tests", "wpe-linux-64-release-tests-js"],
+                      "triggers": ["wpe-linux-64-release-tests", "wpe-linux-64-release-tests-js", "wpe-linux-64-release-tests-webdriver"],
                       "workernames": ["wpe-linux-bot-1"]
                     },
                     {
@@ -612,7 +614,7 @@
                     {
                       "name": "WPE-Linux-64-bit-Debug-Build", "factory": "BuildFactory",
                       "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
-                      "triggers": ["wpe-linux-64-debug-tests", "wpe-linux-64-debug-tests-js"],
+                      "triggers": ["wpe-linux-64-debug-tests", "wpe-linux-64-debug-tests-js", "wpe-linux-64-debug-tests-webdriver"],
                       "workernames": ["wpe-linux-bot-3"]
                     },
                     {
@@ -653,6 +655,16 @@
                       "name": "WPE-Linux-64-bit-Release-Clang-Build", "factory": "BuildFactory",
                       "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                       "workernames": ["wpe-linux-bot-12"]
+                    },
+                    {
+                      "name": "WPE-Linux-64-bit-Release-WebDriver-Tests", "factory": "TestWebDriverFactory",
+                      "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
+                      "workernames": ["wpe-linux-bot-13"]
+                    },
+                    {
+                      "name": "WPE-Linux-64-bit-Debug-WebDriver-Tests", "factory": "TestWebDriverFactory",
+                      "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
+                      "workernames": ["wpe-linux-bot-14"]
                     }
                   ],
 
@@ -866,11 +878,17 @@
                     { "type": "Triggerable", "name": "wpe-linux-64-release-tests-js",
                       "builderNames": ["WPE-Linux-64-bit-Release-JS-Tests"]
                     },
+                    { "type": "Triggerable", "name": "wpe-linux-64-release-tests-webdriver",
+                      "builderNames": ["WPE-Linux-64-bit-Release-WebDriver-Tests"]
+                    },
                     { "type": "Triggerable", "name": "wpe-linux-64-debug-tests",
                       "builderNames": ["WPE-Linux-64-bit-Debug-Tests"]
                     },
                     { "type": "Triggerable", "name": "wpe-linux-64-debug-tests-js",
                       "builderNames": ["WPE-Linux-64-bit-Debug-JS-Tests"]
+                    },
+                    { "type": "Triggerable", "name": "wpe-linux-64-debug-tests-webdriver",
+                      "builderNames": ["WPE-Linux-64-bit-Debug-WebDriver-Tests"]
                     },
                     { "type": "Nightly", "name": "NightlyScheduler", "change_filter": "main_filter",
                       "branch": "main", "hour": 22, "minute": 0,

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -129,7 +129,6 @@ class TestFactory(Factory):
                 self.addStep(RunWebDriverTests())
         if platform == "wpe":
             self.addStep(RunWPEAPITests())
-            self.addStep(RunWebDriverTests())
 
 
 class BuildAndTestFactory(TestFactory):

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1675,7 +1675,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'bindings-generation-tests',
             'builtins-generator-tests',
             'API-tests',
-            'webdriver-test'
         ],
         'WPE-Linux-64-bit-Release-JS-Tests': [
             'configure-build',
@@ -1691,6 +1690,20 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'jscore-test',
             'test262-test'
+        ],
+        'WPE-Linux-64-bit-Release-WebDriver-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'download-built-product',
+            'extract-built-product',
+            'webdriver-test'
         ],
         'WPE-Linux-64-bit-Debug-Build': [
             'configure-build',
@@ -1731,7 +1744,6 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'bindings-generation-tests',
             'builtins-generator-tests',
             'API-tests',
-            'webdriver-test'
         ],
         'WPE-Linux-64-bit-Debug-JS-Tests': [
             'configure-build',
@@ -1747,6 +1759,20 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'jscore-test',
             'test262-test'
+        ],
+        'WPE-Linux-64-bit-Debug-WebDriver-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'jhbuild',
+            'download-built-product',
+            'extract-built-product',
+            'webdriver-test'
         ],
         'WPE-Linux-64bit-Release-Packaging-Nightly-Ubuntu2004': [
             'configure-build',


### PR DESCRIPTION
#### d7c2bedeabde54a62516465358c888e76550927e
<pre>
[build.webkit.org] Add WebDriver post-commit bot for WPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=248269">https://bugs.webkit.org/show_bug.cgi?id=248269</a>

Reviewed by Carlos Alberto Lopez Perez and Aakash Jain.

* Tools/CISupport/build-webkit-org/config.json: Add Release and
  Debug bots for WPE. These bots only run the webdriver test suite.
* Tools/CISupport/build-webkit-org/factories.py:
(TestFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/257111@main">https://commits.webkit.org/257111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8757a2b86deb7b50b7ccae25b0c14e987846292e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106912 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167177 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6970 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35669 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103586 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5231 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84025 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32234 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75159 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/668 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20366 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/96331 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21833 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4889 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5458 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44317 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41184 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->