### PR TITLE
Add support for unbounded repetition terms in the new property parser generator

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -395,6 +395,56 @@ inline double CSSPrimitiveValue::computeDegrees(CSSUnitType type, double angle)
     }
 }
 
+inline CSSValueID valueID(const CSSPrimitiveValue& value)
+{
+    return value.valueID();
+}
+
+inline CSSValueID valueID(const CSSPrimitiveValue* value)
+{
+    return value ? valueID(*value) : CSSValueInvalid;
+}
+
+inline CSSValueID valueID(const CSSValue& value)
+{
+    return value.isPrimitiveValue() ? valueID(downcast<CSSPrimitiveValue>(value)) : CSSValueInvalid;
+}
+
+inline CSSValueID valueID(const CSSValue* value)
+{
+    return value ? valueID(*value) : CSSValueInvalid;
+}
+
+inline bool isValueID(const CSSPrimitiveValue& value, CSSValueID id)
+{
+    return valueID(value) == id;
+}
+
+inline bool isValueID(const CSSPrimitiveValue* value, CSSValueID id)
+{
+    return valueID(value) == id;
+}
+
+inline bool isValueID(const CSSValue& value, CSSValueID id)
+{
+    return valueID(value) == id;
+}
+
+inline bool isValueID(const CSSValue* value, CSSValueID id)
+{
+    return valueID(value) == id;
+}
+
+inline bool isValueID(const RefPtr<CSSValue>& value, CSSValueID id)
+{
+    return isValueID(value.get(), id);
+}
+
+inline bool isValueID(const Ref<CSSValue>& value, CSSValueID id)
+{
+    return isValueID(value.get(), id);
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSPrimitiveValue, isPrimitiveValue())

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1101,9 +1101,7 @@
             "codegen-properties": {
                 "name-for-methods": "CompositeOperation",
                 "settings-flag": "webAnimationsCompositeOperationsEnabled",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-animation-composition>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1121,9 +1119,7 @@
                 ],
                 "name-for-methods": "Delay",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<time>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1144,9 +1140,7 @@
                 ],
                 "name-for-methods": "Direction",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-animation-direction>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1161,9 +1155,7 @@
                 ],
                 "name-for-methods": "Duration",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<time [0,inf]>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1185,9 +1177,7 @@
                 ],
                 "name-for-methods": "FillMode",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-animation-fill-mode>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1202,9 +1192,7 @@
                 ],
                 "name-for-methods": "IterationCount",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-animation-iteration-count>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1219,9 +1207,7 @@
                 ],
                 "name-for-methods": "Name",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-animation-name>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1240,9 +1226,7 @@
                 ],
                 "name-for-methods": "PlayState",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-animation-play-state>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1257,9 +1241,7 @@
                 ],
                 "name-for-methods": "TimingFunction",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<timing-function>#"
             },
             "specification": {
                 "category": "css-animations",
@@ -1296,9 +1278,7 @@
                 "name-for-methods": "Attachment",
                 "fill-layer-property": true,
                 "separator": ",",
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-background-attachment>#"
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1336,9 +1316,7 @@
                 "name-for-methods": "BlendMode",
                 "fill-layer-property": true,
                 "separator": ",",
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-background-blend-mode>#"
             },
             "specification": {
                 "category": "css-compositing",
@@ -1369,9 +1347,7 @@
                 "name-for-methods": "Clip",
                 "fill-layer-property": true,
                 "separator": " ",
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-background-clip>#"
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1394,9 +1370,7 @@
                 "name-for-methods": "Image",
                 "fill-layer-property": true,
                 "separator": " ",
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-background-image>#"
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -1409,9 +1383,7 @@
                 "name-for-methods": "Origin",
                 "fill-layer-property": true,
                 "separator": " ",
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-background-origin>#"
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -3782,9 +3754,7 @@
                 "related-property": "-webkit-mask-clip",
                 "name-for-methods": "Clip",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-mask-clip>#"
             },
             "specification": {
                 "category": "css-masking",
@@ -3796,9 +3766,7 @@
                 "related-property": "-webkit-mask-composite",
                 "name-for-methods": "Composite",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-mask-composite>#"
             },
             "specification": {
                 "category": "css-masking",
@@ -3812,9 +3780,7 @@
                 ],
                 "name-for-methods": "Image",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-mask-image>#"
             },
             "specification": {
                 "category": "css-masking",
@@ -3826,9 +3792,7 @@
                 "related-property": "-webkit-mask-source-type",
                 "name-for-methods": "MaskMode",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-mask-mode>#"
             },
             "specification": {
                 "category": "css-masking",
@@ -3842,9 +3806,7 @@
                 ],
                 "name-for-methods": "Origin",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-mask-origin>#"
             },
             "specification": {
                 "category": "css-masking",
@@ -5523,9 +5485,7 @@
                 ],
                 "name-for-methods": "Delay",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<time>#"
             },
             "specification": {
                 "category": "css-transitions",
@@ -5540,9 +5500,7 @@
                 ],
                 "name-for-methods": "Duration",
                 "separator": ",",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<time [0,inf]>#"
             },
             "specification": {
                 "category": "css-transitions",
@@ -5556,9 +5514,13 @@
                     "-webkit-transition-property"
                 ],
                 "name-for-methods": "Property",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": [
+                    "none",
+                    {
+                        "value": "<single-transition-property>#",
+                        "single-value-optimization": true
+                    }
+                ]
             },
             "specification": {
                 "category": "css-transitions",
@@ -5572,9 +5534,7 @@
                     "-webkit-transition-timing-function"
                 ],
                 "name-for-methods": "TimingFunction",
-                "parser-function": "consumeAnimationPropertyList",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<timing-function>#"
             },
             "specification": {
                 "category": "css-transitions",
@@ -6076,9 +6036,7 @@
                 "related-property": "background-clip",
                 "name-for-methods": "Clip",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-webkit-background-clip>#"
             }
         },
         "-webkit-background-origin": {
@@ -6086,9 +6044,7 @@
                 "related-property": "background-origin",
                 "name-for-methods": "Origin",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-webkit-background-origin>#"
             }
         },
         "-webkit-background-size": {
@@ -7409,9 +7365,7 @@
                 "related-property": "mask-clip",
                 "name-for-methods": "Clip",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-webkit-mask-clip>#"
             },
             "status": {
                 "status": "experimental"
@@ -7426,9 +7380,7 @@
                 "related-property": "mask-composite",
                 "name-for-methods": "Composite",
                 "fill-layer-property": true,
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-webkit-mask-composite>#"
             },
             "status": {
                 "status": "experimental"
@@ -7443,9 +7395,7 @@
                 "related-property": "mask-mode",
                 "synonym": "mask-mode",
                 "comment": "Deprecated alias for mask-mode, supports an 'auto' value, does not support 'match-source'",
-                "parser-function": "consumeCommaSeparatedBackgroundComponent",
-                "parser-requires-current-property": true,
-                "parser-requires-context": true
+                "parser-grammar": "<single-webkit-mask-source-type>#"
             },
             "status": "non-standard",
             "specification": {
@@ -9163,6 +9113,280 @@
             "specification": {
                 "category": "css-fonts-4",
                 "url": "https://drafts.csswg.org/css-fonts-4/#typedef-font-palette-palette-identifier"
+            }
+        },
+        "<shape-radius>": {
+            "grammar": ["<length-percentage [0,inf]>", "closest-side", "farthest-side"],
+            "specification": {
+                "category": "css-shapes",
+                "url": "https://www.w3.org/TR/css-shapes-1/#typedef-shape-radius"
+            }
+        },
+        "<attachment>": {
+            "grammar": ["scroll", "fixed", "local"],
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-attachment"
+            }
+        },
+        "<blend-mode>": {
+            "grammar": [
+                "normal",
+                "multiply",
+                "screen",
+                "overlay",
+                "darken",
+                "lighten",
+                "color-dodge",
+                "color-burn",
+                "hard-light",
+                "soft-light",
+                "difference",
+                "exclusion",
+                "hue",
+                "saturation",
+                "color",
+                "luminosity"
+            ],
+            "specification": {
+                "category": "css-compositing",
+                "url": "https://www.w3.org/TR/compositing-1/#ltblendmodegt"
+            }
+        },
+        "<box>": {
+            "grammar": ["border-box", "padding-box", "content-box"],
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#typedef-box"
+            }
+        },
+        "<shape-box>": {
+            "grammar": ["<box>", "margin-box"],
+            "specification": {
+                "category": "css-shapes",
+                "url": "https://www.w3.org/TR/css-shapes-1/#typedef-shape-box"
+            }
+        },
+        "<geometry-box>": {
+            "grammar": ["<shape-box>", "fill-box", "stroke-box", "view-box"],
+            "exported": true,
+            "specification": {
+                "category": "css-masking",
+                "url": "https://www.w3.org/TR/css-masking-1/#typedef-geometry-box"
+            }
+        },
+        "<compositing-operator>": {
+            "grammar": ["add", "subtract", "intersect", "exclude"],
+            "specification": {
+                "category": "css-masking",
+                "url": "https://www.w3.org/TR/css-masking-1/#typedef-compositing-operator"
+            }
+        },
+        "<masking-mode>": {
+            "grammar": ["alpha", "luminance", "match-source"],
+            "specification": {
+                "category": "css-masking",
+                "url": "https://www.w3.org/TR/css-masking-1/#typedef-masking-mode"
+            }
+        },
+        "<bg-image>": {
+            "grammar": ["<image>", "none"],
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#typedef-bg-image"
+            }
+        },
+        "<mask-reference>": {
+            "grammar": ["<image>", "none"],
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-masking-1/#typedef-mask-reference"
+            }
+        },
+        "<-webkit-origin-box>": {
+            "grammar": ["<box>", "border", "content", "padding", "-webkit-text"],
+            "status": "non-standard"
+        },
+        "<-webkit-clip-box>": {
+            "grammar": ["<-webkit-origin-box>", "text"],
+            "status": "non-standard"
+        },
+        "<-webkit-compositing-operator>": {
+            "grammar": [
+                "clear",
+                "copy",
+                "source-over",
+                "source-in",
+                "source-out",
+                "source-atop",
+                "destination-over",
+                "destination-in",
+                "destination-out",
+                "destination-atop",
+                "xor",
+                "plus-darker",
+                "plus-lighter"
+            ],
+            "status": "non-standard"
+        },
+        "<-webkit-masking-source-type>": {
+            "grammar": ["auto", "alpha", "luminance"],
+            "status": "non-standard"
+        },
+        "<single-background-blend-mode>": {
+            "grammar": ["<blend-mode>"],
+            "exported": true,
+            "specification": {
+                "category": "css-compositing",
+                "url": "https://www.w3.org/TR/compositing-1/#propdef-background-blend-mode"
+            }
+        },
+        "<single-background-attachment>": {
+            "grammar": ["<attachment>"],
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-attachment"
+            }
+        },
+        "<single-background-clip>": {
+            "grammar": ["<box>", "text", "-webkit-text"],
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-clip"
+            },
+            "comment": "Out of spec. 'background-clip' is currently defined to '<box>#'."
+        },
+        "<single-background-origin>": {
+            "grammar": ["<box>"],
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-origin"
+            }
+        },
+        "<single-background-image>": {
+            "grammar": ["<bg-image>"],
+            "exported": true,
+            "specification": {
+                "category": "css-backgrounds",
+                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-image"
+            }
+        },
+        "<single-mask-clip>": {
+            "grammar": ["<box>", "no-clip"],
+            "exported": true,
+            "specification": {
+                "category": "css-masking",
+                "url": "https://www.w3.org/TR/css-masking-1/#the-mask-clip"
+            },
+            "comment": "Out of spec. 'mask-clip' is currently defined to '[ <geometry-box> | no-clip ]#'."
+        },
+        "<single-mask-origin>": {
+            "grammar": ["<box>", "border", "content", "padding", "-webkit-text"],
+            "exported": true,
+            "specification": {
+                "category": "css-masking",
+                "url": "https://www.w3.org/TR/css-masking-1/#the-mask-origin"
+            },
+            "comment": "Out of spec. 'mask-origin' is currently defined to '<geometry-box>#'."
+        },
+        "<single-mask-image>": {
+            "grammar": ["<mask-reference>"],
+            "exported": true,
+            "specification": {
+                "category": "css-masking",
+                "url": "https://www.w3.org/TR/css-masking-1/#the-mask-image"
+            }
+        },
+        "<single-mask-composite>": {
+            "grammar": ["<compositing-operator>"],
+            "exported": true,
+            "specification": {
+                "category": "css-masking",
+                "url": "https://drafts.fxtf.org/css-masking-1/#the-mask-composite"
+            }
+        },
+        "<single-mask-mode>": {
+            "grammar": ["<masking-mode>"],
+            "exported": true,
+            "specification": {
+                "category": "css-masking",
+                "url": "https://drafts.fxtf.org/css-masking-1/#the-mask-mode"
+            }
+        },
+        "<single-webkit-background-clip>": {
+            "grammar": ["<-webkit-clip-box>"],
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-webkit-background-origin>": {
+            "grammar": ["<-webkit-origin-box>"],
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-webkit-mask-composite>": {
+            "grammar": ["<-webkit-compositing-operator>"],
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-webkit-mask-clip>": {
+            "grammar": ["<-webkit-clip-box>"],
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-webkit-mask-source-type>": {
+            "grammar": ["<-webkit-masking-source-type>"],
+            "exported": true,
+            "status": "non-standard"
+        },
+        "<single-animation-composition>": {
+            "grammar": ["replace", "add", "accumulate"],
+            "exported": true,
+            "specification": {
+                "category": "css-animations",
+                "url": "https://drafts.csswg.org/css-animations-2/#animation-composition"
+            }
+        },
+        "<single-animation-direction>": {
+            "grammar": ["normal", "reverse", "alternate", "alternate-reverse"],
+            "exported": true,
+            "specification": {
+                "category": "css-animations",
+                "url": "https://www.w3.org/TR/css-animations-1/#typedef-single-animation-direction"
+            }
+        },
+        "<single-animation-fill-mode>": {
+            "grammar": ["none", "forwards", "backwards", "both"],
+            "exported": true,
+            "specification": {
+                "category": "css-animations",
+                "url": "https://www.w3.org/TR/css-animations-1/#typedef-single-animation-fill-mode"
+            }
+        },
+        "<single-animation-iteration-count>": {
+            "grammar": ["infinite", "<number [0,inf]>"],
+            "exported": true,
+            "specification": {
+                "category": "css-animations",
+                "url": "https://www.w3.org/TR/css-animations-1/#typedef-single-animation-iteration-count"
+            }
+        },
+        "<single-animation-name>": {
+            "grammar": ["none", "<keyframes-name>"],
+            "exported": true,
+            "specification": {
+                "category": "css-animations",
+                "url": "https://www.w3.org/TR/css-animations-1/#animation-name"
+            }
+        },
+        "<single-animation-play-state>": {
+            "grammar": ["running", "paused"],
+            "exported": true,
+            "specification": {
+                "category": "css-animations",
+                "url": "https://www.w3.org/TR/css-animations-1/#typedef-single-animation-play-state"
             }
         }
     }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -457,8 +457,7 @@ static RefPtr<CSSValue> consumeCounterStyleRange(CSSParserTokenRange& range)
     if (auto autoValue = consumeIdent<CSSValueAuto>(range))
         return autoValue;
 
-    auto rangeList = CSSValueList::createCommaSeparated();
-    do {
+    auto rangeList = consumeCommaSeparatedListWithoutSingleValueOptimization(range, [](auto& range) -> RefPtr<CSSValue> {
         auto lowerBound = consumeCounterStyleRangeBound(range);
         if (!lowerBound)
             return nullptr;
@@ -470,9 +469,11 @@ static RefPtr<CSSValue> consumeCounterStyleRange(CSSParserTokenRange& range)
         // ignored.
         if (lowerBound->isInteger() && upperBound->isInteger() && lowerBound->intValue() > upperBound->intValue())
             return nullptr;
-        rangeList->append(createPrimitiveValuePair(lowerBound.releaseNonNull(), upperBound.releaseNonNull(), Pair::IdenticalValueEncoding::DoNotCoalesce));
-    } while (consumeCommaIncludingWhitespace(range));
-    if (!range.atEnd() || !rangeList->length())
+        
+        return createPrimitiveValuePair(lowerBound.releaseNonNull(), upperBound.releaseNonNull(), Pair::IdenticalValueEncoding::DoNotCoalesce);
+    });
+
+    if (!range.atEnd() || !rangeList || !rangeList->length())
         return nullptr;
     return rangeList;
 }
@@ -521,9 +522,8 @@ static RefPtr<CSSValue> consumeCounterStyleSymbols(CSSParserTokenRange& range, c
 // https://www.w3.org/TR/css-counter-styles-3/#counter-style-symbols
 static RefPtr<CSSValue> consumeCounterStyleAdditiveSymbols(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    auto values = CSSValueList::createCommaSeparated();
     std::optional<int> lastWeight;
-    do {
+    auto values = consumeCommaSeparatedListWithoutSingleValueOptimization(range, [&lastWeight](auto& range, auto& context) -> RefPtr<CSSValue> {
         auto integer = consumeNonNegativeInteger(range);
         auto symbol = consumeCounterStyleSymbol(range, context);
         if (!integer) {
@@ -543,9 +543,10 @@ static RefPtr<CSSValue> consumeCounterStyleAdditiveSymbols(CSSParserTokenRange& 
         auto pair = CSSValueList::createSpaceSeparated();
         pair->append(integer.releaseNonNull());
         pair->append(symbol.releaseNonNull());
-        values->append(WTFMove(pair));
-    } while (consumeCommaIncludingWhitespace(range));
-    if (!range.atEnd() || !values->length())
+        return pair;
+    }, context);
+
+    if (!range.atEnd() || !values || !values->length())
         return nullptr;
     return values;
 }
@@ -702,8 +703,7 @@ static RefPtr<CSSPrimitiveValue> consumeBasePaletteDescriptor(CSSParserTokenRang
 
 static RefPtr<CSSValueList> consumeOverrideColorsDescriptor(CSSParserTokenRange& range, const CSSParserContext& context)
 {
-    RefPtr<CSSValueList> list = CSSValueList::createCommaSeparated();
-    do {
+    auto list = consumeCommaSeparatedListWithoutSingleValueOptimization(range, [](auto& range, auto& context) -> RefPtr<CSSValue> {
         auto key = consumeNonNegativeInteger(range);
         if (!key)
             return nullptr;
@@ -712,11 +712,10 @@ static RefPtr<CSSValueList> consumeOverrideColorsDescriptor(CSSParserTokenRange&
         if (!color)
             return nullptr;
 
-        RefPtr<CSSValue> value = CSSFontPaletteValuesOverrideColorsValue::create(key.releaseNonNull(), color.releaseNonNull());
-        list->append(value.releaseNonNull());
-    } while (consumeCommaIncludingWhitespace(range));
-    
-    if (!range.atEnd() || !list->length())
+        return CSSFontPaletteValuesOverrideColorsValue::create(key.releaseNonNull(), color.releaseNonNull());
+    }, context);
+
+    if (!range.atEnd() || !list || !list->length())
         return nullptr;
 
     return list;
@@ -1327,6 +1326,53 @@ bool CSSPropertyParser::consumeLegacyTextOrientation(bool important)
     return true;
 }
 
+static bool isValidAnimationPropertyList(CSSPropertyID property, const CSSValueList& valueList)
+{
+    // If there is more than one <single-transition> in the shorthand, and any of the transitions
+    // has none as the <single-transition-property>, then the declaration is invalid.
+
+    if (property != CSSPropertyTransitionProperty || valueList.length() < 2)
+        return true;
+
+    for (auto& value : valueList) {
+        if (isValueID(value, CSSValueNone))
+            return false;
+    }
+    return true;
+}
+
+static RefPtr<CSSValue> consumeAnimationValueForShorthand(CSSPropertyID property, CSSParserTokenRange& range, const CSSParserContext& context)
+{
+    switch (property) {
+    case CSSPropertyAnimationDelay:
+    case CSSPropertyTransitionDelay:
+        return consumeTime(range, context.mode, ValueRange::All, UnitlessQuirk::Forbid);
+    case CSSPropertyAnimationDirection:
+        return CSSPropertyParsing::consumeSingleAnimationDirection(range);
+    case CSSPropertyAnimationDuration:
+    case CSSPropertyTransitionDuration:
+        return consumeTime(range, context.mode, ValueRange::NonNegative, UnitlessQuirk::Forbid);
+    case CSSPropertyAnimationFillMode:
+        return CSSPropertyParsing::consumeSingleAnimationFillMode(range);
+    case CSSPropertyAnimationIterationCount:
+        return CSSPropertyParsing::consumeSingleAnimationIterationCount(range);
+    case CSSPropertyAnimationName:
+        return CSSPropertyParsing::consumeSingleAnimationName(range, context);
+    case CSSPropertyAnimationPlayState:
+        return CSSPropertyParsing::consumeSingleAnimationPlayState(range);
+    case CSSPropertyAnimationComposition:
+        return CSSPropertyParsing::consumeSingleAnimationComposition(range);
+    case CSSPropertyTransitionProperty:
+        return consumeSingleTransitionPropertyOrNone(range);
+    case CSSPropertyAnimationTimingFunction:
+    case CSSPropertyTransitionTimingFunction:
+        return consumeTimingFunction(range, context);
+    default:
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+}
+
 bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& shorthand, bool important)
 {
     const unsigned longhandCount = shorthand.length();
@@ -1343,7 +1389,7 @@ bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& 
                 if (parsedLonghand[i])
                     continue;
 
-                if (auto value = consumeAnimationValue(shorthand.properties()[i], m_range, m_context)) {
+                if (auto value = consumeAnimationValueForShorthand(shorthand.properties()[i], m_range, m_context)) {
                     parsedLonghand[i] = true;
                     foundProperty = true;
                     longhands[i]->append(*value);
@@ -1371,6 +1417,11 @@ bool CSSPropertyParser::consumeAnimationShorthand(const StylePropertyShorthand& 
         addProperty(shorthand.properties()[i], shorthand.id(), *longhands[i], important);
 
     return m_range.atEnd();
+}
+
+static void addBackgroundValue(RefPtr<CSSValue>& list, Ref<CSSValue>&& value)
+{
+    assignOrDowngradeToListAndAppend(list, WTFMove(value));
 }
 
 static bool consumeBackgroundPosition(CSSParserTokenRange& range, const CSSParserContext& context, CSSPropertyID property, RefPtr<CSSValue>& resultX, RefPtr<CSSValue>& resultY)
@@ -1414,10 +1465,16 @@ bool CSSPropertyParser::consumeBackgroundShorthand(const StylePropertyShorthand&
                     value = WTFMove(position->x);
                     valueY = WTFMove(position->y);
                     m_range = rangeCopy;
-                } else if (property == CSSPropertyBackgroundSize || property == CSSPropertyMaskSize) {
+                } else if (property == CSSPropertyBackgroundSize) {
                     if (!consumeSlashIncludingWhitespace(m_range))
                         continue;
-                    value = consumeBackgroundSize(property, m_range, m_context.mode);
+                    value = consumeSingleBackgroundSize(m_range, m_context);
+                    if (!value || !parsedLonghand[i - 1]) // Position must have been parsed in the current layer.
+                        return false;
+                } else if (property == CSSPropertyMaskSize) {
+                    if (!consumeSlashIncludingWhitespace(m_range))
+                        continue;
+                    value = consumeSingleMaskSize(m_range, m_context);
                     if (!value || !parsedLonghand[i - 1]) // Position must have been parsed in the current layer.
                         return false;
                 } else if (property == CSSPropertyBackgroundPositionY || property == CSSPropertyWebkitMaskPositionY) {

--- a/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
+++ b/Tools/Scripts/webkitpy/style/checkers/jsonchecker.py
@@ -249,6 +249,7 @@ class JSONCSSPropertiesChecker(JSONChecker):
                 'enable-if': self.validate_string,
                 'kind': self.validate_string,
                 'settings-flag': self.validate_string,
+                'single-value-optimization': self.validate_boolean,
                 'status': self.validate_status,
                 'value': self.validate_grammar_term,
             }


### PR DESCRIPTION
#### 19ef95a624848a4b52b40c5c664357a3993fccc6
<pre>
Add support for unbounded repetition terms in the new property parser generator
<a href="https://bugs.webkit.org/show_bug.cgi?id=248355">https://bugs.webkit.org/show_bug.cgi?id=248355</a>
rdar://102675501

Reviewed by Darin Adler.

Adds support for parsing unbounded comma separated lists via CSSProperties.json.
Specifically, this adds support for the `#` operator without range refinement
(e.g. no #{1,4}):

  &quot;&quot;&quot;
   A hash mark (#) indicates that the preceding type, word, or group occurs
   one or more times, separated by comma tokens (which may optionally be
   surrounded by white space and/or comments).
  &quot;&quot;&quot;
    -  <a href="https://www.w3.org/TR/css-values-4/#mult-comma">https://www.w3.org/TR/css-values-4/#mult-comma</a>

This brings with it support for a large collection (29) of longhands in the
animation, transition, background and mask families of properties.

To generate the matching for one of these lists, a new term type can be
specified in CSSProperties.json with &apos;kind&apos; set to &apos;repetition&apos; and &apos;value&apos;
set to whatever should be repeatedly matched. As a shorthand, the spec syntax
utilizing a `#` can also be used. For instance, &apos;animation-duration&apos;, which
has a specified grammar of:

  `&lt;&apos;animation-duration&apos;&gt; = &lt;time [0s,∞]#`

uses the following:

  &quot;parser-grammar&quot;: &quot;&lt;time [0,inf]&gt;#&quot;

* Source/WebCore/css/CSSProperties.json:
Replaces use of custom-parser/parser-function with parser-grammar for the
newly supported properties and adds a set of new shared grammar rules for
implementing them.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeCounterStyleRange): Adopt new consumeCommaSeparatedList* helper.
(WebCore::consumeCounterStyleAdditiveSymbols): Ditto.
(WebCore::consumeOverrideColorsDescriptor): Ditto.
(WebCore::isValidAnimationPropertyList): Moved from CSSPropertyParserHelpers as
now the only caller is in this file.
(WebCore::consumeAnimationValueForShorthand): Ditto. Also now implemented using
more exported shared grammar rules.
(WebCore::CSSPropertyParser::consumeAnimationShorthand): Adopt new
consumeCommaSeparatedList* helper
(WebCore::addBackgroundValue): Moved from CSSPropertyParserHelpers as now the only
caller is in this file.
(WebCore::CSSPropertyParser::consumeBackgroundShorthand): Split background-size and
mask size as they now have separate consume functions (though at the moment identical).

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontVariationSettings): Adopt new
consumeCommaSeparatedList* helper.
(WebCore::CSSPropertyParserHelpers::consumeFontFamily): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeKeyframesName): Added to allow &quot;animation-name&quot;
to be mostly generated. Unused CSSParserContext parameteter is a by product consumers called
from generated consumers are expected to take a CSSParserContext for the moment. This should
be refined to not be required in the future.
(WebCore::CSSPropertyParserHelpers::consumeSingleTransitionPropertyIdent):
(WebCore::CSSPropertyParserHelpers::consumeSingleTransitionPropertyOrNone):
(WebCore::CSSPropertyParserHelpers::consumeSingleTransitionProperty):
Split out shorthand and longhand behaviors into separate functions (with a shared
helper between them). Previously, the shorthand version (allowing &quot;none&quot;) was used
in both places, and then a post consume check if any values were &quot;none&quot; was done.
Now that we are generating the repetition, doing the post consume check is non-trivial
so just doing the parse right makes more sense.
(WebCore::CSSPropertyParserHelpers::consumeSteps): Make static (and remove forward
declaration from header. Nothing outside this file uses this function.
(WebCore::CSSPropertyParserHelpers::consumeCubicBezier): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSpringFunction): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeTimingFunction): Renamed from
consumeAnimationTimingFunction to better reflect the spec naming and to indicate it used
for more than just animation as it transtions also use it.
(WebCore::CSSPropertyParserHelpers::consumeShadow): Make static (and remove forward
declaration from header. Nothing outside this file uses this function.
(WebCore::CSSPropertyParserHelpers::consumeScrollSnapType): Use auto.
(WebCore::CSSPropertyParserHelpers::consumeBasicShapeOrBox): Use a generated helper and
add a note about the spec ambiguity along with link to spec github issue filed:
<a href="https://github.com/w3c/fxtf-drafts/issues/481">https://github.com/w3c/fxtf-drafts/issues/481</a>
(WebCore::CSSPropertyParserHelpers::consumeBaselineKeyword): Make static (and remove forward
declaration from header. Nothing outside this file uses this function
(WebCore::CSSPropertyParserHelpers::consumeBackgroundSize): Make this a template function
generic on CSSPropertyID as the callers all statically know which variant they want.
(WebCore::CSSPropertyParserHelpers::consumeRepeatStyle): Make static (and remove forward
declaration from header. Nothing outside this file uses this function
(WebCore::CSSPropertyParserHelpers::consumeSingleBackgroundRepeat): Added to make it a bit
more clear in consumeBackgroundComponent() what the behavior for each property is.
(WebCore::CSSPropertyParserHelpers::consumeSingleBackgroundPositionX): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleBackgroundPositionY): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleBackgroundSize): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleMaskRepeat): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleMaskSize): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleWebkitBackgroundSize): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleWebkitMaskPositionX): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeSingleWebkitMaskPositionY): Ditto.
(WebCore::CSSPropertyParserHelpers::consumeBackgroundComponent): Reordered to group families
of properties together and updated to use generated consumers where possible or the new
named consumers above.
(WebCore::CSSPropertyParserHelpers::consumeCommaSeparatedBackgroundComponent): Adopt new
consumeCommaSeparatedList* helper

(WebCore::CSSPropertyParserHelpers::consumeAutoOrLengthOrPercent): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeMarginSide): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeSide): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAnimationIterationCount): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAnimationName): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeTransitionProperty): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAnimationTimingFunction): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAnimationValue): Deleted.
(WebCore::CSSPropertyParserHelpers::isValidAnimationPropertyList): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeAnimationPropertyList): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeBackgroundBlendMode): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeBackgroundAttachment): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeBackgroundBox): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeMaskClip): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeBackgroundClip): Deleted.
(WebCore::CSSPropertyParserHelpers::consumePrefixedMaskComposite): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeMaskComposite): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitMaskSourceType): Deleted.
(WebCore::CSSPropertyParserHelpers::consumeWebkitMaskMode): Deleted.
(WebCore::CSSPropertyParserHelpers::consumePrefixedBackgroundBox): Deleted.
(WebCore::CSSPropertyParserHelpers::addBackgroundValue): Deleted.
Replaced by generated shared grammar rules or generated properties..

* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
(WebCore::CSSPropertyParserHelpers::consumeCommaSeparatedListWithSingleValueOptimization):
(WebCore::CSSPropertyParserHelpers::consumeCommaSeparatedListWithoutSingleValueOptimization):
Add two helpers which can consume a comma separated list, one with an optimization to return
the underlying CSSValue if there was only one element in the list (and a CSSValueList otherwise)
and the other which always returns a CSSValueList. This allows callers to maintain their
existing behavior.

* Source/WebCore/css/process-css-properties.py:
(Term.from_json): Create a RepetitionTerm if the &apos;kind&apos; is &apos;repetition&apos;.
(RepetitionTerm): RepetitionTerm has a unique &apos;single-value-optimization&apos; flag
that can be set on it to indicate that it should the variant of consumeCommaSeparatedList*
that does the single value optimizaton.
(TermGeneratorRepetitionTerm:) To generate code for a RepetitionTerm, we utilize one of the
consumeCommaSeparatedList* functions and pass it a lambda which contains the submatch. The
new automatic indentation support really came in handy here to allow an arbitrarty set of
terms to generate inside the lambda without issue.

Canonical link: <a href="https://commits.webkit.org/257051@main">https://commits.webkit.org/257051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc6dfe00035f0997efda524e6a7ca8839b0eb704

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97722 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107214 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167481 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7375 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35734 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103865 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103365 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84354 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101280 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89164 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/958 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/948 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4846 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5769 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41486 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->