### PR TITLE
Stream's structuredCloneForStream should keep resizability of ArrayBuffers

### DIFF
--- a/LayoutTests/http/wpt/fetch/request-clone-resizable-expected.txt
+++ b/LayoutTests/http/wpt/fetch/request-clone-resizable-expected.txt
@@ -1,0 +1,13 @@
+
+PASS Check request clone use structureClone for teed ReadableStreams (Int8Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Int16Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Int32Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (ArrayBufferchunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Uint8Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Uint8ClampedArraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Uint16Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Uint32Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Float32Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (Float64Arraychunk)
+PASS Check request clone use structureClone for teed ReadableStreams (DataViewchunk)
+

--- a/LayoutTests/http/wpt/fetch/request-clone-resizable.html
+++ b/LayoutTests/http/wpt/fetch/request-clone-resizable.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Request clone</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#request">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script src="/fetch/api/resources/utils.js"></script>
+    <script>
+var body = "This is request body";
+var headersInit = { "name" : "value" };
+var requestInit  = { "body" : body,
+                     "method" : "POST",
+                     "headers" : headersInit
+};
+var request = new Request("", requestInit);
+var clonedRequest = request.clone();
+
+function testReadableStreamClone(initialBuffer, bufferType)
+{
+    promise_test(function(test) {
+        var request = new Request("", {"method" : "POST", "body" : new ReadableStream({start : function(controller) {
+            controller.enqueue(initialBuffer);
+            controller.close();
+        }})});
+
+        var clone = request.clone();
+        var stream1 = request.body;
+        var stream2 = clone.body;
+
+        var buffer;
+        return stream1.getReader().read().then(function(data) {
+            assert_false(data.done);
+            assert_true(data.value === initialBuffer, "Buffer of being-cloned response stream is the same as the original buffer");
+            return stream2.getReader().read();
+        }).then(function(data) {
+            assert_false(data.done);
+            if (data.value instanceof ArrayBuffer)
+                assert_array_equals(new Uint8Array(data.value), new Uint8Array(initialBuffer), "Cloned buffer chunks have the same content");
+            else if (data.value instanceof DataView)
+                assert_array_equals(new Uint8Array(data.value.buffer), new Uint8Array(initialBuffer.buffer), "Cloned buffer chunks have the same content");
+            else
+                assert_array_equals(data.value, initialBuffer, "Cloned buffer chunks have the same content");
+            assert_equals(Object.getPrototypeOf(data.value), Object.getPrototypeOf(initialBuffer), "Cloned buffers have the same type");
+            assert_true(data.value !== initialBuffer, "Buffer of cloned response stream is a clone of the original buffer");
+            if (data.value instanceof ArrayBuffer)
+                assert_true(data.value.resizable, "Buffer of cloned response stream is resizable");
+            else
+                assert_true(data.value.buffer.resizable, "Buffer of cloned response stream is resizable");
+        });
+    }, "Check request clone use structureClone for teed ReadableStreams (" + bufferType  + "chunk)");
+}
+
+var arrayBuffer = new ArrayBuffer(16, { maxByteLength: 1024 });
+testReadableStreamClone(new Int8Array(arrayBuffer, 1), "Int8Array");
+testReadableStreamClone(new Int16Array(arrayBuffer, 2, 2), "Int16Array");
+testReadableStreamClone(new Int32Array(arrayBuffer), "Int32Array");
+testReadableStreamClone(arrayBuffer, "ArrayBuffer");
+testReadableStreamClone(new Uint8Array(arrayBuffer), "Uint8Array");
+testReadableStreamClone(new Uint8ClampedArray(arrayBuffer), "Uint8ClampedArray");
+testReadableStreamClone(new Uint16Array(arrayBuffer, 2), "Uint16Array");
+testReadableStreamClone(new Uint32Array(arrayBuffer), "Uint32Array");
+testReadableStreamClone(new Float32Array(arrayBuffer), "Float32Array");
+testReadableStreamClone(new Float64Array(arrayBuffer), "Float64Array");
+testReadableStreamClone(new DataView(arrayBuffer, 2, 8), "DataView");
+    </script>
+  </body>
+</html>

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -326,7 +326,6 @@ private:
     static Ref<ArrayBuffer> createInternal(ArrayBufferContents&&, const void*, size_t);
     static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength, ArrayBufferContents::InitializationPolicy);
     ArrayBuffer(ArrayBufferContents&&);
-    static Ref<ArrayBuffer> createResizable(Ref<BufferMemoryHandle>&&);
     inline size_t clampIndex(double index) const;
     static inline size_t clampValue(double x, size_t left, size_t right);
 


### PR DESCRIPTION
#### afcc2ab7b2c2fbdf5b97a179e204399a69d43bcc
<pre>
Stream&apos;s structuredCloneForStream should keep resizability of ArrayBuffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=248368">https://bugs.webkit.org/show_bug.cgi?id=248368</a>
rdar://102685044

Reviewed by Ross Kirsling.

Apply the structuredClone&apos;s change to structuredCloneForStream too.
This should keep ArrayBuffer / TypedArray&apos;s resizability.

* LayoutTests/http/wpt/fetch/request-clone-resizable-expected.txt: Added.
* LayoutTests/http/wpt/fetch/request-clone-resizable.html: Added.
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/WebCore/bindings/js/StructuredClone.cpp:
(WebCore::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/257043@main">https://commits.webkit.org/257043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d51587c11238155e44b303ac08eddecdbeec03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107174 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167440 "Found 1 new test failure: fast/images/pagewide-play-pause-offscreen-animations.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7313 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35690 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103829 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5485 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84310 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89131 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75392 "Found 3 new API test failures: /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/security-error, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/js-exception, /WebKitGTK/TestConsoleMessage:/webkit/WebKitConsoleMessage/network-error (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88584 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/919 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84255 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22061 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28516 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5728 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44522 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87085 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2397 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41453 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19538 "Passed tests") | 
<!--EWS-Status-Bubble-End-->