### PR TITLE
[JSC] Improve resizable TypedArray's slice implementation's spec conformance

### DIFF
--- a/JSTests/stress/v8-regress-1376784.js
+++ b/JSTests/stress/v8-regress-1376784.js
@@ -1,0 +1,36 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --turbofan
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+function test() {
+  let depth = 100;
+  const arr = [];
+  const factory = class MyArray extends Uint8Array {
+    constructor() {
+      async function foo() { new factory(); }
+      if(depth-- > 0) {
+        const x = foo();
+        super(arr);
+        this.__proto__ = x;
+        const unused1 = super.byteLength;
+      } else {
+        super(arr);
+      }
+    }
+  };
+  const unused2 = new factory();
+  arr.__proto__ = factory;
+  return arr;
+}
+
+test();
+// %PrepareFunctionForOptimization(test);
+test();
+// %OptimizeFunctionOnNextCall(test);
+test();

--- a/JSTests/stress/v8-regress-1380398.js
+++ b/JSTests/stress/v8-regress-1380398.js
@@ -1,0 +1,23 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --turbofan --harmony-rab-gsab
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+function test() {
+  const ab = new ArrayBuffer(2996, { maxByteLength: 8588995 });
+  const dv = new DataView(ab);
+  const len = dv.byteLength;
+  return len >= 255;
+}
+
+// %PrepareFunctionForOptimization(test);
+assertTrue(test());
+assertTrue(test());
+// %OptimizeFunctionOnNextCall(test);
+assertTrue(test());
+// assertOptimized(test);

--- a/JSTests/stress/v8-regress-crbug-1359991.js
+++ b/JSTests/stress/v8-regress-crbug-1359991.js
@@ -1,0 +1,26 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+// Copyright 2022 Apple Inc. All rights reserved.
+// Modified since original V8's test had an issue.
+
+// Flags: --harmony-rab-gsab
+
+"use strict";
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+const rab = new ArrayBuffer(1744, {"maxByteLength": 4000});
+let callSlice = true;
+class MyFloat64Array extends Float64Array {
+  constructor() {
+    super(rab);
+    if (callSlice) {
+      callSlice = false;  // Prevent recursion
+      super.slice();
+    }
+  }
+};
+new MyFloat64Array();

--- a/JSTests/stress/v8-regress-crbug-1362487.js
+++ b/JSTests/stress/v8-regress-crbug-1362487.js
@@ -1,0 +1,22 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+// Copyright 2022 Apple Inc. All rights reserved.
+// Modified since original V8's test had an issue.
+
+// Flags: --harmony-rab-gsab
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+const rab1 = new ArrayBuffer(1000, {'maxByteLength': 4000});
+class MyInt8Array extends Int8Array {
+    constructor() {
+        super(rab1);
+    }
+};
+const rab2 = new ArrayBuffer(2000, {'maxByteLength': 4000});
+const ta = new Int8Array(rab2);
+ta.constructor = MyInt8Array;
+assertThrows(() => { ta.slice(); }, TypeError);

--- a/JSTests/stress/v8-regress-crbug-1384474-variant2.js
+++ b/JSTests/stress/v8-regress-crbug-1384474-variant2.js
@@ -1,0 +1,17 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-rab-gsab
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+const rab1 = new ArrayBuffer(4, {"maxByteLength": 100});
+const ta = new Int8Array(rab1);
+const rab2 = new ArrayBuffer(10, {"maxByteLength": 20});
+const lengthTracking = new Int8Array(rab2);
+rab2.resize(0);
+ta.constructor = { [Symbol.species]: function() { return lengthTracking; } };
+assertThrows(() => { ta.slice(); }, TypeError);

--- a/JSTests/stress/v8-regress-crbug-1384474-variant3.js
+++ b/JSTests/stress/v8-regress-crbug-1384474-variant3.js
@@ -1,0 +1,18 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-rab-gsab
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+const rab1 = new ArrayBuffer(4, {"maxByteLength": 100});
+const ta = new Int8Array(rab1);
+const rab2 = new ArrayBuffer(10, {"maxByteLength": 20});
+const lengthTracking = new Int8Array(rab2);
+rab2.resize(0);
+ta.constructor = { [Symbol.species]: function() { return lengthTracking; } };
+assertThrows(() => { ta.filter(() => { return true; }); },
+             TypeError);

--- a/JSTests/stress/v8-regress-crbug-1384474.js
+++ b/JSTests/stress/v8-regress-crbug-1384474.js
@@ -1,0 +1,16 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-rab-gsab
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+const ta = new Int8Array(4);
+const rab = new ArrayBuffer(10, {"maxByteLength": 20});
+const lengthTracking = new Int8Array(rab);
+rab.resize(0);
+ta.constructor = { [Symbol.species]: function() { return lengthTracking; } };
+assertThrows(() => { ta.slice(); }, TypeError);

--- a/JSTests/stress/v8-regress-crbug-1392577.js
+++ b/JSTests/stress/v8-regress-crbug-1392577.js
@@ -1,0 +1,18 @@
+//@ requireOptions("--useResizableArrayBuffer=1")
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-rab-gsab
+
+load("./resources/v8-mjsunit.js", "caller relative");
+load("./resources/v8-typedarray-helpers.js", "caller relative");
+
+const rab = new ArrayBuffer(50, {"maxByteLength": 100});
+const ta = new Int8Array(rab);
+const start = {};
+start.valueOf = function() {
+  rab.resize(0);
+  return 5;
+}
+ta.fill(5, start);


### PR DESCRIPTION
#### c8c81173ec65dce5414985944e7f12e04a711308
<pre>
[JSC] Improve resizable TypedArray&apos;s slice implementation&apos;s spec conformance
<a href="https://bugs.webkit.org/show_bug.cgi?id=248337">https://bugs.webkit.org/show_bug.cgi?id=248337</a>
rdar://problem/102661384

Reviewed by Ross Kirsling.

This patch fixes TypedArray#slice&apos;s spec conformance a bit: test length against previously passed value (not updatedLength).
We also import new V8 tests more.

* JSTests/stress/v8-regress-1376784.js: Added.
(test.const.factory.async foo):
(test.const.factory):
(test):
* JSTests/stress/v8-regress-1380398.js: Added.
(test):
* JSTests/stress/v8-regress-crbug-1359991.js: Added.
(MyFloat64Array):
* JSTests/stress/v8-regress-crbug-1362487.js: Added.
(MyInt8Array):
(assertThrows):
* JSTests/stress/v8-regress-crbug-1384474-variant2.js: Added.
(ta.Symbol.species):
(assertThrows):
* JSTests/stress/v8-regress-crbug-1384474-variant3.js: Added.
(ta.Symbol.species):
(assertThrows):
* JSTests/stress/v8-regress-crbug-1384474.js: Added.
(ta.Symbol.species):
(assertThrows):
* JSTests/stress/v8-regress-crbug-1392577.js: Added.
(start.valueOf):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::speciesConstruct):
(JSC::genericTypedArrayViewProtoFuncSlice):
(JSC::genericTypedArrayViewProtoFuncSubarray):

Canonical link: <a href="https://commits.webkit.org/257018@main">https://commits.webkit.org/257018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eed6a3bc0952b76a23e859dc011c3e849988a05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107115 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167378 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7224 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35629 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103774 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84249 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88523 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/866 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84195 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/853 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28507 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87022 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2387 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41399 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19529 "Passed tests") | 
<!--EWS-Status-Bubble-End-->