### PR TITLE
[web-animations] opacity should use unclamped values for from/to keyframes with iterationComposite

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt
@@ -8,7 +8,7 @@ PASS iteration composition of <number> type animation
 PASS iteration composition of <shape> type animation
 PASS iteration composition of <calc()> value animation
 PASS iteration composition of <calc()> value animation that the values can'tbe reduced
-FAIL iteration composition of opacity animation assert_equals: Animated opacity style at 50s of the third iteration expected "1" but got "0.9"
+PASS iteration composition of opacity animation
 PASS iteration composition of box-shadow animation
 PASS iteration composition of filter blur animation
 PASS iteration composition of filter brightness for different unit animation

--- a/Source/WebCore/animation/CSSPropertyAnimation.h
+++ b/Source/WebCore/animation/CSSPropertyAnimation.h
@@ -30,6 +30,7 @@
 
 #include "CSSPropertyNames.h"
 #include "CompositeOperation.h"
+#include "IterationCompositeOperation.h"
 #include <wtf/HashSet.h>
 
 namespace WebCore {
@@ -41,13 +42,14 @@ class CSSPropertyAnimation {
 public:
     static bool isPropertyAnimatable(CSSPropertyID);
     static bool isPropertyAdditiveOrCumulative(CSSPropertyID);
+    static bool propertyRequiresBlendingForAccumulativeIteration(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static bool animationOfPropertyIsAccelerated(CSSPropertyID);
     static bool propertiesEqual(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static bool canPropertyBeInterpolated(CSSPropertyID, const RenderStyle& a, const RenderStyle& b);
     static CSSPropertyID getPropertyAtIndex(int, std::optional<bool>& isShorthand);
     static int getNumProperties();
 
-    static void blendProperties(const CSSPropertyBlendingClient*, CSSPropertyID, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation);
+    static void blendProperties(const CSSPropertyBlendingClient*, CSSPropertyID, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress, CompositeOperation, IterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0);
     static void blendCustomProperty(const AtomString&, RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, double progress);
 };
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1531,6 +1531,8 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
         auto startKeyframeStyle = RenderStyle::clone(*startKeyframe.style());
         auto endKeyframeStyle = RenderStyle::clone(*endKeyframe.style());
 
+        auto usedBlendingForAccumulativeIteration = false;
+
         // 12. For each keyframe in interval endpoints:
         //     If keyframe has a composite operation that is not replace, or keyframe has no composite operation and the
         //     composite operation of this keyframe effect is not replace, then perform the following steps:
@@ -1562,7 +1564,8 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
                 }
 
                 // If this keyframe effect has an iteration composite operation of accumulate,
-                if (m_iterationCompositeOperation == IterationCompositeOperation::Accumulate) {
+                if (m_iterationCompositeOperation == IterationCompositeOperation::Accumulate && currentIteration && CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration(cssPropertyId, startKeyframeStyle, endKeyframeStyle)) {
+                    usedBlendingForAccumulativeIteration = true;
                     // apply the following step current iteration times:
                     for (auto i = 0; i < currentIteration; ++i) {
                         // replace the property value of target property on keyframe with the result of combining the
@@ -1608,7 +1611,11 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
         //     property specified on the two keyframes in interval endpoints taking the first such value as Vstart and the second as Vend and using transformed
         //     distance as the interpolation parameter p.
         WTF::switchOn(property,
-            [&] (CSSPropertyID propertyId) { CSSPropertyAnimation::blendProperties(this, propertyId, targetStyle, startKeyframeStyle, endKeyframeStyle, transformedDistance, CompositeOperation::Replace); },
+            [&] (CSSPropertyID propertyId) {
+                auto iterationCompositeOperation = usedBlendingForAccumulativeIteration ? IterationCompositeOperation::Replace : m_iterationCompositeOperation;
+                currentIteration = usedBlendingForAccumulativeIteration ? 0 : currentIteration;
+                CSSPropertyAnimation::blendProperties(this, propertyId, targetStyle, startKeyframeStyle, endKeyframeStyle, transformedDistance, CompositeOperation::Replace, iterationCompositeOperation, currentIteration);
+            },
             [&] (AtomString customProperty) { CSSPropertyAnimation::blendCustomProperty(customProperty, targetStyle, startKeyframeStyle, endKeyframeStyle, transformedDistance); }
         );
     };

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -322,10 +322,10 @@ Length blend(const Length& from, const Length& to, const BlendingContext& contex
     if (from.isCalculated() || to.isCalculated() || (from.type() != to.type()))
         return blendMixedTypes(from, to, context);
 
-    if (!context.progress && context.compositeOperation == CompositeOperation::Replace)
+    if (!context.progress && context.isReplace())
         return from;
 
-    if (context.progress == 1 && context.compositeOperation == CompositeOperation::Replace)
+    if (context.progress == 1 && context.isReplace())
         return to;
 
     LengthType resultType = to.type();

--- a/Source/WebCore/platform/animation/AnimationUtilities.h
+++ b/Source/WebCore/platform/animation/AnimationUtilities.h
@@ -27,6 +27,7 @@
 
 #include "CompositeOperation.h"
 #include "IntPoint.h"
+#include "IterationCompositeOperation.h"
 #include "LayoutPoint.h"
 
 namespace WebCore {
@@ -35,17 +36,32 @@ struct BlendingContext {
     double progress { 0 };
     bool isDiscrete { false };
     CompositeOperation compositeOperation { CompositeOperation::Replace };
+    IterationCompositeOperation iterationCompositeOperation { IterationCompositeOperation::Replace };
+    double currentIteration { 0 };
 
-    BlendingContext(double progress = 0, bool isDiscrete = false, CompositeOperation compositeOperation = CompositeOperation::Replace)
+    BlendingContext(double progress = 0, bool isDiscrete = false, CompositeOperation compositeOperation = CompositeOperation::Replace, IterationCompositeOperation iterationCompositeOperation = IterationCompositeOperation::Replace, double currentIteration = 0)
         : progress(progress)
         , isDiscrete(isDiscrete)
         , compositeOperation(compositeOperation)
+        , iterationCompositeOperation(iterationCompositeOperation)
+        , currentIteration(currentIteration)
     {
+    }
+
+    bool isReplace() const
+    {
+        return compositeOperation == CompositeOperation::Replace && iterationCompositeOperation == IterationCompositeOperation::Replace;
     }
 };
 
 inline int blend(int from, int to, const BlendingContext& context)
 {  
+    if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
+        auto iterationIncrement = static_cast<int>(context.currentIteration * static_cast<double>(to));
+        from += iterationIncrement;
+        to += iterationIncrement;
+    }
+
     if (context.compositeOperation == CompositeOperation::Replace)
         return static_cast<int>(roundTowardsPositiveInfinity(from + (static_cast<double>(to) - from) * context.progress));
     return static_cast<int>(roundTowardsPositiveInfinity(static_cast<double>(from) + static_cast<double>(from) + static_cast<double>(to - from) * context.progress));
@@ -53,6 +69,12 @@ inline int blend(int from, int to, const BlendingContext& context)
 
 inline unsigned blend(unsigned from, unsigned to, const BlendingContext& context)
 {
+    if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
+        auto iterationIncrement = static_cast<unsigned>(context.currentIteration * static_cast<double>(to));
+        from += iterationIncrement;
+        to += iterationIncrement;
+    }
+
     if (context.compositeOperation == CompositeOperation::Replace)
         return static_cast<unsigned>(lround(from + (static_cast<double>(to) - from) * context.progress));
     return static_cast<unsigned>(lround(from + from + (static_cast<double>(to) - from) * context.progress));
@@ -60,6 +82,12 @@ inline unsigned blend(unsigned from, unsigned to, const BlendingContext& context
 
 inline double blend(double from, double to, const BlendingContext& context)
 {  
+    if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
+        auto iterationIncrement = context.currentIteration * to;
+        from += iterationIncrement;
+        to += iterationIncrement;
+    }
+
     if (context.compositeOperation == CompositeOperation::Replace)
         return from + (to - from) * context.progress;
     return from + from + (to - from) * context.progress;
@@ -67,6 +95,12 @@ inline double blend(double from, double to, const BlendingContext& context)
 
 inline float blend(float from, float to, const BlendingContext& context)
 {  
+    if (context.iterationCompositeOperation == IterationCompositeOperation::Accumulate && context.currentIteration) {
+        auto iterationIncrement = static_cast<float>(context.currentIteration * to);
+        from += iterationIncrement;
+        to += iterationIncrement;
+    }
+
     if (context.compositeOperation == CompositeOperation::Replace)
         return static_cast<float>(from + (to - from) * context.progress);
     return static_cast<float>(from + from + (to - from) * context.progress);


### PR DESCRIPTION
#### f0e70ac5078d742d598da042f4728d042aca3e98
<pre>
[web-animations] opacity should use unclamped values for from/to keyframes with iterationComposite
<a href="https://bugs.webkit.org/show_bug.cgi?id=248338">https://bugs.webkit.org/show_bug.cgi?id=248338</a>

Reviewed by Antti Koivisto.

Our last failure in web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation.html
was because of code that looks like this:

    const animation = div.animate({ opacity: [0, 0.4] }, { duration: 1000, iterations: 10, iterationComposite: &apos;accumulate&apos; });
    animation.currentTime += animation.effect.getComputedTiming().duration * 2.5;
    assert_equals(getComputedStyle(div).opacity, &apos;1&apos;, // (0.8 + 1.2) * 0.5
        &apos;Animated opacity style in the middle of the third iteration&apos;);

We failed this test is because in the third iteration we would compute from/to kefyrames to be 0.8 and 1.0, instead
of 0.8 and 1.2. The reason this happens is because in KeyframeEffect::setAnimatedPropertiesInStyle(), we would compute
the from/to values by blending the from/to keyframes with the to keyframe with accumulation to match the current iteration
with CSSPropertyAnimation::blendProperties(). That method stores the resulting value in a RenderStyle which means in this
case RenderStyle::setOpacity() is called and the blended value is clamped to the specified [0-1] range for opacity.

Some property types require special blending code to run for accumulation, for instance transforms, filters, colors and
shadows. But for most other types where the encapsulated values are numbers, we can run some simple maths to accumulate
the values by the number of iterations. The math looks something like this:

    iterationIncrement = currentIteration * to;
    from += iterationIncrement;
    to += iterationIncrement;

We implement this logic in the various blending functions for float, int, etc. and add a requiresBlendingForAccumulativeIteration()
virtual method on animation wrappers such that methods that require the more complex blending code to be ran iteratively can do so.
This includes lengths and length-based types that will yield calc() values as well as the aforementioned transforms, filters,
colors and shadows.

Then in KeyframeEffect::setAnimatedPropertiesInStyle(), we call CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration()
to check whether we must run blending code to compute the from/to keyframes or simply let those values be computed in the final call
to CSSPropertyAnimation::blendProperties() at the end of the function when the composite operation is &quot;replace&quot;.

To do this, we must also expose the &quot;compositeIteration&quot; and &quot;currentIteration&quot; values to the blending context, so we add those two
members to BlendingContext.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/keyframe-effects/effect-value-iteration-composite-operation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyBlendingContext::CSSPropertyBlendingContext):
(WebCore::blendFunc):
(WebCore::AnimationPropertyWrapperBase::requiresBlendingForAccumulativeIteration const):
(WebCore::lengthsRequireBlendingForAccumulativeIteration):
(WebCore::lengthVariantRequiresBlendingForAccumulativeIteration):
(WebCore::CSSPropertyAnimation::blendProperties):
(WebCore::CSSPropertyAnimation::propertyRequiresBlendingForAccumulativeIteration):
* Source/WebCore/animation/CSSPropertyAnimation.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setAnimatedPropertiesInStyle):
* Source/WebCore/platform/Length.cpp:
(WebCore::blend):
* Source/WebCore/platform/animation/AnimationUtilities.h:
(WebCore::BlendingContext::BlendingContext):
(WebCore::BlendingContext::isReplace const):
(WebCore::blend):

Canonical link: <a href="https://commits.webkit.org/257033@main">https://commits.webkit.org/257033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef4f580dedf6cf500c8825d12e18212d0da6f1be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107116 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167379 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7225 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35630 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90013 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103775 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5409 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84250 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32416 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75337 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/867 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/854 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22008 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5674 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44475 "Found 1 new test failure: fast/images/animated-heics-draw.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2392 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41400 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->