### PR TITLE
[GTK] UI process crash when opening video settings

### DIFF
--- a/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp
@@ -261,6 +261,16 @@ Vector<Ref<WebContextMenuItem>> WebContextMenuProxyGtk::proposedItems() const
     return proposedAPIItems;
 }
 
+void WebContextMenuProxyGtk::show()
+{
+    if (m_context.type() != ContextMenuContext::Type::ContextMenu) {
+        useContextMenuItems(proposedItems());
+        return;
+    }
+
+    WebContextMenuProxy::show();
+}
+
 void WebContextMenuProxyGtk::showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&& items)
 {
     if (!items.isEmpty())

--- a/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.h
@@ -56,6 +56,7 @@ public:
 
 private:
     WebContextMenuProxyGtk(GtkWidget*, WebPageProxy&, ContextMenuContextData&&, const UserData&);
+    void show() override;
     Vector<Ref<WebContextMenuItem>> proposedItems() const override;
     void showContextMenuWithItems(Vector<Ref<WebContextMenuItem>>&&) override;
     void append(GMenu*, const WebContextMenuItemGlib&);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageContextMenuClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageContextMenuClient.h
@@ -31,6 +31,7 @@
 #include <wtf/Forward.h>
 
 namespace WebCore {
+class ContextMenuContext;
 class ContextMenuItem;
 class HitTestResult;
 }
@@ -52,7 +53,7 @@ class PageContextMenuClient {
 public:
     virtual ~PageContextMenuClient() { }
 
-    virtual bool getCustomMenuFromDefaultItems(WebKit::WebPage&, const WebCore::HitTestResult&, const Vector<WebCore::ContextMenuItem>& /* defaultMenu */, Vector<WebKit::WebContextMenuItemData>& /* newMenu */, RefPtr<API::Object>& /* userData */) { return false; }
+    virtual bool getCustomMenuFromDefaultItems(WebKit::WebPage&, const WebCore::HitTestResult&, const Vector<WebCore::ContextMenuItem>& /* defaultMenu */, Vector<WebKit::WebContextMenuItemData>& /* newMenu */, const WebCore::ContextMenuContext&, RefPtr<API::Object>& /* userData */) { return false; }
     virtual void prepareForImmediateAction(WebKit::WebPage&, const WebCore::HitTestResult&, RefPtr<API::Object>& /* userData */) { }
 };
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -40,6 +40,7 @@
 #include "WebKitWebProcessEnumTypes.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
+#include <WebCore/ContextMenuContext.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/Frame.h>
@@ -261,8 +262,11 @@ public:
     }
 
 private:
-    bool getCustomMenuFromDefaultItems(WebPage&, const WebCore::HitTestResult& hitTestResult, const Vector<WebCore::ContextMenuItem>& defaultMenu, Vector<WebContextMenuItemData>& newMenu, RefPtr<API::Object>& userData) override
+    bool getCustomMenuFromDefaultItems(WebPage&, const WebCore::HitTestResult& hitTestResult, const Vector<WebCore::ContextMenuItem>& defaultMenu, Vector<WebContextMenuItemData>& newMenu, const WebCore::ContextMenuContext& context, RefPtr<API::Object>& userData) override
     {
+        if (context.type() != ContextMenuContext::Type::ContextMenu)
+            return false;
+
         GRefPtr<WebKitContextMenu> contextMenu = adoptGRef(webkitContextMenuCreate(kitItems(defaultMenu)));
         GRefPtr<WebKitWebHitTestResult> webHitTestResult = adoptGRef(webkitWebHitTestResultCreate(hitTestResult));
         gboolean returnValue;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp
@@ -46,7 +46,7 @@ InjectedBundlePageContextMenuClient::InjectedBundlePageContextMenuClient(const W
     initialize(client);
 }
 
-bool InjectedBundlePageContextMenuClient::getCustomMenuFromDefaultItems(WebPage& page, const HitTestResult& hitTestResult, const Vector<ContextMenuItem>& proposedMenu, Vector<WebContextMenuItemData>& newMenu, RefPtr<API::Object>& userData)
+bool InjectedBundlePageContextMenuClient::getCustomMenuFromDefaultItems(WebPage& page, const HitTestResult& hitTestResult, const Vector<ContextMenuItem>& proposedMenu, Vector<WebContextMenuItemData>& newMenu, const WebCore::ContextMenuContext&, RefPtr<API::Object>& userData)
 {
     if (!m_client.getContextMenuFromDefaultMenu)
         return false;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.h
@@ -40,6 +40,7 @@ template<> struct ClientTraits<WKBundlePageContextMenuClientBase> {
 }
 
 namespace WebCore {
+class ContextMenuContext;
 class ContextMenuItem;
 class HitTestResult;
 }
@@ -53,7 +54,7 @@ public:
     explicit InjectedBundlePageContextMenuClient(const WKBundlePageContextMenuClientBase*);
 
 private:
-    bool getCustomMenuFromDefaultItems(WebPage&, const WebCore::HitTestResult&, const Vector<WebCore::ContextMenuItem>& defaultMenu, Vector<WebContextMenuItemData>& newMenu, RefPtr<API::Object>& userData) override;
+    bool getCustomMenuFromDefaultItems(WebPage&, const WebCore::HitTestResult&, const Vector<WebCore::ContextMenuItem>& defaultMenu, Vector<WebContextMenuItemData>& newMenu, const WebCore::ContextMenuContext&, RefPtr<API::Object>& userData) override;
     void prepareForImmediateAction(WebPage&, const WebCore::HitTestResult&, RefPtr<API::Object>& userData) override;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
@@ -89,7 +89,7 @@ void WebContextMenu::menuItemsWithUserData(Vector<WebContextMenuItemData> &menuI
     // Give the bundle client a chance to process the menu.
     const Vector<ContextMenuItem>& coreItems = menu->items();
 
-    if (m_page->injectedBundleContextMenuClient().getCustomMenuFromDefaultItems(*m_page, controller.hitTestResult(), coreItems, menuItems, userData))
+    if (m_page->injectedBundleContextMenuClient().getCustomMenuFromDefaultItems(*m_page, controller.hitTestResult(), coreItems, menuItems, controller.context(), userData))
         return;
     menuItems = kitItems(coreItems);
 }


### PR DESCRIPTION
#### f4b30ff111b45df522f76483d9e7b6ddd0775f78
<pre>
[GTK] UI process crash when opening video settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=247089">https://bugs.webkit.org/show_bug.cgi?id=247089</a>

Reviewed by Michael Catanzaro.

Do no emit the context-menus signals for video settings popup menu.

* Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.cpp:
(WebKit::WebContextMenuProxyGtk::show):
* Source/WebKit/UIProcess/gtk/WebContextMenuProxyGtk.h:
* Source/WebKit/WebProcess/InjectedBundle/API/APIInjectedBundlePageContextMenuClient.h:
(API::InjectedBundle::PageContextMenuClient::getCustomMenuFromDefaultItems):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.cpp:
(WebKit::InjectedBundlePageContextMenuClient::getCustomMenuFromDefaultItems):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageContextMenuClient.h:
* Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp:
(WebKit::WebContextMenu::menuItemsWithUserData const):

Canonical link: <a href="https://commits.webkit.org/257023@main">https://commits.webkit.org/257023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96cc30fe0b6a6c86c58233fe4dc743d82dde09d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107114 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7223 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35628 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103773 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103266 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84248 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32419 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75340 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/865 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22004 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4835 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41396 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->