### PR TITLE
Remove needsBlackFullscreenBackgroundQuirk

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5980,3 +5980,5 @@ imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/decorations-multi
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/quirks-decor-noblur.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/standards-decor-noblur.html [ ImageOnlyFailure ]
 
+# This test isn't working as expected, it will be fixed in webkit.org/b/248148.
+webkit.org/b/248148 fullscreen/full-screen-layer-dump.html [ Failure ]

--- a/LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt
+++ b/LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt
@@ -24,7 +24,6 @@ foobar
           (children 1
             (GraphicsLayer
               (bounds 800.00 600.00)
-              (contentsOpaque 1)
               (drawsContent 1)
               (backingStoreAttached 1)
             )

--- a/LayoutTests/platform/gtk/compositing/no-compositing-when-fulll-screen-is-present-expected.txt
+++ b/LayoutTests/platform/gtk/compositing/no-compositing-when-fulll-screen-is-present-expected.txt
@@ -24,7 +24,6 @@ foobar
           (children 1
             (GraphicsLayer
               (bounds 800.00 600.00)
-              (contentsOpaque 1)
               (drawsContent 1)
               (backingStoreAttached 1)
             )

--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -42,7 +42,6 @@
 }
 
 :-webkit-full-screen {
-    background-color: white;
     z-index: 2147483647 !important;
     width: 100%;
     height: 100%;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1290,21 +1290,6 @@ bool Quirks::needsFlightAwareSerializationQuirk() const
     return *m_needsFlightAwareSerializationQuirk;
 }
 
-bool Quirks::needsBlackFullscreenBackgroundQuirk() const
-{
-    // MLB.com sets a black background-color on the :backdrop pseudo element, which WebKit does not yet support. This
-    // quirk can be removed once support for :backdrop psedue element is added.
-    if (!needsQuirks())
-        return false;
-
-    if (!m_needsBlackFullscreenBackgroundQuirk) {
-        auto host = m_document->topDocument().url().host();
-        m_needsBlackFullscreenBackgroundQuirk = equalLettersIgnoringASCIICase(host, "mlb.com"_s) || host.endsWithIgnoringASCIICase(".mlb.com"_s);
-    }
-
-    return *m_needsBlackFullscreenBackgroundQuirk;
-}
-
 bool Quirks::requiresUserGestureToPauseInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -135,8 +135,6 @@ public:
     
     bool needsFlightAwareSerializationQuirk() const;
 
-    bool needsBlackFullscreenBackgroundQuirk() const;
-
     bool requiresUserGestureToPauseInPictureInPicture() const;
     bool requiresUserGestureToLoadInPictureInPicture() const;
 

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -92,9 +92,6 @@ public:
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)
 #endif // ENABLE(VIDEO)
-#if ENABLE(FULLSCREEN_API)
-    virtual String extraFullScreenStyleSheet() { return String(); }
-#endif
 #if ENABLE(ATTACHMENT_ELEMENT)
     virtual String attachmentStyleSheet() const;
 #endif

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -49,7 +49,6 @@
 #include "MathMLElement.h"
 #include "MediaQueryEvaluator.h"
 #include "Page.h"
-#include "Quirks.h"
 #include "RenderTheme.h"
 #include "RuleSetBuilder.h"
 #include "SVGElement.h"
@@ -231,12 +230,7 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
 
 #if ENABLE(FULLSCREEN_API)
     if (!fullscreenStyleSheet && element.document().fullscreenManager().isFullscreen()) {
-        StringBuilder fullscreenRules;
-        fullscreenRules.appendCharacters(fullscreenUserAgentStyleSheet, sizeof(fullscreenUserAgentStyleSheet));
-        fullscreenRules.append(RenderTheme::singleton().extraFullScreenStyleSheet());
-        if (element.document().quirks().needsBlackFullscreenBackgroundQuirk())
-            fullscreenRules.append(":-webkit-full-screen { background-color: black; }"_s);
-        fullscreenStyleSheet = parseUASheet(fullscreenRules.toString());
+        fullscreenStyleSheet = parseUASheet(StringImpl::createWithoutCopying(fullscreenUserAgentStyleSheet, sizeof(fullscreenUserAgentStyleSheet)));
         addToDefaultStyle(*fullscreenStyleSheet);
     }
 #endif // ENABLE(FULLSCREEN_API)


### PR DESCRIPTION
#### 6525018e7c182a59c811dfe4e5f37e606ebf89be
<pre>
Remove needsBlackFullscreenBackgroundQuirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=248323">https://bugs.webkit.org/show_bug.cgi?id=248323</a>
rdar://102653160

Reviewed by Tim Nguyen.

This is removing the mlb.com quirk which was needed when
the background was white. Backdrop will take over.
A simple change to allow the fake backdrop to take effect.
SeeAlso <a href="https://github.com/WebKit/WebKit/pull/6021/files">https://github.com/WebKit/WebKit/pull/6021/files</a>
This also aligns WebKit with Gecko for the fullscreen
background.
Further fixes will be made in
<a href="https://github.com/WebKit/WebKit/pull/6688">https://github.com/WebKit/WebKit/pull/6688</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=248148">https://bugs.webkit.org/show_bug.cgi?id=248148</a>

* LayoutTests/TestExpectations:
* LayoutTests/compositing/no-compositing-when-fulll-screen-is-present-expected.txt:
* LayoutTests/platform/gtk/compositing/no-compositing-when-fulll-screen-is-present-expected.txt:
* Source/WebCore/css/fullscreen.css:
(:-webkit-full-screen):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsBlackFullscreenBackgroundQuirk const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::extraFullScreenStyleSheet): Deleted.
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):

Canonical link: <a href="https://commits.webkit.org/257271@main">https://commits.webkit.org/257271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58ca6b24cb73dc0b5331f015741b2946a596b728

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107840 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168109 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84994 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90963 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104066 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1559 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/5011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42038 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2501 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->