### PR TITLE
[WPE] Fix build after 256940@main

### DIFF
--- a/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
+++ b/Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp
@@ -32,6 +32,7 @@
 #include "GamepadLibWPE.h"
 #include "GamepadProviderClient.h"
 #include "Logging.h"
+#include <inttypes.h>
 #include <wpe/wpe.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -122,7 +123,7 @@ void GamepadProviderLibWPE::gamepadConnected(uintptr_t id)
     ASSERT(!m_gamepadMap.get(id));
     ASSERT(m_provider);
 
-    LOG(Gamepad, "GamepadProviderLibWPE device %u added", id);
+    LOG(Gamepad, "GamepadProviderLibWPE device %" PRIuPTR " added", id);
 
     unsigned index = indexForNewlyConnectedDevice();
     auto gamepad = makeUnique<GamepadLibWPE>(m_provider.get(), id, index);
@@ -150,7 +151,7 @@ void GamepadProviderLibWPE::gamepadConnected(uintptr_t id)
 
 void GamepadProviderLibWPE::gamepadDisconnected(uintptr_t id)
 {
-    LOG(Gamepad, "GamepadProviderLibWPE device %u removed", id);
+    LOG(Gamepad, "GamepadProviderLibWPE device %" PRIuPTR " removed", id);
 
     auto removedGamepad = removeGamepadForId(id);
     ASSERT(removedGamepad);


### PR DESCRIPTION
#### 6e03517aaddb74069a4b59bc5936fda90b49d9a5
<pre>
[WPE] Fix build after 256940@main

Unreviewed build fix.

Use proper format specifier for logging.

* Source/WebCore/platform/gamepad/libwpe/GamepadProviderLibWPE.cpp:
(WebCore::GamepadProviderLibWPE::gamepadConnected):
(WebCore::GamepadProviderLibWPE::gamepadDisconnected):

Canonical link: <a href="https://commits.webkit.org/256988@main">https://commits.webkit.org/256988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/341f1b4001fbfdcf903e6495c86e2433696df19d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107023 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7111 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35530 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103692 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103174 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84151 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32332 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/88991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75257 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/776 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/764 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5577 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2374 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2014 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->