### PR TITLE
Add a few new preserve-3d hit-testing tests for currently broken behaviour.

### DIFF
--- a/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (0,0) size 800x600 [border: (1px solid #000000)]
+layer at (0,0) size 785x608
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x600
+  RenderBlock {HTML} at (0,0) size 785x600
+    RenderBody {BODY} at (0,0) size 785x600 [border: (1px solid #000000)]
       RenderBlock {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (243,229) size 4x17
         text run at (243,229) width 4: " "
@@ -12,28 +12,32 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 312x90
-  RenderBlock (positioned) {DIV} at (30,500) size 313x90
+layer at (30,500) size 512x108
+  RenderBlock (positioned) {DIV} at (30,500) size 512x108
     RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
       RenderText {#text} at (0,0) size 313x17
         text run at (0,0) width 313: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
     RenderBR {BR} at (312,0) size 1x17
-    RenderInline {SPAN} at (0,0) size 305x17 [color=#008000]
-      RenderText {#text} at (0,18) size 305x17
-        text run at (0,18) width 305: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
-    RenderBR {BR} at (304,18) size 1x17
+    RenderInline {SPAN} at (0,0) size 512x17 [color=#FF0000]
+      RenderText {#text} at (0,18) size 512x17
+        text run at (0,18) width 512: "FAIL: event at (184, 160) expected to hit box3 at (83, 52) but hit box4 at (62, 32)"
+    RenderBR {BR} at (511,18) size 1x17
     RenderInline {SPAN} at (0,0) size 305x17 [color=#008000]
       RenderText {#text} at (0,36) size 305x17
-        text run at (0,36) width 305: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
+        text run at (0,36) width 305: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (304,36) size 1x17
+    RenderInline {SPAN} at (0,0) size 305x17 [color=#008000]
+      RenderText {#text} at (0,54) size 305x17
+        text run at (0,54) width 305: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
+    RenderBR {BR} at (304,54) size 1x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
-      RenderText {#text} at (0,54) size 312x17
-        text run at (0,54) width 312: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
-    RenderBR {BR} at (311,54) size 1x17
+      RenderText {#text} at (0,72) size 312x17
+        text run at (0,72) width 312: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+    RenderBR {BR} at (311,72) size 1x17
     RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
-      RenderText {#text} at (0,72) size 313x17
-        text run at (0,72) width 313: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
-    RenderBR {BR} at (312,72) size 1x17
+      RenderText {#text} at (0,90) size 313x17
+        text run at (0,90) width 313: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
+    RenderBR {BR} at (312,90) size 1x17
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -1,4 +1,4 @@
-layer at (0,0) size 800x600
+layer at (0,0) size 800x620
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
@@ -12,28 +12,32 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 317x100
-  RenderBlock (positioned) {DIV} at (30,500) size 318x100
+layer at (30,500) size 520x120
+  RenderBlock (positioned) {DIV} at (30,500) size 520x120
     RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
       RenderText {#text} at (0,0) size 318x19
         text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
     RenderBR {BR} at (317,0) size 1x19
-    RenderInline {SPAN} at (0,0) size 310x19 [color=#008000]
-      RenderText {#text} at (0,20) size 310x19
-        text run at (0,20) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
-    RenderBR {BR} at (309,20) size 1x19
+    RenderInline {SPAN} at (0,0) size 520x19 [color=#FF0000]
+      RenderText {#text} at (0,20) size 520x19
+        text run at (0,20) width 520: "FAIL: event at (184, 160) expected to hit box3 at (83, 52) but hit box4 at (62, 32)"
+    RenderBR {BR} at (519,20) size 1x19
     RenderInline {SPAN} at (0,0) size 310x19 [color=#008000]
       RenderText {#text} at (0,40) size 310x19
-        text run at (0,40) width 310: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
+        text run at (0,40) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (309,40) size 1x19
+    RenderInline {SPAN} at (0,0) size 310x19 [color=#008000]
+      RenderText {#text} at (0,60) size 310x19
+        text run at (0,60) width 310: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
+    RenderBR {BR} at (309,60) size 1x19
     RenderInline {SPAN} at (0,0) size 317x19 [color=#008000]
-      RenderText {#text} at (0,60) size 317x19
-        text run at (0,60) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
-    RenderBR {BR} at (316,60) size 1x19
+      RenderText {#text} at (0,80) size 317x19
+        text run at (0,80) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+    RenderBR {BR} at (316,80) size 1x19
     RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
-      RenderText {#text} at (0,80) size 318x19
-        text run at (0,80) width 318: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
-    RenderBR {BR} at (317,80) size 1x19
+      RenderText {#text} at (0,100) size 318x19
+        text run at (0,100) width 318: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
+    RenderBR {BR} at (317,100) size 1x19
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (0,0) size 800x600 [border: (1px solid #000000)]
+layer at (0,0) size 785x608
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x600
+  RenderBlock {HTML} at (0,0) size 785x600
+    RenderBody {BODY} at (0,0) size 785x600 [border: (1px solid #000000)]
       RenderBlock {DIV} at (21,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (243,229) size 4x18
         text run at (243,229) width 4: " "
@@ -12,28 +12,32 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 317x90
-  RenderBlock (positioned) {DIV} at (30,500) size 318x90
+layer at (30,500) size 520x108
+  RenderBlock (positioned) {DIV} at (30,500) size 520x108
     RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
       RenderText {#text} at (0,0) size 318x18
         text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
     RenderBR {BR} at (317,0) size 1x18
-    RenderInline {SPAN} at (0,0) size 310x18 [color=#008000]
-      RenderText {#text} at (0,18) size 310x18
-        text run at (0,18) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
-    RenderBR {BR} at (309,18) size 1x18
+    RenderInline {SPAN} at (0,0) size 520x18 [color=#FF0000]
+      RenderText {#text} at (0,18) size 520x18
+        text run at (0,18) width 520: "FAIL: event at (184, 160) expected to hit box3 at (83, 52) but hit box4 at (62, 32)"
+    RenderBR {BR} at (519,18) size 1x18
     RenderInline {SPAN} at (0,0) size 310x18 [color=#008000]
       RenderText {#text} at (0,36) size 310x18
-        text run at (0,36) width 310: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
+        text run at (0,36) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (309,36) size 1x18
+    RenderInline {SPAN} at (0,0) size 310x18 [color=#008000]
+      RenderText {#text} at (0,54) size 310x18
+        text run at (0,54) width 310: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
+    RenderBR {BR} at (309,54) size 1x18
     RenderInline {SPAN} at (0,0) size 317x18 [color=#008000]
-      RenderText {#text} at (0,54) size 317x18
-        text run at (0,54) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
-    RenderBR {BR} at (316,54) size 1x18
+      RenderText {#text} at (0,72) size 317x18
+        text run at (0,72) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
+    RenderBR {BR} at (316,72) size 1x18
     RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
-      RenderText {#text} at (0,72) size 318x18
-        text run at (0,72) width 318: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
-    RenderBR {BR} at (317,72) size 1x18
+      RenderText {#text} at (0,90) size 318x18
+        text run at (0,90) width 318: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
+    RenderBR {BR} at (317,90) size 1x18
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html
@@ -17,6 +17,7 @@
         document.body.addEventListener('mousemove', mousemoved, false);
 
       dispatchEvent(120, 128, 'box4', 2, 2);
+      dispatchEvent(184, 160, 'box3', 83, 52);
       dispatchEvent(336, 87, 'box7', 2, 2);
       dispatchEvent(348, 86, 'box8', 2, 2);
 

--- a/LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors-expected.txt
+++ b/LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors-expected.txt
@@ -1,0 +1,5 @@
+FAIL child.getBoundingClientRect().width should be 100. Was 0.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors.html
+++ b/LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors.html
@@ -1,0 +1,29 @@
+<!doctype HTML>
+<script src="../../resources/js-test-pre.js"></script>
+
+<style>
+  div {
+    width: 200px;
+    height: 200px;
+  }
+  .parent {
+    transform: rotateY(45deg)
+  }
+
+  .child {
+    transform-style: preserve-3d;
+    transform: rotateY(45deg);
+    background: lightblue
+  }
+</style>
+
+<div class="parent">
+  <div id=child class="child"></div>
+</div>
+
+<script>
+  shouldBe("child.getBoundingClientRect().width", "100");
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+


### PR DESCRIPTION
#### 3eb1748df76d1fa53f1b170dc4ec54e653edd870
<pre>
Add a few new preserve-3d hit-testing tests for currently broken behaviour.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248281">https://bugs.webkit.org/show_bug.cgi?id=248281</a>
&lt;rdar://problem/102632565&gt;

Reviewed by Simon Fraser.

Neither of these tests should change behaviour with interop, but we can fix them at the same
time.

* LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html:

This adds a new subtest check for hitting the parent box3 element in the area where it&apos;s
drawn on top of the child. We&apos;re currently failing this, as we hit-test box4 despite it
being rendered behind.

* LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors-expected.txt: Added.
* LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors.html: Added.

This test has a transformed ancestor of the preserve-3d element, which shouldn&apos;t be
participating in transform accumulation (and rendering already shows that it isn&apos;t).
The bounding client rect should match, and it currently doesn&apos;t.

Canonical link: <a href="https://commits.webkit.org/257091@main">https://commits.webkit.org/257091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaf71050e89088054e7421e7ecda6499418bd38e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107048 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167312 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7141 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35558 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103716 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5349 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84178 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32354 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75278 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/800 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20473 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/788 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4869 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5603 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44422 "Found 1 new test failure: http/wpt/service-workers/fetch-service-worker-preload.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41329 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->