### PR TITLE
Skip lockdown mode for tests that time out on MIPS

### DIFF
--- a/JSTests/microbenchmarks/delete-property-allocation-sinking.js
+++ b/JSTests/microbenchmarks/delete-property-allocation-sinking.js
@@ -1,5 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3"
-//@ $skipModes << :lockdown if $buildType == "debug"
+//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
 
 function assert(condition) {
     if (!condition)

--- a/JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js
+++ b/JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js
@@ -1,5 +1,5 @@
 //@ skip if $model =~ /^Apple Watch/
-//@ $skipModes << :lockdown if $buildType == "debug"
+//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
 
 function assert(b) {
     if (!b)

--- a/JSTests/microbenchmarks/mul-immediate-sub.js
+++ b/JSTests/microbenchmarks/mul-immediate-sub.js
@@ -1,4 +1,5 @@
 //@ skip if not $jitTests
+//@ $skipModes << :lockdown if $architecture == "mips"
 function doTest(max) {
     let sum = 0
     for (let i=0; i<max; ++i) {

--- a/JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js
+++ b/JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js
@@ -1,5 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ $skipModes << :lockdown if $buildType == "debug"
+//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
 
 function sumOfArithSeries(limit) {
     return limit * (limit + 1) / 2;

--- a/JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js
+++ b/JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js
@@ -1,4 +1,4 @@
-//@ $skipModes << :lockdown if $buildType == "debug"
+//@ $skipModes << :lockdown if ($buildType == "debug") or ($architecture == "mips")
 
 function empty() {}
 function empty2() {}


### PR DESCRIPTION
#### b7159741f9cd05b2d8802c846ffabc651441cd2f
<pre>
Skip lockdown mode for tests that time out on MIPS
<a href="https://bugs.webkit.org/show_bug.cgi?id=248341">https://bugs.webkit.org/show_bug.cgi?id=248341</a>

Unreviewed gardening.

* JSTests/microbenchmarks/delete-property-allocation-sinking.js:
* JSTests/microbenchmarks/delete-property-keeps-cacheable-structure.js:
* JSTests/microbenchmarks/mul-immediate-sub.js:
* JSTests/microbenchmarks/sinkable-new-object-with-builtin-constructor.js:
* JSTests/stress/checkpoint-osr-exit-needs-to-reload-baseline-jit-constant-pool-gpr.js:

Canonical link: <a href="https://commits.webkit.org/257112@main">https://commits.webkit.org/257112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3678ff09054a3389f89192a52bcc78c008e9c1c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107125 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7234 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35638 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103782 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5413 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84259 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32424 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75345 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88533 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/875 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20534 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84205 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22013 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28510 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4890 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44480 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87032 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41405 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19532 "Passed tests") | 
<!--EWS-Status-Bubble-End-->