### PR TITLE
ReadableStream::pipeTo memory leak

### DIFF
--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -462,6 +462,7 @@ namespace WebCore {
     macro(XRWebGLLayer) \
     macro(abortAlgorithm) \
     macro(abortSteps) \
+    macro(addAbortAlgorithmToSignal) \
     macro(appendFromJS) \
     macro(applicationCache) \
     macro(associatedReadableByteStreamController) \
@@ -588,6 +589,7 @@ namespace WebCore {
     macro(reader) \
     macro(readyPromise) \
     macro(readyPromiseCapability) \
+    macro(removeAbortAlgorithmFromSignal) \
     macro(requestAnimationFrame) \
     macro(requestIdleCallback) \
     macro(response) \
@@ -647,7 +649,6 @@ namespace WebCore {
     macro(webkitOfflineAudioContext) \
     macro(webkitOscillatorNode) \
     macro(webkitSpeechRecognition) \
-    macro(whenSignalAborted) \
     macro(window) \
     macro(writable) \
     macro(writeAlgorithm) \

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -49,7 +49,8 @@ public:
     static Ref<AbortSignal> abort(JSDOMGlobalObject&, ScriptExecutionContext&, JSC::JSValue reason);
     static Ref<AbortSignal> timeout(ScriptExecutionContext&, uint64_t milliseconds);
 
-    static bool whenSignalAborted(AbortSignal&, Ref<AbortAlgorithm>&&);
+    static uint32_t addAbortAlgorithmToSignal(AbortSignal&, Ref<AbortAlgorithm>&&);
+    static void removeAbortAlgorithmFromSignal(AbortSignal&, uint32_t algorithmIdentifier);
 
     void signalAbort(JSC::JSValue reason);
     void signalFollow(AbortSignal&);
@@ -64,7 +65,8 @@ public:
     using RefCounted::deref;
 
     using Algorithm = Function<void(JSC::JSValue reason)>;
-    void addAlgorithm(Algorithm&& algorithm) { m_algorithms.append(WTFMove(algorithm)); }
+    uint32_t addAlgorithm(Algorithm&&);
+    void removeAlgorithm(uint32_t);
 
     bool isFollowingSignal() const { return !!m_followingSignal; }
 
@@ -84,7 +86,8 @@ private:
     void eventListenersDidChange() final;
     
     bool m_aborted { false };
-    Vector<Algorithm> m_algorithms;
+    Vector<std::pair<uint32_t, Algorithm>> m_algorithms;
+    uint32_t m_algorithmIdentifier { 0 };
     WeakPtr<AbortSignal, WeakPtrImplWithEventTargetData> m_followingSignal;
     JSValueInWrappedObject m_reason;
     bool m_hasActiveTimeoutTimer { false };

--- a/Source/WebCore/dom/AbortSignal.idl
+++ b/Source/WebCore/dom/AbortSignal.idl
@@ -30,8 +30,6 @@
     PrivateIdentifier,
     PublicIdentifier
 ] interface AbortSignal : EventTarget {
-    [PrivateIdentifier] static boolean whenSignalAborted(AbortSignal object, AbortAlgorithm algorithm);
-
     [NewObject, CallWith=CurrentScriptExecutionContext&CurrentGlobalObject] static AbortSignal abort(optional any reason);
     [Exposed=(Window, Worker), NewObject, CallWith=CurrentScriptExecutionContext] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
 


### PR DESCRIPTION
#### cb01f4ca942d355c84e1c6248560cf63a58ebfd0
<pre>
ReadableStream::pipeTo memory leak
<a href="https://bugs.webkit.org/show_bug.cgi?id=247618">https://bugs.webkit.org/show_bug.cgi?id=247618</a>
rdar://problem/102366716

Reviewed by Alex Christensen.

Before the patch, a reference to pipeState would be kept in the AbortSignal.
We are now removing the algorithm from thr AbortSignal when finalizing pipeTo to break the reference cycle.

* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamPipeToWritableStream):
(pipeToFinalize):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):
(WebCore::JSDOMGlobalObject::addBuiltinGlobals):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::signalAbort):
(WebCore::AbortSignal::addAbortAlgorithmToSignal):
(WebCore::AbortSignal::removeAbortAlgorithmFromSignal):
(WebCore::AbortSignal::addAlgorithm):
(WebCore::AbortSignal::removeAlgorithm):
(WebCore::AbortSignal::whenSignalAborted): Deleted.
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/AbortSignal.idl:

Canonical link: <a href="https://commits.webkit.org/257109@main">https://commits.webkit.org/257109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c85a4a396fee33057c579ef69478cd206fac355

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106914 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167179 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/6972 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35402 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103588 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5235 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84027 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32236 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75161 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/670 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20371 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/653 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21839 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4887 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5460 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44318 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41190 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->