### PR TITLE
Unreviewed build fix for PlayStation

### DIFF
--- a/Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.h
+++ b/Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.h
@@ -33,10 +33,10 @@ class UnixFileDescriptor;
 
 namespace IPC {
 
-template<> struct ArgumentCoder<UnixFileDescriptor> {
-    static void encode(Encoder&, const UnixFileDescriptor&);
-    static void encode(Encoder&, UnixFileDescriptor&&);
-    static std::optional<UnixFileDescriptor> decode(Decoder&);
+template<> struct ArgumentCoder<WTF::UnixFileDescriptor> {
+    static void encode(Encoder&, const WTF::UnixFileDescriptor&);
+    static void encode(Encoder&, WTF::UnixFileDescriptor&&);
+    static std::optional<WTF::UnixFileDescriptor> decode(Decoder&);
 };
 
 }


### PR DESCRIPTION
#### 675d141bdcf7fa6df9bdf505d46e46fdac638452
<pre>
Unreviewed build fix for PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=248380">https://bugs.webkit.org/show_bug.cgi?id=248380</a>

* Source/WebKit/Platform/IPC/unix/ArgumentCodersUnix.h:
Add missing `WTF::` prefixes.

Canonical link: <a href="https://commits.webkit.org/257056@main">https://commits.webkit.org/257056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc5685f4f2846911db3987ba7f5269b61c2b5691

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107232 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7401 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35753 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103882 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103383 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84373 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/974 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/965 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5788 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2402 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2220 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->