### PR TITLE
Accurately find all baseline directories

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
@@ -103,6 +103,26 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(self.port.name(), 'test-mac-leopard')
         self.assertIn('platform/test-snow-leopard/websocket/test.html', tests)
 
+    def test_includes_other_platforms_fallback(self):
+        finder = self.finder
+        tests = [t.test_path for t in finder.find_tests_by_path([]) if t.test_path.endswith("/http/test.html")]
+        self.assertEqual(self.port.name(), "test-mac-leopard")
+        self.assertEqual(
+            self.port.baseline_search_path(),
+            [
+                "/test.checkout/LayoutTests/platform/test-mac-leopard",
+                "/test.checkout/LayoutTests/platform/test-mac-snowleopard",
+            ],
+        )
+        self.assertEqual(
+            tests,
+            [
+                "platform/test-mac-leopard/http/test.html",
+                "platform/test-snow-leopard/http/test.html",
+                "platform/test-win-7sp0/http/test.html",
+            ],
+        )
+
     def test_find_one_test(self):
         finder = self.finder
         tests = [t.test_path for t in finder.find_tests_by_path(['failures/expected/image.html'])]

--- a/Tools/Scripts/webkitpy/port/apple.py
+++ b/Tools/Scripts/webkitpy/port/apple.py
@@ -113,6 +113,28 @@ class ApplePort(Port):
                             configurations.append(TestConfiguration(version=version_name, architecture=architecture, build_type=build_type))
         return configurations
 
+    def all_baseline_search_paths(self, device_type=None):
+        paths = (
+            set(self.get_option("additional_platform_directory", []))
+            | set(self._compare_baseline())
+            | (
+                set(self._filesystem.glob(self._apple_baseline_path("*")))
+                if apple_additions()
+                else set()
+            )
+            | set(self._filesystem.glob(self._webkit_baseline_path("*")))
+        )
+
+        assert {p for p in paths if self._filesystem.isdir(p)}.issuperset(
+            {
+                p
+                for p in self.baseline_search_path(device_type=device_type)
+                if self._filesystem.isdir(p)
+            }
+        )
+
+        return paths
+
     def _apple_baseline_path(self, platform):
         return self._filesystem.join(apple_additions().layout_tests_path(), platform)
 

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -245,6 +245,23 @@ class Port(object):
             return factory.get(target_port).default_baseline_search_path()
         return []
 
+    def all_baseline_search_paths(self, device_type=None):
+        paths = (
+            set(self.get_option("additional_platform_directory", []))
+            | set(self._compare_baseline())
+            | set(self._filesystem.glob(self._webkit_baseline_path("*")))
+        )
+
+        assert {p for p in paths if self._filesystem.isdir(p)}.issuperset(
+            {
+                p
+                for p in self.baseline_search_path(device_type=device_type)
+                if self._filesystem.isdir(p)
+            }
+        )
+
+        return paths
+
     def check_build(self):
         """This routine is used to ensure that the build is up to date
         and all the needed binaries are present."""
@@ -1484,7 +1501,7 @@ class Port(object):
         # that isn't in our baseline search path (this mirrors what
         # old-run-webkit-tests does in findTestsToRun()).
         # Note this returns LayoutTests/platform/*, not platform/*/*.
-        entries = self._filesystem.glob(self._webkit_baseline_path('*'))
+        entries = self.all_baseline_search_paths(device_type=device_type)
         dirs_to_skip = []
         for entry in entries:
             if self._filesystem.isdir(entry) and entry not in self.test_search_path(device_type=device_type):


### PR DESCRIPTION
#### 008f6b91afed5564eabc5dc02f2b7880b614c852
<pre>
Accurately find all baseline directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=248340">https://bugs.webkit.org/show_bug.cgi?id=248340</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py:
(LayoutTestFinderTests.test_include_other_platforms_fallback):
* Tools/Scripts/webkitpy/port/apple.py:
(ApplePort.all_baseline_search_paths):
* Tools/Scripts/webkitpy/port/base.py:
(Port.all_baseline_search_paths):
(Port._tests_for_other_platforms):

Canonical link: <a href="https://commits.webkit.org/257480@main">https://commits.webkit.org/257480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c0846264e0a27bad1de0362c2a4ae7e465c2599

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108423 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168674 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85560 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106380 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33666 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/102553 "Found 1 webkitpy python2 test failure: webkitpy.port.server_process_unittest.TestServerProcess.test_broken_pipe") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76520 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23086 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45477 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5147 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42561 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->