### PR TITLE
[web-animations] prefix AnimationEvent and TransitionEvent internal names with CSS

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -751,14 +751,15 @@ set(WebCore_NON_SVG_IDL_FILES
 
     animation/Animatable.idl
     animation/AnimationEffect.idl
-    animation/AnimationEvent.idl
     animation/AnimationFrameProvider.idl
     animation/AnimationFrameRatePreset.idl
     animation/AnimationPlaybackEvent.idl
     animation/AnimationPlaybackEventInit.idl
     animation/AnimationTimeline.idl
     animation/CSSAnimation.idl
+    animation/CSSAnimationEvent.idl
     animation/CSSTransition.idl
+    animation/CSSTransitionEvent.idl
     animation/CompositeOperation.idl
     animation/CompositeOperationOrAuto.idl
     animation/ComputedEffectTiming.idl
@@ -780,7 +781,6 @@ set(WebCore_NON_SVG_IDL_FILES
     animation/KeyframeEffectOptions.idl
     animation/OptionalEffectTiming.idl
     animation/PlaybackDirection.idl
-    animation/TransitionEvent.idl
     animation/WebAnimation.idl
 
     crypto/CryptoAlgorithmParameters.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -873,7 +873,9 @@ $(PROJECT_DIR)/animation/AnimationPlaybackEvent.idl
 $(PROJECT_DIR)/animation/AnimationPlaybackEventInit.idl
 $(PROJECT_DIR)/animation/AnimationTimeline.idl
 $(PROJECT_DIR)/animation/CSSAnimation.idl
+$(PROJECT_DIR)/animation/CSSAnimationEvent.idl
 $(PROJECT_DIR)/animation/CSSTransition.idl
+$(PROJECT_DIR)/animation/CSSTransitionEvent.idl
 $(PROJECT_DIR)/animation/CompositeOperation.idl
 $(PROJECT_DIR)/animation/CompositeOperationOrAuto.idl
 $(PROJECT_DIR)/animation/ComputedEffectTiming.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -321,6 +321,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSPViolationReportBody.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSPViolationReportBody.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSAnimation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSAnimation.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSAnimationEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSAnimationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSColor.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSColor.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSColorValue.cpp
@@ -445,6 +447,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTransformValue.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTransformValue.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTransition.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTransition.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTransitionEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTransitionEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTranslate.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSTranslate.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSUnitValue.cpp
@@ -1769,6 +1773,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Permissions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Permissions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+ScreenWakeLock.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+ScreenWakeLock.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+UserActivation.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+UserActivation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebDriver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebDriver.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+WebXR.cpp
@@ -1797,8 +1803,6 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorShare.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorShare.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorStorage.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorStorage.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+UserActivation.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+UserActivation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNodeFilter.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -757,14 +757,15 @@ JS_BINDING_IDLS := \
     $(WebCore)/accessibility/AriaAttributes.idl \
     $(WebCore)/animation/Animatable.idl \
     $(WebCore)/animation/AnimationEffect.idl \
-    $(WebCore)/animation/AnimationEvent.idl \
     $(WebCore)/animation/AnimationFrameProvider.idl \
     $(WebCore)/animation/AnimationFrameRatePreset.idl \
     $(WebCore)/animation/AnimationPlaybackEvent.idl \
     $(WebCore)/animation/AnimationPlaybackEventInit.idl \
     $(WebCore)/animation/AnimationTimeline.idl \
     $(WebCore)/animation/CSSAnimation.idl \
+    $(WebCore)/animation/CSSAnimationEvent.idl \
     $(WebCore)/animation/CSSTransition.idl \
+    $(WebCore)/animation/CSSTransitionEvent.idl \
     $(WebCore)/animation/CompositeOperation.idl \
     $(WebCore)/animation/CompositeOperationOrAuto.idl \
     $(WebCore)/animation/ComputedEffectTiming.idl \
@@ -786,7 +787,6 @@ JS_BINDING_IDLS := \
     $(WebCore)/animation/KeyframeEffectOptions.idl \
     $(WebCore)/animation/OptionalEffectTiming.idl \
     $(WebCore)/animation/PlaybackDirection.idl \
-    $(WebCore)/animation/TransitionEvent.idl \
     $(WebCore)/animation/WebAnimation.idl \
     $(WebCore)/crypto/CryptoAlgorithmParameters.idl \
     $(WebCore)/crypto/CryptoKey.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -486,13 +486,14 @@ accessibility/AccessibilityTreeItem.cpp
 accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedTree.cpp
 animation/AnimationEffect.cpp
-animation/AnimationEvent.cpp
 animation/AnimationEventBase.cpp
 animation/AnimationPlaybackEvent.cpp
 animation/AnimationTimeline.cpp
 animation/CSSAnimation.cpp
+animation/CSSAnimationEvent.cpp
 animation/CSSPropertyAnimation.cpp
 animation/CSSTransition.cpp
+animation/CSSTransitionEvent.cpp
 animation/CompositeOperation.cpp
 animation/CustomEffect.cpp
 animation/DeclarativeAnimation.cpp
@@ -502,7 +503,6 @@ animation/ElementAnimationRareData.cpp
 animation/FrameRateAligner.cpp
 animation/KeyframeEffect.cpp
 animation/KeyframeEffectStack.cpp
-animation/TransitionEvent.cpp
 animation/WebAnimation.cpp
 animation/WebAnimationUtilities.cpp
 bindings/js/CachedModuleScriptLoader.cpp
@@ -2994,7 +2994,6 @@ JSAesKeyParams.cpp
 JSAnalyserNode.cpp
 JSAnalyserOptions.cpp
 JSAnimationEffect.cpp
-JSAnimationEvent.cpp
 JSAnimationFrameRatePreset.cpp
 JSAnimationPlaybackEvent.cpp
 JSAnimationPlaybackEventInit.cpp
@@ -3057,6 +3056,7 @@ JSByteLengthQueuingStrategy.cpp
 JSCDATASection.cpp
 JSCSPViolationReportBody.cpp
 JSCSSAnimation.cpp
+JSCSSAnimationEvent.cpp
 JSCSSConditionRule.cpp
 JSCSSContainerRule.cpp
 JSCSSCounterStyleRule.cpp
@@ -3081,6 +3081,7 @@ JSCSSStyleRule.cpp
 JSCSSStyleSheet.cpp
 JSCSSSupportsRule.cpp
 JSCSSTransition.cpp
+JSCSSTransitionEvent.cpp
 JSCSSUnknownRule.cpp
 JSCOEPInheritenceViolationReportBody.cpp
 JSCORPViolationReportBody.cpp
@@ -4067,7 +4068,6 @@ JSTrackEvent.cpp
 JSTransferFunction.cpp
 JSTransformStream.cpp
 JSTransformStreamDefaultController.cpp
-JSTransitionEvent.cpp
 JSTreeWalker.cpp
 JSCSSKeywordValue.cpp
 JSCSSStyleImageValue.cpp

--- a/Source/WebCore/animation/AnimationEventBase.h
+++ b/Source/WebCore/animation/AnimationEventBase.h
@@ -43,8 +43,8 @@ public:
     virtual ~AnimationEventBase();
 
     virtual bool isAnimationPlaybackEvent() const { return false; }
-    virtual bool isAnimationEvent() const { return false; }
-    virtual bool isTransitionEvent() const { return false; }
+    virtual bool isCSSAnimationEvent() const { return false; }
+    virtual bool isCSSTransitionEvent() const { return false; }
 
     WebAnimation* animation() const { return m_animation.get(); }
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -28,7 +28,7 @@
 
 #include "Animation.h"
 #include "AnimationEffect.h"
-#include "AnimationEvent.h"
+#include "CSSAnimationEvent.h"
 #include "InspectorInstrumentation.h"
 #include "KeyframeEffect.h"
 #include "RenderStyle.h"
@@ -283,7 +283,7 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
 
 Ref<AnimationEventBase> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
 {
-    return AnimationEvent::create(eventType, this, elapsedTime, m_animationName, pseudoId);
+    return CSSAnimationEvent::create(eventType, this, elapsedTime, m_animationName, pseudoId);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
- * Copyright (C) 2013 Intel Corporation. All rights reserved.
+ * Copyright (C) 2014 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,50 +24,50 @@
  */
 
 #include "config.h"
-#include "TransitionEvent.h"
+#include "CSSAnimationEvent.h"
 
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
-WTF_MAKE_ISO_ALLOCATED_IMPL(TransitionEvent);
+WTF_MAKE_ISO_ALLOCATED_IMPL(CSSAnimationEvent);
 
-TransitionEvent::TransitionEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& propertyName, const String& pseudoElement)
-    : AnimationEventBase(type, animation)
-    , m_propertyName(propertyName)
-    , m_elapsedTime(elapsedTime)
-    , m_pseudoElement(pseudoElement)
-{
-}
-
-TransitionEvent::TransitionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
     : AnimationEventBase(type, initializer, isTrusted)
-    , m_propertyName(initializer.propertyName)
+    , m_animationName(initializer.animationName)
     , m_elapsedTime(initializer.elapsedTime)
     , m_pseudoElement(initializer.pseudoElement)
 {
 }
 
-TransitionEvent::~TransitionEvent() = default;
-
-const String& TransitionEvent::propertyName() const
+CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& animationName, const String& pseudoElement)
+    : AnimationEventBase(type, animation)
+    , m_animationName(animationName)
+    , m_elapsedTime(elapsedTime)
+    , m_pseudoElement(pseudoElement)
 {
-    return m_propertyName;
 }
 
-double TransitionEvent::elapsedTime() const
+CSSAnimationEvent::~CSSAnimationEvent() = default;
+
+const String& CSSAnimationEvent::animationName() const
+{
+    return m_animationName;
+}
+
+double CSSAnimationEvent::elapsedTime() const
 {
     return m_elapsedTime;
 }
 
-const String& TransitionEvent::pseudoElement() const
+const String& CSSAnimationEvent::pseudoElement() const
 {
     return m_pseudoElement;
 }
 
-EventInterface TransitionEvent::eventInterface() const
+EventInterface CSSAnimationEvent::eventInterface() const
 {
-    return TransitionEventInterfaceType;
+    return CSSAnimationEventInterfaceType;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
- * Copyright (C) 2013 Intel Corporation. All rights reserved.
+ * Copyright (C) 2014 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,44 +29,44 @@
 
 namespace WebCore {
 
-class TransitionEvent final : public AnimationEventBase {
-    WTF_MAKE_ISO_ALLOCATED(TransitionEvent);
+class CSSAnimationEvent final : public AnimationEventBase {
+    WTF_MAKE_ISO_ALLOCATED(CSSAnimationEvent);
 public:
-    static Ref<TransitionEvent> create(const AtomString& type, WebAnimation* animation,  double elapsedTime, const String& propertyName, const String& pseudoElement)
+    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& animationName, const String& pseudoElement)
     {
-        return adoptRef(*new TransitionEvent(type, animation, elapsedTime, propertyName, pseudoElement));
+        return adoptRef(*new CSSAnimationEvent(type, animation, elapsedTime, animationName, pseudoElement));
     }
 
     struct Init : EventInit {
-        String propertyName;
+        String animationName;
         double elapsedTime { 0 };
         String pseudoElement;
     };
 
-    static Ref<TransitionEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<CSSAnimationEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new TransitionEvent(type, initializer, isTrusted));
+        return adoptRef(*new CSSAnimationEvent(type, initializer, isTrusted));
     }
 
-    virtual ~TransitionEvent();
+    virtual ~CSSAnimationEvent();
 
-    bool isTransitionEvent() const final { return true; }
+    bool isCSSAnimationEvent() const final { return true; }
 
-    const String& propertyName() const;
+    const String& animationName() const;
     double elapsedTime() const;
     const String& pseudoElement() const;
 
     EventInterface eventInterface() const override;
 
 private:
-    TransitionEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& propertyName, const String& pseudoElement);
-    TransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);
+    CSSAnimationEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& animationName, const String& pseudoElement);
+    CSSAnimationEvent(const AtomString&, const Init&, IsTrusted);
 
-    String m_propertyName;
+    String m_animationName;
     double m_elapsedTime;
     String m_pseudoElement;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(TransitionEvent, isTransitionEvent())
+SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(CSSAnimationEvent, isCSSAnimationEvent())

--- a/Source/WebCore/animation/CSSAnimationEvent.idl
+++ b/Source/WebCore/animation/CSSAnimationEvent.idl
@@ -24,8 +24,9 @@
  */
 
 [
-    Exposed=Window
-] interface AnimationEvent : Event {
+    Exposed=Window,
+    InterfaceName=AnimationEvent
+] interface CSSAnimationEvent : Event {
     constructor([AtomString] DOMString type, optional AnimationEventInit animationEventInitDict);
 
     readonly attribute DOMString animationName;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -27,11 +27,11 @@
 #include "CSSTransition.h"
 
 #include "Animation.h"
+#include "CSSTransitionEvent.h"
 #include "DocumentTimeline.h"
 #include "InspectorInstrumentation.h"
 #include "KeyframeEffect.h"
 #include "StyleResolver.h"
-#include "TransitionEvent.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -95,7 +95,7 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
 
 Ref<AnimationEventBase> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
 {
-    return TransitionEvent::create(eventType, this, elapsedTime, nameString(m_property), pseudoId);
+    return CSSTransitionEvent::create(eventType, this, elapsedTime, nameString(m_property), pseudoId);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,50 +25,50 @@
  */
 
 #include "config.h"
-#include "AnimationEvent.h"
+#include "CSSTransitionEvent.h"
 
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
-WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationEvent);
+WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransitionEvent);
 
-AnimationEvent::AnimationEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : AnimationEventBase(type, initializer, isTrusted)
-    , m_animationName(initializer.animationName)
-    , m_elapsedTime(initializer.elapsedTime)
-    , m_pseudoElement(initializer.pseudoElement)
-{
-}
-
-AnimationEvent::AnimationEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& animationName, const String& pseudoElement)
+CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& propertyName, const String& pseudoElement)
     : AnimationEventBase(type, animation)
-    , m_animationName(animationName)
+    , m_propertyName(propertyName)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
 {
 }
 
-AnimationEvent::~AnimationEvent() = default;
-
-const String& AnimationEvent::animationName() const
+CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+    : AnimationEventBase(type, initializer, isTrusted)
+    , m_propertyName(initializer.propertyName)
+    , m_elapsedTime(initializer.elapsedTime)
+    , m_pseudoElement(initializer.pseudoElement)
 {
-    return m_animationName;
 }
 
-double AnimationEvent::elapsedTime() const
+CSSTransitionEvent::~CSSTransitionEvent() = default;
+
+const String& CSSTransitionEvent::propertyName() const
+{
+    return m_propertyName;
+}
+
+double CSSTransitionEvent::elapsedTime() const
 {
     return m_elapsedTime;
 }
 
-const String& AnimationEvent::pseudoElement() const
+const String& CSSTransitionEvent::pseudoElement() const
 {
     return m_pseudoElement;
 }
 
-EventInterface AnimationEvent::eventInterface() const
+EventInterface CSSTransitionEvent::eventInterface() const
 {
-    return AnimationEventInterfaceType;
+    return CSSTransitionEventInterfaceType;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2007, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,44 +30,44 @@
 
 namespace WebCore {
 
-class AnimationEvent final : public AnimationEventBase {
-    WTF_MAKE_ISO_ALLOCATED(AnimationEvent);
+class CSSTransitionEvent final : public AnimationEventBase {
+    WTF_MAKE_ISO_ALLOCATED(CSSTransitionEvent);
 public:
-    static Ref<AnimationEvent> create(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& animationName, const String& pseudoElement)
+    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation,  double elapsedTime, const String& propertyName, const String& pseudoElement)
     {
-        return adoptRef(*new AnimationEvent(type, animation, elapsedTime, animationName, pseudoElement));
+        return adoptRef(*new CSSTransitionEvent(type, animation, elapsedTime, propertyName, pseudoElement));
     }
 
     struct Init : EventInit {
-        String animationName;
+        String propertyName;
         double elapsedTime { 0 };
         String pseudoElement;
     };
 
-    static Ref<AnimationEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<CSSTransitionEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new AnimationEvent(type, initializer, isTrusted));
+        return adoptRef(*new CSSTransitionEvent(type, initializer, isTrusted));
     }
 
-    virtual ~AnimationEvent();
+    virtual ~CSSTransitionEvent();
 
-    bool isAnimationEvent() const final { return true; }
+    bool isCSSTransitionEvent() const final { return true; }
 
-    const String& animationName() const;
+    const String& propertyName() const;
     double elapsedTime() const;
     const String& pseudoElement() const;
 
     EventInterface eventInterface() const override;
 
 private:
-    AnimationEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& animationName, const String& pseudoElement);
-    AnimationEvent(const AtomString&, const Init&, IsTrusted);
+    CSSTransitionEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& propertyName, const String& pseudoElement);
+    CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
-    String m_animationName;
+    String m_propertyName;
     double m_elapsedTime;
     String m_pseudoElement;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(AnimationEvent, isAnimationEvent())
+SPECIALIZE_TYPE_TRAITS_ANIMATION_EVENT_BASE(CSSTransitionEvent, isCSSTransitionEvent())

--- a/Source/WebCore/animation/CSSTransitionEvent.idl
+++ b/Source/WebCore/animation/CSSTransitionEvent.idl
@@ -25,8 +25,9 @@
  */
 
 [
-    Exposed=Window
-] interface TransitionEvent : Event {
+    Exposed=Window,
+    InterfaceName=TransitionEvent
+] interface CSSTransitionEvent : Event {
     constructor([AtomString] DOMString type, optional TransitionEventInit transitionEventInitDict);
 
     readonly attribute DOMString propertyName;

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -27,7 +27,6 @@
 #include "DeclarativeAnimation.h"
 
 #include "Animation.h"
-#include "AnimationEvent.h"
 #include "CSSAnimation.h"
 #include "CSSTransition.h"
 #include "DocumentTimeline.h"

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -27,16 +27,16 @@
 #include "WebAnimationUtilities.h"
 
 #include "Animation.h"
-#include "AnimationEvent.h"
 #include "AnimationEventBase.h"
 #include "AnimationList.h"
 #include "AnimationPlaybackEvent.h"
 #include "CSSAnimation.h"
+#include "CSSAnimationEvent.h"
 #include "CSSTransition.h"
+#include "CSSTransitionEvent.h"
 #include "DeclarativeAnimation.h"
 #include "Element.h"
 #include "KeyframeEffectStack.h"
-#include "TransitionEvent.h"
 #include "WebAnimation.h"
 
 namespace WebCore {
@@ -236,18 +236,18 @@ bool compareAnimationEventsByCompositeOrder(const AnimationEventBase& a, const A
         return aAnimation->globalPosition() < bAnimation->globalPosition();
     }
 
-    // TransitionEvent instances sort next.
-    bool aIsCSSTransition = is<TransitionEvent>(a);
-    bool bIsCSSTransition = is<TransitionEvent>(b);
+    // CSSTransitionEvent instances sort next.
+    bool aIsCSSTransition = is<CSSTransitionEvent>(a);
+    bool bIsCSSTransition = is<CSSTransitionEvent>(b);
     if (aIsCSSTransition || bIsCSSTransition) {
         if (aIsCSSTransition == bIsCSSTransition)
             return false;
         return !bIsCSSTransition;
     }
 
-    // AnimationEvent instances sort last.
-    bool aIsCSSAnimation = is<AnimationEvent>(a);
-    bool bIsCSSAnimation = is<AnimationEvent>(b);
+    // CSSAnimationEvent instances sort last.
+    bool aIsCSSAnimation = is<CSSAnimationEvent>(a);
+    bool bIsCSSAnimation = is<CSSAnimationEvent>(b);
     if (aIsCSSAnimation || bIsCSSAnimation) {
         if (aIsCSSAnimation == bIsCSSAnimation)
             return false;

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -5,13 +5,14 @@ useNamespaceAsSuffix=false
 Event
 Events interfaceName=Event
 HTMLEvents interfaceName=Event
-AnimationEvent
 AnimationPlaybackEvent
 BeforeLoadEvent interfaceName=Event
 BeforeUnloadEvent
 ClipboardEvent
 CloseEvent
 CompositionEvent
+CSSAnimationEvent
+CSSTransitionEvent
 CustomEvent
 DragEvent
 ExtendableEvent conditional=SERVICE_WORKER
@@ -40,7 +41,6 @@ PushEvent conditional=SERVICE_WORKER
 PushSubscriptionChangeEvent conditional=SERVICE_WORKER
 SubmitEvent
 TextEvent
-TransitionEvent
 UIEvent
 UIEvents interfaceName=UIEvent
 WheelEvent


### PR DESCRIPTION
#### 65da5f9b2e68fb35c7e4e43b77281d005180d4ce
<pre>
[web-animations] prefix AnimationEvent and TransitionEvent internal names with CSS
<a href="https://bugs.webkit.org/show_bug.cgi?id=248365">https://bugs.webkit.org/show_bug.cgi?id=248365</a>

Reviewed by Dean Jackson.

We rename the AnimationEvent and TransitionEvent source files internally to have a CSS prefix and
make it clearer how they relate to CSSAnimation and CSSTransition classes.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationEventBase.h:
(WebCore::AnimationEventBase::isCSSAnimationEvent const):
(WebCore::AnimationEventBase::isCSSTransitionEvent const):
(WebCore::AnimationEventBase::isAnimationEvent const): Deleted.
(WebCore::AnimationEventBase::isTransitionEvent const): Deleted.
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimationEvent.cpp: Renamed from Source/WebCore/animation/AnimationEvent.cpp.
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
(WebCore::CSSAnimationEvent::animationName const):
(WebCore::CSSAnimationEvent::elapsedTime const):
(WebCore::CSSAnimationEvent::pseudoElement const):
(WebCore::CSSAnimationEvent::eventInterface const):
* Source/WebCore/animation/CSSAnimationEvent.h: Renamed from Source/WebCore/animation/AnimationEvent.h.
* Source/WebCore/animation/CSSAnimationEvent.idl: Renamed from Source/WebCore/animation/AnimationEvent.idl.
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransitionEvent.cpp: Renamed from Source/WebCore/animation/TransitionEvent.cpp.
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
(WebCore::CSSTransitionEvent::propertyName const):
(WebCore::CSSTransitionEvent::elapsedTime const):
(WebCore::CSSTransitionEvent::pseudoElement const):
(WebCore::CSSTransitionEvent::eventInterface const):
* Source/WebCore/animation/CSSTransitionEvent.h: Renamed from Source/WebCore/animation/TransitionEvent.h.
* Source/WebCore/animation/CSSTransitionEvent.idl: Renamed from Source/WebCore/animation/TransitionEvent.idl.
* Source/WebCore/animation/DeclarativeAnimation.cpp:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareAnimationEventsByCompositeOrder):
* Source/WebCore/dom/EventNames.in:

Canonical link: <a href="https://commits.webkit.org/257039@main">https://commits.webkit.org/257039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b2a9a3b16322fde1536ec55c77b3ab821c8728

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107172 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167437 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7306 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35687 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103827 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103321 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84308 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32470 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/917 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22058 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2395 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41450 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->