### PR TITLE
StreamClientConnection cannot be held by multiple Remote*Proxy objects

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -66,7 +66,7 @@ StreamClientConnection::StreamConnectionPair StreamClientConnection::create(size
     // The "Client" in StreamClientConnection means the party that mostly does sending, e.g. untrusted party.
     // The "Server" in StreamServerConnection means the party that mostly does receiving, e.g. the trusted party which holds the destination object to communicate with.
     auto dedicatedConnection = Connection::createServerConnection(connectionIdentifiers->server);
-    std::unique_ptr<StreamClientConnection> clientConnection { new StreamClientConnection(WTFMove(dedicatedConnection), bufferSize) };
+    RefPtr<StreamClientConnection> clientConnection { new StreamClientConnection(WTFMove(dedicatedConnection), bufferSize) };
     StreamServerConnection::Handle serverHandle {
         WTFMove(connectionIdentifiers->client),
         clientConnection->streamBuffer().createHandle()

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -54,12 +54,12 @@ namespace IPC {
 // The whole IPC::Connection message order is not preserved.
 //
 // The StreamClientConnection trusts the StreamServerConnection.
-class StreamClientConnection final {
+class StreamClientConnection final : public ThreadSafeRefCounted<StreamClientConnection> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(StreamClientConnection);
 public:
     struct StreamConnectionPair {
-        std::unique_ptr<StreamClientConnection> streamConnection;
+        RefPtr<StreamClientConnection> streamConnection;
         IPC::StreamServerConnection::Handle connectionHandle;
     };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -32,6 +32,7 @@
 #include "RemoteDisplayListRecorderMessages.h"
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
+#include "StreamClientConnection.h"
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/DisplayList.h>
 #include <WebCore/DisplayListDrawingContext.h>
@@ -71,7 +72,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
         return;
 
     m_imageBuffer->backingStoreWillChange();
-    m_renderingBackend->sendToStream(WTFMove(message), m_destinationBufferIdentifier);
+    m_renderingBackend->streamConnection().send(WTFMove(message), m_destinationBufferIdentifier, defaultSendTimeout);
 }
 
 RenderingMode RemoteDisplayListRecorderProxy::renderingMode() const

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -33,6 +33,10 @@
 #include <WebCore/GraphicsContext.h>
 #include <wtf/WeakPtr.h>
 
+namespace IPC {
+class StreamClientConnection;
+}
+
 namespace WebKit {
 
 class RemoteRenderingBackendProxy;
@@ -134,6 +138,7 @@ private:
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatRect&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
 
+    static inline constexpr Seconds defaultSendTimeout = 3_s;
     WebCore::RenderingResourceIdentifier m_destinationBufferIdentifier;
     WeakPtr<RemoteImageBufferProxy> m_imageBuffer;
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -377,7 +377,7 @@ private:
     HashSet<String> m_requestableExtensions;
 
     HashSet<String> m_enabledExtensions;
-    std::unique_ptr<IPC::StreamClientConnection> m_streamConnection;
+    RefPtr<IPC::StreamClientConnection> m_streamConnection;
 };
 
 // The GCGL types map to following WebKit IPC types. The list is used by generate-gpup-webgl script.

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -108,7 +108,7 @@ private:
     GPUProcessConnection* m_gpuProcessConnection;
     bool m_didInitialize { false };
     bool m_lost { false };
-    std::unique_ptr<IPC::StreamClientConnection> m_streamConnection;
+    RefPtr<IPC::StreamClientConnection> m_streamConnection;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -181,7 +181,7 @@ private:
 
 class JSIPCStreamClientConnection : public RefCounted<JSIPCStreamClientConnection>, public CanMakeWeakPtr<JSIPCStreamClientConnection> {
 public:
-    static Ref<JSIPCStreamClientConnection> create(JSIPC& jsIPC, std::unique_ptr<IPC::StreamClientConnection> connection)
+    static Ref<JSIPCStreamClientConnection> create(JSIPC& jsIPC, RefPtr<IPC::StreamClientConnection> connection)
     {
         return adoptRef(*new JSIPCStreamClientConnection(jsIPC, WTFMove(connection)));
     }
@@ -194,7 +194,7 @@ public:
 private:
     friend class JSIPCStreamConnectionBuffer;
 
-    JSIPCStreamClientConnection(JSIPC& jsIPC, std::unique_ptr<IPC::StreamClientConnection> connection)
+    JSIPCStreamClientConnection(JSIPC& jsIPC, RefPtr<IPC::StreamClientConnection> connection)
         : m_jsIPC(jsIPC)
         , m_streamConnection { WTFMove(connection) }
     {
@@ -220,7 +220,7 @@ private:
     static JSValueRef waitForMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
     WeakPtr<JSIPC> m_jsIPC;
-    std::unique_ptr<IPC::StreamClientConnection> m_streamConnection;
+    RefPtr<IPC::StreamClientConnection> m_streamConnection;
 
     // Current tests expect that actions and their induced messages are waited on during same
     // run loop invocation (in JS). This means that messages of interest do not ever enter here.

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -157,7 +157,7 @@ public:
 protected:
     MockMessageReceiver m_mockClientReceiver;
     RefPtr<IPC::StreamConnectionWorkQueue> m_workQueue;
-    std::unique_ptr<IPC::StreamClientConnection> m_clientConnection;
+    RefPtr<IPC::StreamClientConnection> m_clientConnection;
     RefPtr<IPC::StreamServerConnection> m_serverConnection;
 };
 


### PR DESCRIPTION
#### 5d78f243dddd5c77d66e736187a8038c75cce511
<pre>
StreamClientConnection cannot be held by multiple Remote*Proxy objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=248333">https://bugs.webkit.org/show_bug.cgi?id=248333</a>
rdar://problem/102658347

Reviewed by Antti Koivisto.

Make StreamClientConnection a ref counted type. It is natural that all
Remote*Proxy objects send messages, as that is mostly what they are
here to do.

Before, the objects needed to navigate to the connection holder object.

* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::create):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::m_streamConnection):
(WebKit::RemoteDisplayListRecorderProxy::send):
(WebKit::m_renderingBackend): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createRemoteImageBuffer):
(WebKit::RemoteRenderingBackendProxy::getPixelBufferForImageBuffer):
(WebKit::RemoteRenderingBackendProxy::putPixelBufferForImageBuffer):
(WebKit::RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory):
(WebKit::RemoteRenderingBackendProxy::getShareableBitmap):
(WebKit::RemoteRenderingBackendProxy::getFilteredImage):
(WebKit::RemoteRenderingBackendProxy::cacheNativeImage):
(WebKit::RemoteRenderingBackendProxy::cacheFont):
(WebKit::RemoteRenderingBackendProxy::cacheDecomposedGlyphs):
(WebKit::RemoteRenderingBackendProxy::releaseAllRemoteResources):
(WebKit::RemoteRenderingBackendProxy::releaseRemoteResource):
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
(WebKit::RemoteRenderingBackendProxy::markSurfacesVolatile):
(WebKit::RemoteRenderingBackendProxy::finalizeRenderingUpdate):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::send):
(WebKit::RemoteRenderingBackendProxy::sendSync):
(WebKit::RemoteRenderingBackendProxy::sendToStream): Deleted.
(WebKit::RemoteRenderingBackendProxy::sendSyncToStream): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::create):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::JSIPCStreamClientConnection):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:

Canonical link: <a href="https://commits.webkit.org/257620@main">https://commits.webkit.org/257620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77870db550f498b8e3d5c388b83ce2201b92e931

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107381 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167658 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84522 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104017 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32778 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75696 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41653 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->