### PR TITLE
Canvas' security should not take into account Single Origin (for videos and images)

### DIFF
--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -394,6 +394,11 @@ bool CachedResource::isCrossOrigin() const
     return m_responseTainting != ResourceResponse::Tainting::Basic;
 }
 
+bool CachedResource::isCORSCrossOrigin() const
+{
+    return m_responseTainting == ResourceResponse::Tainting::Opaque || m_responseTainting == ResourceResponse::Tainting::Opaqueredirect;
+}
+
 bool CachedResource::isCORSSameOrigin() const
 {
     // Following resource types do not use CORS

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -227,6 +227,7 @@ public:
 
     void setCrossOrigin();
     bool isCrossOrigin() const;
+    bool isCORSCrossOrigin() const;
     bool isCORSSameOrigin() const;
     ResourceResponse::Tainting responseTainting() const { return m_responseTainting; }
 


### PR DESCRIPTION
#### 2c5193d0471c2417232a02a7aff688e4744f5839
<pre>
Canvas&apos; security should not take into account Single Origin (for videos and images)
<a href="https://bugs.webkit.org/show_bug.cgi?id=242889">https://bugs.webkit.org/show_bug.cgi?id=242889</a>
rdar://97245327

Reviewed by Youenn Fablet.

Per canvas&apos; spec:
<a href="https://html.spec.whatwg.org/multipage/canvas.html#the-image-argument-is-not-origin-clean">https://html.spec.whatwg.org/multipage/canvas.html#the-image-argument-is-not-origin-clean</a>

an object image is not origin-clean if:
HTMLOrSVGImageElement
    image&apos;s current request&apos;s image data is CORS-cross-origin.
HTMLVideoElement
    image&apos;s media data is CORS-cross-origin.
HTMLCanvasElement
ImageBitmap
    image&apos;s bitmap&apos;s origin-clean flag is false.

And as per the security&apos;s policy:
<a href="https://html.spec.whatwg.org/multipage/canvas.html#security-with-canvas-elements">https://html.spec.whatwg.org/multipage/canvas.html#security-with-canvas-elements</a>

&quot;To mitigate this, bitmaps used with canvas elements and ImageBitmap objects are defined to have a flag indicating whether they are origin-clean. All bitmaps start with their origin-clean set to true. The flag is set to false when cross-origin images are used.&quot;

The implementation prevented drawing into a canvas a video that was served across multiple mirrors as is commonly found in the media world.

* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::wouldTaintOrigin):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::isCORSCrossOrigin const):
* Source/WebCore/loader/cache/CachedResource.h:

Canonical link: <a href="https://commits.webkit.org/257207@main">https://commits.webkit.org/257207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35fa92118da68ea41a719d450f4203a123f1a461

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107572 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167836 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7814 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36089 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104177 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5873 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84707 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32998 "Found 2 new test failures: http/tests/security/canvas-remote-read-remote-video-redirect.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element/security.pattern.fillStyle.sub.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89457 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1296 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4964 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41804 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->