### PR TITLE
Disable sorting of CALayers that aren't CATransformLayers.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -137,6 +137,9 @@ typedef struct _CARenderContext CARenderContext;
 @property (getter=isSeparated) BOOL separated;
 #endif
 @property BOOL toneMapToStandardDynamicRange;
+#if HAVE(CALAYER_ALLOWS_SORTS_SUBLAYERS)
+@property BOOL allowsSortsSublayers;
+#endif
 @end
 
 #if ENABLE(FILTERS_LEVEL_2)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1926,6 +1926,11 @@ bool GraphicsLayerCA::platformCALayerUseGiantTiles() const
     return client().useGiantTiles();
 }
 
+bool GraphicsLayerCA::platformCALayerUseCSS3DTransformInteroperability() const
+{
+    return client().useCSS3DTransformInteroperability();
+}
+
 void GraphicsLayerCA::platformCALayerLogFilledVisibleFreshTile(unsigned blankPixelCount)
 {
     client().logFilledVisibleFreshTile(blankPixelCount);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -225,6 +225,7 @@ private:
     WEBCORE_EXPORT bool platformCALayerShouldAggressivelyRetainTiles(PlatformCALayer*) const override;
     WEBCORE_EXPORT bool platformCALayerShouldTemporarilyRetainTileCohorts(PlatformCALayer*) const override;
     WEBCORE_EXPORT bool platformCALayerUseGiantTiles() const override;
+    WEBCORE_EXPORT bool platformCALayerUseCSS3DTransformInteroperability() const override;
     WEBCORE_EXPORT void platformCALayerLogFilledVisibleFreshTile(unsigned) override;
 
     bool isCommittingChanges() const override { return m_isCommittingChanges; }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -63,6 +63,7 @@ public:
     virtual bool platformCALayerShouldTemporarilyRetainTileCohorts(PlatformCALayer*) const { return true; }
 
     virtual bool platformCALayerUseGiantTiles() const { return false; }
+    virtual bool platformCALayerUseCSS3DTransformInteroperability() const { return false; }
 
     virtual bool isCommittingChanges() const { return false; }
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -313,6 +313,16 @@ void PlatformCALayerCocoa::commonInit()
         m_customSublayers = makeUnique<PlatformCALayerList>(tileController->containerLayers());
     }
 
+#if HAVE(CALAYER_ALLOWS_SORTS_SUBLAYERS)
+    if (m_owner && m_owner->platformCALayerUseCSS3DTransformInteroperability() && [m_layer respondsToSelector:@selector(setAllowsSortsSublayers:)]) {
+        if (m_layerType == LayerTypeTransformLayer) {
+            [m_layer setAllowsSortsSublayers:YES];
+            [m_layer setSortsSublayers:YES];
+        } else
+            [m_layer setSortsSublayers:NO];
+    }
+#endif
+
     END_BLOCK_OBJC_EXCEPTIONS
 }
 


### PR DESCRIPTION
#### 73cd744e169091de20b1ca62d31cdb37b37bad6f
<pre>
Disable sorting of CALayers that aren&apos;t CATransformLayers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248292">https://bugs.webkit.org/show_bug.cgi?id=248292</a>
rdar://problem/102634551&gt;

Reviewed by Simon Fraser.

CoreAnimation currently sorts all layers by depth, and disabling sorting for a layer also disables
sorting for any transform-layer children.

If supported, this disables sorting for all normal layers and re-enables it for transform-layers,
so that only preserve-3d content is sorted (as specified by css-transforms-2).

This brings the CA rendering in line with other rendering backends, as well as hit-testing/point-mapping.

This doesn&apos;t make any change if we can&apos;t enable sorting just for transform-layers, but this isn&apos;t a regression,
as we already have a mismatch between rendering and hit-testing for that case.

One thing we could do in the future is disable sorting for layers that don&apos;t have any transform-layer children,
and fix a subset of the bugs fixed by the full change here. Keeping track of the child list adds complexity though,
and this is a long-standing bug, so that change isn&apos;t made here.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::platformCALayerUseCSS3DTransformInteroperability const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerUseCSS3DTransformInteroperability const):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::commonInit):

Canonical link: <a href="https://commits.webkit.org/257386@main">https://commits.webkit.org/257386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/737826ea9150258b4a6d8ec5d7088e7d894c27ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107651 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167935 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84786 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104237 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33044 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20944 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75984 "Found 5 new API test failures: /WebKitGTK/TestWebKitUserContentFilterStore:/webkit/WebKitUserContentFilterStore/save-multiple-filters, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/console-api, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22447 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44905 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41871 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->