### PR TITLE
Make TransformState changes to support transform-style:preserve-3d and perspective only apply to direct DOM children.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior-expected.txt
@@ -3,8 +3,8 @@ PASS Direct DOM parent is root of rendering context (normal flow)
 PASS Direct DOM parent is root of rendering context (absolute)
 PASS Direct DOM parent is root of rendering context (fixed)
 PASS Intermediate DOM nodes cause rendering context to end (normal flow)
-FAIL Intermediate DOM nodes cause rendering context to end (absolute) assert_equals: expected 100 but got 200
-FAIL Intermediate DOM nodes cause rendering context to end (fixed) assert_equals: expected 100 but got 200
+PASS Intermediate DOM nodes cause rendering context to end (absolute)
+PASS Intermediate DOM nodes cause rendering context to end (fixed)
 PASS Perspective applies to direct DOM normal-flow children
 PASS Perspective applies to direct DOM abs-pos children
 PASS Perspective applies to direct DOM fixed-pos children

--- a/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 785x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 496x108
-  RenderBlock (positioned) {DIV} at (30,500) size 496x108
+layer at (30,500) size 328x108
+  RenderBlock (positioned) {DIV} at (30,500) size 329x108
     RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
       RenderText {#text} at (0,0) size 313x17
         text run at (0,0) width 313: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
@@ -26,18 +26,18 @@ layer at (30,500) size 496x108
       RenderText {#text} at (0,36) size 305x17
         text run at (0,36) width 305: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (304,36) size 1x17
-    RenderInline {SPAN} at (0,0) size 480x17 [color=#FF0000]
-      RenderText {#text} at (0,54) size 480x17
-        text run at (0,54) width 480: "FAIL: event at (359, 87) expected to hit box8 at (2, 2) but hit box8 at (13, 3)"
-    RenderBR {BR} at (479,54) size 1x17
+    RenderInline {SPAN} at (0,0) size 305x17 [color=#008000]
+      RenderText {#text} at (0,54) size 305x17
+        text run at (0,54) width 305: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+    RenderBR {BR} at (304,54) size 1x17
     RenderInline {SPAN} at (0,0) size 312x17 [color=#008000]
       RenderText {#text} at (0,72) size 312x17
         text run at (0,72) width 312: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
     RenderBR {BR} at (311,72) size 1x17
-    RenderInline {SPAN} at (0,0) size 496x17 [color=#FF0000]
-      RenderText {#text} at (0,90) size 496x17
-        text run at (0,90) width 496: "FAIL: event at (605, 87) expected to hit box12 at (2, 2) but hit box12 at (13, 3)"
-    RenderBR {BR} at (495,90) size 1x17
+    RenderInline {SPAN} at (0,0) size 313x17 [color=#008000]
+      RenderText {#text} at (0,90) size 313x17
+        text run at (0,90) width 313: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+    RenderBR {BR} at (312,90) size 1x17
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt
+++ b/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt
@@ -1,0 +1,53 @@
+layer at (0,0) size 852x644
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x585
+  RenderBlock {HTML} at (0,0) size 785x585
+    RenderBody {BODY} at (8,8) size 769x569
+layer at (30,500) size 339x144
+  RenderBlock (positioned) {DIV} at (30,500) size 340x144
+    RenderInline {SPAN} at (0,0) size 307x17 [color=#008000]
+      RenderText {#text} at (0,0) size 307x17
+        text run at (0,0) width 307: "PASS: event at (170, 112) hit card at offset (2, 2)"
+    RenderBR {BR} at (306,0) size 1x17
+    RenderInline {SPAN} at (0,0) size 323x17 [color=#008000]
+      RenderText {#text} at (0,18) size 323x17
+        text run at (0,18) width 323: "PASS: event at (309, 112) hit card at offset (199, 2)"
+    RenderBR {BR} at (322,18) size 1x17
+    RenderInline {SPAN} at (0,0) size 324x17 [color=#008000]
+      RenderText {#text} at (0,36) size 324x17
+        text run at (0,36) width 324: "PASS: event at (170, 308) hit card at offset (2, 198)"
+    RenderBR {BR} at (323,36) size 1x17
+    RenderInline {SPAN} at (0,0) size 340x17 [color=#008000]
+      RenderText {#text} at (0,54) size 340x17
+        text run at (0,54) width 340: "PASS: event at (309, 308) hit card at offset (199, 198)"
+    RenderBR {BR} at (339,54) size 1x17
+    RenderInline {SPAN} at (0,0) size 307x17 [color=#008000]
+      RenderText {#text} at (0,72) size 307x17
+        text run at (0,72) width 307: "PASS: event at (612, 112) hit card at offset (2, 2)"
+    RenderBR {BR} at (306,72) size 1x17
+    RenderInline {SPAN} at (0,0) size 323x17 [color=#008000]
+      RenderText {#text} at (0,90) size 323x17
+        text run at (0,90) width 323: "PASS: event at (751, 112) hit card at offset (199, 2)"
+    RenderBR {BR} at (322,90) size 1x17
+    RenderInline {SPAN} at (0,0) size 324x17 [color=#008000]
+      RenderText {#text} at (0,108) size 324x17
+        text run at (0,108) width 324: "PASS: event at (612, 308) hit card at offset (2, 198)"
+    RenderBR {BR} at (323,108) size 1x17
+    RenderInline {SPAN} at (0,0) size 340x17 [color=#008000]
+      RenderText {#text} at (0,126) size 340x17
+        text run at (0,126) width 340: "PASS: event at (751, 308) hit card at offset (199, 198)"
+    RenderBR {BR} at (339,126) size 1x17
+layer at (8,8) size 402x402
+  RenderBlock (positioned) {DIV} at (8,8) size 402x402 [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 400x0
+layer at (59,59) size 302x302
+  RenderBlock (positioned) {DIV} at (51,51) size 302x302 [border: (1px solid #0000FF)]
+layer at (110,110) size 200x200
+  RenderBlock (positioned) {DIV} at (51,51) size 200x200 [bgcolor=#81AA8A]
+layer at (450,8) size 402x402
+  RenderBlock (positioned) {DIV} at (450,8) size 402x402 [border: (1px solid #000000)]
+layer at (501,59) size 302x302
+  RenderBlock (positioned) {DIV} at (51,51) size 302x302 [border: (1px solid #0000FF)]
+    RenderBlock {DIV} at (1,1) size 300x0
+layer at (552,110) size 200x200
+  RenderBlock (positioned) {DIV} at (51,51) size 200x200 [bgcolor=#81AA8A]

--- a/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -46,6 +46,8 @@ layer at (21,21) size 202x202
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100
+  RenderBlock (positioned) {DIV} at (21,21) size 100x100 [bgcolor=#FF0000] [border: (1px solid #000000)]
+layer at (63,63) size 100x100
   RenderBlock (relative positioned) {DIV} at (21,21) size 100x100 [bgcolor=#AAAAAA] [border: (1px solid #000000)]
 layer at (267,21) size 202x202
   RenderBlock (positioned) {DIV} at (267,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 800x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 504x120
-  RenderBlock (positioned) {DIV} at (30,500) size 504x120
+layer at (30,500) size 333x120
+  RenderBlock (positioned) {DIV} at (30,500) size 334x120
     RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
       RenderText {#text} at (0,0) size 318x19
         text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
@@ -26,18 +26,18 @@ layer at (30,500) size 504x120
       RenderText {#text} at (0,40) size 310x19
         text run at (0,40) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (309,40) size 1x19
-    RenderInline {SPAN} at (0,0) size 488x19 [color=#FF0000]
-      RenderText {#text} at (0,60) size 488x19
-        text run at (0,60) width 488: "FAIL: event at (359, 87) expected to hit box8 at (2, 2) but hit box8 at (13, 3)"
-    RenderBR {BR} at (487,60) size 1x19
+    RenderInline {SPAN} at (0,0) size 310x19 [color=#008000]
+      RenderText {#text} at (0,60) size 310x19
+        text run at (0,60) width 310: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+    RenderBR {BR} at (309,60) size 1x19
     RenderInline {SPAN} at (0,0) size 317x19 [color=#008000]
       RenderText {#text} at (0,80) size 317x19
         text run at (0,80) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
     RenderBR {BR} at (316,80) size 1x19
-    RenderInline {SPAN} at (0,0) size 504x19 [color=#FF0000]
-      RenderText {#text} at (0,100) size 504x19
-        text run at (0,100) width 504: "FAIL: event at (605, 87) expected to hit box12 at (2, 2) but hit box12 at (13, 3)"
-    RenderBR {BR} at (503,100) size 1x19
+    RenderInline {SPAN} at (0,0) size 318x19 [color=#008000]
+      RenderText {#text} at (0,100) size 318x19
+        text run at (0,100) width 318: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+    RenderBR {BR} at (317,100) size 1x19
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt
@@ -1,0 +1,53 @@
+layer at (0,0) size 852x660
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+layer at (30,500) size 345x160
+  RenderBlock (positioned) {DIV} at (30,500) size 345x160
+    RenderInline {SPAN} at (0,0) size 313x19 [color=#008000]
+      RenderText {#text} at (0,0) size 313x19
+        text run at (0,0) width 313: "PASS: event at (170, 112) hit card at offset (2, 2)"
+    RenderBR {BR} at (312,0) size 1x19
+    RenderInline {SPAN} at (0,0) size 329x19 [color=#008000]
+      RenderText {#text} at (0,20) size 329x19
+        text run at (0,20) width 329: "PASS: event at (309, 112) hit card at offset (199, 2)"
+    RenderBR {BR} at (328,20) size 1x19
+    RenderInline {SPAN} at (0,0) size 329x19 [color=#008000]
+      RenderText {#text} at (0,40) size 329x19
+        text run at (0,40) width 329: "PASS: event at (170, 308) hit card at offset (2, 198)"
+    RenderBR {BR} at (328,40) size 1x19
+    RenderInline {SPAN} at (0,0) size 345x19 [color=#008000]
+      RenderText {#text} at (0,60) size 345x19
+        text run at (0,60) width 345: "PASS: event at (309, 308) hit card at offset (199, 198)"
+    RenderBR {BR} at (344,60) size 1x19
+    RenderInline {SPAN} at (0,0) size 313x19 [color=#008000]
+      RenderText {#text} at (0,80) size 313x19
+        text run at (0,80) width 313: "PASS: event at (612, 112) hit card at offset (2, 2)"
+    RenderBR {BR} at (312,80) size 1x19
+    RenderInline {SPAN} at (0,0) size 329x19 [color=#008000]
+      RenderText {#text} at (0,100) size 329x19
+        text run at (0,100) width 329: "PASS: event at (751, 112) hit card at offset (199, 2)"
+    RenderBR {BR} at (328,100) size 1x19
+    RenderInline {SPAN} at (0,0) size 329x19 [color=#008000]
+      RenderText {#text} at (0,120) size 329x19
+        text run at (0,120) width 329: "PASS: event at (612, 308) hit card at offset (2, 198)"
+    RenderBR {BR} at (328,120) size 1x19
+    RenderInline {SPAN} at (0,0) size 345x19 [color=#008000]
+      RenderText {#text} at (0,140) size 345x19
+        text run at (0,140) width 345: "PASS: event at (751, 308) hit card at offset (199, 198)"
+    RenderBR {BR} at (344,140) size 1x19
+layer at (8,8) size 402x402
+  RenderBlock (positioned) {DIV} at (8,8) size 402x402 [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 400x0
+layer at (59,59) size 302x302
+  RenderBlock (positioned) {DIV} at (51,51) size 302x302 [border: (1px solid #0000FF)]
+layer at (110,110) size 200x200
+  RenderBlock (positioned) {DIV} at (51,51) size 200x200 [bgcolor=#81AA8A]
+layer at (450,8) size 402x402
+  RenderBlock (positioned) {DIV} at (450,8) size 402x402 [border: (1px solid #000000)]
+layer at (501,59) size 302x302
+  RenderBlock (positioned) {DIV} at (51,51) size 302x302 [border: (1px solid #0000FF)]
+    RenderBlock {DIV} at (1,1) size 300x0
+layer at (552,110) size 200x200
+  RenderBlock (positioned) {DIV} at (51,51) size 200x200 [bgcolor=#81AA8A]

--- a/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -46,6 +46,8 @@ layer at (21,21) size 202x202
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100
+  RenderBlock (positioned) {DIV} at (21,21) size 100x100 [bgcolor=#FF0000] [border: (1px solid #000000)]
+layer at (63,63) size 100x100
   RenderBlock (relative positioned) {DIV} at (21,21) size 100x100 [bgcolor=#AAAAAA] [border: (1px solid #000000)]
 layer at (267,21) size 202x202
   RenderBlock (positioned) {DIV} at (267,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt
@@ -12,8 +12,8 @@ layer at (0,0) size 785x600
       RenderBlock {DIV} at (513,21) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
-layer at (30,500) size 504x108
-  RenderBlock (positioned) {DIV} at (30,500) size 504x108
+layer at (30,500) size 333x108
+  RenderBlock (positioned) {DIV} at (30,500) size 334x108
     RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
       RenderText {#text} at (0,0) size 318x18
         text run at (0,0) width 318: "PASS: event at (120, 128) hit box4 at offset (2, 2)"
@@ -26,18 +26,18 @@ layer at (30,500) size 504x108
       RenderText {#text} at (0,36) size 310x18
         text run at (0,36) width 310: "PASS: event at (336, 87) hit box7 at offset (2, 2)"
     RenderBR {BR} at (309,36) size 1x18
-    RenderInline {SPAN} at (0,0) size 488x18 [color=#FF0000]
-      RenderText {#text} at (0,54) size 488x18
-        text run at (0,54) width 488: "FAIL: event at (359, 87) expected to hit box8 at (2, 2) but hit box8 at (13, 3)"
-    RenderBR {BR} at (487,54) size 1x18
+    RenderInline {SPAN} at (0,0) size 310x18 [color=#008000]
+      RenderText {#text} at (0,54) size 310x18
+        text run at (0,54) width 310: "PASS: event at (359, 87) hit box8 at offset (2, 2)"
+    RenderBR {BR} at (309,54) size 1x18
     RenderInline {SPAN} at (0,0) size 317x18 [color=#008000]
       RenderText {#text} at (0,72) size 317x18
         text run at (0,72) width 317: "PASS: event at (582, 87) hit box11 at offset (2, 2)"
     RenderBR {BR} at (316,72) size 1x18
-    RenderInline {SPAN} at (0,0) size 504x18 [color=#FF0000]
-      RenderText {#text} at (0,90) size 504x18
-        text run at (0,90) width 504: "FAIL: event at (605, 87) expected to hit box12 at (2, 2) but hit box12 at (13, 3)"
-    RenderBR {BR} at (503,90) size 1x18
+    RenderInline {SPAN} at (0,0) size 318x18 [color=#008000]
+      RenderText {#text} at (0,90) size 318x18
+        text run at (0,90) width 318: "PASS: event at (605, 87) hit box12 at offset (2, 2)"
+    RenderBR {BR} at (317,90) size 1x18
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt
@@ -1,0 +1,53 @@
+layer at (0,0) size 852x644
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x585
+  RenderBlock {HTML} at (0,0) size 785x585
+    RenderBody {BODY} at (8,8) size 769x569
+layer at (30,500) size 345x144
+  RenderBlock (positioned) {DIV} at (30,500) size 345x144
+    RenderInline {SPAN} at (0,0) size 313x18 [color=#008000]
+      RenderText {#text} at (0,0) size 313x18
+        text run at (0,0) width 313: "PASS: event at (170, 112) hit card at offset (2, 2)"
+    RenderBR {BR} at (312,0) size 1x18
+    RenderInline {SPAN} at (0,0) size 329x18 [color=#008000]
+      RenderText {#text} at (0,18) size 329x18
+        text run at (0,18) width 329: "PASS: event at (309, 112) hit card at offset (199, 2)"
+    RenderBR {BR} at (328,18) size 1x18
+    RenderInline {SPAN} at (0,0) size 329x18 [color=#008000]
+      RenderText {#text} at (0,36) size 329x18
+        text run at (0,36) width 329: "PASS: event at (170, 308) hit card at offset (2, 198)"
+    RenderBR {BR} at (328,36) size 1x18
+    RenderInline {SPAN} at (0,0) size 345x18 [color=#008000]
+      RenderText {#text} at (0,54) size 345x18
+        text run at (0,54) width 345: "PASS: event at (309, 308) hit card at offset (199, 198)"
+    RenderBR {BR} at (344,54) size 1x18
+    RenderInline {SPAN} at (0,0) size 313x18 [color=#008000]
+      RenderText {#text} at (0,72) size 313x18
+        text run at (0,72) width 313: "PASS: event at (612, 112) hit card at offset (2, 2)"
+    RenderBR {BR} at (312,72) size 1x18
+    RenderInline {SPAN} at (0,0) size 329x18 [color=#008000]
+      RenderText {#text} at (0,90) size 329x18
+        text run at (0,90) width 329: "PASS: event at (751, 112) hit card at offset (199, 2)"
+    RenderBR {BR} at (328,90) size 1x18
+    RenderInline {SPAN} at (0,0) size 329x18 [color=#008000]
+      RenderText {#text} at (0,108) size 329x18
+        text run at (0,108) width 329: "PASS: event at (612, 308) hit card at offset (2, 198)"
+    RenderBR {BR} at (328,108) size 1x18
+    RenderInline {SPAN} at (0,0) size 345x18 [color=#008000]
+      RenderText {#text} at (0,126) size 345x18
+        text run at (0,126) width 345: "PASS: event at (751, 308) hit card at offset (199, 198)"
+    RenderBR {BR} at (344,126) size 1x18
+layer at (8,8) size 402x402
+  RenderBlock (positioned) {DIV} at (8,8) size 402x402 [border: (1px solid #000000)]
+    RenderBlock {DIV} at (1,1) size 400x0
+layer at (59,59) size 302x302
+  RenderBlock (positioned) {DIV} at (51,51) size 302x302 [border: (1px solid #0000FF)]
+layer at (110,110) size 200x200
+  RenderBlock (positioned) {DIV} at (51,51) size 200x200 [bgcolor=#81AA8A]
+layer at (450,8) size 402x402
+  RenderBlock (positioned) {DIV} at (450,8) size 402x402 [border: (1px solid #000000)]
+layer at (501,59) size 302x302
+  RenderBlock (positioned) {DIV} at (51,51) size 302x302 [border: (1px solid #0000FF)]
+    RenderBlock {DIV} at (1,1) size 300x0
+layer at (552,110) size 200x200
+  RenderBlock (positioned) {DIV} at (51,51) size 200x200 [bgcolor=#81AA8A]

--- a/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-expected.txt
+++ b/LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-expected.txt
@@ -46,6 +46,8 @@ layer at (21,21) size 202x202
 layer at (42,42) size 140x140
   RenderBlock {DIV} at (21,21) size 140x140 [bgcolor=#DDDDDD] [border: (1px solid #000000)]
 layer at (63,63) size 100x100
+  RenderBlock (positioned) {DIV} at (21,21) size 100x100 [bgcolor=#FF0000] [border: (1px solid #000000)]
+layer at (63,63) size 100x100
   RenderBlock (relative positioned) {DIV} at (21,21) size 100x100 [bgcolor=#AAAAAA] [border: (1px solid #000000)]
 layer at (267,21) size 202x202
   RenderBlock (positioned) {DIV} at (267,21) size 202x202 [border: (1px solid #000000)]

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-4.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping-4.html
@@ -10,10 +10,15 @@
       if (!window.testRunner)
         document.body.addEventListener('mousemove', mousemoved, false);
 
-      dispatchEvent(158, 83, 'card', 2, 2);
-      dispatchEvent(309, 112, 'card', 198, 2);
-      dispatchEvent(158, 338, 'card', 2, 198);
-      dispatchEvent(309, 308, 'card', 198, 198);
+      dispatchEvent(170, 112, 'card', 2, 2);
+      dispatchEvent(309, 112, 'card', 199, 2);
+      dispatchEvent(170, 308, 'card', 2, 198);
+      dispatchEvent(309, 308, 'card', 199, 198);
+
+      dispatchEvent(612, 112, 'card', 2, 2);
+      dispatchEvent(751, 112, 'card', 199, 2);
+      dispatchEvent(612, 308, 'card', 2, 198);
+      dispatchEvent(751, 308, 'card', 199, 198);
     }
   </script>
   <style type="text/css" media="screen">
@@ -26,6 +31,10 @@
     -webkit-transform-style: preserve-3d;
   }
 
+  .two {
+    left: 450px;
+  }
+
   #container {
     position: absolute;
     height: 300px;
@@ -34,7 +43,7 @@
     border: 1px solid blue;
     -webkit-transform-style: preserve-3d;
   }
-  
+
   #card {
     position: absolute;
     top: 50px;
@@ -45,7 +54,7 @@
     -webkit-transform-origin: right top;
     -webkit-transform: rotateY(45deg);
   }
-  
+
   #card:hover {
     background-color: orange;
   }
@@ -55,11 +64,11 @@
     left: 30px;
     top: 500px;
   }
-  
+
   #mousepos {
     position: absolute;
     left: 430px;
-    top: 400px;
+    top: 420px;
     color: gray;
     font-size: smaller;
   }
@@ -70,8 +79,18 @@
 <div id="results"></div>
 
 <div id="scene">
+  <div id="spacer">
+    <div id="container">
+      <div id="card"></div>
+    </div>
+  </div>
+</div>
+
+<div id="scene" class="two">
   <div id="container">
-    <div id="card"></div>
+    <div id="spacer">
+      <div id="card"></div>
+    </div>
   </div>
 </div>
 

--- a/LayoutTests/transforms/3d/point-mapping/3d-point-mapping.html
+++ b/LayoutTests/transforms/3d/point-mapping/3d-point-mapping.html
@@ -84,7 +84,13 @@
       -webkit-box-sizing: border-box;
       -webkit-transform: translateZ(100px) rotateY(-40deg);
     }
-    
+
+    .behind {
+      position: absolute;
+      -webkit-transform: translateZ(110px) rotateY(-40deg);
+      background-color: red;
+    }
+
     .layer {
       padding: 20px;
       background-color: #C0D69E;
@@ -116,6 +122,7 @@
 <div class="test one">
   <!-- Simple transformed div in perpsective -->
   <div class="container box" id="box1">
+    <div class="transformed box behind"></div>
     <div class="transformed box" id="box2">
     </div>
   </div>

--- a/LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors-expected.txt
+++ b/LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors-expected.txt
@@ -1,4 +1,4 @@
-FAIL child.getBoundingClientRect().width should be 100. Was 0.
+PASS child.getBoundingClientRect().width is 100
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1412,7 +1412,7 @@ FloatPoint GraphicsLayerCA::computePositionRelativeToBase(float& pageScale) cons
 
 void GraphicsLayerCA::flushCompositingState(const FloatRect& visibleRect)
 {
-    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
+    TransformState state(client().useCSS3DTransformInteroperability(), TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
     state.setSecondaryQuad(FloatQuad { visibleRect });
 
     CommitState commitState;
@@ -1496,7 +1496,7 @@ bool GraphicsLayerCA::recursiveVisibleRectChangeRequiresFlush(const CommitState&
 
 bool GraphicsLayerCA::visibleRectChangeRequiresFlush(const FloatRect& clipRect) const
 {
-    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(clipRect));
+    TransformState state(client().useCSS3DTransformInteroperability(), TransformState::UnapplyInverseTransformDirection, FloatQuad(clipRect));
     CommitState commitState;
     return recursiveVisibleRectChangeRequiresFlush(commitState, state);
 }

--- a/Source/WebCore/platform/graphics/transforms/TransformState.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.h
@@ -44,30 +44,33 @@ public:
     enum TransformAccumulation { FlattenTransform, AccumulateTransform };
     enum TransformMatrixTracking { DoNotTrackTransformMatrix, TrackSVGCTMMatrix, TrackSVGScreenCTMMatrix };
 
-    TransformState(TransformDirection mappingDirection, const FloatPoint& p, const FloatQuad& quad)
+    TransformState(bool useCSS3DTransformInterop, TransformDirection mappingDirection, const FloatPoint& p, const FloatQuad& quad)
         : m_lastPlanarPoint(p)
         , m_lastPlanarQuad(quad)
         , m_accumulatingTransform(false)
         , m_mapPoint(true)
         , m_mapQuad(true)
+        , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
         , m_direction(mappingDirection)
     {
     }
     
-    TransformState(TransformDirection mappingDirection, const FloatPoint& p)
+    TransformState(bool useCSS3DTransformInterop, TransformDirection mappingDirection, const FloatPoint& p)
         : m_lastPlanarPoint(p)
         , m_accumulatingTransform(false)
         , m_mapPoint(true)
         , m_mapQuad(false)
+        , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
         , m_direction(mappingDirection)
     {
     }
     
-    TransformState(TransformDirection mappingDirection, const FloatQuad& quad)
+    TransformState(bool useCSS3DTransformInterop, TransformDirection mappingDirection, const FloatQuad& quad)
         : m_lastPlanarQuad(quad)
         , m_accumulatingTransform(false)
         , m_mapPoint(false)
         , m_mapQuad(true)
+        , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
         , m_direction(mappingDirection)
     {
     }
@@ -125,6 +128,9 @@ private:
     void translateMappedCoordinates(const LayoutSize&);
     void flattenWithTransform(const TransformationMatrix&, bool* wasClamped);
     void applyAccumulatedOffset();
+
+    bool shouldFlattenBefore(TransformAccumulation accumulate);
+    bool shouldFlattenAfter(TransformAccumulation accumulate);
     
     TransformDirection inverseDirection() const;
 
@@ -141,6 +147,7 @@ private:
     bool m_accumulatingTransform;
     bool m_mapPoint;
     bool m_mapQuad;
+    bool m_useCSS3DTransformInterop;
     TransformMatrixTracking m_tracking { DoNotTrackTransformMatrix };
     TransformDirection m_direction;
 };

--- a/Source/WebCore/rendering/LayerOverlapMap.cpp
+++ b/Source/WebCore/rendering/LayerOverlapMap.cpp
@@ -279,7 +279,7 @@ String OverlapMapContainer::dump(unsigned indent) const
 }
 
 LayerOverlapMap::LayerOverlapMap(const RenderLayer& rootLayer)
-    : m_geometryMap(UseTransforms)
+    : m_geometryMap(UseTransforms, rootLayer.renderer().settings().css3DTransformInteroperabilityEnabled())
     , m_rootLayer(rootLayer)
 {
     // Begin assuming the root layer will be composited so that there is

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -34,8 +34,9 @@
 
 namespace WebCore {
 
-RenderGeometryMap::RenderGeometryMap(OptionSet<MapCoordinatesMode> flags)
+RenderGeometryMap::RenderGeometryMap(OptionSet<MapCoordinatesMode> flags, bool useCSS3DTransformInterop)
     : m_mapCoordinatesFlags(flags)
+    , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
 {
 }
 
@@ -107,7 +108,7 @@ FloatPoint RenderGeometryMap::mapToContainer(const FloatPoint& p, const RenderLa
         result.move(m_accumulatedOffset);
         ASSERT(m_accumulatedOffsetMightBeSaturated || areEssentiallyEqual(rendererMappedResult, result));
     } else {
-        TransformState transformState(TransformState::ApplyTransformDirection, p);
+        TransformState transformState(m_useCSS3DTransformInterop, TransformState::ApplyTransformDirection, p);
         mapToContainer(transformState, container);
         result = transformState.lastPlanarPoint();
         ASSERT(areEssentiallyEqual(rendererMappedResult, result));
@@ -124,7 +125,7 @@ FloatQuad RenderGeometryMap::mapToContainer(const FloatRect& rect, const RenderL
         result = rect;
         result.move(m_accumulatedOffset);
     } else {
-        TransformState transformState(TransformState::ApplyTransformDirection, rect.center(), rect);
+        TransformState transformState(m_useCSS3DTransformInterop, TransformState::ApplyTransformDirection, rect.center(), rect);
         mapToContainer(transformState, container);
         result = transformState.lastPlanarQuad();
     }

--- a/Source/WebCore/rendering/RenderGeometryMap.h
+++ b/Source/WebCore/rendering/RenderGeometryMap.h
@@ -73,7 +73,7 @@ struct RenderGeometryMapStep {
 class RenderGeometryMap {
     WTF_MAKE_NONCOPYABLE(RenderGeometryMap);
 public:
-    explicit RenderGeometryMap(OptionSet<MapCoordinatesMode> = UseTransforms);
+    explicit RenderGeometryMap(OptionSet<MapCoordinatesMode> = UseTransforms, bool useCSS3DTransformInterop = false);
     ~RenderGeometryMap();
 
     OptionSet<MapCoordinatesMode> mapCoordinatesFlags() const { return m_mapCoordinatesFlags; }
@@ -130,6 +130,7 @@ private:
     RenderGeometryMapSteps m_mapping;
     LayoutSize m_accumulatedOffset;
     OptionSet<MapCoordinatesMode> m_mapCoordinatesFlags;
+    bool m_useCSS3DTransformInterop { false };
 #if ASSERT_ENABLED
     bool m_accumulatedOffsetMightBeSaturated { false };
 #endif

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -945,7 +945,7 @@ void RenderLayer::updateLayerPositionsAfterLayout(bool isRelayoutingSubtree, boo
     LOG(Compositing, "RenderLayer %p updateLayerPositionsAfterLayout", this);
     willUpdateLayerPositions();
 
-    RenderGeometryMap geometryMap(UseTransforms);
+    RenderGeometryMap geometryMap(UseTransforms, renderer().settings().css3DTransformInteroperabilityEnabled());
     if (!isRenderViewLayer())
         geometryMap.pushMappingsToAncestor(parent(), nullptr);
 
@@ -1168,7 +1168,7 @@ void RenderLayer::clearRepaintRects()
 
 void RenderLayer::updateLayerPositionsAfterOverflowScroll()
 {
-    RenderGeometryMap geometryMap(UseTransforms);
+    RenderGeometryMap geometryMap(UseTransforms, renderer().settings().css3DTransformInteroperabilityEnabled());
     if (!isRenderViewLayer())
         geometryMap.pushMappingsToAncestor(parent(), nullptr);
 
@@ -1186,7 +1186,7 @@ void RenderLayer::updateLayerPositionsAfterDocumentScroll()
 
     willUpdateLayerPositions();
 
-    RenderGeometryMap geometryMap(UseTransforms);
+    RenderGeometryMap geometryMap(UseTransforms, renderer().settings().css3DTransformInteroperabilityEnabled());
     recursiveUpdateLayerPositionsAfterScroll(&geometryMap);
 }
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1382,7 +1382,7 @@ void RenderObject::outputRenderSubTreeAndMark(TextStream& stream, const RenderOb
 
 FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const
 {
-    TransformState transformState(TransformState::ApplyTransformDirection, localPoint);
+    TransformState transformState(settings().css3DTransformInteroperabilityEnabled(), TransformState::ApplyTransformDirection, localPoint);
     mapLocalToContainer(nullptr, transformState, mode | ApplyContainerFlip, wasFixed);
     transformState.flatten();
     
@@ -1391,7 +1391,7 @@ FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet
 
 FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, OptionSet<MapCoordinatesMode> mode) const
 {
-    TransformState transformState(TransformState::UnapplyInverseTransformDirection, containerPoint);
+    TransformState transformState(settings().css3DTransformInteroperabilityEnabled(), TransformState::UnapplyInverseTransformDirection, containerPoint);
     mapAbsoluteToLocalPoint(mode, transformState);
     transformState.flatten();
     
@@ -1400,7 +1400,7 @@ FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, Optio
 
 FloatQuad RenderObject::absoluteToLocalQuad(const FloatQuad& quad, OptionSet<MapCoordinatesMode> mode) const
 {
-    TransformState transformState(TransformState::UnapplyInverseTransformDirection, quad.boundingBox().center(), quad);
+    TransformState transformState(settings().css3DTransformInteroperabilityEnabled(), TransformState::UnapplyInverseTransformDirection, quad.boundingBox().center(), quad);
     mapAbsoluteToLocalPoint(mode, transformState);
     transformState.flatten();
     return transformState.lastPlanarQuad();
@@ -1505,7 +1505,7 @@ void RenderObject::getTransformFromContainer(const RenderObject* containerObject
 
 void RenderObject::pushOntoTransformState(TransformState& transformState, OptionSet<MapCoordinatesMode> mode, const RenderLayerModelObject* repaintContainer, const RenderElement* container, const LayoutSize& offsetInContainer, bool containerSkipped) const
 {
-    bool preserve3D = mode.contains(UseTransforms) && (container->style().preserves3D() || style().preserves3D());
+    bool preserve3D = mode.contains(UseTransforms) && participatesInPreserve3D(container);
     if (mode.contains(UseTransforms) && shouldUseTransformFromContainer(container)) {
         TransformationMatrix matrix;
         getTransformFromContainer(container, offsetInContainer, matrix);
@@ -1534,7 +1534,7 @@ void RenderObject::pushOntoGeometryMap(RenderGeometryMap& geometryMap, const Ren
     bool offsetDependsOnPoint = false;
     LayoutSize containerOffset = offsetFromContainer(*container, LayoutPoint(), &offsetDependsOnPoint);
 
-    bool preserve3D = container->style().preserves3D() || style().preserves3D();
+    bool preserve3D = participatesInPreserve3D(container);
     if (shouldUseTransformFromContainer(container) && (geometryMap.mapCoordinatesFlags() & UseTransforms)) {
         TransformationMatrix t;
         getTransformFromContainer(container, containerOffset, t);
@@ -1551,7 +1551,7 @@ FloatQuad RenderObject::localToContainerQuad(const FloatQuad& localQuad, const R
 {
     // Track the point at the center of the quad's bounding box. As mapLocalToContainer() calls offsetFromContainer(),
     // it will use that point as the reference point to decide which column's transform to apply in multiple-column blocks.
-    TransformState transformState(TransformState::ApplyTransformDirection, localQuad.boundingBox().center(), localQuad);
+    TransformState transformState(settings().css3DTransformInteroperabilityEnabled(), TransformState::ApplyTransformDirection, localQuad.boundingBox().center(), localQuad);
     mapLocalToContainer(container, transformState, mode | ApplyContainerFlip, wasFixed);
     transformState.flatten();
     
@@ -1560,7 +1560,7 @@ FloatQuad RenderObject::localToContainerQuad(const FloatQuad& localQuad, const R
 
 FloatPoint RenderObject::localToContainerPoint(const FloatPoint& localPoint, const RenderLayerModelObject* container, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const
 {
-    TransformState transformState(TransformState::ApplyTransformDirection, localPoint);
+    TransformState transformState(settings().css3DTransformInteroperabilityEnabled(), TransformState::ApplyTransformDirection, localPoint);
     mapLocalToContainer(container, transformState, mode | ApplyContainerFlip, wasFixed);
     transformState.flatten();
 
@@ -1599,6 +1599,13 @@ LayoutSize RenderObject::offsetFromAncestorContainer(const RenderElement& contai
     } while (currContainer != &container);
 
     return offset;
+}
+
+bool RenderObject::participatesInPreserve3D(const RenderElement* container) const
+{
+    if (settings().css3DTransformInteroperabilityEnabled())
+        return hasLayer() && downcast<RenderLayerModelObject>(*this).layer()->participatesInPreserve3D();
+    return container->style().preserves3D() || style().preserves3D();
 }
 
 HostWindow* RenderObject::hostWindow() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -784,6 +784,8 @@ public:
     void pushOntoTransformState(TransformState&, OptionSet<MapCoordinatesMode>, const RenderLayerModelObject* repaintContainer, const RenderElement* container, const LayoutSize& offsetInContainer, bool containerSkipped) const;
     void pushOntoGeometryMap(RenderGeometryMap&, const RenderLayerModelObject* repaintContainer, RenderElement* container, bool containerSkipped) const;
 
+    bool participatesInPreserve3D(const RenderElement* container) const;
+
     virtual void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& /* additionalOffset */, const RenderLayerModelObject* /* paintContainer */ = nullptr) const { };
 
     LayoutRect absoluteOutlineBounds() const { return outlineBoundsForRepaint(nullptr); }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -554,7 +554,7 @@ void RenderSVGRoot::mapLocalToContainer(const RenderLayerModelObject* repaintCon
 
     auto containerOffset = offsetFromContainer(*container, LayoutPoint(transformState.mappedPoint()));
 
-    bool preserve3D = mode & UseTransforms && (container->style().preserves3D() || style().preserves3D());
+    bool preserve3D = mode & UseTransforms && participatesInPreserve3D(container);
     if (mode & UseTransforms && shouldUseTransformFromContainer(container)) {
         TransformationMatrix t;
         getTransformFromContainer(container, containerOffset, t);
@@ -599,7 +599,7 @@ void RenderSVGRoot::mapLocalToContainer(const RenderLayerModelObject* repaintCon
     // For getCTM/getScreenCTM computations the result must be independent of the page zoom factor.
     // To compute these matrices within a non-SVG context (e.g. SVG embedded in HTML -- inline SVG)
     // the scaling needs to be removed from the CSS transform state.
-    TransformState transformStateAboveSVGFragment(transformState.direction(), transformState.mappedPoint());
+    TransformState transformStateAboveSVGFragment(settings().css3DTransformInteroperabilityEnabled(), transformState.direction(), transformState.mappedPoint());
     transformStateAboveSVGFragment.setTransformMatrixTracking(transformState.transformMatrixTracking());
     container->mapLocalToContainer(repaintContainer, transformStateAboveSVGFragment, mode, wasFixed);
 

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -70,7 +70,7 @@ public:
             ancestorContainer = ancestorsOfType<RenderLayerModelObject>(*stopAtRenderer).first();
         }
 
-        TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint { });
+        TransformState transformState(m_renderer.settings().css3DTransformInteroperabilityEnabled(), TransformState::ApplyTransformDirection, FloatPoint { });
         transformState.setTransformMatrixTracking(trackingMode);
 
         renderer->mapLocalToContainer(ancestorContainer, transformState, { UseTransforms, ApplyContainerFlip });

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -508,7 +508,7 @@ void GraphicsLayerWC::flushCompositingState(const FloatRect& passedVisibleRect)
     // passedVisibleRect doesn't contain the scrollbar area. Inflate it.
     FloatRect visibleRect = passedVisibleRect;
     visibleRect.inflate(20.f);
-    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
+    TransformState state(client().useCSS3DTransformInteroperability(), TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
     state.setSecondaryQuad(FloatQuad { visibleRect });
     recursiveCommitChanges(state);
 }


### PR DESCRIPTION
#### 96c4f6e9ec7c5d548021e4ec2d35d08329377654
<pre>
Make TransformState changes to support transform-style:preserve-3d and perspective only apply to direct DOM children.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248284">https://bugs.webkit.org/show_bug.cgi?id=248284</a>
&lt;rdar://problem/102632597&gt;

Reviewed by Simon Fraser.

This changes TransformState to support applying the flattening both before and after the specified transform is accounted for,
and reverses which happens if 3d transform interop is enabled.

This is because flattening under interop is a property of the child rather than the parent. We flatten just that child if it isn&apos;t
accumulating its parent&apos;s transform, rather than flattening all children because we&apos;re not preserve-3d).

The existing TransformState only supported flattening after, which I believe was always incorrect if we were pushing transforms onto
the state from innermost to outermost. This happens for getBoundingClientRect/ApplyTransformDirection, and is why preserve-3d-not-applied-to-ancestors.html
failed (despite not being affected being interop changes). These changes make that test work correctly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-behavior-expected.txt:
* LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt: Added.
* LayoutTests/platform/gtk/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt: Added.
* LayoutTests/platform/ios/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-2-expected.txt:
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-4-expected.png: Added.
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-4-expected.txt: Added.
* LayoutTests/platform/mac/transforms/3d/point-mapping/3d-point-mapping-expected.txt:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-3.html:
* LayoutTests/transforms/3d/point-mapping/3d-point-mapping-4.html: Copied from LayoutTests/transforms/3d/point-mapping/3d-point-mapping-3.html.A

New test with spacers around preserve-3d, and confirming that point mapping works correctly.

* LayoutTests/transforms/3d/point-mapping/3d-point-mapping.html:
* LayoutTests/transforms/3d/preserve-3d-not-applied-to-ancestors-expected.txt:

Fixed due to supporting flattening on the right &apos;side&apos; regardless of which order transforms are pushed to the
TransformState (innermost to outermost, or outermost to innermost).

* Source/WebCore/platform/graphics/transforms/TransformState.cpp:
(WebCore::TransformState::operator=):
(WebCore::TransformState::move):
(WebCore::TransformState::shouldFlattenBefore):
(WebCore::TransformState::shouldFlattenAfter):
(WebCore::TransformState::applyTransform):
* Source/WebCore/platform/graphics/transforms/TransformState.h:
(WebCore::TransformState::TransformState):
* Source/WebCore/rendering/LayerOverlapMap.cpp:
(WebCore::LayerOverlapMap::LayerOverlapMap):
* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::RenderGeometryMap::RenderGeometryMap):
(WebCore::RenderGeometryMap::mapToContainer const):
* Source/WebCore/rendering/RenderGeometryMap.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::updateLayerPositionsAfterLayout):
(WebCore::RenderLayer::updateLayerPositionsAfterOverflowScroll):
(WebCore::RenderLayer::updateLayerPositionsAfterDocumentScroll):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::localToAbsolute const):
(WebCore::RenderObject::absoluteToLocal const):
(WebCore::RenderObject::absoluteToLocalQuad const):
(WebCore::RenderObject::pushOntoTransformState const):
(WebCore::RenderObject::pushOntoGeometryMap const):
(WebCore::RenderObject::localToContainerQuad const):
(WebCore::RenderObject::localToContainerPoint const):
(WebCore::RenderObject::participatesInPreserve3D const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::mapLocalToContainer const):
* Source/WebCore/rendering/svg/SVGLayerTransformComputation.h:
(WebCore::SVGLayerTransformComputation::computeAccumulatedTransform const):

Canonical link: <a href="https://commits.webkit.org/257432@main">https://commits.webkit.org/257432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/178c408010279fe84de6e15f8e4f10028bafe60e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108227 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168484 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85389 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106141 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33520 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1934 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22966 "Found 30 new test failures: editing/input/page-up-down-scrolls.html, http/tests/websocket/tests/hybi/bad-handshake-crash.html, http/wpt/cache-storage/cache-quota-add.any.html, http/wpt/cache-storage/cache-quota.any.html, http/wpt/fetch/response-opaque-clone.html, imported/w3c/web-platform-tests/IndexedDB/reading-autoincrement-indexes-cursors.any.sharedworker.html, imported/w3c/web-platform-tests/cookies/attributes/expires.html, imported/w3c/web-platform-tests/fetch/api/response/response-clone.any.sharedworker.html, imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/worker-inheritance.sub.https.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1843 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45387 "Found 1 new test failure: media/video-inactive-playback.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5117 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6799 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42424 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->