### PR TITLE
[web-animations] move scheduledTime from AnimationPlaybackEvent to AnimationEventBase

### DIFF
--- a/Source/WebCore/animation/AnimationEventBase.cpp
+++ b/Source/WebCore/animation/AnimationEventBase.cpp
@@ -34,9 +34,10 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationEventBase);
 
-AnimationEventBase::AnimationEventBase(const AtomString& type, WebAnimation* animation)
+AnimationEventBase::AnimationEventBase(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime)
     : Event(type, CanBubble::Yes, IsCancelable::No)
     , m_animation(animation)
+    , m_scheduledTime(scheduledTime)
 {
 }
 

--- a/Source/WebCore/animation/AnimationEventBase.h
+++ b/Source/WebCore/animation/AnimationEventBase.h
@@ -35,11 +35,6 @@ class WebAnimation;
 class AnimationEventBase : public Event {
     WTF_MAKE_ISO_ALLOCATED(AnimationEventBase);
 public:
-    static Ref<AnimationEventBase> create(const AtomString& type, WebAnimation* animation)
-    {
-        return adoptRef(*new AnimationEventBase(type, animation));
-    }
-
     virtual ~AnimationEventBase();
 
     virtual bool isAnimationPlaybackEvent() const { return false; }
@@ -47,12 +42,15 @@ public:
     virtual bool isCSSTransitionEvent() const { return false; }
 
     WebAnimation* animation() const { return m_animation.get(); }
+    std::optional<Seconds> scheduledTime() const { return m_scheduledTime; }
 
 protected:
-    AnimationEventBase(const AtomString&, WebAnimation*);
+    AnimationEventBase(const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime);
     AnimationEventBase(const AtomString&, const EventInit&, IsTrusted);
 
+private:
     RefPtr<WebAnimation> m_animation;
+    Markable<Seconds, Seconds::MarkableTraits> m_scheduledTime;
 };
 
 }

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -47,10 +47,9 @@ AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, const Ani
         m_timelineTime = std::nullopt;
 }
 
-AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> timelineTime, std::optional<Seconds> scheduledTime, std::optional<Seconds> currentTime)
-    : AnimationEventBase(type, animation)
+AnimationPlaybackEvent::AnimationPlaybackEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime)
+    : AnimationEventBase(type, animation, scheduledTime)
     , m_timelineTime(timelineTime)
-    , m_scheduledTime(scheduledTime)
     , m_currentTime(currentTime)
 {
 }

--- a/Source/WebCore/animation/AnimationPlaybackEvent.h
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.h
@@ -34,9 +34,9 @@ namespace WebCore {
 class AnimationPlaybackEvent final : public AnimationEventBase {
     WTF_MAKE_ISO_ALLOCATED(AnimationPlaybackEvent);
 public:
-    static Ref<AnimationPlaybackEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> timelineTime, std::optional<Seconds> scheduledTime, std::optional<Seconds> currentTime)
+    static Ref<AnimationPlaybackEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime)
     {
-        return adoptRef(*new AnimationPlaybackEvent(type, animation, timelineTime, scheduledTime, currentTime));
+        return adoptRef(*new AnimationPlaybackEvent(type, animation, scheduledTime, timelineTime, currentTime));
     }
 
     static Ref<AnimationPlaybackEvent> create(const AtomString& type, const AnimationPlaybackEventInit& initializer, IsTrusted isTrusted = IsTrusted::No)
@@ -51,19 +51,16 @@ public:
     std::optional<Seconds> timelineTime() const { return m_timelineTime; }
     std::optional<double> bindingsTimelineTime() const;
 
-    std::optional<Seconds> scheduledTime() const { return m_scheduledTime; }
-
     std::optional<double> bindingsCurrentTime() const;
     std::optional<Seconds> currentTime() const { return m_currentTime; }
 
     EventInterface eventInterface() const override { return AnimationPlaybackEventInterfaceType; }
 
 private:
-    AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<Seconds> timelineTime, std::optional<Seconds> scheduledTime, std::optional<Seconds> currentTime);
+    AnimationPlaybackEvent(const AtomString&, WebAnimation*, std::optional<Seconds> scheduledTime, std::optional<Seconds> timelineTime, std::optional<Seconds> currentTime);
     AnimationPlaybackEvent(const AtomString&, const AnimationPlaybackEventInit&, IsTrusted);
 
     Markable<Seconds, Seconds::MarkableTraits> m_timelineTime;
-    Markable<Seconds, Seconds::MarkableTraits> m_scheduledTime;
     Markable<Seconds, Seconds::MarkableTraits> m_currentTime;
 };
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -283,7 +283,7 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
 
 Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
 {
-    return CSSAnimationEvent::create(eventType, this, elapsedTime, pseudoId, m_animationName);
+    return CSSAnimationEvent::create(eventType, this, std::nullopt, elapsedTime, pseudoId, m_animationName);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -38,8 +38,8 @@ CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, const Init& initial
 {
 }
 
-CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& pseudoElement, const String& animationName)
-    : DeclarativeAnimationEvent(type, animation, elapsedTime, pseudoElement)
+CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& animationName)
+    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElement)
     , m_animationName(animationName)
 {
 }

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -32,9 +32,9 @@ namespace WebCore {
 class CSSAnimationEvent final : public DeclarativeAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSAnimationEvent);
 public:
-    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& pseudoElement, const String& animationName)
+    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& animationName)
     {
-        return adoptRef(*new CSSAnimationEvent(type, animation, elapsedTime, pseudoElement, animationName));
+        return adoptRef(*new CSSAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElement, animationName));
     }
 
     struct Init : EventInit {
@@ -57,7 +57,7 @@ public:
     EventInterface eventInterface() const override { return CSSAnimationEventInterfaceType; }
 
 private:
-    CSSAnimationEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& animationName, const String& pseudoElement);
+    CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& animationName);
     CSSAnimationEvent(const AtomString&, const Init&, IsTrusted);
 
     String m_animationName;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -95,7 +95,7 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
 
 Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
 {
-    return CSSTransitionEvent::create(eventType, this, elapsedTime, pseudoId, nameString(m_property));
+    return CSSTransitionEvent::create(eventType, this, std::nullopt, elapsedTime, pseudoId, nameString(m_property));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -33,8 +33,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransitionEvent);
 
-CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& pseudoElement, const String& propertyName)
-    : DeclarativeAnimationEvent(type, animation, elapsedTime, pseudoElement)
+CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& propertyName)
+    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElement)
     , m_propertyName(propertyName)
 {
 }

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -33,9 +33,9 @@ namespace WebCore {
 class CSSTransitionEvent final : public DeclarativeAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSTransitionEvent);
 public:
-    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation,  double elapsedTime, const String& pseudoElement, const String& propertyName)
+    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, const String& pseudoElement, const String& propertyName)
     {
-        return adoptRef(*new CSSTransitionEvent(type, animation, elapsedTime, pseudoElement, propertyName));
+        return adoptRef(*new CSSTransitionEvent(type, animation, scheduledTime, elapsedTime, pseudoElement, propertyName));
     }
 
     struct Init : EventInit {
@@ -58,7 +58,7 @@ public:
     EventInterface eventInterface() const override { return CSSTransitionEventInterfaceType; }
 
 private:
-    CSSTransitionEvent(const AtomString& type, WebAnimation*, double elapsedTime, const String& pseudoElement, const String& propertyName);
+    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& propertyName);
     CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
     String m_propertyName;

--- a/Source/WebCore/animation/DeclarativeAnimationEvent.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimationEvent.cpp
@@ -32,8 +32,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DeclarativeAnimationEvent);
 
-DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, WebAnimation* animation, double elapsedTime, const String& pseudoElement)
-    : AnimationEventBase(type, animation)
+DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement)
+    : AnimationEventBase(type, animation, scheduledTime)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
 {

--- a/Source/WebCore/animation/DeclarativeAnimationEvent.h
+++ b/Source/WebCore/animation/DeclarativeAnimationEvent.h
@@ -38,7 +38,7 @@ public:
     const String& pseudoElement() const { return m_pseudoElement; }
 
 protected:
-    DeclarativeAnimationEvent(const AtomString& type, WebAnimation*, double, const String&);
+    DeclarativeAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const String&);
     DeclarativeAnimationEvent(const AtomString&, const EventInit&, IsTrusted, double, const String&);
 
 private:

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -772,7 +772,7 @@ void WebAnimation::willChangeRenderer()
 void WebAnimation::enqueueAnimationPlaybackEvent(const AtomString& type, std::optional<Seconds> currentTime, std::optional<Seconds> scheduledTime)
 {
     auto timelineTime = m_timeline ? m_timeline->currentTime() : std::nullopt;
-    auto event = AnimationPlaybackEvent::create(type, this, timelineTime, scheduledTime, currentTime);
+    auto event = AnimationPlaybackEvent::create(type, this, scheduledTime, timelineTime, currentTime);
     event->setTarget(Ref { *this });
     enqueueAnimationEvent(WTFMove(event));
 }


### PR DESCRIPTION
#### 7602b29151e9b209f256945d6221b2943ca21f57
<pre>
[web-animations] move scheduledTime from AnimationPlaybackEvent to AnimationEventBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=248374">https://bugs.webkit.org/show_bug.cgi?id=248374</a>

Reviewed by Sam Weinig.

Currently only AnimationPlaybackEvent has the notion of a scheduled event time but, in order to fix bug 235145,
we&apos;ll need to add that notion to CSS Animations and CSS Transitions events as well. So it would make sense to
promote it to AnimationEventBase such that all the animation event subclasses benefit from it.

We currently pass std::nullopt for the scheduled event time value when creating CSSAnimationEvent
and CSSTransitionEvent but we will soon compute a resolved value for the patch to bug 235145.

* Source/WebCore/animation/AnimationEventBase.cpp:
(WebCore::AnimationEventBase::AnimationEventBase):
* Source/WebCore/animation/AnimationEventBase.h:
(WebCore::AnimationEventBase::scheduledTime const):
(WebCore::AnimationEventBase::create): Deleted.
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
(WebCore::AnimationPlaybackEvent::AnimationPlaybackEvent):
* Source/WebCore/animation/AnimationPlaybackEvent.h:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimationEvent.cpp:
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/DeclarativeAnimationEvent.cpp:
(WebCore::DeclarativeAnimationEvent::DeclarativeAnimationEvent):
* Source/WebCore/animation/DeclarativeAnimationEvent.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::enqueueAnimationPlaybackEvent):

Canonical link: <a href="https://commits.webkit.org/257048@main">https://commits.webkit.org/257048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0951c5d0f9a6d17d6848b252a2967f8f300f313c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107200 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167466 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101654 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7354 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35719 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103852 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5515 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84338 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32489 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75409 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/946 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22085 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44543 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2400 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41477 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->