### PR TITLE
Change event should be dispatched after "option" removal and "selection" update

### DIFF
--- a/LayoutTests/fast/forms/select/menulist-remove-option-onchange.html
+++ b/LayoutTests/fast/forms/select/menulist-remove-option-onchange.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<body>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<select id="select1">
+<option value="">Placeholder</option>
+<option>a</option>
+<option>b</option>
+<option>c</option>
+</select>
+<select id="select2">
+<option value="">Placeholder</option>
+<option>a</option>
+<option>b</option>
+<option>c</option>
+</select>
+<script>
+var select = document.querySelector('select');
+var placeholderOption = document.querySelector('option');
+var selectedValue;
+select.focus();
+select.addEventListener('change', function() {
+    selectedValue = select.value;
+    if (placeholderOption.parentNode == select)
+        select.removeChild(placeholderOption);
+});
+test(function() {
+    eventSender.keyDown('a');
+    assert_equals(selectedValue, 'a');
+    assert_equals(placeholderOption.parentNode, null);
+    internals.resetTypeAheadSession(select);
+
+    eventSender.keyDown('b');
+    assert_equals(select.value, 'b');
+    assert_equals(selectedValue, 'b');
+    internals.resetTypeAheadSession(select);
+
+    eventSender.keyDown('c');
+    assert_equals(selectedValue, 'c');
+}, 'Change event should be dispatched after the option removal.');
+
+selectedValue = null;
+var select2 = document.querySelector('#select2');
+select2.focus();
+select2.addEventListener('change', function() {
+    selectedValue = select2.value;
+    if (select2.options[0].value == '') {
+        var options = select2.options;
+        for (var i = 0; i < options.length - 1; ++i) {
+            options[i].label = options[i + 1].label;
+            options[i].value = options[i + 1].value;
+            options[i].textContent = options[i + 1].textContent;
+        }
+        select2.removeChild(options[options.length - 1]);
+        select2.value = selectedValue;
+    }
+});
+test(function() {
+    eventSender.keyDown('a');
+    assert_equals(select2.selectedIndex, 0);
+    assert_equals(selectedValue, 'a');
+    internals.resetTypeAheadSession(select2);
+
+    eventSender.keyDown('b');
+    assert_equals(select2.selectedIndex, 1);
+    assert_equals(selectedValue, 'b');
+}, 'Change event should be dispatched after updating selection programatically.');
+</script>
+</body>

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -3,8 +3,8 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2022 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -153,6 +153,8 @@ private:
     void deselectItems(HTMLOptionElement* excludeElement = nullptr);
     void typeAheadFind(KeyboardEvent&);
     void saveLastSelection();
+    // Returns the first selected OPTION, or nullptr.
+    HTMLOptionElement* selectedOption() const;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
 
@@ -200,7 +202,7 @@ private:
     Vector<bool> m_cachedStateForActiveSelection;
     TypeAhead m_typeAhead;
     unsigned m_size;
-    int m_lastOnChangeIndex;
+    RefPtr<HTMLOptionElement> m_lastOnChangeOption;
     int m_activeSelectionAnchorIndex;
     int m_activeSelectionEndIndex;
     bool m_isProcessingUserDrivenChange;


### PR DESCRIPTION
<pre>
Change event should be dispatched after "option" removal and "selection" update
<a href="https://bugs.webkit.org/show_bug.cgi?id=248359">https://bugs.webkit.org/show_bug.cgi?id=248359</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/28b7146e377afc89011fccc464e69f0700e2057a">https://chromium.googlesource.com/chromium/src.git/+/28b7146e377afc89011fccc464e69f0700e2057a</a>

We didn't update m_lastOnChangeIndex when an OPTION is removed. This CL change m_lastOnChangeIndex to m_lastOnChangeOption
which holds HTMLOptionElement.  It is robust for DOM structure changes.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElemet::HTMLSelectElement): Update variable
(HTMLSelectElement::remove): Update logic
(HTMLSelectElement::selectAll): Ditto
(HTMLSelectElement::dispatchChangeEventForMenuList): Ditto
(HTMLSelectElement::selectOption): New function
(HTMLSelectElement::optionRemoved): New function
* Source/WebCore/html/HTMLSelectElement.h: Add related definitions of new functions
* LayoutTests/fast/forms/select/menulist-remove-option-onchange.html: Add Test Case
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7d5871506a5b0fd261f3745b3efa7fef7f4213c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97665 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6911 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30831 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107162 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167426 "Hash c7d58715 for PR 6824 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101613 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7289 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35675 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90061 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103817 "Hash c7d58715 for PR 6824 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103310 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/7289 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84296 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/90061 "Hash c7d58715 for PR 6824 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/7289 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/43/builds/30831 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/90061 "Hash c7d58715 for PR 6824 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/909 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/43/builds/30831 "Hash c7d58715 for PR 6824 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/899 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/43/builds/30831 "Hash c7d58715 for PR 6824 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5716 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/84296 "Hash c7d58715 for PR 6824 does not build (failure)") | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2149 "Hash c7d58715 for PR 6824 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/43/builds/30831 "Hash c7d58715 for PR 6824 does not build (failure)") | | 
<!--EWS-Status-Bubble-End-->