### PR TITLE
[web-animations] correctly accumulate and clamp filter values when blending with "none"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt
@@ -19,42 +19,42 @@ PASS Web Animations: property <filter> from [none] to [blur(10px)] at (0) should
 PASS Web Animations: property <filter> from [none] to [blur(10px)] at (0.5) should be [blur(5px)]
 PASS Web Animations: property <filter> from [none] to [blur(10px)] at (1) should be [blur(10px)]
 PASS Web Animations: property <filter> from [none] to [blur(10px)] at (1.5) should be [blur(15px)]
-FAIL CSS Transitions: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)] assert_equals: expected "brightness ( 0 ) " but got "brightness ( - 1 ) "
+PASS CSS Transitions: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)]
 PASS CSS Transitions: property <filter> from [brightness(0)] to [none] at (0) should be [brightness(0)]
 PASS CSS Transitions: property <filter> from [brightness(0)] to [none] at (0.5) should be [brightness(0.5)]
 PASS CSS Transitions: property <filter> from [brightness(0)] to [none] at (1) should be [brightness(1)]
 PASS CSS Transitions: property <filter> from [brightness(0)] to [none] at (1.5) should be [brightness(1.5)]
-FAIL CSS Transitions with transition: all: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)] assert_equals: expected "brightness ( 0 ) " but got "brightness ( - 1 ) "
+PASS CSS Transitions with transition: all: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)]
 PASS CSS Transitions with transition: all: property <filter> from [brightness(0)] to [none] at (0) should be [brightness(0)]
 PASS CSS Transitions with transition: all: property <filter> from [brightness(0)] to [none] at (0.5) should be [brightness(0.5)]
 PASS CSS Transitions with transition: all: property <filter> from [brightness(0)] to [none] at (1) should be [brightness(1)]
 PASS CSS Transitions with transition: all: property <filter> from [brightness(0)] to [none] at (1.5) should be [brightness(1.5)]
-FAIL CSS Animations: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)] assert_equals: expected "brightness ( 0 ) " but got "brightness ( - 1 ) "
+PASS CSS Animations: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)]
 PASS CSS Animations: property <filter> from [brightness(0)] to [none] at (0) should be [brightness(0)]
 PASS CSS Animations: property <filter> from [brightness(0)] to [none] at (0.5) should be [brightness(0.5)]
 PASS CSS Animations: property <filter> from [brightness(0)] to [none] at (1) should be [brightness(1)]
 PASS CSS Animations: property <filter> from [brightness(0)] to [none] at (1.5) should be [brightness(1.5)]
-FAIL Web Animations: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)] assert_equals: expected "brightness ( 0 ) " but got "brightness ( - 1 ) "
+PASS Web Animations: property <filter> from [brightness(0)] to [none] at (-1) should be [brightness(0)]
 PASS Web Animations: property <filter> from [brightness(0)] to [none] at (0) should be [brightness(0)]
 PASS Web Animations: property <filter> from [brightness(0)] to [none] at (0.5) should be [brightness(0.5)]
 PASS Web Animations: property <filter> from [brightness(0)] to [none] at (1) should be [brightness(1)]
 PASS Web Animations: property <filter> from [brightness(0)] to [none] at (1.5) should be [brightness(1.5)]
-FAIL CSS Transitions: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)] assert_equals: expected "contrast ( 0 ) " but got "contrast ( - 1 ) "
+PASS CSS Transitions: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)]
 PASS CSS Transitions: property <filter> from [contrast(0)] to [none] at (0) should be [contrast(0)]
 PASS CSS Transitions: property <filter> from [contrast(0)] to [none] at (0.5) should be [contrast(0.5)]
 PASS CSS Transitions: property <filter> from [contrast(0)] to [none] at (1) should be [contrast(1)]
 PASS CSS Transitions: property <filter> from [contrast(0)] to [none] at (1.5) should be [contrast(1.5)]
-FAIL CSS Transitions with transition: all: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)] assert_equals: expected "contrast ( 0 ) " but got "contrast ( - 1 ) "
+PASS CSS Transitions with transition: all: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)]
 PASS CSS Transitions with transition: all: property <filter> from [contrast(0)] to [none] at (0) should be [contrast(0)]
 PASS CSS Transitions with transition: all: property <filter> from [contrast(0)] to [none] at (0.5) should be [contrast(0.5)]
 PASS CSS Transitions with transition: all: property <filter> from [contrast(0)] to [none] at (1) should be [contrast(1)]
 PASS CSS Transitions with transition: all: property <filter> from [contrast(0)] to [none] at (1.5) should be [contrast(1.5)]
-FAIL CSS Animations: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)] assert_equals: expected "contrast ( 0 ) " but got "contrast ( - 1 ) "
+PASS CSS Animations: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)]
 PASS CSS Animations: property <filter> from [contrast(0)] to [none] at (0) should be [contrast(0)]
 PASS CSS Animations: property <filter> from [contrast(0)] to [none] at (0.5) should be [contrast(0.5)]
 PASS CSS Animations: property <filter> from [contrast(0)] to [none] at (1) should be [contrast(1)]
 PASS CSS Animations: property <filter> from [contrast(0)] to [none] at (1.5) should be [contrast(1.5)]
-FAIL Web Animations: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)] assert_equals: expected "contrast ( 0 ) " but got "contrast ( - 1 ) "
+PASS Web Animations: property <filter> from [contrast(0)] to [none] at (-1) should be [contrast(0)]
 PASS Web Animations: property <filter> from [contrast(0)] to [none] at (0) should be [contrast(0)]
 PASS Web Animations: property <filter> from [contrast(0)] to [none] at (0.5) should be [contrast(0.5)]
 PASS Web Animations: property <filter> from [contrast(0)] to [none] at (1) should be [contrast(1)]
@@ -139,42 +139,42 @@ PASS Web Animations: property <filter> from [none] to [invert(1)] at (0) should 
 PASS Web Animations: property <filter> from [none] to [invert(1)] at (0.5) should be [invert(0.5)]
 PASS Web Animations: property <filter> from [none] to [invert(1)] at (1) should be [invert(1)]
 PASS Web Animations: property <filter> from [none] to [invert(1)] at (1.5) should be [invert(1)]
-FAIL CSS Transitions: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)] assert_equals: expected "opacity ( 0 ) " but got "opacity ( - 1 ) "
+PASS CSS Transitions: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)]
 PASS CSS Transitions: property <filter> from [opacity(0)] to [none] at (0) should be [opacity(0)]
 PASS CSS Transitions: property <filter> from [opacity(0)] to [none] at (0.5) should be [opacity(0.5)]
 PASS CSS Transitions: property <filter> from [opacity(0)] to [none] at (1) should be [opacity(1)]
-FAIL CSS Transitions: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)] assert_equals: expected "opacity ( 1 ) " but got "opacity ( 1.5 ) "
-FAIL CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)] assert_equals: expected "opacity ( 0 ) " but got "opacity ( - 1 ) "
+PASS CSS Transitions: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)]
+PASS CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)]
 PASS CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (0) should be [opacity(0)]
 PASS CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (0.5) should be [opacity(0.5)]
 PASS CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (1) should be [opacity(1)]
-FAIL CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)] assert_equals: expected "opacity ( 1 ) " but got "opacity ( 1.5 ) "
-FAIL CSS Animations: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)] assert_equals: expected "opacity ( 0 ) " but got "opacity ( - 1 ) "
+PASS CSS Transitions with transition: all: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)]
+PASS CSS Animations: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)]
 PASS CSS Animations: property <filter> from [opacity(0)] to [none] at (0) should be [opacity(0)]
 PASS CSS Animations: property <filter> from [opacity(0)] to [none] at (0.5) should be [opacity(0.5)]
 PASS CSS Animations: property <filter> from [opacity(0)] to [none] at (1) should be [opacity(1)]
-FAIL CSS Animations: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)] assert_equals: expected "opacity ( 1 ) " but got "opacity ( 1.5 ) "
-FAIL Web Animations: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)] assert_equals: expected "opacity ( 0 ) " but got "opacity ( - 1 ) "
+PASS CSS Animations: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)]
+PASS Web Animations: property <filter> from [opacity(0)] to [none] at (-1) should be [opacity(0)]
 PASS Web Animations: property <filter> from [opacity(0)] to [none] at (0) should be [opacity(0)]
 PASS Web Animations: property <filter> from [opacity(0)] to [none] at (0.5) should be [opacity(0.5)]
 PASS Web Animations: property <filter> from [opacity(0)] to [none] at (1) should be [opacity(1)]
-FAIL Web Animations: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)] assert_equals: expected "opacity ( 1 ) " but got "opacity ( 1.5 ) "
-FAIL CSS Transitions: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)] assert_equals: expected "saturate ( 0 ) " but got "saturate ( - 1 ) "
+PASS Web Animations: property <filter> from [opacity(0)] to [none] at (1.5) should be [opacity(1)]
+PASS CSS Transitions: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)]
 PASS CSS Transitions: property <filter> from [saturate(0)] to [none] at (0) should be [saturate(0)]
 PASS CSS Transitions: property <filter> from [saturate(0)] to [none] at (0.5) should be [saturate(0.5)]
 PASS CSS Transitions: property <filter> from [saturate(0)] to [none] at (1) should be [saturate(1)]
 PASS CSS Transitions: property <filter> from [saturate(0)] to [none] at (1.5) should be [saturate(1.5)]
-FAIL CSS Transitions with transition: all: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)] assert_equals: expected "saturate ( 0 ) " but got "saturate ( - 1 ) "
+PASS CSS Transitions with transition: all: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)]
 PASS CSS Transitions with transition: all: property <filter> from [saturate(0)] to [none] at (0) should be [saturate(0)]
 PASS CSS Transitions with transition: all: property <filter> from [saturate(0)] to [none] at (0.5) should be [saturate(0.5)]
 PASS CSS Transitions with transition: all: property <filter> from [saturate(0)] to [none] at (1) should be [saturate(1)]
 PASS CSS Transitions with transition: all: property <filter> from [saturate(0)] to [none] at (1.5) should be [saturate(1.5)]
-FAIL CSS Animations: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)] assert_equals: expected "saturate ( 0 ) " but got "saturate ( - 1 ) "
+PASS CSS Animations: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)]
 PASS CSS Animations: property <filter> from [saturate(0)] to [none] at (0) should be [saturate(0)]
 PASS CSS Animations: property <filter> from [saturate(0)] to [none] at (0.5) should be [saturate(0.5)]
 PASS CSS Animations: property <filter> from [saturate(0)] to [none] at (1) should be [saturate(1)]
 PASS CSS Animations: property <filter> from [saturate(0)] to [none] at (1.5) should be [saturate(1.5)]
-FAIL Web Animations: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)] assert_equals: expected "saturate ( 0 ) " but got "saturate ( - 1 ) "
+PASS Web Animations: property <filter> from [saturate(0)] to [none] at (-1) should be [saturate(0)]
 PASS Web Animations: property <filter> from [saturate(0)] to [none] at (0) should be [saturate(0)]
 PASS Web Animations: property <filter> from [saturate(0)] to [none] at (0.5) should be [saturate(0.5)]
 PASS Web Animations: property <filter> from [saturate(0)] to [none] at (1) should be [saturate(1)]

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
@@ -16,7 +16,7 @@ PASS iteration composition of filter brightness animation
 PASS iteration composition of filter drop-shadow animation
 PASS iteration composition of same filter list animation
 PASS iteration composition of discrete filter list because of mismatch of the order
-FAIL iteration composition of different length filter list animation assert_equals: Animated filter list at 0s of the third iteration expected "sepia(1) contrast(3)" but got "sepia(1) contrast(4)"
+PASS iteration composition of different length filter list animation
 PASS iteration composition of transform(rotate) animation
 PASS iteration composition of transform: [ scale(0), scale(1) ] animation
 PASS iteration composition of transform: [ scale(1), scale(2) ] animation

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.cpp
@@ -134,7 +134,7 @@ RefPtr<FilterOperation> BasicColorMatrixFilterOperation::blend(const FilterOpera
         return this;
 
     if (blendToPassthrough)
-        return BasicColorMatrixFilterOperation::create(WebCore::blend(m_amount, passthroughAmount(), context), m_type);
+        return BasicColorMatrixFilterOperation::create(blendAmounts(m_amount, passthroughAmount(), context), m_type);
 
     const BasicColorMatrixFilterOperation* fromOperation = downcast<BasicColorMatrixFilterOperation>(from);
     double fromAmount = fromOperation ? fromOperation->amount() : passthroughAmount();
@@ -203,7 +203,7 @@ RefPtr<FilterOperation> BasicComponentTransferFilterOperation::blend(const Filte
         return this;
     
     if (blendToPassthrough)
-        return BasicComponentTransferFilterOperation::create(WebCore::blend(m_amount, passthroughAmount(), context), m_type);
+        return BasicComponentTransferFilterOperation::create(blendAmounts(m_amount, passthroughAmount(), context), m_type);
         
     const BasicComponentTransferFilterOperation* fromOperation = downcast<BasicComponentTransferFilterOperation>(from);
     double fromAmount = fromOperation ? fromOperation->amount() : passthroughAmount();


### PR DESCRIPTION
#### 85de8f728bd846fc046de0128994e6949dea9b40
<pre>
[web-animations] correctly accumulate and clamp filter values when blending with &quot;none&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=248272">https://bugs.webkit.org/show_bug.cgi?id=248272</a>

Reviewed by Simon Fraser.

Blending a valid operation with a &quot;none&quot; operation is done using a passthrough value in the
WebCore filter blending code. However, when we added support for accumulation and clamping in
bug 248235, we only did so for the case when blending between two valid operations. We now use
the blendAmounts() method in the passthrough cases as well.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/animation/filter-interpolation-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt:
* Source/WebCore/platform/graphics/filters/FilterOperation.cpp:
(WebCore::BasicColorMatrixFilterOperation::blend):
(WebCore::BasicComponentTransferFilterOperation::blend):

Canonical link: <a href="https://commits.webkit.org/256976@main">https://commits.webkit.org/256976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fba683981af1074bec4dab0313257bd1e0a7f06f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/106936 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7003 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35430 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89825 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103082 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84052 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75182 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/690 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/675 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5483 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2366 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/1923 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->