### PR TITLE
Wrong overflow behavior for input fields containing ::-webkit-textfield-decoration-container in vertical writing-mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Reference: Number input in vertical writing mode with long value does not cause ink overflow</title>
+<p>Number input with long value does not cause ink overflow</p>
+<style>
+    input {
+        writing-mode: vertical-lr;
+        appearance: none;
+        inline-size: 10em;
+    }
+</style>
+<input type="number">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Reference: Number input in vertical writing mode with long value does not cause ink overflow</title>
+<p>Number input with long value does not cause ink overflow</p>
+<style>
+    input {
+        writing-mode: vertical-lr;
+        appearance: none;
+        inline-size: 10em;
+    }
+</style>
+<input type="number">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#the-input-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Number input in vertical writing mode with long value does not cause ink overflow</title>
+<meta charset="utf-8">
+<link rel="match" href="number-input-vertical-overflow-ref.html">
+<style>
+    input {
+        writing-mode: vertical-lr;
+        color: transparent;
+        appearance: none;
+        inline-size: 10em;
+    }
+</style>
+<p>Number input with long value does not cause ink overflow</p>
+<input type="number" value="11111111111111111111111111111111111">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll-expected.txt
@@ -1,0 +1,17 @@
+
+
+PASS input[type=text] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=text] in vertical-rl: typing characters in input should not cause the page to scroll
+PASS input[type=email] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=email] in vertical-rl: typing characters in input should not cause the page to scroll
+PASS input[type=tel] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=tel] in vertical-rl: typing characters in input should not cause the page to scroll
+PASS input[type=url] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=url] in vertical-rl: typing characters in input should not cause the page to scroll
+PASS input[type=password] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=password] in vertical-rl: typing characters in input should not cause the page to scroll
+PASS input[type=search] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=search] in vertical-rl: typing characters in input should not cause the page to scroll
+PASS input[type=number] in vertical-lr: typing characters in input should not cause the page to scroll
+PASS input[type=number] in vertical-rl: typing characters in input should not cause the page to scroll
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://html.spec.whatwg.org/#the-input-element">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-4/#block-flow">
+<title>Test that typing lots of characters inside vertical text inputs doesn't cause scroll position changes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+    .spacer {
+        height: 100vh;
+    }
+    input { font-family: monospace; }
+</style>
+
+<div class="spacer"></div>
+<input id="testInput">
+<div class="spacer"></div>
+
+<script>
+for (const inputType of ["text", "email", "tel", "url", "password", "search", "number"]) {
+    testInput.type = inputType;
+    for (const writingMode of ["vertical-lr", "vertical-rl", "sideways-lr", "sideways-rl"]) {
+        if (!CSS.supports("writing-mode", writingMode))
+            continue;
+        promise_test(async t => {
+            assert_true(
+                document.documentElement.scrollHeight > document.documentElement.clientHeight,
+                "Page is scrollable"
+            );
+            testInput.style.writingMode = writingMode;
+            document.documentElement.scrollTop = 0;
+            t.add_cleanup(() => {
+                document.documentElement.scrollTop = 0;
+                testInput.value = "";
+            });
+
+            // Align input to the bottom edge
+            testInput.scrollIntoView({block: "end", inline: "nearest"});
+
+            assert_true(
+                document.documentElement.scrollTop > 0,
+                "Successfully scrolled"
+            );
+
+            const oldScrollTop = document.documentElement.scrollTop;
+
+            const numCharsToOverflow = document.documentElement.clientHeight / parseInt(getComputedStyle(testInput).fontSize);
+            const value = "1".repeat(numCharsToOverflow);
+
+            await test_driver.click(testInput);
+
+            assert_true(testInput.matches(":focus"), "input is focused");
+
+            await test_driver.send_keys(testInput, value);
+
+            assert_equals(
+                document.documentElement.scrollTop,
+                oldScrollTop,
+                "Typing lots of characters in input did not cause scrolling"
+            );
+        }, `input[type=${inputType}] in ${writingMode}: typing characters in input should not cause the page to scroll`);
+    }
+}
+</script>

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -111,7 +111,13 @@ std::optional<Style::ElementStyle> TextControlInnerElement::resolveCustomStyle(c
     auto newStyle = RenderStyle::createPtr();
     newStyle->inheritFrom(*shadowHostStyle);
     newStyle->setFlexGrow(1);
-    newStyle->setMinWidth(Length { 0, LengthType::Fixed }); // Needed for correct shrinking.
+
+    // Needed for correct shrinking.
+    if (newStyle->isHorizontalWritingMode())
+        newStyle->setMinWidth(Length { 0, LengthType::Fixed });
+    else
+        newStyle->setMinHeight(Length { 0, LengthType::Fixed });
+
     newStyle->setDisplay(DisplayType::Block);
     newStyle->setDirection(TextDirection::LTR);
     // We don't want the shadow DOM to be editable, so we set this block to read-only in case the input itself is editable.


### PR DESCRIPTION
#### 13ee07bc7a8e703c96573e18cdf6527c40c593c1
<pre>
Wrong overflow behavior for input fields containing ::-webkit-textfield-decoration-container in vertical writing-mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=248321">https://bugs.webkit.org/show_bug.cgi?id=248321</a>
rdar://102652144

Reviewed by Cameron McCormack.

min-width: 0; is set to avoid the inner &lt;div&gt; (which has flex-grow: 1) from growing. We need the equivalent in vertical writing mode.

* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/number-input-vertical-overflow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-writing-modes/forms/text-input-vertical-overflow-no-scroll.html: Added.
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlInnerElement::resolveCustomStyle):

Canonical link: <a href="https://commits.webkit.org/257008@main">https://commits.webkit.org/257008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d9504e4fc7e92a6d617f38b26a005e93bb58f34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107105 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7211 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35620 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103764 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103258 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84239 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/857 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/844 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/21998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5664 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2382 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2097 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->