### PR TITLE
Basic grammar support for data driven CSS property parsing

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -229,9 +229,11 @@
         "Indicates that a CSSValuePool is required by the custom parser. Either 'custom-parser'",
         "or 'parser-function' must also be specified for this to be valid.",
         "",
-        "* partial-keyword-property:",
-        "Indicates that in addition to single keyword values, this property can also take other",
-        "values in a valid parse. ",
+        "* parser-grammar:",
+        "An array of terms that define the grammar for the property.",
+        "",
+        "* parser-grammar-comment:",
+        "A comment specific to the `parser-grammar` value.",
         "",
         "2. Lesser known capabilities of this file format",
         "",
@@ -285,8 +287,7 @@
                 "auto-functions": true,
                 "color-property": true,
                 "settings-flag": "accentColorEnabled",
-                "parser-function": "consumeAutoOrColor",
-                "parser-requires-context": true
+                "parser-grammar": ["auto", "<color>"]
             },
             "status": {
                 "status": "experimental"
@@ -302,8 +303,7 @@
                 "visited-link-color-support": true,
                 "color-property": true,
                 "custom": "All",
-                "parser-function": "consumeAutoOrColor",
-                "parser-requires-context": true
+                "parser-grammar": ["auto", "<color>"]
             },
             "specification": {
                 "category": "css-ui",
@@ -318,9 +318,7 @@
                 "custom": "Value",
                 "high-priority": true,
                 "fast-path-inherited": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true,
-                "parser-requires-quirks-mode": true
+                "parser-grammar": ["<color accept-quirky-colors-in-quirks-mode>"]
             },
             "status": {
                 "comment": "All the values from CSS Color Level 3 are supported, as well as the 8- and 4-digit forms of hex color, and the color() function."
@@ -431,9 +429,8 @@
             "codegen-properties": {
                 "custom": "All",
                 "high-priority": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<absolute-size>", "<relative-size>", "<length-percentage [0,inf] unitless-allowed>", "<-webkit-absolute-size>", "<-webkit-relative-size>"],
+                "parser-exported": true
             },
             "specification": {
                 "category": "css-fonts",
@@ -446,7 +443,7 @@
                 "custom": "Value",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true
+                "parser-grammar": ["none", "<number [0,inf]>"]
             },
             "specification": {
                 "category": "css-fonts",
@@ -589,7 +586,7 @@
                 "converter": "FontPalette",
                 "font-property": true,
                 "high-priority": true,
-                "custom-parser": true
+                "parser-grammar": ["normal", "light", "dark", "<palette-identifier>"]
             },
             "specification": {
                 "category": "css-fonts",
@@ -634,7 +631,8 @@
             "codegen-properties": {
                 "name-for-methods": "VariantPosition",
                 "font-property": true,
-                "high-priority": true
+                "high-priority": true,
+                "parser-exported": true
             },
             "status": {
                 "status": "in development",
@@ -659,7 +657,8 @@
             "codegen-properties": {
                 "name-for-methods": "VariantCaps",
                 "font-property": true,
-                "high-priority": true
+                "high-priority": true,
+                "parser-exported": true
             },
             "specification": {
                 "category": "css-fonts",
@@ -846,7 +845,7 @@
                 "font-property": true,
                 "high-priority": true,
                 "name-for-methods": "SpecifiedLocale",
-                "parser-function": "consumeAutoOrString"
+                "parser-grammar": ["auto", "<string>"]
             },
             "status": "non-standard"
         },
@@ -897,7 +896,7 @@
                 "high-priority": true,
                 "enable-if": "ENABLE_TEXT_AUTOSIZING",
                 "settings-flag": "textAutosizingEnabled",
-                "parser-function": "consumeTextSizeAdjust"
+                "parser-grammar": ["auto", "none", "<percentage [0,inf]>"]
             },
             "status": "experimental",
             "specification": {
@@ -983,7 +982,7 @@
             "codegen-properties": {
                 "custom": "All",
                 "high-priority": true,
-                "custom-parser": true
+                "parser-grammar": ["normal", "reset", "document", "<percentage [0,inf]>", "<number [0,inf]>"]
             },
             "status": "non-standard",
             "specification": {
@@ -1383,9 +1382,7 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true,
-                "parser-requires-quirks-mode": true
+                "parser-grammar": ["<color accept-quirky-colors-in-quirks-mode>"]
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1491,7 +1488,7 @@
             "codegen-properties": {
                 "custom": "Value",
                 "svg": true,
-                "custom-parser": true
+                "parser-grammar": ["baseline", "sub", "super", "<length-percentage svg>"]
             },
             "specification": {
                 "category": "svg",
@@ -1508,8 +1505,7 @@
                     "name": "size",
                     "resolver": "block"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true
+                "parser-grammar": ["<width-or-height>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -1597,8 +1593,7 @@
                     "name": "border-color",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -1643,9 +1638,7 @@
                     "name": "border-width",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeLineWidth",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<line-width>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -1680,8 +1673,7 @@
                     "name": "border-color",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -1726,9 +1718,7 @@
                     "name": "border-width",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeLineWidth",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<line-width>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -1977,8 +1967,7 @@
         "border-image-source": {
             "codegen-properties": {
                 "converter": "StyleImage<CSSPropertyBorderImageSource>",
-                "parser-function": "consumeImageOrNone",
-                "parser-requires-context": true
+                "parser-grammar": ["none", "<image>"]
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -2054,8 +2043,7 @@
                     "name": "border-color",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -2100,9 +2088,7 @@
                     "name": "border-width",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeLineWidth",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<line-width>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -2137,8 +2123,7 @@
                     "name": "border-color",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -2183,9 +2168,7 @@
                     "name": "border-width",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeLineWidth",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<line-width>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -2933,8 +2916,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-additional-parameters": ["SVGAttributeMode", "ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage svg>"]
             },
             "specification": {
                 "category": "svg",
@@ -2945,8 +2927,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-additional-parameters": ["SVGAttributeMode", "ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage svg>"]
             },
             "specification": {
                 "category": "svg",
@@ -3018,7 +2999,7 @@
             "codegen-properties": {
                 "converter": "Opacity",
                 "svg": true,
-                "parser-function": "consumeOpacity"
+                "parser-grammar": "<alpha-value>"
             },
             "specification": {
                 "category": "svg",
@@ -3065,8 +3046,7 @@
             "codegen-properties": {
                 "svg": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "svg",
@@ -3077,11 +3057,11 @@
             "codegen-properties": {
                 "converter": "Opacity",
                 "svg": true,
-                "parser-function": "consumeOpacity"
+                "parser-grammar": "<alpha-value>"
             },
             "specification": {
-                "category": "svg",
-                "url": "https://www.w3.org/TR/SVG/filters.html#FloodOpacityProperty"
+                "category": "css-filters",
+                "url": "https://www.w3.org/TR/filter-effects/#FloodOpacityProperty"
             }
         },
         "glyph-orientation-horizontal": {
@@ -3089,8 +3069,7 @@
             "codegen-properties": {
                 "converter": "GlyphOrientation",
                 "svg": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<angle unitless-allowed unitless-zero-allowed>"]
             },
             "specification": {
                 "category": "svg",
@@ -3102,8 +3081,7 @@
             "codegen-properties": {
                 "converter": "GlyphOrientationOrAuto",
                 "svg": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<angle unitless-allowed unitless-zero-allowed>"]
             },
             "specification": {
                 "category": "svg",
@@ -3129,9 +3107,7 @@
                     "name": "size",
                     "resolver": "vertical"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<width-or-height-unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -3215,8 +3191,7 @@
                     "name": "size",
                     "resolver": "inline"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true
+                "parser-grammar": ["<width-or-height>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3271,9 +3246,7 @@
                     "name": "inset",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<inset-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3287,9 +3260,7 @@
                     "name": "inset",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<inset-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3316,9 +3287,7 @@
                     "name": "inset",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<inset-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3332,9 +3301,7 @@
                     "name": "inset",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<inset-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3346,8 +3313,7 @@
             "codegen-properties": {
                 "converter": "SVGLengthValue",
                 "svg": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "normal", "<length unitless-allowed>"]
             },
             "specification": {
                 "category": "svg",
@@ -3379,8 +3345,7 @@
                 "high-priority": true,
                 "sink-priority": true,
                 "converter": "Spacing",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["normal", "<length unitless-allowed>"]
             },
             "specification": {
                 "category": "css-text",
@@ -3391,8 +3356,7 @@
             "codegen-properties": {
                 "svg": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             }
         },
         "line-height": {
@@ -3401,20 +3365,20 @@
                 {
                     "custom": "All",
                     "enable-if": "ENABLE_TEXT_AUTOSIZING",
-                    "custom-parser": true,
-                    "parser-requires-context-mode": true
+                    "parser-grammar": ["normal", "<number [0,inf]>", "<length-percentage [0,inf]>"],
+                    "parser-exported": true
                 },
                 {
                     "getter": "specifiedLineHeight",
                     "conditional-converter": "LineHeight",
                     "enable-if": "!ENABLE_TEXT_AUTOSIZING",
-                    "custom-parser": true,
-                    "parser-requires-context-mode": true
+                    "parser-grammar": ["normal", "<number [0,inf]>", "<length-percentage [0,inf]>"],
+                    "parser-exported": true
                 }
             ],
             "specification": {
-                "category": "css-22",
-                "url": "https://www.w3.org/TR/CSS22/visudet.html#propdef-line-height"
+                "category": "css-inline",
+                "url": "https://www.w3.org/TR/css-inline-3/#line-height-property"
             }
         },
         "list-style": {
@@ -3436,9 +3400,7 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "StyleImage<CSSPropertyListStyleImage>",
-                "parser-function": "consumeImageOrNone",
-                "parser-requires-context": true
-
+                "parser-grammar": ["none", "<image>"]
             },
             "specification": {
                 "category": "css-lists",
@@ -3557,9 +3519,7 @@
             ],
             "codegen-properties": {
                 "custom": "All",
-                "custom-parser": true,
-                "parser-requires-context": true,
-                "partial-keyword-property": true
+                "parser-grammar": ["<<values>>", "<string>"]
             },
             "specification": {
                 "category": "css-lists",
@@ -3604,9 +3564,7 @@
                     "name": "margin",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<margin-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3623,9 +3581,7 @@
                     "name": "margin",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<margin-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3672,9 +3628,7 @@
                     "name": "margin",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<margin-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3691,9 +3645,7 @@
                     "name": "margin",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeMarginOrOffset",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<margin-logical-start-end>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -3772,7 +3724,7 @@
                 "name-for-methods": "MarkerEndResource",
                 "converter": "SVGURIReference",
                 "svg": true,
-                "parser-function": "consumeNoneOrURL"
+                "parser-grammar": ["none", "<marker-ref>"]
             },
             "specification": {
                 "category": "svg",
@@ -3785,7 +3737,7 @@
                 "name-for-methods": "MarkerMidResource",
                 "converter": "SVGURIReference",
                 "svg": true,
-                "parser-function": "consumeNoneOrURL"
+                "parser-grammar": ["none", "<marker-ref>"]
             },
             "specification": {
                 "category": "svg",
@@ -3798,7 +3750,7 @@
                 "name-for-methods": "MarkerStartResource",
                 "converter": "SVGURIReference",
                 "svg": true,
-                "parser-function": "consumeNoneOrURL"
+                "parser-grammar": ["none", "<marker-ref>"]
             },
             "specification": {
                 "category": "svg",
@@ -4027,8 +3979,7 @@
                     "name": "max-size",
                     "resolver": "block"
                 },
-                "parser-function": "consumeMaxWidthOrHeight",
-                "parser-requires-context": true
+                "parser-grammar": ["<max-width-or-height>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4043,9 +3994,7 @@
                     "name": "max-size",
                     "resolver": "vertical"
                 },
-                "parser-function": "consumeMaxWidthOrHeight",
-                "parser-requires-context": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<max-width-or-height-unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4062,8 +4011,7 @@
                     "name": "max-size",
                     "resolver": "inline"
                 },
-                "parser-function": "consumeMaxWidthOrHeight",
-                "parser-requires-context": true
+                "parser-grammar": ["<max-width-or-height>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4078,9 +4026,7 @@
                     "name": "max-size",
                     "resolver": "horizontal"
                 },
-                "parser-function": "consumeMaxWidthOrHeight",
-                "parser-requires-context": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<max-width-or-height-unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4097,8 +4043,7 @@
                     "name": "min-size",
                     "resolver": "block"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true
+                "parser-grammar": ["<width-or-height>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4113,9 +4058,7 @@
                     "name": "min-size",
                     "resolver": "vertical"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<width-or-height-unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4132,8 +4075,7 @@
                     "name": "min-size",
                     "resolver": "inline"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true
+                "parser-grammar": ["<width-or-height>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4148,9 +4090,7 @@
                     "name": "min-size",
                     "resolver": "horizontal"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<width-or-height-unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4173,9 +4113,7 @@
         "object-position": {
             "codegen-properties": {
                 "converter": "Position",
-                "parser-function": "consumePosition",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid", "PositionSyntax::Position"]
+                "parser-grammar": ["<position>"]
             },
             "specification": {
                 "category": "css-images",
@@ -4199,9 +4137,7 @@
             "codegen-properties": {
                 "converter": "Length",
                 "settings-flag": "cssMotionPathEnabled",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage>"]
             },
             "specification": {
                 "category": "css-motion-path",
@@ -4212,9 +4148,7 @@
             "codegen-properties": {
                 "converter": "PositionOrAuto",
                 "settings-flag": "cssMotionPathEnabled",
-                "parser-function": "consumeAutoOrPosition",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid", "PositionSyntax::Position"]
+                "parser-grammar": ["auto", "<position>"]
             },
             "specification": {
                 "category": "css-motion-path",
@@ -4225,9 +4159,7 @@
             "codegen-properties": {
                 "converter": "PositionOrAuto",
                 "settings-flag": "cssMotionPathEnabled",
-                "parser-function": "consumeAutoOrPosition",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid", "PositionSyntax::Position"]
+                "parser-grammar": ["auto", "<position>"]
             },
             "specification": {
                 "category": "css-motion-path",
@@ -4269,21 +4201,21 @@
                 "aliases": [
                     "-webkit-opacity"
                 ],
-                "parser-function": "consumeOpacity"
+                "parser-grammar": ["<alpha-value>"]
             },
             "status": {
                 "comment": "Honor -webkit-opacity as a synonym for opacity. This was the only syntax that worked in Safari 1.1, and may be in use on some websites and widgets."
             },
             "specification": {
                 "category": "css-color",
-                "url": "https://www.w3.org/TR/css3-color/#opacity"
+                "url": "https://www.w3.org/TR/css-color-4/#propdef-opacity"
             }
         },
         "orphans": {
             "inherited": true,
             "codegen-properties": {
                 "auto-functions": true,
-                "parser-function": "consumePositiveInteger"
+                "parser-grammar": ["<integer [1,inf]>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4309,8 +4241,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["-webkit-focus-ring-color", "<color>"]
             },
             "specification": {
                 "category": "css-ui",
@@ -4320,9 +4251,7 @@
         "outline-offset": {
             "codegen-properties": {
                 "converter": "ComputedLength<float>",
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-ui",
@@ -4353,9 +4282,7 @@
         "outline-width": {
             "codegen-properties": {
                 "converter": "LineWidth<float>",
-                "parser-function": "consumeLineWidth",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<line-width>"]
             },
             "specification": {
                 "category": "css-ui",
@@ -4480,7 +4407,8 @@
                 "logical-property-group": {
                     "name": "overscroll-behavior",
                     "resolver": "horizontal"
-                }
+                },
+                "parser-exported": true
             },
             "status": {
                 "status": "in development"
@@ -4500,7 +4428,8 @@
                 "logical-property-group": {
                     "name": "overscroll-behavior",
                     "resolver": "vertical"
-                }
+                },
+                "parser-exported": true
             },
             "status": {
                 "status": "in development"
@@ -4601,9 +4530,7 @@
                     "name": "padding",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4620,9 +4547,7 @@
                     "name": "padding",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4637,9 +4562,7 @@
                     "name": "padding",
                     "resolver": "bottom"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Allow"]
+                "parser-grammar": ["<length-percentage [0,inf] unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4669,9 +4592,7 @@
                     "name": "padding",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4688,9 +4609,7 @@
                     "name": "padding",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-logical-props",
@@ -4705,9 +4624,7 @@
                     "name": "padding",
                     "resolver": "left"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Allow"]
+                "parser-grammar": ["<length-percentage [0,inf] unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4722,9 +4639,7 @@
                     "name": "padding",
                     "resolver": "right"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Allow"]
+                "parser-grammar": ["<length-percentage [0,inf] unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4739,9 +4654,7 @@
                     "name": "padding",
                     "resolver": "top"
                 },
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Allow"]
+                "parser-grammar": ["<length-percentage [0,inf] unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -4751,7 +4664,7 @@
         "page": {
             "codegen-properties": {
                 "skip-builder": true,
-                "custom-parser": true
+                "parser-grammar": ["auto", "<custom-ident>"]
             },
             "specification": {
                 "category": "css-page",
@@ -4867,9 +4780,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "svg",
@@ -4924,8 +4835,7 @@
             "codegen-properties": {
                 "initial": "initialRadius",
                 "converter": "LengthOrAuto",
-                "parser-function": "consumeRxOrRy",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "svg",
@@ -4936,8 +4846,7 @@
             "codegen-properties": {
                 "initial": "initialRadius",
                 "converter": "LengthOrAuto",
-                "parser-function": "consumeRxOrRy",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "svg",
@@ -5008,8 +4917,7 @@
             "codegen-properties": {
                 "svg": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "svg",
@@ -5020,7 +4928,7 @@
             "codegen-properties": {
                 "converter": "Opacity",
                 "svg": true,
-                "parser-function": "consumeOpacity"
+                "parser-grammar": ["<alpha-value>"]
             },
             "specification": {
                 "category": "svg",
@@ -5060,8 +4968,7 @@
                 "initial": "initialZeroLength",
                 "name-for-methods": "StrokeDashOffset",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-additional-parameters": ["SVGAttributeMode", "ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage svg>"]
             },
             "specification": {
                 "category": "svg",
@@ -5109,8 +5016,7 @@
             "codegen-properties": {
                 "name-for-methods": "StrokeMiterLimit",
                 "converter": "Number<float>",
-                "parser-function": "consumeNumber",
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative"]
+                "parser-grammar": ["<number [0,inf]>"]
             },
             "status": "supported",
             "specification": {
@@ -5125,7 +5031,7 @@
             "codegen-properties": {
                 "converter": "Opacity",
                 "svg": true,
-                "parser-function": "consumeOpacity"
+                "parser-grammar": ["<alpha-value>"]
             },
             "specification": {
                 "category": "svg",
@@ -5138,8 +5044,7 @@
                 "custom": "Value",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "status": "supported",
             "specification": {
@@ -5153,8 +5058,7 @@
                 "custom": "Value",
                 "initial": "initialOneLength",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-additional-parameters": ["SVGAttributeMode", "ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage svg>"]
             },
             "status": "supported",
             "specification": {
@@ -5201,8 +5105,7 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "TabSize",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<number [0,inf]>", "<length [0,inf]>"]
             },
             "specification": {
                 "category": "css-text",
@@ -5757,8 +5660,21 @@
         "vertical-align": {
             "codegen-properties": {
                 "custom": "Inherit|Value",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": [
+                    "baseline",
+                    "sub",
+                    "super",
+                    "top",
+                    "text-top",
+                    "middle",
+                    "bottom",
+                    "text-bottom",
+                    {
+                        "value": "-webkit-baseline-middle",
+                        "status": "non-standard"
+                    },
+                    "<length-percentage unitless-allowed>"
+                 ]
             },
             "specification": {
                 "category": "css-22",
@@ -5796,7 +5712,7 @@
             "inherited": true,
             "codegen-properties": {
                 "auto-functions": true,
-                "parser-function": "consumePositiveInteger"
+                "parser-grammar": ["<integer [1,inf]>"]
             },
             "specification": {
                 "category": "css-22",
@@ -5811,9 +5727,7 @@
                     "name": "size",
                     "resolver": "horizontal"
                 },
-                "parser-function": "consumeWidthOrHeight",
-                "parser-requires-context": true,
-                "parser-requires-additional-parameters": ["UnitlessQuirk::Allow"]
+                "parser-grammar": ["<width-or-height-unitless-allowed>"]
             },
             "specification": {
                 "category": "css-22",
@@ -5853,8 +5767,8 @@
             "inherited": true,
             "codegen-properties": {
                 "conditional-converter": "WordSpacing",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["normal", "<length-percentage unitless-allowed>"],
+                "parser-grammar-comment": "The current specification has a <length>, not a <length-percentage>"
             },
             "specification": {
                 "category": "css-22",
@@ -5865,8 +5779,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-additional-parameters": ["SVGAttributeMode", "ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage svg>"]
             },
             "specification": {
                 "category": "svg",
@@ -5877,8 +5790,7 @@
             "codegen-properties": {
                 "initial": "initialZeroLength",
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-additional-parameters": ["SVGAttributeMode", "ValueRange::All", "UnitlessQuirk::Forbid"]
+                "parser-grammar": ["<length-percentage svg>"]
             },
             "specification": {
                 "category": "svg",
@@ -5889,7 +5801,7 @@
             "codegen-properties": {
                 "auto-functions": true,
                 "name-for-methods": "SpecifiedZIndex",
-                "custom-parser": true
+                "parser-grammar": ["auto", "<integer>"]
             },
             "specification": {
                 "category": "css-22",
@@ -6195,9 +6107,7 @@
             "codegen-properties": {
                 "name-for-methods": "HorizontalBorderSpacing",
                 "converter": "ComputedLength<float>",
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative"]
+                "parser-grammar": ["<length [0,inf]>"]
             },
             "status": "non-standard"
         },
@@ -6235,9 +6145,7 @@
             "codegen-properties": {
                 "name-for-methods": "VerticalBorderSpacing",
                 "converter": "ComputedLength<float>",
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative"]
+                "parser-grammar": ["<length [0,inf]>"]
             },
             "status": "non-standard"
         },
@@ -6269,8 +6177,7 @@
         },
         "-webkit-box-flex": {
             "codegen-properties": {
-                "parser-function": "consumeNumber",
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<number>"]
             },
             "status": "obsolete",
             "specification":  {
@@ -6280,7 +6187,7 @@
         },
         "-webkit-box-flex-group": {
             "codegen-properties": {
-                "parser-function": "consumeIntegerZeroAndGreater"
+                "parser-grammar": ["<integer [0,inf]>"]
             },
             "status": "obsolete",
             "specification":  {
@@ -6301,7 +6208,7 @@
         },
         "-webkit-box-ordinal-group": {
             "codegen-properties": {
-                "parser-function": "consumePositiveInteger"
+                "parser-grammar": ["<integer [1,inf]>"]
             },
             "status": "obsolete",
             "specification":  {
@@ -6418,7 +6325,8 @@
                     "-webkit-column-count"
                 ],
                 "auto-functions": true,
-                "custom-parser": true
+                "parser-grammar": ["auto", "<integer [1,inf]>"],
+                "parser-exported": true
             },
             "specification":  {
                 "category": "css-multicol",
@@ -6447,10 +6355,10 @@
                     "-webkit-column-gap"
                 ],
                 "converter": "GapLength",
-                "parser-function": "consumeGapLength",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<gap-gutter>"],
+                "parser-exported": true
             },
-            "specification":  {
+            "specification": {
                 "category": "css-align",
                 "url": "https://drafts.csswg.org/css-align/#column-row-gap"
             }
@@ -6461,8 +6369,8 @@
                     "grid-row-gap"
                 ],
                 "converter": "GapLength",
-                "parser-function": "consumeGapLength",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<gap-gutter>"],
+                "parser-exported": true
             },
             "specification": {
                 "category": "css-align",
@@ -6520,8 +6428,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification":  {
                 "category": "css-multicol",
@@ -6558,8 +6465,7 @@
                     "-webkit-column-rule-width"
                 ],
                 "converter": "LineWidth<unsigned short>",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<line-width>"]
             },
             "specification":  {
                 "category": "css-multicol",
@@ -6588,7 +6494,8 @@
                 ],
                 "converter": "ComputedLength<float>",
                 "auto-functions": true,
-                "custom-parser": true
+                "parser-grammar": ["auto", "<length [0,inf] strict>"],
+                "parser-exported": true
             },
             "specification":  {
                 "category": "css-multicol",
@@ -6789,8 +6696,7 @@
                     "-webkit-flex-basis"
                 ],
                 "converter": "LengthSizing",
-                "custom-parser": true,
-                "parser-requires-context": true
+                "parser-grammar": ["auto", "content", "<width-or-height-keyword>", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-flexbox",
@@ -6835,8 +6741,7 @@
                 "aliases": [
                     "-webkit-flex-grow"
                 ],
-                "parser-function": "consumeNumber",
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative"]
+                "parser-grammar": ["<number [0,inf]>"]
             },
             "specification": {
                 "category": "css-flexbox",
@@ -6848,8 +6753,7 @@
                 "aliases": [
                     "-webkit-flex-shrink"
                 ],
-                "parser-function": "consumeNumber",
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative"]
+                "parser-grammar": ["<number [0,inf]>"]
             },
             "specification": {
                 "category": "css-flexbox",
@@ -6913,9 +6817,7 @@
             "codegen-properties": {
                 "skip-builder": true,
                 "internal-only": true,
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All, UnitlessQuirk::Allow"]
+                "parser-grammar": ["<length unitless-allowed>"]
             },
             "status": "non-standard"
         },
@@ -7172,7 +7074,7 @@
             "codegen-properties": {
                 "name-for-methods": "HyphenationString",
                 "converter": "StringOrAutoAtom",
-                "parser-function": "consumeAutoOrString"
+                "parser-grammar": ["auto", "<string>"]
             },
             "status": {
                 "status": "experimental"
@@ -7187,8 +7089,7 @@
             "codegen-properties": {
                 "name-for-methods": "HyphenationLimitAfter",
                 "converter": "NumberOrAuto<short>",
-                "parser-function": "consumeHyphenateLimit",
-                "parser-requires-additional-parameters": ["CSSValueAuto"]
+                "parser-grammar": ["auto", "<number [0,inf]>"]
             },
             "status": "non-standard"
         },
@@ -7197,8 +7098,7 @@
             "codegen-properties": {
                 "name-for-methods": "HyphenationLimitBefore",
                 "converter": "NumberOrAuto<short>",
-                "parser-function": "consumeHyphenateLimit",
-                "parser-requires-additional-parameters": ["CSSValueAuto"]
+                "parser-grammar": ["auto", "<number [0,inf]>"]
             },
             "status": "non-standard"
         },
@@ -7207,8 +7107,7 @@
             "codegen-properties": {
                 "name-for-methods": "HyphenationLimitLines",
                 "converter": "WebkitHyphenateLimitLines",
-                "parser-function": "consumeHyphenateLimit",
-                "parser-requires-additional-parameters": ["CSSValueNoLimit"]
+                "parser-grammar": ["no-limit", "<number [0,inf]>"]
             },
             "status": {
                 "status": "experimental"
@@ -7312,7 +7211,7 @@
         },
         "-webkit-line-clamp": {
             "codegen-properties": {
-                "custom-parser": true
+                "parser-grammar": ["<percentage [0,inf]>", "<integer [1,inf]>"]
             },
             "status": "non-standard"
         },
@@ -7320,7 +7219,7 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "StringOrNoneAtom",
-                "custom-parser": true
+                "parser-grammar": ["none", "<custom-ident>"]
             },
             "status": {
                 "status": "experimental"
@@ -7386,8 +7285,7 @@
             "codegen-properties": {
                 "conditional-converter": "MarqueeIncrement",
                 "internal-only": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<length-percentage unitless-allowed>"]
             },
             "status": "non-standard"
         },
@@ -7396,7 +7294,7 @@
                 "name-for-methods": "MarqueeLoopCount",
                 "converter": "MarqueeRepetition",
                 "internal-only": true,
-                "custom-parser": true
+                "parser-grammar": ["<number [0,inf]>"]
             },
             "status": "non-standard"
         },
@@ -7404,8 +7302,7 @@
             "codegen-properties": {
                 "converter": "MarqueeSpeed",
                 "internal-only": true,
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<time [0,inf] unitless-allowed>"]
             },
             "status": "non-standard"
         },
@@ -7489,8 +7386,7 @@
         "-webkit-mask-box-image-source": {
             "codegen-properties": {
                 "converter": "StyleImage<CSSPropertyWebkitMaskBoxImageSource>",
-                "parser-function": "consumeImageOrNone",
-                "parser-requires-context": true
+                "parser-grammar": ["none", "<image>"]
             },
             "status": "non-standard",
             "specification": {
@@ -7613,7 +7509,7 @@
                 "aliases": [
                     "-webkit-order"
                 ],
-                "parser-function": "consumeInteger"
+                "parser-grammar": ["<integer>"]
             },
             "specification": {
                 "category": "css-flexbox",
@@ -7855,8 +7751,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "specification": {
                 "category": "css-text-decor",
@@ -7913,8 +7808,8 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "TextUnderlineOffset",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length>"],
+                "parser-grammar-comment": "The current specification has a <length> | <percentage>, not just <length>"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -7924,8 +7819,8 @@
         "text-decoration-thickness": {
             "codegen-properties": {
                 "converter": "TextDecorationThickness",
-                "custom-parser": true,
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "from-font", "<length>"],
+                "parser-grammar-comment": "The current specification has a <length> | <percentage>, not just <length>"
             },
             "specification": {
                 "category": "css-text-decor",
@@ -7982,8 +7877,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "status": {
                 "status": "experimental"
@@ -8034,8 +7928,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "status": {
                 "status": "non-standard",
@@ -8069,8 +7962,7 @@
                 "initial": "currentColor",
                 "visited-link-color-support": true,
                 "color-property": true,
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "status": {
                 "status": "non-standard",
@@ -8081,8 +7973,7 @@
             "inherited": true,
             "codegen-properties": {
                 "converter": "TextStrokeWidth",
-                "parser-function": "consumeTextStrokeWidth",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["<line-width>"]
             },
             "status": {
                 "status": "non-standard",
@@ -8173,9 +8064,7 @@
                 ],
                 "computable": false,
                 "converter": "ComputedLength<float>",
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-transforms",
@@ -8324,9 +8213,7 @@
                     "name": "scroll-margin",
                     "resolver": "bottom"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8344,9 +8231,7 @@
                     "name": "scroll-margin",
                     "resolver": "left"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8364,9 +8249,7 @@
                     "name": "scroll-margin",
                     "resolver": "right"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8384,9 +8267,7 @@
                     "name": "scroll-margin",
                     "resolver": "top"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8400,9 +8281,7 @@
                     "name": "scroll-margin",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8416,9 +8295,7 @@
                     "name": "scroll-margin",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8432,9 +8309,7 @@
                     "name": "scroll-margin",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8448,9 +8323,7 @@
                     "name": "scroll-margin",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeLength",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<length>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8506,8 +8379,7 @@
                     "name": "scroll-padding",
                     "resolver": "bottom"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8522,8 +8394,7 @@
                     "name": "scroll-padding",
                     "resolver": "left"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8538,8 +8409,7 @@
                     "name": "scroll-padding",
                     "resolver": "right"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8554,8 +8424,7 @@
                     "name": "scroll-padding",
                     "resolver": "top"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8569,8 +8438,7 @@
                     "name": "scroll-padding",
                     "resolver": "inline-start"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8584,8 +8452,7 @@
                     "name": "scroll-padding",
                     "resolver": "block-start"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8599,8 +8466,7 @@
                     "name": "scroll-padding",
                     "resolver": "inline-end"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8614,8 +8480,7 @@
                     "name": "scroll-padding",
                     "resolver": "block-end"
                 },
-                "parser-function": "consumeScrollPadding",
-                "parser-requires-context-mode": true
+                "parser-grammar": ["auto", "<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-scroll-snap",
@@ -8701,9 +8566,7 @@
                     "-webkit-shape-margin"
                 ],
                 "converter": "Length",
-                "parser-function": "consumeLengthOrPercent",
-                "parser-requires-context-mode": true,
-                "parser-requires-additional-parameters": ["ValueRange::NonNegative"]
+                "parser-grammar": ["<length-percentage [0,inf]>"]
             },
             "specification": {
                 "category": "css-shapes",
@@ -8716,8 +8579,7 @@
                     "-webkit-shape-image-threshold"
                 ],
                 "converter": "NumberOrAuto<float>",
-                "parser-function": "consumeNumber",
-                "parser-requires-additional-parameters": ["ValueRange::All"]
+                "parser-grammar": ["<number>"]
             },
             "specification": {
                 "category": "css-shapes",
@@ -8741,8 +8603,7 @@
             "codegen-properties": {
                 "converter": "TapHighlightColor",
                 "enable-if": "ENABLE_TOUCH_EVENTS",
-                "parser-function": "consumeColor",
-                "parser-requires-context": true
+                "parser-grammar": ["<color>"]
             },
             "status": "non-standard"
         },
@@ -9031,7 +8892,7 @@
         "css-inline": {
             "shortname": "CSS Inline Layout",
             "longname": "CSS Inline Layout Module",
-            "url": "https://www.w3.org/TR/css-inline/"
+            "url": "https://www.w3.org/TR/css-inline-3/"
         },
         "css-line-grid": {
             "shortname": "CSS Line Grid",
@@ -9162,6 +9023,147 @@
             "shortname": "SVG",
             "longname": "SVG",
             "url": "https://www.w3.org/TR/SVG11/"
+        }
+    },
+    "shared-grammar-rules": {
+        "<alpha-value>": {
+            "grammar": ["<number>", "<percentage>"],
+            "specification": {
+                "category": "css-color",
+                "url": "https://www.w3.org/TR/css-color-4/#typedef-alpha-value"
+            }
+        },
+        "<marker-ref>": {
+            "grammar": ["<url>"],
+            "specification": {
+                "category": "svg",
+                "url": "https://www.w3.org/TR/SVG/painting.html#DataTypeMarkerRef"
+            }
+        },
+        "<absolute-size>": {
+            "grammar": ["xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "xxx-large"],
+            "specification": {
+                "category": "css-fonts-4",
+                "url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-size-absolute-size"
+            }
+        },
+        "<-webkit-absolute-size>": {
+            "grammar": [
+                {
+                    "value": "-webkit-xxx-large",
+                    "aliased-to": "xxx-large"
+                }
+            ],
+            "status": "non-standard"
+        },
+        "<relative-size>": {
+            "grammar": ["larger", "smaller"],
+            "specification": {
+                "category": "css-fonts-4",
+                "url": "https://drafts.csswg.org/css-fonts-4/#valdef-font-size-relative-size"
+            }
+        },
+        "<-webkit-relative-size>": {
+            "grammar": ["-webkit-ruby-text"],
+            "status": "non-standard"
+        },
+        "<gap-gutter>": {
+            "grammar": ["normal", "<length-percentage [0,inf]>"],
+            "specification": {
+                "category": "css-align",
+                "url": "https://drafts.csswg.org/css-align/#column-row-gap"
+            }
+        },
+        "<width-or-height-keyword>": {
+            "grammar": [
+                "intrinsic",
+                "min-intrinsic",
+                "min-content",
+                "webkit-min-content",
+                "max-content",
+                "webkit-max-content",
+                "webkit-fill-available",
+                "fit-content",
+                "webkit-fit-content"
+            ]
+        },
+        "<width-or-height>": {
+            "grammar": [
+                "auto",
+                "<width-or-height-keyword>",
+                "<length-percentage [0,inf]>"
+            ],
+            "exported": true,
+            "comment": "Doesn't match current specification",
+            "specification": {
+                "category": "css-sizing",
+                "url": "https://www.w3.org/TR/css-sizing-3/#preferred-size-properties"
+            }
+        },
+        "<width-or-height-unitless-allowed>": {
+            "grammar": [
+                "auto",
+                "<width-or-height-keyword>",
+                "<length-percentage [0,inf] unitless-allowed>"
+            ],
+            "comment": "Doesn't match current specification",
+            "specification": {
+                "category": "css-sizing",
+                "url": "https://www.w3.org/TR/css-sizing-3/#preferred-size-properties"
+            }
+        },
+        "<max-width-or-height>": {
+            "grammar": [
+                "none",
+                "<width-or-height-keyword>",
+                "<length-percentage [0,inf]>"
+            ],
+            "comment": "Doesn't match current specification",
+            "specification": {
+                "category": "css-sizing",
+                "url": "https://www.w3.org/TR/css-sizing-3/#max-size-properties"
+            }
+        },
+        "<max-width-or-height-unitless-allowed>": {
+            "grammar": [
+                "none",
+                "<width-or-height-keyword>",
+                "<length-percentage [0,inf] unitless-allowed>"
+            ],
+            "comment": "Doesn't match current specification",
+            "specification": {
+                "category": "css-sizing",
+                "url": "https://www.w3.org/TR/css-sizing-3/#max-size-properties"
+            }
+        },
+        "<line-width>": {
+            "grammar": ["thin", "medium", "thick", "<length [0,inf]>"],
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://drafts.csswg.org/css-backgrounds/#typedef-line-width"
+            }
+        },
+        "<inset-logical-start-end>": {
+            "grammar": ["auto", "<length-percentage>"],
+            "specification": {
+                "category": "css-logical-props",
+                "url": "https://www.w3.org/TR/css-logical/#inset-properties"
+            }
+        },
+        "<margin-logical-start-end>": {
+            "grammar": ["auto", "<length-percentage>"],
+            "specification": {
+                "category": "css-logical-props",
+                "url": "https://www.w3.org/TR/css-logical/#margin-properties"
+            }
+        },
+        "<palette-identifier>": {
+            "grammar": ["<dashed-ident>"],
+            "specification": {
+                "category": "css-fonts-4",
+                "url": "https://drafts.csswg.org/css-fonts-4/#typedef-font-palette-palette-identifier"
+            }
         }
     }
 }

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -40,7 +40,7 @@ struct StylePropertyMetadata {
         , m_inherited(inherited)
     {
         ASSERT(propertyID != CSSPropertyInvalid);
-        ASSERT(propertyID < firstShorthandProperty);
+        ASSERT_WITH_MESSAGE(propertyID < firstShorthandProperty, "unexpected property: %d", propertyID);
     }
 
     CSSPropertyID shorthandID() const;

--- a/Source/WebCore/css/MediaQueryExpression.cpp
+++ b/Source/WebCore/css/MediaQueryExpression.cpp
@@ -223,7 +223,7 @@ static inline bool isFeatureValidWithoutValue(const AtomString& mediaFeature, co
 
 inline RefPtr<CSSPrimitiveValue> consumeFirstValue(const String& mediaFeature, CSSParserTokenRange& range)
 {
-    if (auto value = CSSPropertyParserHelpers::consumeIntegerZeroAndGreater(range))
+    if (auto value = CSSPropertyParserHelpers::consumeNonNegativeInteger(range))
         return value;
 
     if (!featureExpectingPositiveInteger(mediaFeature) && !isAspectRatioFeature(AtomString { mediaFeature })) {

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -652,7 +652,7 @@ RefPtr<StyleRuleFontFeatureValuesBlock> CSSParserImpl::consumeFontFeatureValuesR
 
         Vector<unsigned> values;
         while (!range.atEnd()) {
-            auto value = CSSPropertyParserHelpers::consumeIntegerZeroAndGreater(range);
+            auto value = CSSPropertyParserHelpers::consumeNonNegativeInteger(range);
             if (!value)
                 return { };
             ASSERT(value->isInteger());

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -546,7 +546,7 @@ static RefPtr<CSSFontFeatureValue> consumeFontFeatureTag(CSSParserTokenRange& ra
     int tagValue = 1;
     if (!range.atEnd() && range.peek().type() != CommaToken) {
         // Feature tag values could follow: <integer> | on | off
-        if (auto integer = CSSPropertyParserHelpers::consumeIntegerZeroAndGreaterRaw(range))
+        if (auto integer = CSSPropertyParserHelpers::consumeNonNegativeIntegerRaw(range))
             tagValue = *integer;
         else if (range.peek().id() == CSSValueOn || range.peek().id() == CSSValueOff)
             tagValue = range.consumeIncludingWhitespace().id() == CSSValueOn;

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -25,7 +25,6 @@
 import json
 import re
 
-
 class JSONChecker(object):
     """Processes JSON lines for checking style."""
 
@@ -119,42 +118,81 @@ class JSONCSSPropertiesChecker(JSONChecker):
 
         try:
             properties_definition = json.loads('\n'.join(lines) + '\n')
-            if 'properties' not in properties_definition:
-                self._handle_style_error(0, 'json/syntax', 5, '"properties" key not found, the key is mandatory.')
-                return
 
+            if 'categories' not in properties_definition:
+                self._handle_style_error(0, 'json/syntax', 5, '"categories" key not found, the key is mandatory.')
+                return
             self._categories = properties_definition['categories']
             self.check_categories()
 
-            properties = properties_definition['properties']
-            if not isinstance(properties, dict):
-                self._handle_style_error(0, 'json/syntax', 5, '"properties" is not a dictionary.')
+            if 'shared-grammar-rules' not in properties_definition:
+                self._handle_style_error(0, 'json/syntax', 5, '"shared-grammar-rules" key not found, the key is mandatory.')
                 return
+            self._shared_grammar_rules = properties_definition['shared-grammar-rules']
+            self.check_shared_grammar_rules()
 
-            for property_name, property_value in properties.items():
-                self.check_property(property_name, property_value)
+            if 'properties' not in properties_definition:
+                self._handle_style_error(0, 'json/syntax', 5, '"properties" key not found, the key is mandatory.')
+                return
+            self._properties = properties_definition['properties']
+            self.check_properties()
 
         except Exception as e:
             print(e)
             pass
 
-    def check_category(self, category, category_value):
+    def check_category(self, category_name, category_value):
         keys_and_validators = {
-            "shortname": self.validate_string,
-            "longname": self.validate_string,
-            "url": self.validate_url,
-            "status": self.validate_status_type,
+            'shortname': self.validate_string,
+            'longname': self.validate_string,
+            'url': self.validate_url,
+            'status': self.validate_status,
         }
         for key, value in category_value.items():
             if key not in keys_and_validators:
-                self._handle_style_error(0, 'json/syntax', 5, 'dictionary for specification "%s" has unexpected key "%s".' % (category, key))
+                self._handle_style_error(0, 'json/syntax', 5, 'dictionary for category "%s" has unexpected key "%s".' % (category_name, key))
                 return
 
-            keys_and_validators[key](category, "", key, value)
+            keys_and_validators[key](category_name, "", key, value)
 
     def check_categories(self):
+        if not isinstance(self._categories, dict):
+            self._handle_style_error(0, 'json/syntax', 5, '"categories" is not a dictionary.')
+            return
+
         for key, value in self._categories.items():
             self.check_category(key, value)
+
+    def check_shared_grammar_rule(self, rule_name, rule_value):
+        keys_and_validators = {
+            'comment': self.validate_comment,
+            'exported': self.validate_boolean,
+            'grammar': self.validate_grammar,
+            'specification': self.validate_specification,
+            'status': self.validate_status,
+        }
+        for key, value in rule_value.items():
+            if key not in keys_and_validators:
+                self._handle_style_error(0, 'json/syntax', 5, 'dictionary for shared property rule "%s" has unexpected key "%s".' % (rule_name, key))
+                return
+
+            keys_and_validators[key](rule_name, "", key, value)
+
+    def check_shared_grammar_rules(self):
+        if not isinstance(self._shared_grammar_rules, dict):
+            self._handle_style_error(0, 'json/syntax', 5, '"shared-grammar-rules" is not a dictionary.')
+            return
+
+        for rule_name, rule_value in self._shared_grammar_rules.items():
+            self.check_shared_grammar_rule(rule_name, rule_value)
+
+    def check_properties(self):
+        if not isinstance(self._properties, dict):
+            self._handle_style_error(0, 'json/syntax', 5, '"properties" is not a dictionary.')
+            return
+
+        for property_name, property_value in self._properties.items():
+            self.check_property(property_name, property_value)
 
     def validate_type(self, property_name, property_key, key, value, expected_type):
         if not isinstance(value, expected_type):
@@ -185,6 +223,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'not implemented',
             'not considering',
             'obsolete',
+            'removed',
         }
         if value not in allowed_statuses:
             self._handle_style_error(0, 'json/syntax', 5, 'status "%s" for property "%s" is not one of the recognized status values' % (value, property_name))
@@ -198,6 +237,33 @@ class JSONCSSPropertiesChecker(JSONChecker):
                 self.check_codegen_properties(property_name, entry)
         else:
             self.check_codegen_properties(property_name, value)
+
+    def validate_grammar(self, property_name, property_key, key, value):
+        self.validate_grammar_term(property_name, property_key, key, value)
+
+    def validate_grammar_term(self, property_name, property_key, key, value):
+        if isinstance(value, dict):
+            keys_and_validators = {
+                'aliased-to': self.validate_string,
+                'comment': self.validate_comment,
+                'enable-if': self.validate_string,
+                'kind': self.validate_string,
+                'settings-flag': self.validate_string,
+                'status': self.validate_status,
+                'value': self.validate_grammar_term,
+            }
+
+            for key, value in value.items():
+                if key not in keys_and_validators:
+                    self._handle_style_error(0, 'json/syntax', 5, 'dictionary for "parser-grammar" of property "%s" has unexpected key "%s".' % (property_name, key))
+                    return
+
+                keys_and_validators[key](property_name, "", key, value)
+        elif isinstance(value, list):
+            for entry in value:
+                self.validate_grammar_term(property_name, "", "", entry)
+        else:
+            self.validate_string(property_name, property_key, key, value)
 
     def validate_logical_property_group(self, property_name, property_key, key, value):
         self.validate_type(property_name, property_key, key, value, dict)
@@ -224,7 +290,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
 
                 keys_and_validators[key](property_name, "", key, value)
         else:
-            self.validate_string(property_name, property_key, key, value)
+            self.validate_status_type(property_name, property_key, key, value)
 
     def validate_property_category(self, property_name, property_key, key, value):
         self.validate_string(property_name, property_key, key, value)
@@ -233,7 +299,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             self._handle_style_error(0, 'json/syntax', 5, 'property "%s" has category "%s" which is not in the set of categories.' % (property_name, value))
             return
 
-    def validate_property_specification(self, property_name, property_key, key, value):
+    def validate_specification(self, property_name, property_key, key, value):
         self.validate_type(property_name, property_key, key, value, dict)
 
         keys_and_validators = {
@@ -265,7 +331,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'values': self.validate_array,
             'codegen-properties': self.validate_codegen_properties,
             'status': self.validate_status,
-            'specification': self.validate_property_specification,
+            'specification': self.validate_specification,
         }
 
         for key, value in value.items():
@@ -303,6 +369,9 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'logical-property-group': self.validate_logical_property_group,
             'longhands': self.validate_array,
             'name-for-methods': self.validate_string,
+            'parser-exported': self.validate_boolean,
+            'parser-grammar': self.validate_grammar,
+            'parser-grammar-comment': self.validate_comment,
             'parser-function': self.validate_string,
             'parser-requires-additional-parameters': self.validate_array,
             'parser-requires-context': self.validate_boolean,
@@ -311,7 +380,6 @@ class JSONCSSPropertiesChecker(JSONChecker):
             'parser-requires-current-property': self.validate_boolean,
             'parser-requires-quirks-mode': self.validate_boolean,
             'parser-requires-value-pool': self.validate_boolean,
-            'partial-keyword-property': self.validate_boolean,
             'no-default-color': self.validate_boolean,
             'related-property': self.validate_string,
             'runtime-flag': self.validate_string,


### PR DESCRIPTION
#### a3765e734adbb3b98eec9cf11bab639b4fd58e5c
<pre>
Basic grammar support for data driven CSS property parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=248275">https://bugs.webkit.org/show_bug.cgi?id=248275</a>
rdar://102630092

Reviewed by Darin Adler.

Adds initial support for using a grammar to drive generation of CSS property
parsing functions. This first cut only supports simple grammars with a single
result term, but builds some foundations to build on.

Not too certain with the syntax choices used for the grammar yet, but the
current model is that every type of term is represented as a dictionary with
a &apos;kind&apos; property defining the kind and &apos;value&apos; property for the value. The
current set of kinds are: &apos;match-one&apos; (disjunction e.g. [ foo | bar | baz ]),
&apos;reference&apos; (e.g. [ &lt;foo&gt; ]) and &apos;keyword&apos; (e.g. [ foo ]). The value property
of a &apos;match-one&apos; term must be a list of terms, and the value type of a &apos;reference&apos;
or &apos;keyword&apos; term must be a string.

As an example:

   &apos;property-grammar&apos;: {
       &apos;kind&apos;: &apos;match-one&apos;,
       &apos;value&apos;: [
           { &quot;kind&quot;: &quot;keyword&quot;, &quot;value&quot;: &quot;auto&quot; },
           { &quot;kind&quot;: &quot;reference&quot;, &quot;value&quot;: &quot;&lt;length unitless-allowed&gt;&quot; }
       ]
   }

would be equilent to the following grammar using CSS spec syntax:

  auto | &lt;length unitless-allowed&gt;

Given how much wordier this base syntax is, there is also a shorthand
syntax for these:

  - &apos;match-one&apos; terms can just use a list directly, bypassing the dictionary.
  - &apos;reference&apos; terms can use a string starting with &apos;&lt;&apos; and ending with &apos;&gt;&apos;.
  - &apos;keyword&apos; terms can use a string (as long as it doesn&apos;t conflict with the
      reference syntax.

This allows the example to be written as:

   &apos;property-grammar&apos;: [ &quot;auto&quot;, &quot;&lt;length unitless-allowed&gt;&quot; ]

While this works for now, once we introduce multiple consecutive terms, the
ambiguity may become too burdensome and we may need to find a better syntax
for &apos;match-one&apos; than just a list.

* Source/WebCore/css/CSSProperties.json:
Replace &apos;custom-parser&apos; and &apos;parser-function&apos; values with the new &apos;parser-grammar&apos;
for all supported properties. Also adds new &apos;shared-grammar-rules&apos; section with
productions that are needed by multiple properities.

* Source/WebCore/css/MediaQueryExpression.cpp:
(WebCore::consumeFirstValue):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontFeatureValuesRuleBlock):
Update CSSPropertyParserHelpers::consumeIntegerZeroAndGreater() to
use new name CSSPropertyParserHelpers::consumeNonNegativeInteger(),
which is more consistent with our value range naming.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::canParseTypedCustomPropertyValue):
(WebCore::CSSPropertyParser::collectParsedCustomPropertyValueDependencies):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
Replace hand written consumeWidthOrHeight() with generated one.

(WebCore::consumeCounterStylePad):
(WebCore::consumeCounterStyleAdditiveSymbols):
Update more uses of CSSPropertyParserHelpers::consumeIntegerZeroAndGreater().

(WebCore::CSSPropertyParser::parseFontFaceDescriptor):
Replace hand written consumeFontVariantCaps() and consumeFontVariantPosition()
with generated counterparts.

(WebCore::consumeBasePaletteDescriptor):
(WebCore::consumeOverrideColorsDescriptor):
Update more uses of CSSPropertyParserHelpers::consumeIntegerZeroAndGreater().

(WebCore::CSSPropertyParser::consumeFont):
Replace hand written consumeFontSize() and consumeLineHeight() with
generated counterparts.

(WebCore::CSSPropertyParser::consumeFontVariantShorthand):
Replace more uses of consumeFontVariantCaps() and consumeFontVariantPosition().

(WebCore::CSSPropertyParser::consumeColumns):
Replace hand written consumeColumnWidth() and consumeColumnCount() with
generated counterparts.

(WebCore::CSSPropertyParser::consumeBorder):
Replace hand written consumeLineWidth() with generated counterpart.

(WebCore::CSSPropertyParser::consumeOverscrollBehaviorShorthand):
Replace hand written consumeOverscrollBehavior() with generated counterparts.

(WebCore::CSSPropertyParser::parseShorthand):
Replace hand written consumeGapLength() with generated counterparts.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::computeMinimumValue):
(WebCore::CSSPropertyParserHelpers::consumeIntegerTypeRaw):
(WebCore::CSSPropertyParserHelpers::consumeIntegerType):
(WebCore::CSSPropertyParserHelpers::consumeIntegerRaw):
(WebCore::CSSPropertyParserHelpers::consumeInteger):
(WebCore::CSSPropertyParserHelpers::consumeNonNegativeIntegerRaw):
(WebCore::CSSPropertyParserHelpers::consumeNonNegativeInteger):
(WebCore::CSSPropertyParserHelpers::consumePositiveIntegerRaw):
(WebCore::CSSPropertyParserHelpers::consumePositiveInteger):
Replace file specific IntegerRange with new IntegerValueRange enum
and update naming to be more inline with the ValueRange enum (e.g.
non-negative rather than zero-or-greater, and positive rather than
one-or-greater). Adds a new consumeInteger overload that takes
the new enum as a parameter to allow similar overloading of
&lt;integer&gt; and &lt;number&gt; in the grammars.

(WebCore::CSSPropertyParserHelpers::consumeSingleAxisPosition):
(WebCore::CSSPropertyParserHelpers::isPredefinedCounterStyle):
(WebCore::CSSPropertyParserHelpers::consumeFontWeightRaw):
(WebCore::CSSPropertyParserHelpers::consumeFontStyleRaw):
(WebCore::CSSPropertyParserHelpers::consumeAutoOrLengthOrPercent):
Mark a few functions that are only used in this file as static (and
remove there declarations from the header.

(WebCore::CSSPropertyParserHelpers::consumeIntegerZeroAndGreaterRaw): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeIntegerZeroAndGreater): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAutoOrString): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAutoOrColor): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAutoOrPosition): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeNoneOrURL): Deleted.
(WebCore::CSSPropertyParserHelpers::consumePage): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFontVariantCaps): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFontVariantPosition): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFontPalette): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeLetterSpacing): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWordSpacing): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeTabSize): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeTextSizeAdjust): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFontSize): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFontSizeAdjust): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeLineHeight): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeScrollPadding): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeMaxWidthOrHeight): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWidthOrHeight): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeMarginOrOffset): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitLineClamp): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeHyphenateLimit): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeColumnWidth): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeColumnCount): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeGapLength): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeZoom): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeZIndex): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeOutlineColor): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeLineWidth): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeTextStrokeWidth): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeColumnRuleWidth): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeOpacity): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeGlyphOrientationHorizontal): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeGlyphOrientationVertical): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeFlexBasis): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeKerning): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeBaselineShift): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeRxOrRy): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeOverscrollBehavior): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeTextUnderlineOffset): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeTextDecorationThickness): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeVerticalAlign): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitLineGrid): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitMarqueeIncrement): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitMarqueeRepetition): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitMarqueeSpeed): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeListStyleType): Deleted.
Remove a nice large set of now generated consumer functions!

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
(WebCore::CSSPropertyParserHelpers::identMatches):
(WebCore::CSSPropertyParserHelpers::consumeIdentRaw):
(WebCore::CSSPropertyParserHelpers::consumeIdent):
(WebCore::CSSPropertyParserHelpers::consumeIdentWorkerSafe):
(WebCore::CSSPropertyParserHelpers::isFontStyleAngleInRange):
(WebCore::CSSPropertyParserHelpers::isSystemFontShorthand):
(WebCore::CSSPropertyParserHelpers::lowerFontShorthand):
(WebCore::CSSPropertyParserHelpers::createPrimitiveValuePair):
Remove the declarations for no longer needed consumers and resort
remaining declarations so the inline and template functions are
again at the bottom as the comment in the header reads.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFeatureTag):
Update more uses of CSSPropertyParserHelpers::consumeIntegerZeroAndGreater().

* Source/WebCore/css/process-css-properties.py:
(compact):
(compact_map):
(flatten):
Add a few more helper functions.

(Schema.Entry.__init__):
(Schema.__add__):
(Schema.validate_keys):
(Schema.apply_conversions):
Add support to Schema for merging two schemas together (via + operator)
and for automatically applying a type conversion via a new &quot;convert_to&quot;
property on the entries.

(Name):
(Name.convert_name_to_id):
Support a special case list for conversions to allow &quot;url&quot; to be canonicalized
as URL instead of Url (needed to keep consumeURL() working without a stub).

(ValueKeywordName.from_json):
(Status.from_json):
(Specification.from_json):
Update for new validate_dictionary signature.

(Value._build_keyword_term):
As a syntatic convenience, we allow properties with only keywords to avoid
defining a &apos;parser-grammar&apos; and use the &apos;values&apos; array instead. But for
processing, it is easier if everthing is a grammar, so we automatically
create KeywordTerms for every value.

(LogicalPropertyGroup.from_json):
(Longhand.from_json):
Update for new validate_dictionary signature.

(CodeGenProperties):
(CodeGenProperties.from_json):
Add support for the &apos;parser-exported&apos;, &apos;parser-grammar&apos; and &apos;parser-grammar-comment&apos;
properties, and remove support for &apos;partial-keyword-property&apos;.

When processing the &apos;parser-grammar&apos; property we &apos;perform fixups&apos; on it, which
replaces any references to shared grammar rules with the contents of the rule
and flattens the final grammar out.

(Property):
Replace _values_sorted_by_name with _fast_path_keyword_terms_sorted_by_name
to better support generation and add a few helper predicates to support selecting
the correct generation needed.

Additionally, support another convenience, the &quot;&lt;&lt;values&gt;&gt;&quot; (note double arrow-brackets)
reference that can be used in a grammar to indicate that the keywords from the properities
values array should replace it, via perform_fixups_for_values_references. This allows
for existing properties like &apos;list-style-type&apos; to have a grammar like:

  [&quot;&lt;&lt;values&gt;&gt;&quot;, &quot;&lt;string&gt;&quot;]

rather than repeating the entire list of values in the grammar. Eventually, we should
likely consolidate the values array and the parser-grammar into a single property, but
for now, keeping the values array around reduces changes and allows the other users of
CSSProperties.json (like webkit.org) to continue working without changes.

(Properties):
(Properties.__init__):
(Properties._perform_fixups):
Move top level parsing out of the Properties class and into a new ParsingContext.TopLevelObject
class. But, keep the encapsulated fixup concept in Properties by hoisting it into the
init function.

(Properties.all_with_fast_path_keyword_terms):
Replace another &apos;values&apos; centric property with a new one that better expresses
the real intent, fast-path keyword only property parsing.

(Term):
Base type for grammar terms. Used to aid parsing of the recursive grammar data structure.

(BuiltinSchema):
(BuiltinSchema.OptionalParameter):
(BuiltinSchema.RequiredParameter):
(BuiltinSchema.Entry):
(BuiltinSchema.validate_and_construct_if_builtin):
The BuiltinSchema class provides support for defining the leaf parser terms; those
that currently require calling into WebCore like consumeLength() and consumeColor().
The builtin terms are allowed to define optional and required parameters to augment
how the &apos;consume&apos; function is called. For instance, some have an optional range
parameter that looks like &apos;[0,inf]&apos; (to mimic the spec syntax) which corresponds with
passing &apos;ValueRange::NonNegative&apos; to the consume function. Any reference term (that
is, any term of the form &quot;&lt;...&gt;&quot;) that does not have a shared grammar rule or a
builtin defined for it is assumed to have the calling convention of being passed
the token range and the parser context.

(ReferenceTerm):
(ReferenceTerm.__init__):
(ReferenceTerm.__str__):
(ReferenceTerm.__repr__):
(ReferenceTerm.is_reference_string):
(ReferenceTerm.from_json):
(ReferenceTerm.perform_fixups):
(ReferenceTerm.perform_fixups_for_values_references):
(ReferenceTerm.is_builtin):
Reference terms are strings that start with &apos;&lt;&apos; and end with &apos;&gt;&apos;. They come in a
few forms:

 - Reference to a shared grammar rule defined in the &quot;shared-grammar-rule&quot; section.
 - Reference to a builtin rule defined as BuiltinSchema above.
 - Reference to a builtin rule without a BuiltinSchema
 - Reference to a special. Currently the only special is &apos;&lt;&lt;values&gt;&gt;&apos; which is
   a constucted reference to the properties &apos;values&apos; array.

At fixup time, any reference that can be resolved is resolved and simplified.

(KeywordTerm):
(KeywordTerm.__init__):
(KeywordTerm.__str__):
(KeywordTerm.__repr__):
(KeywordTerm.from_json):
(KeywordTerm.perform_fixups):
(KeywordTerm.perform_fixups_for_values_references):
(KeywordTerm.requires_context):
(KeywordTerm.is_eligible_for_fast_path):
(KeywordTerm.name):
Keyword terms match CSSValueID identifiers. In most cases, the match is as
simple as that, but if an &apos;aliased-to&apos; property is defined, the keyword
must match but return the other value. This makes the keyword in-eligible
for the fast path.

(MatchOneTerm):
(MatchOneTerm.__init__):
(MatchOneTerm.__str__):
(MatchOneTerm.__repr__):
(MatchOneTerm.from_json):
(MatchOneTerm.perform_fixups):
(MatchOneTerm.perform_fixups_for_values_references):
(MatchOneTerm.is_values_reference):
(MatchOneTerm.has_keyword_term):
(MatchOneTerm.has_only_keyword_terms):
(MatchOneTerm.keyword_terms):
(MatchOneTerm.fast_path_keyword_terms):
(MatchOneTerm.has_fast_path_keyword_terms):
(MatchOneTerm.has_only_fast_path_keyword_terms):
Base disjuction type, workhorse of the simple grammar. Contains
a list of terms, exactly one of which, must match.0

(Grammar):
(Grammar.__init__):
(Grammar.__str__):
(Grammar.__repr__):
(Grammar.from_json):
(Grammar.perform_fixups):
(Grammar.perform_fixups_for_values_references):
(Grammar.has_fast_path_keyword_terms):
(Grammar.has_only_keyword_terms):
(Grammar.has_only_fast_path_keyword_terms):
(Grammar.fast_path_keyword_terms):
The grammar is where matching starts. It owns the root term. It is in turn
owned by either a Property (via codegen-properties.property-grammar&apos;) or by
a SharedGrammarRule.

(SharedGrammarRule):
(SharedGrammarRule.__init__):
(SharedGrammarRule.__str__):
(SharedGrammarRule.__repr__):
(SharedGrammarRule.from_json):
(SharedGrammarRule.perform_fixups):
(SharedGrammarRules):
(SharedGrammarRules.__init__):
(SharedGrammarRules.__str__):
(SharedGrammarRules.__repr__):
(SharedGrammarRules._perform_fixups):
(SharedGrammarRules.all):
Set of grammar rules that can use as the target of a ReferenceTerm. Used
to define a sub-grammar that can be use by multiple properties or by other
shared grammar rules.

(ParsingContext):
(ParsingContext.TopLevelObject):
(ParsingContext.__init__):
(ParsingContext.parse_shared_grammar_rules):
(ParsingContext.parse_properties):
(ParsingContext.is_enabled):
(ParsingContext.select_enabled_variant):
Moved and expanded. Now parses the &apos;shared-grammar-rules&apos; section and
stores them so they can be available when parsing the properties.

(GenerationContext):
(GenerationContext.__init__):
(GenerationContext.generate_heading):
(GenerationContext.generate_open_namespace):
(GenerationContext.generate_close_namespace):
(GenerationContext.generate_using_namespace_declarations):
(GenerationContext.generate_property_id_switch_function):
(GenerationContext.generate_property_id_switch_function_bool):
GenerationContext no longer contains all the generation functions,
but rather serves more a similar purpose as ParsingContext, holding
onto shared state useful during generation and providing a few
helper functions for common generation tasks.

The generation functions now live in a set of &quot;Generate*&quot; classes,
one for each logical set of files to generate:

  - GenerateCSSPropertyNames
  - GenerateCSSPropertyParsing
  - GenerateCSSStyleDeclarationPropertyNames
  - GenerateStyleBuilderGenerated
  - GenerateStylePropertyShorthandFunctions

(TermGenerator):
To complement the grammar terms, we have TermGenerators which
encapsulate code generation for a specific term.

(TermGeneratorMatchOneTerm):
Owns an builds sub term generators for each sub term of. If the caller
passes a KeywordFastPathGenerator that means this a top level generator
and any eligible keywords can use a fast path parsing path specialization.

(TermGeneratorReferenceTerm):
Generator for non-simplied references. These end up being the builtins,
so this is where the logic for converting the builtin schema entries
into &quot;consume*&quot; functions lives. NOTE: the Builtin*Consumer classes are
dynamically created and injected into the global object in BuiltinSchema&apos;s
Entry class.

(TermGeneratorNonFastPathKeywordTerm):
Generator for a set of keyword terms that can&apos;t use the fast path. At
the moment, this is only keywords that have an &apos;aliased-to&apos; property.

(TermGeneratorFastPathKeywordTerms):
Generator for a set of keyword terms that can use the fast path. Uses
the KeywordFastPathGenerator that it is passed to identify the name of
the generated predicate, and uses the predicate taking &apos;consumeIdent&apos;.

(KeywordFastPathGenerator):
Extracted to build the &apos;isKeywordValidFor*&apos; functions used by the
keyword-only fast path parser.

(SharedGrammarRuleConsumer):
The shared grammar rule consumer class cluster is responsible for
generating functions for any shared grammar rules that are marked
&apos;exported&apos;. It utilizes the TermGenerators to actually generate the
parser text. There are currently only two kinds:

  - SkipSharedGrammarRuleConsumer (does nothing as you might expect)
  - GeneratedSharedGrammarRuleConsumer (used for expored rules)

(PropertyConsumer):
The property consumer class cluster is, like for SharedGrammarRuleConsumer,
responsible for generating consume functions, but for CSS properties.
It comes in a few more flavors than SharedGrammarRuleConsumer:

  - SkipPropertyConsumer
  - CustomPropertyConsumer (used for &apos;custom-parser&apos; or &apos;parser-fuction&apos;)
  - FastPathKeywordOnlyPropertyConsumer (used when the main parse function
      can use the predicate taking consumeIdent function with a fast path
      predicate directly).
  - DirectPropertyConsumer (used when a grammar contains only a single
      non-simplifiable reference term, in which case the main parse function
      can call it directly).
  - GeneratedPropertyConsumer (default generator, used for any other
      variaty of property / grammar).

* Tools/Scripts/webkitpy/style/checkers/jsonchecker.py:
(JSONCSSPropertiesChecker.check):
(JSONCSSPropertiesChecker.check_category):
(JSONCSSPropertiesChecker.check_categories):
(JSONCSSPropertiesChecker.check_shared_grammar_rule):
(JSONCSSPropertiesChecker):
(JSONCSSPropertiesChecker.check_shared_grammar_rules):
(JSONCSSPropertiesChecker.check_properties):
(JSONCSSPropertiesChecker.validate_status_type):
(JSONCSSPropertiesChecker.validate_grammar):
(JSONCSSPropertiesChecker.validate_grammar_term):
(JSONCSSPropertiesChecker.validate_status):
(JSONCSSPropertiesChecker.validate_specification):
(JSONCSSPropertiesChecker.check_property):
(JSONCSSPropertiesChecker.check_codegen_properties):
(JSONCSSPropertiesChecker.validate_property_specification): Deleted.

Canonical link: <a href="https://commits.webkit.org/257026@main">https://commits.webkit.org/257026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a8c69b752460d6e9d4584598c05e97239c8f744

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97636 "20 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107132 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167395 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7243 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35644 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103788 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103282 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84266 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32439 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101197 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75358 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/881 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/870 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22022 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4837 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5688 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41414 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->