### PR TITLE
compositionstart event's data should contain text to replace

### DIFF
--- a/LayoutTests/fast/events/ime-composition-events-001.html
+++ b/LayoutTests/fast/events/ime-composition-events-001.html
@@ -53,6 +53,7 @@ test.value = 'I have a pen';
 test.selectionStart = 2;
 test.selectionEnd = 6;
 textInputController.setMarkedText('lost', 0, 1);
+shouldBeEqualToString('test.value', 'I lost a pen');
 textInputController.insertText('made');
 shouldBeEqualToString('test.value', 'I made a pen');
 </script>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -2184,6 +2184,11 @@ void Editor::setComposition(const String& text, const Vector<CompositionUnderlin
             // We should send a compositionstart event only when the given text is not empty because this
             // function doesn't create a composition node when the text is empty.
             if (!text.isEmpty()) {
+                auto selection = m_document.selection().selection();
+                if (selection.isRange()) {
+                    auto range = m_document.selection().selection().toNormalizedRange();
+                    String selectionText = plainText(*range);
+                }
                 target->dispatchEvent(CompositionEvent::create(eventNames().compositionstartEvent, document().windowProxy(), originalText));
                 event = CompositionEvent::create(eventNames().compositionupdateEvent, document().windowProxy(), text);
             }


### PR DESCRIPTION
<pre>
compositionstart event's data should contain text to replace
<a href="https://bugs.webkit.org/show_bug.cgi?id=248367">https://bugs.webkit.org/show_bug.cgi?id=248367</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium and Web-Specification:

Web-Specification: <a href="https://www.w3.org/TR/uievents/#event-type-compositionstart">https://www.w3.org/TR/uievents/#event-type-compositionstart</a>
MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent/data">https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent/data</a>

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=153319">https://src.chromium.org/viewvc/blink?view=revision&revision=153319</a>

This patch align's Webkit behavior with web-specification for "compositionstart.data" event, which is refers to the original
string being edited, otherwise the empty string,
which means the string to be replaced with the IME composition text.

* Source/WebCore/editing/Editor.cpp:
(Editor:setComposition): Update logic for "compositionstart.data"
* LayoutTests/fast/event/ime-composition-events-001.html: Update from Chromium / Blink
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78417b3b08ee520f1afdaab84942125e37bbdd08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107186 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167451 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7327 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35703 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103837 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5489 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84323 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32476 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89137 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75396 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/931 "Built successfully") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20580 "Found 1 new test failure: fast/events/ime-composition-events-001.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/918 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22067 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44528 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41459 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->