### PR TITLE
[GCC] Unreviewed, build fix for Ubuntu 20.04 after 257055@main

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -49,6 +49,11 @@ inline bool operator==(const GraphicsDropShadow& a, const GraphicsDropShadow& b)
     return a.offset == b.offset && a.radius == b.radius && a.color == b.color;
 }
 
+inline bool operator!=(const GraphicsDropShadow& a, const GraphicsDropShadow& b)
+{
+    return !(a == b);
+}
+
 struct GraphicsGaussianBlur {
     FloatSize radius;
 
@@ -61,6 +66,11 @@ inline bool operator==(const GraphicsGaussianBlur& a, const GraphicsGaussianBlur
     return a.radius == b.radius;
 }
 
+inline bool operator!=(const GraphicsGaussianBlur& a, const GraphicsGaussianBlur& b)
+{
+    return !(a == b);
+}
+
 struct GraphicsColorMatrix {
     std::array<float, 20> values;
 
@@ -71,6 +81,11 @@ struct GraphicsColorMatrix {
 inline bool operator==(const GraphicsColorMatrix& a, const GraphicsColorMatrix& b)
 {
     return a.values == b.values;
+}
+
+inline bool operator!=(const GraphicsColorMatrix& a, const GraphicsColorMatrix& b)
+{
+    return !(a == b);
 }
 
 using GraphicsStyle = std::variant<


### PR DESCRIPTION
#### c8bde1bc788fadf19b5448545072cd56db9d0972
<pre>
[GCC] Unreviewed, build fix for Ubuntu 20.04 after 257055@main

* Source/WebCore/platform/graphics/GraphicsStyle.h:
(WebCore::operator!=): Define operator!= for GraphicsDropShadow,
GraphicsGaussianBlur and GraphicsColorMatrix.

Canonical link: <a href="https://commits.webkit.org/257060@main">https://commits.webkit.org/257060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48df8df90b5a7bf50db7a846ade724dce9699776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/6991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107241 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167511 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7412 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35762 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103891 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5565 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84381 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32529 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75450 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/982 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/973 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5796 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2405 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41520 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->