### PR TITLE
[GTK][WPE] Deprecate old script message handler API in WebKitUserContentManager

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp
@@ -96,6 +96,8 @@ static void webkit_user_content_manager_class_init(WebKitUserContentManagerClass
      * webkit_user_content_manager_register_script_message_handler()
      *
      * Since: 2.8
+     *
+     * Deprecated: 2.40
      */
     signals[SCRIPT_MESSAGE_RECEIVED] =
         g_signal_new(
@@ -456,6 +458,8 @@ private:
  * Returns: %TRUE if message handler was registered successfully, or %FALSE otherwise.
  *
  * Since: 2.8
+ *
+ * Deprecated: 2.40
  */
 gboolean webkit_user_content_manager_register_script_message_handler(WebKitUserContentManager* manager, const char* name)
 {
@@ -543,6 +547,8 @@ gboolean webkit_user_content_manager_register_script_message_handler_with_reply(
  * Returns: %TRUE if message handler was registered successfully, or %FALSE otherwise.
  *
  * Since: 2.22
+ *
+ * Deprecated: 2.40
  */
 gboolean webkit_user_content_manager_register_script_message_handler_in_world(WebKitUserContentManager* manager, const char* name, const char* worldName)
 {

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in
@@ -75,7 +75,7 @@ webkit_user_content_manager_remove_style_sheet                         (WebKitUs
 WEBKIT_API void
 webkit_user_content_manager_remove_all_style_sheets                    (WebKitUserContentManager *manager);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED gboolean
 webkit_user_content_manager_register_script_message_handler            (WebKitUserContentManager *manager,
                                                                         const gchar              *name);
 WEBKIT_API void
@@ -87,7 +87,7 @@ webkit_user_content_manager_register_script_message_handler_with_reply (WebKitUs
                                                                         const char               *name,
                                                                         const char               *world_name);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED gboolean
 webkit_user_content_manager_register_script_message_handler_in_world   (WebKitUserContentManager *manager,
                                                                         const gchar              *name,
                                                                         const gchar              *world_name);

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -716,7 +716,7 @@ static void activate(GApplication *application, WebKitSettings *webkitSettings)
     webkit_web_context_register_uri_scheme(webContext, BROWSER_ABOUT_SCHEME, (WebKitURISchemeRequestCallback)aboutURISchemeRequestCallback, webContext, NULL);
 
     WebKitUserContentManager *userContentManager = webkit_user_content_manager_new();
-    webkit_user_content_manager_register_script_message_handler(userContentManager, "aboutData");
+    webkit_user_content_manager_register_script_message_handler_with_reply(userContentManager, "aboutData", "");
     g_signal_connect(userContentManager, "script-message-received::aboutData", G_CALLBACK(aboutDataScriptMessageReceivedCallback), webContext);
 
     WebKitWebsitePolicies *defaultWebsitePolicies = webkit_website_policies_new_with_policies(


### PR DESCRIPTION
#### eac40798e93c61f3e0c0b93dfb9edd7c6b8f8392
<pre>
[GTK][WPE] Deprecate old script message handler API in WebKitUserContentManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=243666">https://bugs.webkit.org/show_bug.cgi?id=243666</a>

Reviewed by NOBODY (OOPS!).

Mark as deprecated since 2.40 the legacy functions
webkit_user_content_manager_register_script_message_handler(), and
webkit_user_content_manager_register_script_message_handler_in_world(),
as well as the signal WebKitUserContentManager::script-message-received.

* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitUserContentManager.h.in:
* Tools/MiniBrowser/gtk/main.c:
(activate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eac40798e93c61f3e0c0b93dfb9edd7c6b8f8392

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107189 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167454 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7334 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35707 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103840 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5496 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84326 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32480 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75400 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/934 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20584 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/921 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22071 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5743 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44531 "Found 2 new test failures: fast/images/animated-heics-draw.html, fast/images/animated-heics-verify.html (failure)") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41463 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->