### PR TITLE
[iOS] Add expectation for clip-path-content-use-007.svg

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-007-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-007-expected.txt
@@ -1,0 +1,16 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 200x200
+    RenderSVGContainer {g} at (0,0) size 0x0
+    RenderSVGHiddenContainer {defs} at (0,0) size 0x0
+      RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=200.00] [height=200.00]
+      RenderSVGContainer {use} at (0,0) size 200x200
+        RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=200.00] [height=200.00]
+    RenderSVGResourceClipper {clipPath} [id="clip1"] [clipPathUnits=userSpaceOnUse]
+      RenderSVGContainer {use} at (0,0) size 200x200
+        RenderSVGContainer {g} at (0,0) size 200x200
+          RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=200.00] [height=200.00]
+    RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=400.00] [height=400.00]
+      [clipPath="clip1"] RenderSVGResourceClipper {clipPath} at (0,0) size 200x200
+    RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=200.00] [height=200.00]


### PR DESCRIPTION
#### 2b1ab2783dd126acb4752842396c72f85edb6644
<pre>
[iOS] Add expectation for clip-path-content-use-007.svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=248100">https://bugs.webkit.org/show_bug.cgi?id=248100</a>

Unreviewed test gardening.

Commit 256850@main added DumpJSConsoleLogInStdErr, which removed the
console message from the output. But the -expected.txt still had it.
So add an iOS expectation without the console message.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-content-use-007-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/257052@main">https://commits.webkit.org/257052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26687d2047b79ad3e0abc1b4ab0f5d7802bcb199

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107219 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167486 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7381 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35739 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103870 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5536 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84359 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32504 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/963 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22099 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4847 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5774 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2208 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41493 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->