### PR TITLE
[web-animations] correctly blend transform with iterationComposite is set to "accumulate"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
@@ -23,8 +23,8 @@ PASS iteration composition of transform: [ scale(1), scale(2) ] animation
 PASS iteration composition of transform: scale(2) animation
 PASS iteration composition of transform list animation
 PASS iteration composition of transform of matrix function
-FAIL iteration composition of transform list animation whose order is mismatched assert_approx_equals: expected matrix(6.5, 0, 0, 6.5, 135, 0) but got matrix(6.5, 0, 0, 6.5, 75, 0): Animated transform list at 50s of the third iteration expected 135 +/- 0.0001 but got 75
-FAIL iteration composition of transform list animation whose order is mismatched because of missing functions assert_approx_equals: expected matrix(3.5, 0, 0, 3.5, 80, 0) but got matrix(3.5, 0, 0, 3.5, 50, 0): Animated transform list at 50s of the third iteration expected 80 +/- 0.0001 but got 50
+PASS iteration composition of transform list animation whose order is mismatched
+PASS iteration composition of transform list animation whose order is mismatched because of missing functions
 PASS iteration composition of transform from none to translate
 PASS iteration composition of transform of matrix3d function
 PASS iteration composition of transform of rotate3d function

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -175,8 +175,18 @@ static inline TransformOperations blendFunc(const TransformOperations& from, con
         resultOperations.operations().appendVector(to.operations());
         return resultOperations;
     }
+
+    auto prefix = [&]() -> std::optional<unsigned> {
+        // We cannot use the pre-computed prefix when dealing with accumulation
+        // since the values used to accumulate may be different than those held
+        // in the initial keyframe list.
+        if (context.compositeOperation == CompositeOperation::Accumulate)
+            return std::nullopt;
+        return context.client->transformFunctionListPrefix();
+    };
+
     auto boxSize = is<RenderBox>(context.client->renderer()) ? downcast<RenderBox>(*context.client->renderer()).borderBoxRect().size() : LayoutSize();
-    return to.blend(from, context, boxSize, context.client->transformFunctionListPrefix());
+    return to.blend(from, context, boxSize, prefix());
 }
 
 static RefPtr<ScaleTransformOperation> blendFunc(ScaleTransformOperation* from, ScaleTransformOperation* to, const CSSPropertyBlendingContext& context)


### PR DESCRIPTION
#### 71e209c557898b92a216b8206bae5a86e1234830
<pre>
[web-animations] correctly blend transform with iterationComposite is set to &quot;accumulate&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=248312">https://bugs.webkit.org/show_bug.cgi?id=248312</a>

Reviewed by Antti Koivisto.

When animating transform, we pre-compute the number of matching transform operations.
However, in the case of `iterationComposite` we end up blending the &quot;to&quot; value with
itself multiple times with an accumulation composite operation (per
<a href="https://drafts.csswg.org/web-animations-2/#the-effect-value-of-a-keyframe-animation-effect).">https://drafts.csswg.org/web-animations-2/#the-effect-value-of-a-keyframe-animation-effect).</a>

Indeed, when computing the final keyframe, we accumulate the end keyframe onto itself
to match the current iteration interval. In that case, since we&apos;re blending the same
value with itself, the pre-computed matching prefix is incorrect, so we use std::nullopt
instead to indicate that the operations fully match.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):

Canonical link: <a href="https://commits.webkit.org/256996@main">https://commits.webkit.org/256996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0447c0760e36350ffb79233afb953a9c50341e23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107044 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167308 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7136 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35552 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103712 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103194 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84173 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32350 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75275 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/796 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/21948 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2378 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41324 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->