### PR TITLE
Remove StyleProperties::textDecorationSkipValue()

### DIFF
--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -321,7 +321,6 @@ String StyleProperties::getPropertyValue(CSSPropertyID propertyID) const
     case CSSPropertyFontSynthesis:
         return fontSynthesisValue();
     case CSSPropertyTextDecorationSkip:
-        return textDecorationSkipValue();
     case CSSPropertyTextDecoration:
     case CSSPropertyWebkitBackgroundSize:
     case CSSPropertyWebkitTextOrientation:
@@ -568,18 +567,6 @@ String StyleProperties::offsetValue() const
     }
 
     return result.toString();
-}
-
-String StyleProperties::textDecorationSkipValue() const
-{
-    ASSERT(textDecorationSkipShorthand().length() == 1);
-    int textDecorationSkipInkPropertyIndex = findPropertyIndex(CSSPropertyTextDecorationSkipInk);
-    if (textDecorationSkipInkPropertyIndex == -1)
-        return emptyString();
-    PropertyReference textDecorationSkipInkProperty = propertyAt(textDecorationSkipInkPropertyIndex);
-    if (textDecorationSkipInkProperty.isImplicit())
-        return emptyString();
-    return textDecorationSkipInkProperty.value()->cssText();
 }
 
 String StyleProperties::fontVariantValue(const StylePropertyShorthand& shorthand) const
@@ -1626,6 +1613,11 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     case CSSPropertyWebkitTextOrientation:
         return false;
 
+    // No other browser currently supports text-decoration-skip, so it's currently more web
+    // compatible to avoid collapsing text-decoration-skip-ink, its only longhand.
+    case CSSPropertyTextDecorationSkip:
+        return false;
+
     // FIXME: -webkit-mask is a legacy shorthand but it's used to serialize -webkit-mask-clip,
     // which should be a legacy shorthand of mask-clip, but it's implemented as a longhand.
     case CSSPropertyWebkitMask:
@@ -1662,7 +1654,6 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     case CSSPropertyPlaceContent:
     case CSSPropertyPlaceItems:
     case CSSPropertyPlaceSelf:
-    case CSSPropertyTextDecorationSkip:
     case CSSPropertyTextEmphasis:
     case CSSPropertyWebkitTextStroke:
         return false;

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -168,7 +168,6 @@ private:
     String fontValue(const StylePropertyShorthand&) const;
     String fontVariantValue(const StylePropertyShorthand&) const;
     String fontSynthesisValue() const;
-    String textDecorationSkipValue() const;
     String offsetValue() const;
     String commonShorthandChecks(const StylePropertyShorthand&) const;
     StringBuilder asTextInternal() const;


### PR DESCRIPTION
#### b564ed1fb7d6716892d3931b5401fba3c9ed02f7
<pre>
Remove StyleProperties::textDecorationSkipValue()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248386">https://bugs.webkit.org/show_bug.cgi?id=248386</a>
rdar://102708232

Reviewed by Antti Koivisto.

text-decoration-skip can share the serialization handling with other shorthands with single longhands.

- We don&apos;t ever need to serialize `ink` because it gets changed to `auto` at parse-time
- We don&apos;t need to take care of implicit property references, since we never add text-decoration-skip-ink as implicit in `consumeTextDecorationSkip()`.

This part of an effort to remove the implicit flag for property references.

* Source/WebCore/css/StyleProperties.cpp:
(WebCore::StyleProperties::getPropertyValue const):
(WebCore::canUseShorthandForLonghand):
(WebCore::StyleProperties::textDecorationSkipValue const): Deleted.
* Source/WebCore/css/StyleProperties.h:

Canonical link: <a href="https://commits.webkit.org/257067@main">https://commits.webkit.org/257067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20478df5b75181802deedb7d2ebaa8599d2b944f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107254 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167524 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7428 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35776 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103901 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5575 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84395 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32535 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89203 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75455 "Found 1 new API test failure: /WebKitGTK/TestConsoleMessage:afterAll (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/992 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/984 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22134 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4854 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5808 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41535 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->