### PR TITLE
Fix mouse position to truncate the coordinate for mouseMoveTo(...)

### DIFF
--- a/LayoutTests/svg/text/resources/SelectionTestCase.js
+++ b/LayoutTests/svg/text/resources/SelectionTestCase.js
@@ -63,16 +63,16 @@ function selectRange(id, start, end, expectedText) {
 
     if (window.eventSender) {
         // Trigger 'partial glyph selection' code, by adjusting the end x position by half glyph width
-        var xOld = endPos.x;
+        var xOldStart = startPos.x;
+        var xOldEnd = endPos.x;
         endPos.x -= endExtent.width / 2 - 1;
-
-        var absStartPos = toAbsoluteCoordinates(startPos, element);
-        var absEndPos = toAbsoluteCoordinates(endPos, element);
 
         // Round the points "inwards" to avoid being affected by the truncation taking place in 
         // eventSender.mouseMoveTo(...).
-        absStartPos.x = Math.ceil(absStartPos.x);
-        absEndPos.x = Math.floor(absEndPos.x);
+        startPos.x = Math.ceil(startPos.x);
+
+        var absStartPos = toAbsoluteCoordinates(startPos, element);
+        var absEndPos = toAbsoluteCoordinates(endPos, element);
 
         // Move to selection origin and hold down mouse
         eventSender.mouseMoveTo(absStartPos.x, absStartPos.y);
@@ -85,7 +85,8 @@ function selectRange(id, start, end, expectedText) {
         eventSender.mouseMoveTo(absEndPos.x, absEndPos.y);
         eventSender.mouseUp();
 
-        endPos.x = xOld;
+        startPos.x = xOldStart;
+        endPos.x = xOldEnd;
     }
 
     // Mark start position using a green line


### PR DESCRIPTION
<pre>
Fix mouse position to truncate the coordinate for mouseMoveTo(...)
<a href="https://bugs.webkit.org/show_bug.cgi?id=248356">https://bugs.webkit.org/show_bug.cgi?id=248356</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=194744">https://src.chromium.org/viewvc/blink?view=revision&revision=194744</a>

eventSender.mouseMoveTo(...) truncates the coordinates it is passed.
Because fractional coordinates should yield incorrect position.
So this patch could adjust mouse position.

* LayoutTests/svg/text/resources/SelectionTestCase.js:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bf8bc702ecc27756d8253e52a1316031fb1e278

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107159 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167423 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7282 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35672 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90058 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103814 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5457 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84293 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32460 "Found 1 new test failure: svg/text/select-textLength-spacing-squeeze-2.svg (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75380 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/906 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20564 "Found 1 new test failure: svg/text/select-textLength-spacingAndGlyphs-squeeze-3.svg (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/896 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22048 "Found 1 new test failure: svg/text/select-textLength-spacingAndGlyphs-squeeze-3.svg (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5713 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44509 "Found 14 new test failures: fast/images/animated-heics-draw.html, http/tests/navigation/fragment-navigation-policy-ignore.html, http/tests/privateClickMeasurement/attribution-conversion-through-image-redirect-ephemeral.html, imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/sharedworker-import.https.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-img-environment-change.https.sub.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/back-forward-cache/service-worker-unregister.https.html, imported/w3c/web-platform-tests/html/capability-delegation/delegation-sender-checks.tentative.html, imported/w3c/web-platform-tests/html/cross-origin-embedder-policy/reflection-credentialless.tentative.https.any.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/historical/popup-same-origin-unsafe-allow-outgoing-with-same-origin.https.html, imported/w3c/web-platform-tests/service-workers/cache-storage/cross-partition.https.tentative.html ... (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2146 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41440 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->