### PR TITLE
Simplify valueForImageSliceSide

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -234,18 +234,11 @@ static CSSValueID valueForRepeatRule(NinePieceImageRule rule)
 
 static Ref<CSSPrimitiveValue> valueForImageSliceSide(const Length& length)
 {
-    // These values can be percentages, numbers, or while an animation of mixed types is in progress,
-    // a calculation that combines a percentage and a number.
+    // These values can be percentages or numbers.
     if (length.isPercent())
         return CSSPrimitiveValue::create(length.percent(), CSSUnitType::CSS_PERCENTAGE);
-    if (length.isFixed())
-        return CSSPrimitiveValue::create(length.value());
-
-    // Calculating the actual length currently in use would require most of the code from RenderBoxModelObject::paintNinePieceImage.
-    // And even if we could do that, it's not clear if that's exactly what we'd want during animation.
-    // FIXME: For now, just return 0.
-    ASSERT(length.isCalculated());
-    return CSSPrimitiveValue::create(0);
+    ASSERT(length.isFixed());
+    return CSSPrimitiveValue::create(length.value());
 }
 
 static inline Ref<CSSBorderImageSliceValue> valueForNinePieceImageSlice(const NinePieceImage& image)


### PR DESCRIPTION
#### 1a42ba835f13f09de8d08525461111b1b713ec2f
<pre>
Simplify valueForImageSliceSide
<a href="https://bugs.webkit.org/show_bug.cgi?id=248325">https://bugs.webkit.org/show_bug.cgi?id=248325</a>

Reviewed by Tim Nguyen.

A check for calculated values was added in bug 131480, since back then
animations could wrongly produce that. But it seems that has been fixed
and now a number and a percentage just interpolate discretely, so the
check can be removed.

I have verified that the relevant test still passes.
No test since there should be no observable change in behavior.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForImageSliceSide):

Canonical link: <a href="https://commits.webkit.org/262121@main">https://commits.webkit.org/262121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d713046c5c3066666b13480f204772ad16413e31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/280 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/533 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/358 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/262 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/312 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/309 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/285 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/529 "1 flakes 2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/315 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/295 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/38 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/145 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/289 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/313 "Built successfully") | 
| | | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/38 "Passed tests") | 
<!--EWS-Status-Bubble-End-->