### PR TITLE
[Filters] Manage applying the SVGFilter using FilterTargetSwitcher

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
@@ -36,6 +36,8 @@ public:
     FilterStyleTargetSwitcher(GraphicsContext& destinationContext, Filter&, const FloatRect &sourceImageRect);
 
 private:
+    bool needsRedrawSourceImage() const override { return true; }
+
     void beginDrawSourceImage(GraphicsContext& destinationContext) override;
     void endDrawSourceImage(GraphicsContext& destinationContext) override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -87,9 +87,17 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
 
     if (m_rendererFilterDataMap.contains(&renderer)) {
         FilterData* filterData = m_rendererFilterDataMap.get(&renderer);
-        if (filterData->state == FilterData::PaintingSource || filterData->state == FilterData::Applying)
+        if (filterData->state == FilterData::PaintingSource || filterData->state == FilterData::Applying) {
             filterData->state = FilterData::CycleDetected;
-        return false; // Already built, or we're in a cycle, or we're marked for removal. Regardless, just do nothing more now.
+            return false; // Already built, or we're in a cycle, or we're marked for removal. Regardless, just do nothing more now.
+        }
+        
+        ASSERT(filterData->targetSwitcher);
+        if (!filterData->targetSwitcher->needsRedrawSourceImage())
+            return false;
+
+        filterData->targetSwitcher->beginDrawSourceImage(*context);
+        return true;
     }
 
     auto addResult = m_rendererFilterDataMap.set(&renderer, makeUnique<FilterData>());
@@ -128,8 +136,19 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
         return false;
     }
 
-    if (filterData->filter->clampFilterRegionIfNeeded())
-        filterScale = filterData->filter->filterScale();
+    filterData->filter->clampFilterRegionIfNeeded();
+
+#if ENABLE(DESTINATION_COLOR_SPACE_LINEAR_SRGB)
+    auto colorSpace = DestinationColorSpace::LinearSRGB();
+#else
+    auto colorSpace = DestinationColorSpace::SRGB();
+#endif
+
+    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, *filterData->filter, filterData->sourceImageRect, colorSpace, &filterData->results);
+    if (!filterData->targetSwitcher) {
+        m_rendererFilterDataMap.remove(&renderer);
+        return false;
+    }
     
     // If the sourceImageRect is empty, we have something like <g filter=".."/>.
     // Even if the target objectBoundingBox() is empty, we still have to draw the last effect result image in postApplyResource.
@@ -139,21 +158,10 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
         return false;
     }
 
-#if ENABLE(DESTINATION_COLOR_SPACE_LINEAR_SRGB)
-    auto colorSpace = DestinationColorSpace::LinearSRGB();
-#else
-    auto colorSpace = DestinationColorSpace::SRGB();
-#endif
-
-    filterData->sourceImage = context->createScaledImageBuffer(filterData->sourceImageRect, filterScale, colorSpace, filterData->filter->renderingMode());
-    if (!filterData->sourceImage) {
-        ASSERT(m_rendererFilterDataMap.contains(&renderer));
-        filterData->savedContext = context;
-        return false;
-    }
+    filterData->targetSwitcher->beginDrawSourceImage(*context);
 
     filterData->savedContext = context;
-    context = &filterData->sourceImage->context();
+    context = filterData->targetSwitcher->drawingContext(*context);
 
     ASSERT(m_rendererFilterDataMap.contains(&renderer));
     return true;
@@ -200,9 +208,9 @@ void RenderSVGResourceFilter::postApplyResource(RenderElement& renderer, Graphic
         break;
     }
 
-    if (filterData.filter) {
+    if (filterData.targetSwitcher) {
         filterData.state = FilterData::Built;
-        context->drawFilteredImageBuffer(filterData.sourceImage.get(), filterData.sourceImageRect, *filterData.filter, filterData.results);
+        filterData.targetSwitcher->endDrawSourceImage(*context);
     }
 
     LOG_WITH_STREAM(Filters, stream << "RenderSVGResourceFilter " << this << " postApplyResource done\n");

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "FilterResults.h"
-#include "ImageBuffer.h"
+#include "FilterTargetSwitcher.h"
 #include "RenderSVGResourceContainer.h"
 #include "SVGFilter.h"
 #include "SVGUnitTypes.h"
@@ -47,7 +47,7 @@ public:
     RefPtr<SVGFilter> filter;
     FilterResults results;
 
-    RefPtr<ImageBuffer> sourceImage;
+    std::unique_ptr<FilterTargetSwitcher> targetSwitcher;
     FloatRect sourceImageRect;
 
     GraphicsContext* savedContext { nullptr };


### PR DESCRIPTION
#### dae05ac9cd872cb362ff1df8949b71fce4fe3541
<pre>
[Filters] Manage applying the SVGFilter using FilterTargetSwitcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=248354">https://bugs.webkit.org/show_bug.cgi?id=248354</a>
rdar://102674910

Reviewed by Simon Fraser.

FilterTargetSwitcher will be used to apply the SVGFilter. It will replace the
sourceImage of FilterData. GraphicsContext filters will be used if
FilterTargetSwitcher::create() decides to create FilterStyleTargetSwitcher.

Unlike the CSSFilter, the SVGFilter does not require clipping the drawingContext
before drawing since it draws the whole filtered image in one time.

* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
(WebCore::RenderSVGResourceFilter::postApplyResource):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:

Canonical link: <a href="https://commits.webkit.org/257151@main">https://commits.webkit.org/257151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44a1b0dbc53f4180ccbaa6fedbb601d8a814fb40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107410 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167682 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7624 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35932 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104041 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5745 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84549 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32849 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89337 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1140 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22275 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4922 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5956 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41676 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->