### PR TITLE
Add some helpers to ColorMatrix to generate some filter matrices

### DIFF
--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -72,8 +72,33 @@ constexpr bool operator!=(const ColorMatrix<ColumnCount, RowCount>& a, const Col
     return !(a == b);
 }
 
+constexpr ColorMatrix<3, 3> brightnessColorMatrix(float amount)
+{
+    // Brightness is specified as a compontent transfer function: https://www.w3.org/TR/filter-effects-1/#brightnessEquivalent
+    // which is equivalent to the following matrix.
+    amount = std::max(amount, 0.0f);
+    return ColorMatrix<3, 3> {
+        amount, 0.0f, 0.0f,
+        0.0f, amount, 0.0f,
+        0.0f, 0.0f, amount,
+    };
+}
 
-// FIXME: These are only used in FilterOperations.cpp. Consider moving them there.
+constexpr ColorMatrix<5, 4> contrastColorMatrix(float amount)
+{
+    // Contrast is specified as a compontent transfer function: https://www.w3.org/TR/filter-effects-1/#contrastEquivalent
+    // which is equivalent to the following matrix.
+    amount = std::max(amount, 0.0f);
+    float intercept = -0.5f * amount + 0.5f;
+
+    return ColorMatrix<5, 4> {
+        amount, 0.0f, 0.0f, 0.0f, intercept,
+        0.0f, amount, 0.0f, 0.0f, intercept,
+        0.0f, 0.0f, amount, 0.0f, intercept,
+        0.0f, 0.0f, 0.0f, 1.0f, 0.0f
+    };
+}
+
 constexpr ColorMatrix<3, 3> grayscaleColorMatrix(float amount)
 {
     // Values from https://www.w3.org/TR/filter-effects-1/#grayscaleEquivalent
@@ -82,6 +107,33 @@ constexpr ColorMatrix<3, 3> grayscaleColorMatrix(float amount)
         0.2126f + 0.7874f * oneMinusAmount, 0.7152f - 0.7152f * oneMinusAmount, 0.0722f - 0.0722f * oneMinusAmount,
         0.2126f - 0.2126f * oneMinusAmount, 0.7152f + 0.2848f * oneMinusAmount, 0.0722f - 0.0722f * oneMinusAmount,
         0.2126f - 0.2126f * oneMinusAmount, 0.7152f - 0.7152f * oneMinusAmount, 0.0722f + 0.9278f * oneMinusAmount
+    };
+}
+
+constexpr ColorMatrix<5, 4> invertColorMatrix(float amount)
+{
+    // Invert is specified as a compontent transfer function: https://www.w3.org/TR/filter-effects-1/#invertEquivalent
+    // which is equivalent to the following matrix.
+    amount = std::clamp(amount, 0.0f, 1.0f);
+    float multiplier = 1.0f - amount * 2.0f;
+    return ColorMatrix<5, 4> {
+        multiplier, 0.0f, 0.0f, 0.0f, amount,
+        0.0f, multiplier, 0.0f, 0.0f, amount,
+        0.0f, 0.0f, multiplier, 0.0f, amount,
+        0.0f, 0.0f, 0.0f, 1.0f, 0.0f
+    };
+}
+
+constexpr ColorMatrix<5, 4> opacityColorMatrix(float amount)
+{
+    // Opacity is specified as a compontent transfer function: https://www.w3.org/TR/filter-effects-1/#opacityEquivalent
+    // which is equivalent to the following matrix.
+    amount = std::clamp(amount, 0.0f, 1.0f);
+    return ColorMatrix<5, 4> {
+        1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, amount, 0.0f
     };
 }
 


### PR DESCRIPTION
#### d16383b4c526cd199501368e69f9d1b8b744ba75
<pre>
Add some helpers to ColorMatrix to generate some filter matrices
<a href="https://bugs.webkit.org/show_bug.cgi?id=248348">https://bugs.webkit.org/show_bug.cgi?id=248348</a>

Reviewed by Sam Weinig.

Add some static functions that create a ColorMatrix&lt;&gt; equivalent to some common
filter operations (including those described in the CSS Filters spec as FEComponentTransfer
operations).

Use them when setting up CALayer filters.

* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::brightnessColorMatrix):
(WebCore::contrastColorMatrix):
(WebCore::invertColorMatrix):
(WebCore::opacityColorMatrix):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::caColorMatrixFromColorMatrix):
(WebCore::PlatformCAFilters::colorMatrixValueForFilter):

Canonical link: <a href="https://commits.webkit.org/257040@main">https://commits.webkit.org/257040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f222349730866bd855ed90cfead89b1fb7e73300

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107167 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167431 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7297 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35679 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103821 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5471 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84301 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75387 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/913 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/904 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22053 "Found 2 new test failures: imported/w3c/web-platform-tests/webstorage/event_case_sensitive.html, media/video-seek-have-nothing.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4841 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44516 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41445 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->