### PR TITLE
Implement hit-testing changes for transform-style:preserve-3d and perspective to only apply to direct DOM children.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior-expected.txt
@@ -9,6 +9,6 @@ PASS Perspective applies to direct DOM normal-flow children
 PASS Perspective applies to direct DOM abs-pos children
 PASS Perspective applies to direct DOM fixed-pos children
 PASS Perspective does not apply to DOM normal-flow grandchildren
-FAIL Perspective does not apply to DOM abs-pos grandchildren assert_approx_equals: expected 141 +/- 1 but got 161.62440490722656
-FAIL Perspective does not apply to DOM fixed-pos grandchildren assert_approx_equals: expected 141 +/- 1 but got 161.62440490722656
+PASS Perspective does not apply to DOM abs-pos grandchildren
+PASS Perspective does not apply to DOM fixed-pos grandchildren
 

--- a/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -12,32 +12,32 @@ layer at (0,0) size 785x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 512x108
-  RenderBlock (positioned) {DIV} at (30,500) size 512x108
+layer at (30,500) size 496x108
+  RenderBlock (positioned) {DIV} at (30,500) size 496x108
     RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
       RenderText {#text} at (0,0) size 313x17
         text run at (0,0) width 313: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
     RenderBR {BR} at (312,0) size 1x17
-    RenderInline {SPAN} at (0,0) size 512x17 [color=#FF0000]
-      RenderText {#text} at (0,18) size 512x17
-        text run at (0,18) width 512: "FAIL: event at (184, 160) expected to hit box3 at (83, 52) but hit box4 at (62, 32)"
-    RenderBR {BR} at (511,18) size 1x17
+    RenderInline {SPAN} at (0,0) size 329x17 [color=#008000]
+      RenderText {#text} at (0,18) size 329x17
+        text run at (0,18) width 329: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+    RenderBR {BR} at (328,18) size 1x17
     RenderInline {SPAN} at (0,0) size 305x17 [color=#008000]
       RenderText {#text} at (0,36) size 305x17
         text run at (0,36) width 305: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (304,36) size 1x17
-    RenderInline {SPAN} at (0,0) size 305x17 [color=#008000]
-      RenderText {#text} at (0,54) size 305x17
-        text run at (0,54) width 305: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
-    RenderBR {BR} at (304,54) size 1x17
+    RenderInline {SPAN} at (0,0) size 480x17 [color=#FF0000]
+      RenderText {#text} at (0,54) size 480x17
+        text run at (0,54) width 480: "FAIL: event at (359, 87) expected to hit box8 at (2, 2) but hit box8 at (13, 3)"
+    RenderBR {BR} at (479,54) size 1x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,72) size 312x17
         text run at (0,72) width 312: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
     RenderBR {BR} at (311,72) size 1x17
-    RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
-      RenderText {#text} at (0,90) size 313x17
-        text run at (0,90) width 313: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
-    RenderBR {BR} at (312,90) size 1x17
+    RenderInline {SPAN} at (0,0) size 496x17 [color=#FF0000]
+      RenderText {#text} at (0,90) size 496x17
+        text run at (0,90) width 496: "FAIL: event at (605, 87) expected to hit box12 at (2, 2) but hit box12 at (13, 3)"
+    RenderBR {BR} at (495,90) size 1x17
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -12,32 +12,32 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 520x120
-  RenderBlock (positioned) {DIV} at (30,500) size 520x120
+layer at (30,500) size 504x120
+  RenderBlock (positioned) {DIV} at (30,500) size 504x120
     RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
       RenderText {#text} at (0,0) size 318x19
         text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
     RenderBR {BR} at (317,0) size 1x19
-    RenderInline {SPAN} at (0,0) size 520x19 [color=#FF0000]
-      RenderText {#text} at (0,20) size 520x19
-        text run at (0,20) width 520: "FAIL: event at (184, 160) expected to hit box3 at (83, 52) but hit box4 at (62, 32)"
-    RenderBR {BR} at (519,20) size 1x19
+    RenderInline {SPAN} at (0,0) size 334x19 [color=#008000]
+      RenderText {#text} at (0,20) size 334x19
+        text run at (0,20) width 334: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+    RenderBR {BR} at (333,20) size 1x19
     RenderInline {SPAN} at (0,0) size 310x19 [color=#008000]
       RenderText {#text} at (0,40) size 310x19
         text run at (0,40) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (309,40) size 1x19
-    RenderInline {SPAN} at (0,0) size 310x19 [color=#008000]
-      RenderText {#text} at (0,60) size 310x19
-        text run at (0,60) width 310: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
-    RenderBR {BR} at (309,60) size 1x19
+    RenderInline {SPAN} at (0,0) size 488x19 [color=#FF0000]
+      RenderText {#text} at (0,60) size 488x19
+        text run at (0,60) width 488: "FAIL: event at (359, 87) expected to hit box8 at (2, 2) but hit box8 at (13, 3)"
+    RenderBR {BR} at (487,60) size 1x19
     RenderInline {SPAN} at (0,0) size 317x19 [color=#008000]
       RenderText {#text} at (0,80) size 317x19
         text run at (0,80) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
     RenderBR {BR} at (316,80) size 1x19
-    RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
-      RenderText {#text} at (0,100) size 318x19
-        text run at (0,100) width 318: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
-    RenderBR {BR} at (317,100) size 1x19
+    RenderInline {SPAN} at (0,0) size 504x19 [color=#FF0000]
+      RenderText {#text} at (0,100) size 504x19
+        text run at (0,100) width 504: "FAIL: event at (605, 87) expected to hit box12 at (2, 2) but hit box12 at (13, 3)"
+    RenderBR {BR} at (503,100) size 1x19
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -12,32 +12,32 @@ layer at (0,0) size 785x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 520x108
-  RenderBlock (positioned) {DIV} at (30,500) size 520x108
+layer at (30,500) size 504x108
+  RenderBlock (positioned) {DIV} at (30,500) size 504x108
     RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
       RenderText {#text} at (0,0) size 318x18
         text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
     RenderBR {BR} at (317,0) size 1x18
-    RenderInline {SPAN} at (0,0) size 520x18 [color=#FF0000]
-      RenderText {#text} at (0,18) size 520x18
-        text run at (0,18) width 520: "FAIL: event at (184, 160) expected to hit box3 at (83, 52) but hit box4 at (62, 32)"
-    RenderBR {BR} at (519,18) size 1x18
+    RenderInline {SPAN} at (0,0) size 334x18 [color=#008000]
+      RenderText {#text} at (0,18) size 334x18
+        text run at (0,18) width 334: "PASS: event at (184, 160) hit box3 at offset (83, 52)"
+    RenderBR {BR} at (333,18) size 1x18
     RenderInline {SPAN} at (0,0) size 310x18 [color=#008000]
       RenderText {#text} at (0,36) size 310x18
         text run at (0,36) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (309,36) size 1x18
-    RenderInline {SPAN} at (0,0) size 310x18 [color=#008000]
-      RenderText {#text} at (0,54) size 310x18
-        text run at (0,54) width 310: "PASS: event at (348, 86) hit box8 at offset (2, 2)"
-    RenderBR {BR} at (309,54) size 1x18
+    RenderInline {SPAN} at (0,0) size 488x18 [color=#FF0000]
+      RenderText {#text} at (0,54) size 488x18
+        text run at (0,54) width 488: "FAIL: event at (359, 87) expected to hit box8 at (2, 2) but hit box8 at (13, 3)"
+    RenderBR {BR} at (487,54) size 1x18
     RenderInline {SPAN} at (0,0) size 317x18 [color=#008000]
       RenderText {#text} at (0,72) size 317x18
         text run at (0,72) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
     RenderBR {BR} at (316,72) size 1x18
-    RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
-      RenderText {#text} at (0,90) size 318x18
-        text run at (0,90) width 318: "PASS: event at (594, 86) hit box12 at offset (2, 2)"
-    RenderBR {BR} at (317,90) size 1x18
+    RenderInline {SPAN} at (0,0) size 504x18 [color=#FF0000]
+      RenderText {#text} at (0,90) size 504x18
+        text run at (0,90) width 504: "FAIL: event at (605, 87) expected to hit box12 at (2, 2) but hit box12 at (13, 3)"
+    RenderBR {BR} at (503,90) size 1x18
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/transforms/3d/hit-testing/overlapping-layers-hit-test-expected.txt
+++ b/LayoutTests/transforms/3d/hit-testing/overlapping-layers-hit-test-expected.txt
@@ -1,5 +1,6 @@
 Element at 10, 100 has id "container-nopreserve": PASS
 Element at 20, 100 has id "target2": PASS
+Element at 50, 100 has id "target1": PASS
 Element at 80, 100 has id "target1": PASS
 Element at 100, 100 has id "target1": PASS
 Element at 120, 100 has id "target1": PASS
@@ -12,4 +13,12 @@ Element at 100, 250 has id "target4": PASS
 Element at 120, 250 has id "target3": PASS
 Element at 180, 250 has id "target3": PASS
 Element at 190, 250 has id "container-preserve": PASS
+Element at 10, 550 has id "container-preserve": PASS
+Element at 20, 550 has id "target5": PASS
+Element at 50, 550 has id "target6": PASS
+Element at 80, 550 has id "target6": PASS
+Element at 100, 550 has id "target6": PASS
+Element at 120, 550 has id "target6": PASS
+Element at 180, 550 has id "target6": PASS
+Element at 190, 550 has id "container-preserve": PASS
 

--- a/LayoutTests/transforms/3d/hit-testing/overlapping-layers-hit-test.html
+++ b/LayoutTests/transforms/3d/hit-testing/overlapping-layers-hit-test.html
@@ -22,6 +22,10 @@
 			-moz-transform-style: preserve-3d;
 		}
 
+		.last {
+			top: 500px;
+		}
+
 		.box {
 				width: 100%;
 				position: absolute;
@@ -56,7 +60,7 @@
 		}
 
 		#results {
-			margin-top: 460px;
+			margin-top: 710px;
 		}
 	</style>
 	<script src="resources/hit-test-utils.js"></script>
@@ -65,6 +69,7 @@
 
 			{ 'point': [10, 100], 'target' : 'container-nopreserve' },
 			{ 'point': [20, 100], 'target' : 'target2' },
+			{ 'point': [50, 100], 'target' : 'target1' },
 			{ 'point': [80, 100], 'target' : 'target1' },
 			{ 'point': [100, 100], 'target' : 'target1' },
 			{ 'point': [120, 100], 'target' : 'target1' },
@@ -78,6 +83,15 @@
 			{ 'point': [120, 250], 'target' : 'target3' },
 			{ 'point': [180, 250], 'target' : 'target3' },
 			{ 'point': [190, 250], 'target' : 'container-preserve' },
+
+			{ 'point': [10, 550], 'target' : 'container-preserve' },
+			{ 'point': [20, 550], 'target' : 'target5' },
+			{ 'point': [50, 550], 'target' : 'target6' },
+			{ 'point': [80, 550], 'target' : 'target6' },
+			{ 'point': [100, 550], 'target' : 'target6' },
+			{ 'point': [120, 550], 'target' : 'target6' },
+			{ 'point': [180, 550], 'target' : 'target6' },
+			{ 'point': [190, 550], 'target' : 'container-preserve' },
 
 		];
 
@@ -97,6 +111,15 @@
 		<div id="target3" class="box blue">
 		</div>
 		<div id="target4" class="box red">
+		</div>
+	</div>
+
+	<div id="container-preserve" class="container preserve last">
+		<div id="spacer">
+			<div id="target5" class="box red">
+			</div>
+			<div id="target6" class="box blue">
+			</div>
 		</div>
 	</div>
 

--- a/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2-expected.txt
+++ b/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2-expected.txt
@@ -1,0 +1,7 @@
+Element at 56, 100 has id "container": PASS
+Element at 57, 100 has id "target": PASS
+Element at 100, 100 has id "target": PASS
+Element at 195, 100 has id "target": PASS
+Element at 180, 60 has id "target": PASS
+Element at 180, 240 has id "target": PASS
+

--- a/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2.html
+++ b/LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2.html
@@ -1,0 +1,55 @@
+<html>
+<head>
+  <style type="text/css">
+    body {
+      margin: 0;
+    }
+    #container {
+      width: 200px;
+      height: 200px;
+      margin: 50px;
+      border: 1px solid black;
+      -webkit-perspective: 500px;
+    }
+
+    .box {
+      position: absolute;
+      width: 200px;
+      height: 200px;
+      background-color: gray;
+      opacity: 0.75;
+    }
+
+    #target {
+      -webkit-transform-origin: 10% 50%;
+      -webkit-transform: rotateY(45deg);
+    }
+
+    .box:hover {
+      background-color: orange;
+    }
+  </style>
+  <script src="resources/hit-test-utils.js"></script>
+  <script>
+      var hitTestData = [
+        { 'point': [56, 100], 'target' : 'container' },
+        { 'point': [57, 100], 'target' : 'target' },
+        { 'point': [100, 100], 'target' : 'target' },
+        { 'point': [195, 100], 'target' : 'target' },
+        { 'point': [180, 60], 'target' : 'target' },
+        { 'point': [180, 240], 'target' : 'target' },
+      ];
+      window.addEventListener('load', runTest, false);
+  </script>
+</head>
+<body>
+
+<div id="container">
+  <div id="spacer">
+      <div class="box" id="target"></div>
+  </div>
+</div>
+
+<div id="results"></div>
+</body>
+</html>

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html
@@ -19,10 +19,10 @@
       dispatchEvent(120, 128, 'box4', 2, 2);
       dispatchEvent(184, 160, 'box3', 83, 52);
       dispatchEvent(336, 87, 'box7', 2, 2);
-      dispatchEvent(348, 86, 'box8', 2, 2);
+      dispatchEvent(359, 87, 'box8', 2, 2);
 
       dispatchEvent(582, 87, 'box11', 2, 2);
-      dispatchEvent(594, 86, 'box12', 2, 2);
+      dispatchEvent(605, 87, 'box12', 2, 2);
     }
   </script>
   <style type="text/css" media="screen">

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3842,14 +3842,14 @@ bool RenderLayer::hitTest(const HitTestRequest& request, const HitTestLocation& 
             hitTestArea.intersect(renderer().view().frameView().visibleContentRect(ScrollableArea::LegacyIOSDocumentVisibleRect));
     }
 
-    RenderLayer* insideLayer = hitTestLayer(this, nullptr, request, result, hitTestArea, hitTestLocation, false);
-    if (!insideLayer) {
+    auto insideLayer = hitTestLayer(this, nullptr, request, result, hitTestArea, hitTestLocation, false);
+    if (!insideLayer.layer) {
         // We didn't hit any layer. If we are the root layer and the mouse is -- or just was -- down, 
         // return ourselves. We do this so mouse events continue getting delivered after a drag has 
         // exited the WebView, and so hit testing over a scrollbar hits the content document.
         if (!request.isChildFrameHitTest() && (request.active() || request.release()) && isRenderViewLayer()) {
             renderer().updateHitTestResult(result, downcast<RenderView>(renderer()).flipForWritingMode(hitTestLocation.point()));
-            insideLayer = this;
+            insideLayer = { this };
         }
     }
 
@@ -3860,7 +3860,7 @@ bool RenderLayer::hitTest(const HitTestRequest& request, const HitTestLocation& 
 
     // Now return whether we were inside this layer (this will always be true for the root
     // layer).
-    return insideLayer;
+    return insideLayer.layer;
 }
 
 Element* RenderLayer::enclosingElement() const
@@ -3967,8 +3967,16 @@ Ref<HitTestingTransformState> RenderLayer::createLocalTransformState(RenderLayer
     return transformState.releaseNonNull();
 }
 
+static bool parentLayerIsDOMParent(const RenderLayer& layer)
+{
+    if (!layer.parent())
+        return false;
+    if (!layer.renderer().element() || !layer.renderer().element()->parentElement())
+        return false;
+    return layer.parent()->renderer().element() == layer.renderer().element()->parentElement();
+}
 
-static bool isHitCandidate(const RenderLayer* hitLayer, bool canDepthSort, double* zOffset, const HitTestingTransformState* transformState)
+static bool isHitCandidateLegacy(const RenderLayer* hitLayer, bool canDepthSort, double* zOffset, const HitTestingTransformState* transformState)
 {
     if (!hitLayer)
         return false;
@@ -3976,7 +3984,7 @@ static bool isHitCandidate(const RenderLayer* hitLayer, bool canDepthSort, doubl
     // The hit layer is depth-sorting with other layers, so just say that it was hit.
     if (canDepthSort)
         return true;
-    
+
     // We need to look at z-depth to decide if this layer was hit.
     if (zOffset) {
         ASSERT(transformState);
@@ -3992,6 +4000,11 @@ static bool isHitCandidate(const RenderLayer* hitLayer, bool canDepthSort, doubl
     return true;
 }
 
+bool RenderLayer::participatesInPreserve3D() const
+{
+    return parentLayerIsDOMParent(*this) && parent()->preserves3D() && (transform() || renderer().style().backfaceVisibility() == BackfaceVisibility::Hidden || preserves3D());
+}
+
 // hitTestLocation and hitTestRect are relative to rootLayer.
 // A 'flattening' layer is one preserves3D() == false.
 // transformState.m_accumulatedTransform holds the transform from the containing flattening layer.
@@ -4000,14 +4013,14 @@ static bool isHitCandidate(const RenderLayer* hitLayer, bool canDepthSort, doubl
 // 
 // If zOffset is non-null (which indicates that the caller wants z offset information), 
 //  *zOffset on return is the z offset of the hit point relative to the containing flattening layer.
-RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest& request, HitTestResult& result,
-                                       const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation, bool appliedTransform,
-                                       const HitTestingTransformState* transformState, double* zOffset)
+RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest& request, HitTestResult& result,
+    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation, bool appliedTransform,
+    const HitTestingTransformState* transformState, double* zOffset)
 {
     updateLayerListsIfNeeded();
 
     if (!isSelfPaintingLayer() && !hasSelfPaintingLayerDescendant())
-        return nullptr;
+        return { nullptr };
 
     // The natural thing would be to keep HitTestingTransformState on the stack, but it's big, so we heap-allocate.
 
@@ -4022,7 +4035,7 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
             ClipRect clipRect = backgroundClipRect(clipRectsContext);
             // Test the enclosing clip now.
             if (!clipRect.intersects(hitTestLocation))
-                return nullptr;
+                return { nullptr };
         }
 
         return hitTestLayerByApplyingTransform(rootLayer, containerLayer, request, result, hitTestRect, hitTestLocation, transformState, zOffset);
@@ -4046,11 +4059,12 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
         std::optional<TransformationMatrix> invertedMatrix = localTransformState->m_accumulatedTransform.inverse();
         // If the z-vector of the matrix is negative, the back is facing towards the viewer.
         if (invertedMatrix && invertedMatrix.value().m33() < 0)
-            return nullptr;
+            return { nullptr, 0 };
     }
 
+    bool using3DTransformsInterop = renderer().settings().css3DTransformInteroperabilityEnabled();
     RefPtr<HitTestingTransformState> unflattenedTransformState = localTransformState;
-    if (localTransformState && !preserves3D()) {
+    if (!using3DTransformsInterop && localTransformState && !preserves3D()) {
         // Keep a copy of the pre-flattening state, for computing z-offsets for the container
         unflattenedTransformState = HitTestingTransformState::create(*localTransformState);
         // This layer is flattening, so flatten the state passed to descendants.
@@ -4062,7 +4076,7 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
     double localZOffset = -std::numeric_limits<double>::infinity();
     double* zOffsetForDescendantsPtr = nullptr;
     double* zOffsetForContentsPtr = nullptr;
-    
+
     bool depthSortDescendants = false;
     if (preserves3D()) {
         depthSortDescendants = true;
@@ -4075,8 +4089,10 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
         zOffsetForContentsPtr = zOffset;
     }
 
+    double selfZOffset = localTransformState ? computeZOffset(*localTransformState) : 0;
+
     // This variable tracks which layer the mouse ends up being inside.
-    RenderLayer* candidateLayer = nullptr;
+    auto candidateLayer = HitLayer { nullptr, -std::numeric_limits<double>::infinity() };
 #if ASSERT_ENABLED
     LayerListMutationDetector mutationChecker(*this);
 #endif
@@ -4084,24 +4100,30 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
     auto offsetFromRoot = offsetFromAncestor(rootLayer);
     // FIXME: We need to correctly hit test the clip-path when we have a RenderInline too.
     if (auto* rendererBox = this->renderBox(); rendererBox && !rendererBox->hitTestClipPath(hitTestLocation, toLayoutPoint(offsetFromRoot - toLayoutSize(rendererLocation()))))
-        return nullptr;
+        return { nullptr };
 
     // Begin by walking our list of positive layers from highest z-index down to the lowest z-index.
-    auto* hitLayer = hitTestList(positiveZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation,
-                                        localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
-    if (hitLayer) {
+    auto hitLayer = hitTestList(positiveZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+    if (hitLayer.layer) {
         if (!depthSortDescendants)
             return hitLayer;
-        candidateLayer = hitLayer;
+        if (using3DTransformsInterop) {
+            if (hitLayer.zOffset > candidateLayer.zOffset)
+                candidateLayer = hitLayer;
+        } else
+            candidateLayer = hitLayer;
     }
 
     // Now check our overflow objects.
-    hitLayer = hitTestList(normalFlowLayers(), rootLayer, request, result, hitTestRect, hitTestLocation,
-                           localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
-    if (hitLayer) {
+    hitLayer = hitTestList(normalFlowLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+    if (hitLayer.layer) {
         if (!depthSortDescendants)
             return hitLayer;
-        candidateLayer = hitLayer;
+        if (using3DTransformsInterop) {
+            if (hitLayer.zOffset > candidateLayer.zOffset)
+                candidateLayer = hitLayer;
+        } else
+            candidateLayer = hitLayer;
     }
 
     // Collect the fragments. This will compute the clip rectangles for each layer fragment.
@@ -4111,8 +4133,14 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
     LayoutPoint localPoint;
     if (canResize() && m_scrollableArea && m_scrollableArea->hitTestResizerInFragments(layerFragments, hitTestLocation, localPoint)) {
         renderer().updateHitTestResult(result, localPoint);
-        return this;
+        return { this, selfZOffset };
     }
+
+    auto isHitCandidate = [&]() {
+        if (using3DTransformsInterop)
+            return !depthSortDescendants || selfZOffset > candidateLayer.zOffset;
+        return isHitCandidateLegacy(this, false, zOffsetForContentsPtr, unflattenedTransformState.get());
+    };
 
     // Next we want to see if the mouse pos is inside the child RenderObjects of the layer. Check
     // every fragment in reverse order.
@@ -4120,49 +4148,52 @@ RenderLayer* RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLayer* cont
         // Hit test with a temporary HitTestResult, because we only want to commit to 'result' if we know we're frontmost.
         HitTestResult tempResult(result.hitTestLocation());
         bool insideFragmentForegroundRect = false;
-        if (hitTestContentsForFragments(layerFragments, request, tempResult, hitTestLocation, HitTestDescendants, insideFragmentForegroundRect)
-            && isHitCandidate(this, false, zOffsetForContentsPtr, unflattenedTransformState.get())) {
+        if (hitTestContentsForFragments(layerFragments, request, tempResult, hitTestLocation, HitTestDescendants, insideFragmentForegroundRect) && isHitCandidate()) {
             if (request.resultIsElementList())
                 result.append(tempResult, request);
             else
                 result = tempResult;
             if (!depthSortDescendants)
-                return this;
+                return { this, selfZOffset };
             // Foreground can depth-sort with descendant layers, so keep this as a candidate.
-            candidateLayer = this;
+            candidateLayer = { this, selfZOffset };
         } else if (insideFragmentForegroundRect && request.resultIsElementList())
             result.append(tempResult, request);
     }
 
     // Now check our negative z-index children.
-    hitLayer = hitTestList(negativeZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation,
-        localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
-    if (hitLayer) {
+    hitLayer = hitTestList(negativeZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, zOffset, unflattenedTransformState.get(), depthSortDescendants);
+    if (hitLayer.layer) {
         if (!depthSortDescendants)
             return hitLayer;
-        candidateLayer = hitLayer;
+        if (using3DTransformsInterop) {
+            if (hitLayer.zOffset > candidateLayer.zOffset)
+                candidateLayer = hitLayer;
+        } else
+            candidateLayer = hitLayer;
     }
 
     // If we found a layer, return. Child layers, and foreground always render in front of background.
-    if (candidateLayer)
+    if (candidateLayer.layer && (!depthSortDescendants || !using3DTransformsInterop))
         return candidateLayer;
 
     if (isSelfPaintingLayer()) {
         HitTestResult tempResult(result.hitTestLocation());
         bool insideFragmentBackgroundRect = false;
-        if (hitTestContentsForFragments(layerFragments, request, tempResult, hitTestLocation, HitTestSelf, insideFragmentBackgroundRect)
-            && isHitCandidate(this, false, zOffsetForContentsPtr, unflattenedTransformState.get())) {
+            if (hitTestContentsForFragments(layerFragments, request, tempResult, hitTestLocation, HitTestSelf, insideFragmentBackgroundRect)  && isHitCandidate()) {
             if (request.resultIsElementList())
                 result.append(tempResult, request);
             else
                 result = tempResult;
-            return this;
+            if (!depthSortDescendants)
+                return { this, selfZOffset };
+            candidateLayer = { this, selfZOffset };
         }
         if (insideFragmentBackgroundRect && request.resultIsElementList())
             result.append(tempResult, request);
     }
 
-    return nullptr;
+    return candidateLayer;
 }
 
 bool RenderLayer::hitTestContentsForFragments(const LayerFragments& layerFragments, const HitTestRequest& request, HitTestResult& result,
@@ -4184,7 +4215,7 @@ bool RenderLayer::hitTestContentsForFragments(const LayerFragments& layerFragmen
     return false;
 }
 
-RenderLayer* RenderLayer::hitTestTransformedLayerInFragments(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest& request, HitTestResult& result,
+RenderLayer::HitLayer RenderLayer::hitTestTransformedLayerInFragments(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest& request, HitTestResult& result,
     const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation, const HitTestingTransformState* transformState, double* zOffset)
 {
     LayerFragments enclosingPaginationFragments;
@@ -4214,25 +4245,24 @@ RenderLayer* RenderLayer::hitTestTransformedLayerInFragments(RenderLayer* rootLa
         if (!hitTestLocation.intersects(clipRect))
             continue;
 
-        RenderLayer* hitLayer = hitTestLayerByApplyingTransform(rootLayer, containerLayer, request, result, hitTestRect, hitTestLocation,
+        auto hitLayer = hitTestLayerByApplyingTransform(rootLayer, containerLayer, request, result, hitTestRect, hitTestLocation,
             transformState, zOffset, fragment.paginationOffset);
-        if (hitLayer)
+        if (hitLayer.layer)
             return hitLayer;
     }
     
-    return nullptr;
+    return { nullptr };
 }
 
-RenderLayer* RenderLayer::hitTestLayerByApplyingTransform(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest& request, HitTestResult& result,
-    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation, const HitTestingTransformState* transformState, double* zOffset,
-    const LayoutSize& translationOffset)
+RenderLayer::HitLayer RenderLayer::hitTestLayerByApplyingTransform(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest& request, HitTestResult& result,
+    const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation, const HitTestingTransformState* transformState, double* zOffset, const LayoutSize& translationOffset)
 {
     // Create a transform state to accumulate this transform.
     Ref<HitTestingTransformState> newTransformState = createLocalTransformState(rootLayer, containerLayer, hitTestRect, hitTestLocation, transformState, translationOffset);
 
     // If the transform can't be inverted, then don't hit test this layer at all.
     if (!newTransformState->m_accumulatedTransform.isInvertible())
-        return nullptr;
+        return { nullptr };
 
     // Compute the point and the hit test rect in the coords of this layer by using the values
     // from the transformState, which store the point and quad in the coords of the last flattened
@@ -4279,27 +4309,35 @@ bool RenderLayer::hitTestContents(const HitTestRequest& request, HitTestResult& 
     return true;
 }
 
-RenderLayer* RenderLayer::hitTestList(LayerList layerIterator, RenderLayer* rootLayer,
-                                      const HitTestRequest& request, HitTestResult& result,
-                                      const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation,
-                                      const HitTestingTransformState* transformState, 
-                                      double* zOffsetForDescendants, double* zOffset,
-                                      const HitTestingTransformState* unflattenedTransformState,
-                                      bool depthSortDescendants)
+RenderLayer::HitLayer RenderLayer::hitTestList(LayerList layerIterator, RenderLayer* rootLayer, const HitTestRequest& request, HitTestResult& result, const LayoutRect& hitTestRect, const HitTestLocation& hitTestLocation, const HitTestingTransformState* transformState, double* zOffsetForDescendants, double* zOffset, const HitTestingTransformState* unflattenedTransformState, bool depthSortDescendants)
 {
     if (layerIterator.begin() == layerIterator.end())
-        return nullptr;
+        return { nullptr };
 
     if (!hasSelfPaintingLayerDescendant())
-        return nullptr;
+        return { nullptr };
 
-    RenderLayer* resultLayer = nullptr;
+    auto resultLayer = HitLayer { nullptr, -std::numeric_limits<double>::infinity() };
 
+    RefPtr<HitTestingTransformState> flattenedTransformState;
+    double unflattenedZOffset = 0;
     for (auto iter = layerIterator.rbegin(); iter != layerIterator.rend(); ++iter) {
         auto* childLayer = *iter;
 
+        // If we're about to cross a flattening boundary, then pass the (lazily-initialized)
+        // flattened transfomState to the child layer.
+        auto* transformStateForChild = transformState;
+        if (transformState && !childLayer->participatesInPreserve3D() && renderer().settings().css3DTransformInteroperabilityEnabled()) {
+            if (!flattenedTransformState) {
+                flattenedTransformState = HitTestingTransformState::create(*transformState);
+                flattenedTransformState->flatten();
+                unflattenedZOffset = computeZOffset(*transformState);
+            }
+            transformStateForChild = flattenedTransformState.get();
+        }
+
         HitTestResult tempResult(result.hitTestLocation());
-        auto* hitLayer = childLayer->hitTestLayer(rootLayer, this, request, tempResult, hitTestRect, hitTestLocation, false, transformState, zOffsetForDescendants);
+        auto hitLayer = childLayer->hitTestLayer(rootLayer, this, request, tempResult, hitTestRect, hitTestLocation, false, transformStateForChild, zOffsetForDescendants);
 
         // If it is a list-based test, we can safely append the temporary result since it might had hit
         // nodes but not necessarily had hitLayer set.
@@ -4307,12 +4345,29 @@ RenderLayer* RenderLayer::hitTestList(LayerList layerIterator, RenderLayer* root
         if (request.resultIsElementList())
             result.append(tempResult, request);
 
-        if (isHitCandidate(hitLayer, depthSortDescendants, zOffset, unflattenedTransformState)) {
-            resultLayer = hitLayer;
-            if (!request.resultIsElementList())
-                result = tempResult;
-            if (!depthSortDescendants)
-                break;
+        if (renderer().settings().css3DTransformInteroperabilityEnabled()) {
+            if (hitLayer.layer) {
+                // If the child was flattened, then override the returned depth with the depth of the
+                // plane we flattened into (ourselves) instead.
+                if (transformStateForChild == flattenedTransformState)
+                    hitLayer.zOffset = unflattenedZOffset;
+
+                if (!depthSortDescendants || hitLayer.zOffset > resultLayer.zOffset) {
+                    resultLayer = hitLayer;
+                    if (!request.resultIsElementList())
+                        result = tempResult;
+                    if (!depthSortDescendants)
+                        break;
+                }
+            }
+        } else {
+            if (isHitCandidateLegacy(hitLayer.layer, depthSortDescendants, zOffset, unflattenedTransformState)) {
+                resultLayer = hitLayer;
+                if (!request.resultIsElementList())
+                    result = tempResult;
+                if (!depthSortDescendants)
+                    break;
+            }
         }
     }
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -755,6 +755,7 @@ public:
     bool hasPerspective() const { return renderer().style().hasPerspective(); }
     bool has3DTransform() const { return m_transform && !m_transform->isAffine(); }
     bool hasTransformedAncestor() const { return m_hasTransformedAncestor; }
+    bool participatesInPreserve3D() const;
 
     bool hasFixedContainingBlockAncestor() const { return m_hasFixedContainingBlockAncestor; }
 
@@ -1108,13 +1109,17 @@ private:
     RenderLayer* transparentPaintingAncestor();
     void beginTransparencyLayers(GraphicsContext&, const LayerPaintingInfo&, const LayoutRect& dirtyRect);
 
-    RenderLayer* hitTestLayer(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest&, HitTestResult&,
+    struct HitLayer {
+        RenderLayer* layer;
+        double zOffset = 0;
+    };
+    HitLayer hitTestLayer(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest&, HitTestResult&,
         const LayoutRect& hitTestRect, const HitTestLocation&, bool appliedTransform,
         const HitTestingTransformState* = nullptr, double* zOffset = nullptr);
-    RenderLayer* hitTestLayerByApplyingTransform(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest&, HitTestResult&,
+    HitLayer hitTestLayerByApplyingTransform(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest&, HitTestResult&,
         const LayoutRect& hitTestRect, const HitTestLocation&, const HitTestingTransformState* = nullptr, double* zOffset = nullptr,
         const LayoutSize& translationOffset = LayoutSize());
-    RenderLayer* hitTestList(LayerList, RenderLayer* rootLayer, const HitTestRequest&, HitTestResult&,
+    HitLayer hitTestList(LayerList, RenderLayer* rootLayer, const HitTestRequest&, HitTestResult&,
         const LayoutRect& hitTestRect, const HitTestLocation&,
         const HitTestingTransformState*, double* zOffsetForDescendants, double* zOffset,
         const HitTestingTransformState* unflattenedTransformState, bool depthSortDescendants);
@@ -1126,7 +1131,7 @@ private:
     
     bool hitTestContents(const HitTestRequest&, HitTestResult&, const LayoutRect& layerBounds, const HitTestLocation&, HitTestFilter) const;
     bool hitTestContentsForFragments(const LayerFragments&, const HitTestRequest&, HitTestResult&, const HitTestLocation&, HitTestFilter, bool& insideClipRect) const;
-    RenderLayer* hitTestTransformedLayerInFragments(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest&, HitTestResult&,
+    HitLayer hitTestTransformedLayerInFragments(RenderLayer* rootLayer, RenderLayer* containerLayer, const HitTestRequest&, HitTestResult&,
         const LayoutRect& hitTestRect, const HitTestLocation&, const HitTestingTransformState* = nullptr, double* zOffset = nullptr);
 
     bool listBackgroundIsKnownToBeOpaqueInRect(const LayerList&, const LayoutRect&) const;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1459,7 +1459,14 @@ void RenderObject::mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode> mode, T
 bool RenderObject::shouldUseTransformFromContainer(const RenderObject* containerObject) const
 {
 #if ENABLE(3D_TRANSFORMS)
-    return hasTransform() || (containerObject && containerObject->style().hasPerspective());
+    if (hasTransform())
+        return true;
+    if (containerObject && containerObject->style().hasPerspective()) {
+        if (settings().css3DTransformInteroperabilityEnabled())
+            return containerObject == parent();
+        return true;
+    }
+    return false;
 #else
     UNUSED_PARAM(containerObject);
     return hasTransform();
@@ -1475,13 +1482,17 @@ void RenderObject::getTransformFromContainer(const RenderObject* containerObject
         transform.multiply(layer->currentTransform());
     
 #if ENABLE(3D_TRANSFORMS)
-    if (containerObject && containerObject->hasLayer() && containerObject->style().hasPerspective()) {
+    const RenderObject* perspectiveObject = containerObject;
+    if (settings().css3DTransformInteroperabilityEnabled())
+        perspectiveObject = parent();
+
+    if (perspectiveObject && perspectiveObject->hasLayer() && perspectiveObject->style().hasPerspective()) {
         // Perpsective on the container affects us, so we have to factor it in here.
-        ASSERT(containerObject->hasLayer());
-        FloatPoint perspectiveOrigin = downcast<RenderLayerModelObject>(*containerObject).layer()->perspectiveOrigin();
+        ASSERT(perspectiveObject->hasLayer());
+        FloatPoint perspectiveOrigin = downcast<RenderLayerModelObject>(*perspectiveObject).layer()->perspectiveOrigin();
 
         TransformationMatrix perspectiveMatrix;
-        perspectiveMatrix.applyPerspective(containerObject->style().usedPerspective());
+        perspectiveMatrix.applyPerspective(perspectiveObject->style().usedPerspective());
         
         transform.translateRight3d(-perspectiveOrigin.x(), -perspectiveOrigin.y(), 0);
         transform = perspectiveMatrix * transform;


### PR DESCRIPTION
#### dc9396c615610f61cdefb62e3a014ee111ef3a76
<pre>
Implement hit-testing changes for transform-style:preserve-3d and perspective to only apply to direct DOM children.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248283">https://bugs.webkit.org/show_bug.cgi?id=248283</a>
rdar://problem/102632592&gt;

Reviewed by Simon Fraser.

Unfortunately this is fairly complex, due to needing to support both the new and old behaviour and switch at runtime.

The new behaviour is that all hit-testing methods return both the hit layer, as well as the depth that it was hit at.
There&apos;s no shared mutable state between calls (zOffset, zOffsetForDescendantsPtr etc), and each function is separately
responsible for determing the frontmost layer if sorting is enabled for that context.

hitTestList detects when we&apos;re about to recurse into a child that doesn&apos;t share the same 3d coordinate space as the current
layer, and passes down a flattened transformState if so. It also then overrides the returned hit depth with that of the plane
that we flattened into.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:

New test passing, but also two newly failing due to point-mapping and hit-testing being out of sync.
These will be fixed in a follow-up to implement the point-mapping changes.

* LayoutTests/transforms/3d/hit-testing/overlapping-layers-hit-test-expected.txt:
* LayoutTests/transforms/3d/hit-testing/overlapping-layers-hit-test.html:

New subtest added that has a empty spacer div inbetween the element with preserve-3d and the transformed
descendants, confirms that we hit test this without the transform being accumulated.

* LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2-expected.txt: Added.
* LayoutTests/transforms/3d/hit-testing/rotated-hit-test-2.html: Added.

New test with perspective separated from the transformed descendant with a spacer.

* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-2.html:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTest):
(WebCore::parentLayerIsDOMParent):
(WebCore::isHitCandidateLegacy):
(WebCore::RenderLayer::participatesInPreserve3D const):
(WebCore::RenderLayer::hitTestLayer):
(WebCore::RenderLayer::hitTestTransformedLayerInFragments):
(WebCore::RenderLayer::hitTestLayerByApplyingTransform):
(WebCore::RenderLayer::hitTestList):
(WebCore::isHitCandidate): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::shouldUseTransformFromContainer const):
(WebCore::RenderObject::getTransformFromContainer const):

Only include the perspective transform if the container with perspective is
the direct DOM parent.

Canonical link: <a href="https://commits.webkit.org/257255@main">https://commits.webkit.org/257255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fff444849ea56e81752d7238a3e6617de880505

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107652 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167931 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7898 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36170 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104238 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5934 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84787 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33046 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89513 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1368 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20945 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4997 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6201 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44958 "Found 2 new test failures: http/wpt/service-workers/fetch-service-worker-preload-download.https.html, http/wpt/service-workers/fetch-service-worker-preload.https.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41872 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->