### PR TITLE
Fix date-time inputs in vertical writing mode and enable all text-based inputs

### DIFF
--- a/LayoutTests/fast/css/text-overflow-ellipsis-and-floating-input-hittest.html
+++ b/LayoutTests/fast/css/text-overflow-ellipsis-and-floating-input-hittest.html
@@ -26,7 +26,7 @@ function test() {
     shouldBe("document.elementFromPoint(inputRight - 10, inputTop).id", "'left-floating-input'");
     shouldBe("document.elementFromPoint(inputRight + 10, inputTop).id", "'container-rtl'");
 
-    inputBox = document.getElementById('vertial-left-floating-input');
+    inputBox = document.getElementById('vertical-left-floating-input');
     inputRight = offset(inputBox).left + inputBox.offsetWidth;;
     inputTop = offset(inputBox).top;
     shouldBe("document.elementFromPoint(inputRight - 10, inputTop).id", "'container-vertical-rl'");
@@ -44,9 +44,11 @@ function test() {
     border: solid 1px red;
     padding: 10px;
   }
-  
+
+  input { writing-mode: horizontal-tb; }
+
   #container-vertical-rl {
-    -webkit-writing-mode: vertical-rl;
+    writing-mode: vertical-rl;
     height: 150px;
   }
 </style>
@@ -56,7 +58,7 @@ function test() {
   </div>
   <div dir='rtl' id='container-rtl'><input id='left-floating-input' style='float: left' type='text'>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </div>
-  <div id='container-vertical-rl'><input id='vertial-left-floating-input' style='float: right' type='text'>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  <div id='container-vertical-rl'><input id='vertical-left-floating-input' style='float: right' type='text'>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   </div>
   <br>
   <div>Hittest for the vertical mode needs updating after fixing this: <a href='https://bugs.webkit.org/show_bug.cgi?id=116413'>Text does not get truncated properly in vertical writing mode when overflow:hidden and text-overflow:ellipsis are set</a></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002-expected.txt
@@ -20,7 +20,12 @@ Test3: "height: calc(140px + 100%)"
 
 
 
-PASS .flexbox 1
+FAIL .flexbox 1 assert_equals:
+<div class="flexbox">
+      <div class="spacer"></div>
+      <input type="text" class="test1" data-expected-height="100">
+    </div>
+height expected 100 but got 40
 FAIL .flexbox 2 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>
@@ -45,7 +50,12 @@ FAIL .flexbox 5 assert_equals:
       <input type="reset" value="XXXXXXX" class="test1" data-expected-height="140">
     </div>
 height expected 140 but got 100
-PASS .flexbox 6
+FAIL .flexbox 6 assert_equals:
+<div class="flexbox">
+      <div class="spacer"></div>
+      <input type="text" class="test2" data-expected-height="100">
+    </div>
+height expected 100 but got 40
 FAIL .flexbox 7 assert_equals:
 <div class="flexbox">
       <div class="spacer"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional-expected.txt
@@ -1,0 +1,17 @@
+
+
+PASS Test input[type=text] block-size in writing-mode: vertical-lr
+PASS Test input[type=text] block-size in writing-mode: vertical-rl
+PASS Test input[type=email] block-size in writing-mode: vertical-lr
+PASS Test input[type=email] block-size in writing-mode: vertical-rl
+PASS Test input[type=password] block-size in writing-mode: vertical-lr
+PASS Test input[type=password] block-size in writing-mode: vertical-rl
+PASS Test input[type=search] block-size in writing-mode: vertical-lr
+PASS Test input[type=search] block-size in writing-mode: vertical-rl
+PASS Test input[type=tel] block-size in writing-mode: vertical-lr
+PASS Test input[type=tel] block-size in writing-mode: vertical-rl
+PASS Test input[type=url] block-size in writing-mode: vertical-lr
+PASS Test input[type=url] block-size in writing-mode: vertical-rl
+PASS Test input[type=number] block-size in writing-mode: vertical-lr
+PASS Test input[type=number] block-size in writing-mode: vertical-rl
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#the-input-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test block-size of text-based inputs is consistent across writing-modes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+    input { appearance: none }
+</style>
+
+<input id="horizontalInput">
+<input id="verticalInput">
+
+<script>
+for (const inputType of ["text", "email", "password", "search", "tel", "url", "number"]) {
+    horizontalInput.type = inputType;
+    verticalInput.type = inputType;
+    for (const writingMode of ["vertical-lr", "vertical-rl", "sideways-lr", "sideways-rl"]) {
+        if (!CSS.supports(`writing-mode: ${writingMode}`))
+            continue;
+        test(t => {
+            verticalInput.style.writingMode = writingMode;
+            t.add_cleanup(() => {
+                verticalInput.removeAttribute("style");
+            });
+
+            const verticalRect = verticalInput.getBoundingClientRect();
+            assert_true(
+                verticalRect.width < verticalRect.height,
+                "input has correct aspect ratio for default input size"
+            );
+
+            const horizontalRect = horizontalInput.getBoundingClientRect();
+            assert_equals(
+                Math.round(verticalRect.width),
+                Math.round(horizontalRect.height),
+                "width of vertical input matches height of horizontal input"
+            );
+        }, `Test input[type=${inputType}] block-size in writing-mode: ${writingMode}`);
+    }
+}
+</script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS progress[style="writing-mode: horizontal-tb"] block size should match height and inline should match width
+FAIL progress[style="writing-mode: vertical-lr"] block size should match width and inline should match width assert_equals: expected "160px" but got "16px"
+FAIL progress[style="writing-mode: vertical-rl"] block size should match width and inline should match width assert_equals: expected "160px" but got "16px"
+

--- a/Source/WebCore/css/horizontalFormControls.css
+++ b/Source/WebCore/css/horizontalFormControls.css
@@ -25,6 +25,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* Every time a new control is supported in vertical writing mode, it should be added here and removed from the html.css rule */
-input:is([type="color"],[type="range"]), textarea {
+textarea, input:not([type="button"], [type="submit"], [type="reset"], [type="file"]) {
     writing-mode: horizontal-tb !important;
 }

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -390,7 +390,7 @@ button {
 }
 
 /* Every time a new control is supported in vertical writing mode, it should be removed from here and added in the horizontalFormControls.css rule */
-input:not([type="color"],[type="range"]), select, button, meter, progress {
+select, button, meter, progress, input:is([type="button"], [type="submit"], [type="reset"], [type="file"]) {
     writing-mode: horizontal-tb !important;
 }
 

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -70,7 +70,7 @@ std::optional<Style::ElementStyle> DateTimeFieldElement::resolveCustomStyle(cons
         return std::nullopt;
 
     auto& style = *elementStyle.renderStyle;
-    adjustMinWidth(style);
+    adjustMinInlineSize(style);
 
     if (!hasValue() && shadowHostStyle) {
         auto textColor = shadowHostStyle->visitedDependentColorWithColorFilter(CSSPropertyColor);

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.h
@@ -79,7 +79,7 @@ protected:
     Locale& localeForOwner() const;
     AtomString localeIdentifier() const;
     void updateVisibleValue(EventBehavior);
-    virtual void adjustMinWidth(RenderStyle&) const = 0;
+    virtual void adjustMinInlineSize(RenderStyle&) const = 0;
     virtual int valueAsInteger() const = 0;
     virtual void handleKeyboardEvent(KeyboardEvent&) = 0;
     virtual void handleBlurEvent(Event&);

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp
@@ -61,7 +61,7 @@ DateTimeNumericFieldElement::DateTimeNumericFieldElement(Document& document, Fie
 {
 }
 
-void DateTimeNumericFieldElement::adjustMinWidth(RenderStyle& style) const
+void DateTimeNumericFieldElement::adjustMinInlineSize(RenderStyle& style) const
 {
     auto& font = style.fontCascade();
 
@@ -73,13 +73,16 @@ void DateTimeNumericFieldElement::adjustMinWidth(RenderStyle& style) const
 
     auto& locale = localeForOwner();
 
-    float width = 0;
+    float inlineSize = 0;
     for (char c = '0'; c <= '9'; ++c) {
         auto numberString = locale.convertToLocalizedNumber(makeString(pad(c, length, makeString(c))));
-        width = std::max(width, font.width(RenderBlock::constructTextRun(numberString, style)));
+        inlineSize = std::max(inlineSize, font.width(RenderBlock::constructTextRun(numberString, style)));
     }
 
-    style.setMinWidth({ width, LengthType::Fixed });
+    if (style.isHorizontalWritingMode())
+        style.setMinWidth({ inlineSize, LengthType::Fixed });
+    else
+        style.setMinHeight({ inlineSize, LengthType::Fixed });
 }
 
 int DateTimeNumericFieldElement::maximum() const

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
@@ -63,7 +63,7 @@ protected:
 
 private:
     // DateTimeFieldElement functions:
-    void adjustMinWidth(RenderStyle&) const final;
+    void adjustMinInlineSize(RenderStyle&) const final;
     String value() const final;
     String placeholderValue() const final;
     void handleKeyboardEvent(KeyboardEvent&) final;

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -51,15 +51,18 @@ DateTimeSymbolicFieldElement::DateTimeSymbolicFieldElement(Document& document, F
     ASSERT(!m_symbols.isEmpty());
 }
 
-void DateTimeSymbolicFieldElement::adjustMinWidth(RenderStyle& style) const
+void DateTimeSymbolicFieldElement::adjustMinInlineSize(RenderStyle& style) const
 {
     auto& font = style.fontCascade();
 
-    float width = 0;
+    float inlineSize = 0;
     for (auto& symbol : m_symbols)
-        width = std::max(width, font.width(RenderBlock::constructTextRun(symbol, style)));
+        inlineSize = std::max(inlineSize, font.width(RenderBlock::constructTextRun(symbol, style)));
 
-    style.setMinWidth({ width, LengthType::Fixed });
+    if (style.isHorizontalWritingMode())
+        style.setMinWidth({ inlineSize, LengthType::Fixed });
+    else
+        style.setMinHeight({ inlineSize, LengthType::Fixed });
 }
 
 bool DateTimeSymbolicFieldElement::hasValue() const

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h
@@ -48,7 +48,7 @@ private:
     static constexpr int invalidIndex = -1;
 
     // DateTimeFieldElement functions:
-    void adjustMinWidth(RenderStyle&) const final;
+    void adjustMinInlineSize(RenderStyle&) const final;
     void stepDown() final;
     void stepUp() final;
     String value() const final;


### PR DESCRIPTION
#### 40359210a8f97059de9443f7bffbd2e6595206da
<pre>
Fix date-time inputs in vertical writing mode and enable all text-based inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=248302">https://bugs.webkit.org/show_bug.cgi?id=248302</a>
rdar://102642911

Reviewed by Antti Koivisto.

Text-based inputs in vertical writing mode are mainly a rotated version of the horizontal one.
However, inner elements of date-time inputs were setting a min-width, which wrongly increased the opposite dimension in vertical writing mode making it inconsistent with the height in horizontal mode.
Fix this by setting the min-inline-size (consistent with CSS terminology), which is writing-mode aware.

Also enable vertical text-based inputs behind the VerticalFormControlsEnabled flag, they are working mostly fine aside from these issues, which will be addressed later:
- positioning bugs in inputs with decorations (search, number, autofill, etc.)
- native search input (not unstyled) is not rendered properly
- text input border should be rendered rotated

* LayoutTests/fast/css/text-overflow-ellipsis-and-floating-input-hittest.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flex-item-compressible-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-block-size.optional.html: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional-expected.txt: Added.
* Source/WebCore/css/horizontalFormControls.css:
(@namespace &quot;<a href="http://www.w3.org/1999/xhtml&quot">http://www.w3.org/1999/xhtml&quot</a>;;):
* Source/WebCore/css/html.css:
(select, button, meter, progress, input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;], [type=&quot;file&quot;])):
(input:not([type=&quot;color&quot;]), select, button, meter, progress): Deleted.
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::resolveCustomStyle):
* Source/WebCore/html/shadow/DateTimeFieldElement.h:
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.cpp:
(WebCore::DateTimeNumericFieldElement::adjustMinInlineSize const):
(WebCore::DateTimeNumericFieldElement::adjustMinWidth const): Deleted.
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.h:
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp:
(WebCore::DateTimeSymbolicFieldElement::adjustMinInlineSize const):
(WebCore::DateTimeSymbolicFieldElement::adjustMinWidth const): Deleted.
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.h:

Canonical link: <a href="https://commits.webkit.org/256995@main">https://commits.webkit.org/256995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d796e50ecfaa55ac2e76bae133fa91b027f02ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30727 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/107061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7157 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35570 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89958 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103212 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84191 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2376 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2053 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->