### PR TITLE
[web-animations] support blending of mismatched filter lists

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-002-expected.txt
@@ -23,30 +23,30 @@ PASS Web Animations: property <filter> from [none] to [opacity(0.5) hue-rotate(1
 PASS Web Animations: property <filter> from [none] to [opacity(0.5) hue-rotate(180deg)] at (0.5) should be [opacity(0.75) hue-rotate(90deg)]
 PASS Web Animations: property <filter> from [none] to [opacity(0.5) hue-rotate(180deg)] at (1) should be [opacity(0.5) hue-rotate(180deg)]
 PASS Web Animations: property <filter> from [none] to [opacity(0.5) hue-rotate(180deg)] at (1.5) should be [opacity(0.25) hue-rotate(270deg)]
-FAIL CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)] assert_equals: expected "blur ( 4px ) hue - rotate ( - 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)] assert_equals: expected "blur ( 6px ) hue - rotate ( 0deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)] assert_equals: expected "blur ( 7px ) hue - rotate ( 45deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)] assert_equals: expected "blur ( 8px ) hue - rotate ( 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
+PASS CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)]
+PASS CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)]
+PASS CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)]
+PASS CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)]
 PASS CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1) should be [blur(10px) hue-rotate(180deg)]
-FAIL CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)] assert_equals: expected "blur ( 12px ) hue - rotate ( 270deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)] assert_equals: expected "blur ( 4px ) hue - rotate ( - 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)] assert_equals: expected "blur ( 6px ) hue - rotate ( 0deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)] assert_equals: expected "blur ( 7px ) hue - rotate ( 45deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)] assert_equals: expected "blur ( 8px ) hue - rotate ( 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
+PASS CSS Transitions: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)]
+PASS CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)]
+PASS CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)]
+PASS CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)]
+PASS CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)]
 PASS CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1) should be [blur(10px) hue-rotate(180deg)]
-FAIL CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)] assert_equals: expected "blur ( 12px ) hue - rotate ( 270deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)] assert_equals: expected "blur ( 4px ) hue - rotate ( - 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)] assert_equals: expected "blur ( 6px ) hue - rotate ( 0deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)] assert_equals: expected "blur ( 7px ) hue - rotate ( 45deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)] assert_equals: expected "blur ( 8px ) hue - rotate ( 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
+PASS CSS Transitions with transition: all: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)]
+PASS CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)]
+PASS CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)]
+PASS CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)]
+PASS CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)]
 PASS CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1) should be [blur(10px) hue-rotate(180deg)]
-FAIL CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)] assert_equals: expected "blur ( 12px ) hue - rotate ( 270deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)] assert_equals: expected "blur ( 4px ) hue - rotate ( - 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)] assert_equals: expected "blur ( 6px ) hue - rotate ( 0deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)] assert_equals: expected "blur ( 7px ) hue - rotate ( 45deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
-FAIL Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)] assert_equals: expected "blur ( 8px ) hue - rotate ( 90deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
+PASS CSS Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)]
+PASS Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (-0.5) should be [blur(4px) hue-rotate(-90deg)]
+PASS Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0) should be [blur(6px) hue-rotate(0deg)]
+PASS Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.25) should be [blur(7px) hue-rotate(45deg)]
+PASS Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (0.5) should be [blur(8px) hue-rotate(90deg)]
 PASS Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1) should be [blur(10px) hue-rotate(180deg)]
-FAIL Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)] assert_equals: expected "blur ( 12px ) hue - rotate ( 270deg ) " but got "blur ( 10px ) hue - rotate ( 180deg ) "
+PASS Web Animations: property <filter> from [blur(6px)] to [blur(10px) hue-rotate(180deg)] at (1.5) should be [blur(12px) hue-rotate(270deg)]
 PASS CSS Transitions: property <filter> from [none] to [hue-rotate(180deg)] at (-0.5) should be [hue-rotate(-90deg)]
 PASS CSS Transitions: property <filter> from [none] to [hue-rotate(180deg)] at (0) should be [hue-rotate(0deg)]
 PASS CSS Transitions: property <filter> from [none] to [hue-rotate(180deg)] at (0.25) should be [hue-rotate(45deg)]
@@ -133,16 +133,16 @@ PASS CSS Transitions with transition: all: property <filter> from [grayscale(0) 
 PASS CSS Transitions with transition: all: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.6) should be [blur(10px)]
 PASS CSS Transitions with transition: all: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (1) should be [blur(10px)]
 PASS CSS Transitions with transition: all: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (1.5) should be [blur(10px)]
-FAIL CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (-0.3) should be [grayscale(0) blur(0px)] assert_equals: expected "grayscale ( 0 ) blur ( 0px ) " but got "blur ( 10px ) "
-FAIL CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0) should be [grayscale(0) blur(0px)] assert_equals: expected "grayscale ( 0 ) blur ( 0px ) " but got "blur ( 10px ) "
-FAIL CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.3) should be [grayscale(0) blur(0px)] assert_equals: expected "grayscale ( 0 ) blur ( 0px ) " but got "blur ( 10px ) "
+PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (-0.3) should be [grayscale(0) blur(0px)]
+PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0) should be [grayscale(0) blur(0px)]
+PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.3) should be [grayscale(0) blur(0px)]
 PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.5) should be [blur(10px)]
 PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.6) should be [blur(10px)]
 PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (1) should be [blur(10px)]
 PASS CSS Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (1.5) should be [blur(10px)]
-FAIL Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (-0.3) should be [grayscale(0) blur(0px)] assert_equals: expected "grayscale ( 0 ) blur ( 0px ) " but got "blur ( 10px ) "
-FAIL Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0) should be [grayscale(0) blur(0px)] assert_equals: expected "grayscale ( 0 ) blur ( 0px ) " but got "blur ( 10px ) "
-FAIL Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.3) should be [grayscale(0) blur(0px)] assert_equals: expected "grayscale ( 0 ) blur ( 0px ) " but got "blur ( 10px ) "
+PASS Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (-0.3) should be [grayscale(0) blur(0px)]
+PASS Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0) should be [grayscale(0) blur(0px)]
+PASS Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.3) should be [grayscale(0) blur(0px)]
 PASS Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.5) should be [blur(10px)]
 PASS Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (0.6) should be [blur(10px)]
 PASS Web Animations: property <filter> from [grayscale(0) blur(0px)] to [blur(10px)] at (1) should be [blur(10px)]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt
@@ -241,16 +241,16 @@ PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilt
 PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.6) should be [blur(5px)]
 PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [blur(5px)] at (1) should be [blur(5px)]
 PASS CSS Transitions with transition: all: property <filter> from [url("#svgfilter")] to [blur(5px)] at (1.5) should be [blur(5px)]
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (-0.3) should be [url("#svgfilter")] assert_equals: expected "url ( \" # svgfilter \" ) " but got "blur ( 5px ) "
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0) should be [url("#svgfilter")] assert_equals: expected "url ( \" # svgfilter \" ) " but got "blur ( 5px ) "
-FAIL CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.3) should be [url("#svgfilter")] assert_equals: expected "url ( \" # svgfilter \" ) " but got "blur ( 5px ) "
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (-0.3) should be [url("#svgfilter")]
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0) should be [url("#svgfilter")]
+PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.3) should be [url("#svgfilter")]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.5) should be [blur(5px)]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.6) should be [blur(5px)]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (1) should be [blur(5px)]
 PASS CSS Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (1.5) should be [blur(5px)]
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (-0.3) should be [url("#svgfilter")] assert_equals: expected "url ( \" # svgfilter \" ) " but got "blur ( 5px ) "
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0) should be [url("#svgfilter")] assert_equals: expected "url ( \" # svgfilter \" ) " but got "blur ( 5px ) "
-FAIL Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.3) should be [url("#svgfilter")] assert_equals: expected "url ( \" # svgfilter \" ) " but got "blur ( 5px ) "
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (-0.3) should be [url("#svgfilter")]
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0) should be [url("#svgfilter")]
+PASS Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.3) should be [url("#svgfilter")]
 PASS Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.5) should be [blur(5px)]
 PASS Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (0.6) should be [blur(5px)]
 PASS Web Animations: property <filter> from [url("#svgfilter")] to [blur(5px)] at (1) should be [blur(5px)]

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -244,9 +244,9 @@ FAIL filter: hue-rotate function with different unit(deg -> rad) assert_equals: 
 PASS filter: drop-shadow function
 PASS filter: percentage or numeric-specifiable functions (number value)
 PASS filter: percentage or numeric-specifiable functions (percentage value)
-FAIL filter: interpolate different length of filter-function-list with function which lacuna value is 1 assert_equals: The value should be grayscale(0.5) brightness(0.5) contrast(0.5) opacity(0.5) saturate(0.5) at 500ms expected "grayscale(0.5) brightness(0.5) contrast(0.5) opacity(0.5) saturate(0.5)" but got "grayscale(1) brightness(0) contrast(0) opacity(0) saturate(0)"
-FAIL filter: interpolate different length of filter-function-list with function which lacuna value is 0 assert_equals: The value should be opacity(0.5) grayscale(0.5) invert(0.5) sepia(0.5) blur(5px) at 500ms expected "opacity(0.5) grayscale(0.5) invert(0.5) sepia(0.5) blur(5px)" but got "opacity(0) grayscale(1) invert(1) sepia(1) blur(10px)"
-FAIL filter: interpolate different length of filter-function-list with drop-shadow function assert_equals: The value should be blur(5px) drop-shadow(rgba(0, 0, 255, 0.4) 5px 5px 5px) at 500ms expected "blur(5px) drop-shadow(rgba(0, 0, 255, 0.4) 5px 5px 5px)" but got "blur(10px) drop-shadow(rgba(0, 0, 255, 0.8) 10px 10px 10px)"
+PASS filter: interpolate different length of filter-function-list with function which lacuna value is 1
+PASS filter: interpolate different length of filter-function-list with function which lacuna value is 0
+PASS filter: interpolate different length of filter-function-list with drop-shadow function
 PASS filter: interpolate from none
 PASS filter: url function (interpoalte as discrete)
 PASS flex-basis (type: lengthPercentageOrCalc) has testInterpolation function

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
@@ -15,8 +15,8 @@ PASS iteration composition of filter brightness for different unit animation
 PASS iteration composition of filter brightness animation
 PASS iteration composition of filter drop-shadow animation
 PASS iteration composition of same filter list animation
-FAIL iteration composition of discrete filter list because of mismatch of the order assert_equals: Animated filter list at 0s of the third iteration expected "brightness(1) contrast(1)" but got "contrast(2) brightness(2)"
-FAIL iteration composition of different length filter list animation assert_equals: Animated filter list at 50s of the first iteration expected "sepia(0.5) contrast(1.5)" but got "sepia(1) contrast(2)"
+PASS iteration composition of discrete filter list because of mismatch of the order
+FAIL iteration composition of different length filter list animation assert_equals: Animated filter list at 0s of the third iteration expected "sepia(1) contrast(3)" but got "sepia(1) contrast(4)"
 PASS iteration composition of transform(rotate) animation
 PASS iteration composition of transform: [ scale(0), scale(1) ] animation
 PASS iteration composition of transform: [ scale(1), scale(2) ] animation

--- a/Source/WebCore/animation/CSSPropertyBlendingClient.h
+++ b/Source/WebCore/animation/CSSPropertyBlendingClient.h
@@ -37,12 +37,7 @@ public:
 
     virtual RenderElement* renderer() const = 0;
     virtual const RenderStyle& currentStyle() const = 0;
-    virtual bool filterFunctionListsMatch() const = 0;
     virtual std::optional<unsigned> transformFunctionListPrefix() const = 0;
-#if ENABLE(FILTERS_LEVEL_2)
-    virtual bool backdropFilterFunctionListsMatch() const = 0;
-#endif
-    virtual bool colorFilterFunctionListsMatch() const = 0;
 
     virtual ~CSSPropertyBlendingClient() = default;
 };

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1003,11 +1003,6 @@ void KeyframeEffect::setBlendingKeyframes(KeyframeList& blendingKeyframes)
     computeHasKeyframeComposingAcceleratedProperty();
 
     checkForMatchingTransformFunctionLists();
-    checkForMatchingFilterFunctionLists();
-#if ENABLE(FILTERS_LEVEL_2)
-    checkForMatchingBackdropFilterFunctionLists();
-#endif
-    checkForMatchingColorFilterFunctionLists();
 }
 
 void KeyframeEffect::checkForMatchingTransformFunctionLists()
@@ -1022,66 +1017,6 @@ void KeyframeEffect::checkForMatchingTransformFunctionLists()
         prefix.update(keyframe.style()->transform());
 
     m_transformFunctionListsMatchPrefix = prefix.primitives().size();
-}
-
-bool KeyframeEffect::checkForMatchingFilterFunctionLists(CSSPropertyID propertyID, const std::function<const FilterOperations& (const RenderStyle&)>& filtersGetter) const
-{
-    if (!m_blendingKeyframes.containsProperty(propertyID))
-        return false;
-
-    if (m_blendingKeyframes.size() < 2)
-        return true;
-
-    // Empty filters match anything, so find the first non-empty entry as the reference.
-    size_t numKeyframes = m_blendingKeyframes.size();
-    size_t firstNonEmptyKeyframeIndex = numKeyframes;
-
-    for (size_t i = 0; i < numKeyframes; ++i) {
-        if (filtersGetter(*m_blendingKeyframes[i].style()).operations().size()) {
-            firstNonEmptyKeyframeIndex = i;
-            break;
-        }
-    }
-
-    if (firstNonEmptyKeyframeIndex == numKeyframes)
-        return false;
-
-    auto& firstVal = filtersGetter(*m_blendingKeyframes[firstNonEmptyKeyframeIndex].style());
-    for (size_t i = firstNonEmptyKeyframeIndex + 1; i < numKeyframes; ++i) {
-        auto& value = filtersGetter(*m_blendingKeyframes[i].style());
-
-        // An empty filter list matches anything.
-        if (value.operations().isEmpty())
-            continue;
-
-        if (!firstVal.operationsMatch(value))
-            return false;
-    }
-
-    return true;
-}
-
-void KeyframeEffect::checkForMatchingFilterFunctionLists()
-{
-    m_filterFunctionListsMatch = checkForMatchingFilterFunctionLists(CSSPropertyFilter, [] (const RenderStyle& style) -> const FilterOperations& {
-        return style.filter();
-    });
-}
-
-#if ENABLE(FILTERS_LEVEL_2)
-void KeyframeEffect::checkForMatchingBackdropFilterFunctionLists()
-{
-    m_backdropFilterFunctionListsMatch = checkForMatchingFilterFunctionLists(CSSPropertyWebkitBackdropFilter, [] (const RenderStyle& style) -> const FilterOperations& {
-        return style.backdropFilter();
-    });
-}
-#endif
-
-void KeyframeEffect::checkForMatchingColorFilterFunctionLists()
-{
-    m_colorFilterFunctionListsMatch = checkForMatchingFilterFunctionLists(CSSPropertyAppleColorFilter, [] (const RenderStyle& style) -> const FilterOperations& {
-        return style.appleColorFilter();
-    });
 }
 
 void KeyframeEffect::computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext& resolutionContext)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -143,19 +143,12 @@ public:
     // FIXME: These ignore the fact that some timing functions can prevent acceleration.
     bool isAboutToRunAccelerated() const { return m_acceleratedPropertiesState != AcceleratedProperties::None && m_lastRecordedAcceleratedAction != AcceleratedAction::Stop; }
 
-    bool filterFunctionListsMatch() const override { return m_filterFunctionListsMatch; }
-
     // The CoreAnimation animation code can only use direct function interpolation when all keyframes share the same
     // prefix of shared transform function primitives, whereas software animations simply calls blend(...) which can do
     // direct interpolation based on the function list of any two particular keyframes. The prefix serves as a way to
     // make sure that the results of blend(...) can be made to return the same results as rendered by the hardware
     // animation code.
     std::optional<unsigned> transformFunctionListPrefix() const override { return (!preventsAcceleration()) ? std::optional<unsigned>(m_transformFunctionListsMatchPrefix) : std::nullopt; }
-
-#if ENABLE(FILTERS_LEVEL_2)
-    bool backdropFilterFunctionListsMatch() const override { return m_backdropFilterFunctionListsMatch; }
-#endif
-    bool colorFilterFunctionListsMatch() const override { return m_colorFilterFunctionListsMatch; }
 
     void computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const KeyframeList& blendingKeyframes() const { return m_blendingKeyframes; }
@@ -233,12 +226,6 @@ private:
     void setBlendingKeyframes(KeyframeList&);
     bool isTargetingTransformRelatedProperty() const;
     void checkForMatchingTransformFunctionLists();
-    void checkForMatchingFilterFunctionLists();
-    void checkForMatchingColorFilterFunctionLists();
-    bool checkForMatchingFilterFunctionLists(CSSPropertyID, const std::function<const FilterOperations& (const RenderStyle&)>&) const;
-#if ENABLE(FILTERS_LEVEL_2)
-    void checkForMatchingBackdropFilterFunctionLists();
-#endif
     void computeHasImplicitKeyframeForAcceleratedProperty();
     void computeHasKeyframeComposingAcceleratedProperty();
     void abilityToBeAcceleratedDidChange();
@@ -275,11 +262,6 @@ private:
     bool m_needsForcedLayout { false };
     bool m_triggersStackingContext { false };
     size_t m_transformFunctionListsMatchPrefix { 0 };
-    bool m_filterFunctionListsMatch { false };
-#if ENABLE(FILTERS_LEVEL_2)
-    bool m_backdropFilterFunctionListsMatch { false };
-#endif
-    bool m_colorFilterFunctionListsMatch { false };
     bool m_inTargetEffectStack { false };
     bool m_someKeyframesUseStepsTimingFunction { false };
     bool m_hasImplicitKeyframeForAcceleratedProperty { false };


### PR DESCRIPTION
#### e77c6ec7d3fe383255e32ab058d5844289fabbfb
<pre>
[web-animations] support blending of mismatched filter lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=248270">https://bugs.webkit.org/show_bug.cgi?id=248270</a>

Reviewed by Simon Fraser.

We would fail to blend when filter lists mismatch and instead always fall back to the &quot;to&quot; value.

Instead of the matching filter functions on KeyframeEffect, we implement the specification for when
blending is supported in PropertyWrapperFilter::canInterpolate() such that we correctly identify
more discrete cases.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/animation/CSSPropertyBlendingClient.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::checkForMatchingFilterFunctionLists const): Deleted.
(WebCore::KeyframeEffect::checkForMatchingFilterFunctionLists): Deleted.
(WebCore::KeyframeEffect::checkForMatchingBackdropFilterFunctionLists): Deleted.
(WebCore::KeyframeEffect::checkForMatchingColorFilterFunctionLists): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/256975@main">https://commits.webkit.org/256975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/051b01e9ab05ee274f3203bf190cb9025859c0bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106935 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167201 "Failed to checkout and rebase branch from PR 6758") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7002 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35429 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89824 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103609 "Failed to checkout and rebase branch from PR 6758") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103081 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84051 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/689 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/674 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5482 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2365 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1922 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->