### PR TITLE
Slider thumb is wrongly placed in vertical writing-mode + RTL

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-painting-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-painting-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Reference: painting of input[type=range] does not happen outside of its bounds</title>
+<p>The range input below should be fully covered.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Reference: painting of input[type=range] does not happen outside of its bounds</title>
+<p>The range input below should be fully covered.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#range-state-(type=range)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test that painting of input[type=range] does not happen outside of its bounds</title>
+<meta charset="utf-8">
+<link rel="match" href="range-input-painting-ref.html">
+
+<style>
+    #container {
+        position: relative;
+    }
+    #cover {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: red;
+    }
+    @supports (writing-mode: vertical-lr) {
+        #cover {
+            background-color: Canvas;
+        }
+    }
+    input {
+        appearance: none; /* Disable any native appearance that could cause ink overflow */
+        writing-mode: vertical-lr;
+    }
+</style>
+
+<p>The range input below should be fully covered.</p>
+
+<div id="container">
+    <input type="range">
+    <div id="cover"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>Reference: painting of input[type=range] does not happen outside of its bounds</title>
+<p>The range input below should be fully covered.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#range-state-(type=range)">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test that painting of input[type=range] does not happen outside of its bounds</title>
+<meta charset="utf-8">
+<link rel="match" href="range-input-painting-ref.html">
+
+<style>
+    #container {
+        position: relative;
+    }
+    #cover {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: red;
+    }
+    @supports (writing-mode: vertical-lr) and (direction: rtl) {
+        #cover {
+            background-color: Canvas;
+        }
+    }
+    input {
+        appearance: none; /* Disable any native appearance that could cause ink overflow */
+        writing-mode: vertical-lr;
+        direction: rtl;
+    }
+</style>
+
+<p>The range input below should be fully covered.</p>
+
+<div id="container">
+    <input type="range">
+    <div id="cover"></div>
+</div>
+

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -160,13 +160,14 @@ void RenderSliderContainer::layout()
     LayoutUnit offset { percentageOffset * availableExtent };
     LayoutPoint thumbLocation = thumb->location();
     if (isVertical) {
-        // RTL in vertical writing mode or appearance: slider-vertical in horizontal writing mode.
-        if (!style().isLeftToRightDirection() || style().isHorizontalWritingMode())
+        // appearance: slider-vertical in horizontal writing mode.
+        if (style().isHorizontalWritingMode())
             thumbLocation.setY(thumbLocation.y() + track->contentHeight() - thumb->height() - offset);
-        else // LTR in vertical writing mode.
+        else if (style().isLeftToRightDirection()) // LTR in vertical writing mode.
             thumbLocation.setY(thumbLocation.y() + offset);
-    }
-    else if (style().isLeftToRightDirection())
+        else // RTL in vertical writing mode.
+            thumbLocation.setY(thumbLocation.y() - offset);
+    } else if (style().isLeftToRightDirection())
         thumbLocation.setX(thumbLocation.x() + offset);
     else
         thumbLocation.setX(thumbLocation.x() - offset);


### PR DESCRIPTION
#### 7275c7c8b394ea3e97330b45887428e5331f8414
<pre>
Slider thumb is wrongly placed in vertical writing-mode + RTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=248320">https://bugs.webkit.org/show_bug.cgi?id=248320</a>
rdar://102652014

Reviewed by Cameron McCormack.

thumb-&gt;setLocation() uses logical coordinates, so we can&apos;t share the same path with appearance: slider-vertical, otherwise we
end up placing the thumb outside of the track.

Add reftests that check that we don&apos;t paint anything outside the bounds of the input.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-painting-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-rtl-painting.html: Added.
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::layout):

Canonical link: <a href="https://commits.webkit.org/257002@main">https://commits.webkit.org/257002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd8df11c0edd691b560c3d324badcbe25ae24848

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107078 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7180 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35590 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/89976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103741 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84211 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89042 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75302 "Found 1 new API test failure: /TestWTF:WTF_ParkingLot.UnparkOneOneFast (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/830 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/818 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4823 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5636 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41362 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->