### PR TITLE
Add xfail annotations to existing webkitpy scm_unittest

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -373,6 +373,7 @@ class Git(SCM, SVNRepository):
             command += ['-O', order_file]
 
         if git_index:
+            assert command[1] == 'diff'
             command += ['--cached']
         elif git_commit:
             command += [merge_base]

--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py
@@ -900,6 +900,7 @@ class GitTest(SCMTest):
         os.chdir(self.untracking_checkout_path)
         self.assertRaises(ScriptError, self.untracking_scm.remote_branch_ref)
 
+    @xfail
     def test_multiple_remotes(self):
         run_command(['git', 'config', '--add', 'svn-remote.svn.fetch', 'trunk:remote1'])
         run_command(['git', 'config', '--add', 'svn-remote.svn.fetch', 'trunk:remote2'])
@@ -914,6 +915,7 @@ class GitTest(SCMTest):
         patch = scm.create_patch()
         self.assertNotRegexpMatches(patch, b'Subversion Revision:')
 
+    @xfail
     def test_create_patch_with_git_index(self):
         # First change. Committed.
         write_into_file_at_path('test_file_commit1', 'first cat')
@@ -1007,6 +1009,7 @@ class GitTest(SCMTest):
         scm = self.tracking_scm
         self.assertIn(scm.native_branch(scm.checkout_root), ('master', 'main'))
 
+    @xfail
     def test_rename_files(self):
         scm = self.tracking_scm
 
@@ -1064,6 +1067,7 @@ class GitSVNTest(SCMTest):
         self.assertEqual(self.scm.read_git_config(key), value)
 
     @slow
+    @xfail
     def test_local_commits(self):
         test_file = os.path.join(self.git_checkout_path, 'test_file')
         write_into_file_at_path(test_file, 'foo')
@@ -1072,6 +1076,7 @@ class GitSVNTest(SCMTest):
         self.assertEqual(len(self.scm.local_commits()), 1)
 
     @slow
+    @xfail
     def test_discard_local_commits(self):
         test_file = os.path.join(self.git_checkout_path, 'test_file')
         write_into_file_at_path(test_file, 'foo')
@@ -1094,6 +1099,7 @@ class GitSVNTest(SCMTest):
         self.assertNotRegexpMatches(run_command(['git', 'branch']), r'foo')
 
     @slow
+    @xfail
     def test_remote_merge_base(self):
         # Diff to merge-base should include working-copy changes,
         # which the diff to svn_branch.. doesn't.
@@ -1135,12 +1141,14 @@ class GitSVNTest(SCMTest):
         Checkout(self.scm).apply_patch(patch)
 
     @slow
+    @xfail
     def test_commit_text_parsing(self):
         write_into_file_at_path('test_file', 'more test content')
         commit_text = self.scm.commit_with_message("another test commit")
         self.assertEqual(self.scm.svn_revision_from_commit_text(commit_text), '6')
 
     @slow
+    @xfail
     def test_commit_with_message_working_copy_only(self):
         write_into_file_at_path('test_file_commit1', 'more test content')
         run_command(['git', 'add', 'test_file_commit1'])
@@ -1180,6 +1188,7 @@ class GitSVNTest(SCMTest):
         self.assertEqual(self.scm.revisions_changing_file('test_file_commit1'), [])
 
     @slow
+    @xfail
     def test_commit_with_message(self):
         self._one_local_commit_plus_working_copy_changes()
         self.assertRaises(AmbiguousCommitError, self.scm.commit_with_message, "yet another test commit")
@@ -1191,6 +1200,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(svn_log, r'test_file_commit1')
 
     @slow
+    @xfail
     def test_commit_with_message_git_commit(self):
         self._two_local_commits()
 
@@ -1202,6 +1212,7 @@ class GitSVNTest(SCMTest):
         self.assertNotRegexpMatches(svn_log, r'test_file_commit2')
 
     @slow
+    @xfail
     def test_commit_with_message_git_commit_range(self):
         self._three_local_commits()
 
@@ -1214,6 +1225,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(svn_log, r'test_file_commit2')
 
     @slow
+    @xfail
     def test_commit_with_message_only_local_commit(self):
         self._one_local_commit()
         commit_text = self.scm.commit_with_message("another test commit")
@@ -1221,6 +1233,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(svn_log, r'test_file_commit1')
 
     @slow
+    @xfail
     def test_commit_with_message_multiple_local_commits_and_working_copy(self):
         self._two_local_commits()
         write_into_file_at_path('test_file_commit1', 'working copy change')
@@ -1240,6 +1253,7 @@ class GitSVNTest(SCMTest):
         self.assertRaises(ScriptError, self.scm.commit_with_message, "another test commit", git_commit="HEAD^")
 
     @slow
+    @xfail
     def test_commit_with_message_multiple_local_commits_always_squash(self):
         run_command(['git', 'config', 'webkit-patch.commit-should-always-squash', 'true'])
         self._two_local_commits()
@@ -1251,6 +1265,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(svn_log, r'test_file_commit1')
 
     @slow
+    @xfail
     def test_commit_with_message_multiple_local_commits(self):
         self._two_local_commits()
         self.assertRaises(AmbiguousCommitError, self.scm.commit_with_message, "yet another test commit")
@@ -1263,6 +1278,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(svn_log, r'test_file_commit1')
 
     @slow
+    @xfail
     def test_commit_with_message_not_synced(self):
         run_command(['git', 'checkout', '-b', 'my-branch', 'trunk~3'])
         self._two_local_commits()
@@ -1291,18 +1307,22 @@ class GitSVNTest(SCMTest):
         self.assertEqual(self.scm._upstream_branch(), 'my-branch')
 
     @slow
+    @xfail
     def test_remote_branch_ref(self):
         self.assertEqual(self.scm.remote_branch_ref(), 'refs/remotes/trunk')
 
     @slow
+    @xfail
     def test_reverse_diff(self):
         self._shared_test_reverse_diff()
 
     @slow
+    @xfail
     def test_diff_for_revision(self):
         self._shared_test_diff_for_revision()
 
     @slow
+    @xfail
     def test_create_patch_local_plus_working_copy(self):
         self._one_local_commit_plus_working_copy_changes()
         patch = self.scm.create_patch()
@@ -1310,6 +1330,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'test_file_commit2')
 
     @slow
+    @xfail
     def test_create_patch(self):
         self._one_local_commit_plus_working_copy_changes()
         patch = self.scm.create_patch()
@@ -1318,6 +1339,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'Subversion Revision: 5')
 
     @slow
+    @xfail
     def test_create_patch_after_merge(self):
         run_command(['git', 'checkout', '-b', 'dummy-branch', 'trunk~3'])
         self._one_local_commit()
@@ -1328,12 +1350,14 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'Subversion Revision: 5')
 
     @slow
+    @xfail
     def test_create_patch_with_changed_files(self):
         self._one_local_commit_plus_working_copy_changes()
         patch = self.scm.create_patch(changed_files=['test_file_commit2'])
         self.assertRegexpMatches(patch, b'test_file_commit2')
 
     @slow
+    @xfail
     def test_create_patch_with_rm_and_changed_files(self):
         self._one_local_commit_plus_working_copy_changes()
         os.remove('test_file_commit1')
@@ -1357,6 +1381,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'test_file_commit1')
 
     @slow
+    @xfail
     def test_create_patch_working_copy_only(self):
         self._one_local_commit_plus_working_copy_changes()
         patch = self.scm.create_patch(git_commit="HEAD....")
@@ -1364,6 +1389,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'test_file_commit2')
 
     @slow
+    @xfail
     def test_create_patch_multiple_local_commits(self):
         self._two_local_commits()
         patch = self.scm.create_patch()
@@ -1371,6 +1397,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'test_file_commit1')
 
     @slow
+    @xfail
     def test_create_patch_not_synced(self):
         run_command(['git', 'checkout', '-b', 'my-branch', 'trunk~3'])
         self._two_local_commits()
@@ -1380,6 +1407,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch, b'test_file_commit1')
 
     @slow
+    @xfail
     def test_create_binary_patch(self):
         # Create a git binary patch and check the contents.
         test_file_name = 'binary_file'
@@ -1412,6 +1440,7 @@ class GitSVNTest(SCMTest):
         self.assertRegexpMatches(patch_from_local_commit, b'\nliteral 256\n')
 
     @slow
+    @xfail
     def test_changed_files_local_plus_working_copy(self):
         self._one_local_commit_plus_working_copy_changes()
         files = self.scm.changed_files()
@@ -1460,6 +1489,7 @@ class GitSVNTest(SCMTest):
         self.assertIn('test_file_commit2', files)
 
     @slow
+    @xfail
     def test_changed_files_multiple_local_commits(self):
         self._two_local_commits()
         files = self.scm.changed_files()
@@ -1467,6 +1497,7 @@ class GitSVNTest(SCMTest):
         self.assertIn('test_file_commit1', files)
 
     @slow
+    @xfail
     def test_changed_files_not_synced(self):
         run_command(['git', 'checkout', '-b', 'my-branch', 'trunk~3'])
         self._two_local_commits()
@@ -1476,6 +1507,7 @@ class GitSVNTest(SCMTest):
         self.assertIn('test_file_commit1', files)
 
     @slow
+    @xfail
     def test_changed_files_not_synced(self):
         run_command(['git', 'checkout', '-b', 'my-branch', 'trunk~3'])
         self._two_local_commits()
@@ -1485,10 +1517,12 @@ class GitSVNTest(SCMTest):
         self.assertIn('test_file_commit1', files)
 
     @slow
+    @xfail
     def test_changed_files(self):
         self._shared_test_changed_files()
 
     @slow
+    @xfail
     def test_changed_files_for_revision(self):
         self._shared_test_changed_files_for_revision()
 
@@ -1514,6 +1548,7 @@ class GitSVNTest(SCMTest):
         self.assertIn('test_file_commit0', files)
 
     @slow
+    @xfail
     def test_contents_at_revision(self):
         self._shared_test_contents_at_revision()
 
@@ -1526,6 +1561,7 @@ class GitSVNTest(SCMTest):
         self._shared_test_added_files()
 
     @slow
+    @xfail
     def test_committer_email_for_revision(self):
         self._shared_test_committer_email_for_revision()
 


### PR DESCRIPTION
#### 73bf03b537e5bcba6e58a3f89ca9979e98ebc3b9
<pre>
Add xfail annotations to existing webkitpy scm_unittest
<a href="https://bugs.webkit.org/show_bug.cgi?id=244292">https://bugs.webkit.org/show_bug.cgi?id=244292</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/webkitpy/common/checkout/scm/git.py:
(Git.create_patch): Add assert to make failure more obvious
* Tools/Scripts/webkitpy/common/checkout/scm/scm_unittest.py:
(SVNTest): Add various @xfail
(GitTest): Add various @xfail
(GitSVNTest): Add various @xfail

Canonical link: <a href="https://commits.webkit.org/257437@main">https://commits.webkit.org/257437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6761d3dc201e4ea749db359b59eb5fb2fc34c67e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107028 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167292 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84156 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103697 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/88997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32338 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101093 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75263 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/769 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44406 "Found 1 new test failure: fast/events/blur-remove-parent-crash.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5122 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41312 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->