### PR TITLE
Remove references to WebRTC third party library usrsctp

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -2081,30 +2081,6 @@ else ()
         Source/third_party/libyuv/source/scale_neon.cc
         Source/third_party/libyuv/source/scale_neon64.cc
 
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_asconf.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_auth.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_bsd_addr.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_callout.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_cc_functions.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_crc32.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_indata.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_input.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_output.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_peeloff.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sha1.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_ss_functions.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_timer.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_userspace.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_usrreq.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctputil.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet6/sctp6_usrreq.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_environment.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_mbuf.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_recv_thread.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_socket.c
-
         Source/webrtc/modules/audio_device/linux/alsasymboltable_linux.cc
         Source/webrtc/modules/audio_device/linux/audio_device_alsa_linux.cc
         Source/webrtc/modules/audio_device/linux/audio_device_pulse_linux.cc
@@ -2216,10 +2192,6 @@ set(webrtc_INCLUDE_DIRECTORIES PRIVATE
     Source/third_party/opus/src/include
     Source/third_party/opus/src/silk
     Source/third_party/opus/src/silk/float
-    Source/third_party/usrsctp
-    Source/third_party/usrsctp/usrsctplib
-    Source/third_party/usrsctp/usrsctplib/usrsctplib
-    Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet
     Source/webrtc
     Source/webrtc/common_audio/resampler/include
     Source/webrtc/common_audio/signal_processing/include
@@ -2305,47 +2277,6 @@ target_include_directories(libsrtp PRIVATE
 )
 
 if (APPLE)
-    add_library(usrsctp STATIC
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_asconf.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_auth.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_bsd_addr.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_callout.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_cc_functions.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_crc32.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_indata.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_input.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_output.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_peeloff.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sha1.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_ss_functions.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_timer.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_userspace.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_usrreq.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctputil.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/netinet6/sctp6_usrreq.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_environment.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_mbuf.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_recv_thread.c
-        Source/third_party/usrsctp/usrsctplib/usrsctplib/user_socket.c
-    )
-    target_compile_options(usrsctp PRIVATE
-        -D__Userspace_os_Darwin
-    )
-
-    target_include_directories(usrsctp PRIVATE
-        Source/third_party/boringssl/src/include
-        Source/third_party/usrsctp/usrsctplib/usrsctplib
-    )
-
-    target_compile_definitions(usrsctp PRIVATE
-        __Userspace__
-        SCTP_SIMPLE_ALLOCATOR
-        SCTP_PROCESS_LEVEL_LOCKS
-        SCTP_USE_OPENSSL_SHA1
-    )
-
     set(opus_SOURCES
         Source/third_party/opus/src/celt/kiss_fft.c
         Source/third_party/opus/src/celt/rate.c

--- a/Source/ThirdParty/libwebrtc/Source/DEPS
+++ b/Source/ThirdParty/libwebrtc/Source/DEPS
@@ -69,8 +69,6 @@ deps = {
     Var('chromium_git') + '/external/github.com/cisco/openh264' + '@' + '0fd88df93c5dcaf858c57eb7892bd27763f0f0ac',
   'src/third_party/openmax_dl':
     Var('chromium_git') + '/external/webrtc/deps/third_party/openmax.git' + '@' +  Var('openmax_dl_revision'),
-  'src/third_party/usrsctp/usrsctplib':
-    Var('chromium_git') + '/external/github.com/sctplab/usrsctp' + '@' + '2f6478eb8d40f1766a96b5b033ed26c0c2244589',
   'src/third_party/yasm/source/patched-yasm':
     Var('chromium_git') + '/chromium/deps/yasm/patched-yasm.git' + '@' + '7da28c6c7c6a1387217352ce02b31754deb54d2a',
   'src/tools':


### PR DESCRIPTION
#### ee56f48f9734da735edc19f3fa24f5070ea8b91b
<pre>
Remove references to WebRTC third party library usrsctp
<a href="https://bugs.webkit.org/show_bug.cgi?id=248336">https://bugs.webkit.org/show_bug.cgi?id=248336</a>

Reviewed by Youenn Fablet and Carlos Garcia Campos.

The library was removed in 256830@main but there were still references
to it in LibWebRTC&apos;s CMakeLists.txt.

* Source/ThirdParty/libwebrtc/CMakeLists.txt: Remove references to
  usrsctp.
* Source/ThirdParty/libwebrtc/Source/DEPS: Remove references to usrsctp.

Canonical link: <a href="https://commits.webkit.org/257020@main">https://commits.webkit.org/257020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/744d918ba128dad665cc01f31aaa11db11b0cd31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107111 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167374 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7220 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35625 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103770 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103263 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84245 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32410 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75332 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/862 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/849 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4833 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5669 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41394 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->