### PR TITLE
Reuse the StylePropertyShorthand in StyleProperties::getPropertyValue()

### DIFF
--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -157,19 +157,19 @@ private:
     String getShorthandValue(const StylePropertyShorthand&, const char* separator = " ") const;
     String getCommonValue(const StylePropertyShorthand&) const;
     String getAlignmentShorthandValue(const StylePropertyShorthand&) const;
-    String borderImagePropertyValue(CSSPropertyID) const;
+    String borderImagePropertyValue(const StylePropertyShorthand&) const;
     String borderPropertyValue(const StylePropertyShorthand&, const StylePropertyShorthand&, const StylePropertyShorthand&) const;
     String pageBreakPropertyValue(const StylePropertyShorthand&) const;
     String getLayeredShorthandValue(const StylePropertyShorthand&) const;
     String get2Values(const StylePropertyShorthand&) const;
     String get4Values(const StylePropertyShorthand&) const;
     String borderSpacingValue(const StylePropertyShorthand&) const;
-    String fontValue() const;
-    String fontVariantValue() const;
+    String fontValue(const StylePropertyShorthand&) const;
+    String fontVariantValue(const StylePropertyShorthand&) const;
     String fontSynthesisValue() const;
     String textDecorationSkipValue() const;
     String offsetValue() const;
-    String commonShorthandChecks(CSSPropertyID) const;
+    String commonShorthandChecks(const StylePropertyShorthand&) const;
     StringBuilder asTextInternal() const;
 
     friend class PropertySetCSSStyleDeclaration;


### PR DESCRIPTION
#### 70230d10f272f17151f1e77d496553716b449cea
<pre>
Reuse the StylePropertyShorthand in StyleProperties::getPropertyValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248311">https://bugs.webkit.org/show_bug.cgi?id=248311</a>

Reviewed by Tim Nguyen.

StyleProperties::getPropertyValue() calls commonShorthandChecks(), which
used shorthandForProperty(propertyID) to get the StylePropertyShorthand,
and later it would get the StylePropertyShorthand again in most cases.

So it&apos;s better to use shorthandForProperty() in getPropertyValue(), and
then pass it to commonShorthandChecks() and others.

Also adds some ASSERTs for the length of the StylePropertyShorthand.

No test since there should be no observable change in behavior.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::commonShorthandChecks const):
(WebCore::StyleProperties::getPropertyValue const):
(WebCore::StyleProperties::borderSpacingValue const):
(WebCore::StyleProperties::fontValue const):
(WebCore::StyleProperties::offsetValue const):
(WebCore::StyleProperties::textDecorationSkipValue const):
(WebCore::StyleProperties::fontVariantValue const):
(WebCore::StyleProperties::fontSynthesisValue const):
(WebCore::StyleProperties::get2Values const):
(WebCore::StyleProperties::get4Values const):
(WebCore::StyleProperties::getGridTemplateValue const):
(WebCore::StyleProperties::getGridValue const):
(WebCore::StyleProperties::getGridRowColumnShorthandValue const):
(WebCore::StyleProperties::getGridAreaShorthandValue const):
(WebCore::StyleProperties::borderImagePropertyValue const):
(WebCore::StyleProperties::pageBreakPropertyValue const):
(WebCore::canUseShorthandForLonghand):
* Source/WebCore/css/StyleProperties.h:

Canonical link: <a href="https://commits.webkit.org/257011@main">https://commits.webkit.org/257011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/653b03a7c76e83367116cf37b31205d99fb70243

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107104 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167367 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7210 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35619 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103763 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103257 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84238 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32405 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75327 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/856 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/843 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21997 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4828 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5663 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41388 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->