### PR TITLE
Only send one drawing command per list marker

### DIFF
--- a/LayoutTests/fast/lists/list-type-translucent-color-expected.html
+++ b/LayoutTests/fast/lists/list-type-translucent-color-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.square {
+  list-style-type: square;
+}
+
+.disc {
+  list-style-type: disc;
+}
+
+.circle {
+  list-style-type: circle;
+}
+
+li {
+  color: #000000;
+  opacity: 0.2;
+}
+</style>
+</head>
+<body>
+<ul>
+  <li class="square"></li>
+  <li class="disc"></li>
+  <li class="circle"></li>
+</ul>
+</body>
+</html>

--- a/LayoutTests/fast/lists/list-type-translucent-color.html
+++ b/LayoutTests/fast/lists/list-type-translucent-color.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+    <meta name="fuzzy" content="maxDifference=1-6; totalPixels=32-42" />
+</head>
+<body>
+<ul>
+    <li style="list-style-type:square; color:rgba(0,0,0,0.2);"></li>
+    <li style="list-style-type:disc; color:rgba(0,0,0,0.2);"></li>
+    <li style="list-style-type:circle; color:rgba(0,0,0,0.2);"></li>
+</ul>
+</body>

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Andrew Wellington (proton@wiretapped.net)
  * Copyright (C) 2010 Daniel Bates (dbates@intudata.com)
  *
@@ -1622,14 +1622,13 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 
     switch (style().listStyleType()) {
     case ListStyleType::Disc:
-        context.drawEllipse(markerRect);
+        context.fillEllipse(markerRect);
         return;
     case ListStyleType::Circle:
-        context.setFillColor(Color::transparentBlack);
-        context.drawEllipse(markerRect);
+        context.strokeEllipse(markerRect);
         return;
     case ListStyleType::Square:
-        context.drawRect(markerRect);
+        context.fillRect(markerRect);
         return;
     default:
         break;


### PR DESCRIPTION
#### 5e81d33ff5c0150dbabbebbe2e96fb08ff4d6ad3
<pre>
Only send one drawing command per list marker

Only send one drawing command per list marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=248378">https://bugs.webkit.org/show_bug.cgi?id=248378</a>

Reviewed by Tim Nguyen.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=151161

Previously, some list markers (notably list-style-type: disc, circle, square)
would send two drawing commands per marker: one to fill the marker, and
then a second one to fill it. This constructs unnecessary paints and causes
a weird visual effect if the color is translucent.

This should have a minor visible effect on these list markers, but it&apos;s not
identical: since the stroke area isn&apos;t drawn again, the antialiasing varies.

* Source/WebCore/rendering/RenderListMarker.cpp:
(RenderListMarker::paint): Update draw to fill or stroke for &quot;disc&quot;, &quot;circle&quot; and &quot;square&quot;
* LayoutTests/fast/lists/list-type-translucent-color.html: Added Test Case
* LayoutTests/fast/lists/list-type-translucent-color-expected.html: Added Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257175@main">https://commits.webkit.org/257175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de1364badddf2f9c6838ac6adfd0d6752b3e657f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107431 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167704 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7646 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35955 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90636 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104059 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5765 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84570 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32948 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89361 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1161 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20785 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22298 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44750 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41698 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->