### PR TITLE
[WPE][GTK] Enable permissions request API

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -1284,7 +1284,7 @@ PermissionsAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA)" : true
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)" : true
       default: false
     WebCore:
       default: false

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -151,6 +151,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitOptionMenu.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitOptionMenuItem.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPermissionRequest.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPermissionStateQuery.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPolicyDecision.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -186,6 +186,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitOptionMenu.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitOptionMenuItem.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPermissionRequest.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPermissionStateQuery.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPolicyDecision.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitResponsePolicyDecision.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -164,6 +164,7 @@ UIProcess/API/glib/WebKitNotificationProvider.cpp @no-unify
 UIProcess/API/glib/WebKitOptionMenu.cpp @no-unify
 UIProcess/API/glib/WebKitOptionMenuItem.cpp @no-unify
 UIProcess/API/glib/WebKitPermissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitPermissionStateQuery.cpp @no-unify
 UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 UIProcess/API/glib/WebKitPointerLockPermissionRequest.cpp @no-unify
 UIProcess/API/glib/WebKitPolicyDecision.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -156,6 +156,7 @@ UIProcess/API/glib/WebKitNotificationProvider.cpp @no-unify
 UIProcess/API/glib/WebKitOptionMenu.cpp @no-unify
 UIProcess/API/glib/WebKitOptionMenuItem.cpp @no-unify
 UIProcess/API/glib/WebKitPermissionRequest.cpp @no-unify
+UIProcess/API/glib/WebKitPermissionStateQuery.cpp @no-unify
 UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 UIProcess/API/glib/WebKitPolicyDecision.cpp @no-unify
 UIProcess/API/glib/WebKitPrivate.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in
@@ -91,6 +91,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitUserStyleSheet, webkit_user_style_sheet_unr
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitUserContentFilter, webkit_user_content_filter_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebsiteData, webkit_website_data_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebViewSessionState, webkit_web_view_session_state_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitPermissionStateQuery, webkit_permission_state_query_unref)
 
 #endif /* __GI_SCANNER__ */
 #endif /* G_DEFINE_AUTOPTR_CLEANUP_FUNC */

--- a/Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQuery.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQuery.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitPermissionStateQuery.h"
+
+#include "APISecurityOrigin.h"
+#include "WebKitPermissionStateQueryPrivate.h"
+#include "WebKitSecurityOriginPrivate.h"
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WebKitPermissionStateQuery:
+ * @See_also: #WebKitWebView
+ *
+ * This query represents a user's choice to allow or deny access to "powerful features" of the
+ * platform, as specified in the [Permissions W3C
+ * Specification](https://w3c.github.io/permissions/).
+ *
+ * When signalled by the #WebKitWebView through the `query-permission-state` signal, the application
+ * has to eventually respond, via `webkit_permission_state_query_finish()`, whether it grants,
+ * denies or requests a dedicated permission prompt for the given query.
+ *
+ * When a #WebKitPermissionStateQuery is not handled by the user, the user-agent is instructed to
+ * `prompt` the user for the given permission.
+ */
+
+struct _WebKitPermissionStateQuery {
+    explicit _WebKitPermissionStateQuery(const WTF::String& permissionName, API::SecurityOrigin& origin, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
+        : permissionName(permissionName.utf8())
+        , securityOrigin(webkitSecurityOriginCreate(origin.securityOrigin().isolatedCopy()))
+        , completionHandler(WTFMove(completionHandler))
+    {
+    }
+
+    ~_WebKitPermissionStateQuery()
+    {
+        // Fallback to Prompt response unless the completion handler was already called.
+        if (completionHandler)
+            completionHandler(WebCore::PermissionState::Prompt);
+
+        webkit_security_origin_unref(securityOrigin);
+    }
+
+    CString permissionName;
+    WebKitSecurityOrigin* securityOrigin;
+    CompletionHandler<void(std::optional<WebCore::PermissionState>)> completionHandler;
+    int referenceCount { 1 };
+};
+
+G_DEFINE_BOXED_TYPE(WebKitPermissionStateQuery, webkit_permission_state_query, webkit_permission_state_query_ref, webkit_permission_state_query_unref)
+
+WebKitPermissionStateQuery* webkitPermissionStateQueryCreate(const WTF::String& permissionName, API::SecurityOrigin& origin, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
+{
+    WebKitPermissionStateQuery* query = static_cast<WebKitPermissionStateQuery*>(fastMalloc(sizeof(WebKitPermissionStateQuery)));
+    new (query) WebKitPermissionStateQuery(permissionName, origin, WTFMove(completionHandler));
+    return query;
+}
+
+/**
+ * webkit_permission_state_query_ref:
+ * @query: a #WebKitPermissionStateQuery
+ *
+ * Atomically increments the reference count of @query by one.
+ *
+ * This function is MT-safe and may be called from any thread.
+ *
+ * Returns: The passed #WebKitPermissionStateQuery
+ *
+ * Since: 2.40
+ */
+WebKitPermissionStateQuery* webkit_permission_state_query_ref(WebKitPermissionStateQuery* query)
+{
+    g_return_val_if_fail(query, nullptr);
+
+    g_atomic_int_inc(&query->referenceCount);
+    return query;
+}
+
+/**
+ * webkit_permission_state_query_unref:
+ * @query: a #WebKitPermissionStateQuery
+ *
+ * Atomically decrements the reference count of @query by one.
+ *
+ * If the reference count drops to 0, all memory allocated by #WebKitPermissionStateQuery is
+ * released. This function is MT-safe and may be called from any thread.
+ *
+ * Since: 2.40
+ */
+void webkit_permission_state_query_unref(WebKitPermissionStateQuery* query)
+{
+    g_return_if_fail(query);
+
+    if (g_atomic_int_dec_and_test(&query->referenceCount)) {
+        query->~WebKitPermissionStateQuery();
+        fastFree(query);
+    }
+}
+
+/**
+ * webkit_permission_state_query_get_name:
+ * @query: a #WebKitPermissionStateQuery
+ *
+ * Get the permission name for which access is being queried.
+ *
+ * Returns: the permission name for @query
+ *
+ * Since: 2.40
+ */
+const gchar*
+webkit_permission_state_query_get_name(WebKitPermissionStateQuery* query)
+{
+    g_return_val_if_fail(query, nullptr);
+
+    return query->permissionName.data();
+}
+
+/**
+ * webkit_permission_state_query_get_security_origin:
+ * @query: a #WebKitPermissionStateQuery
+ *
+ * Get the permission origin for which access is being queried.
+ *
+ * Returns: (transfer none): A #WebKitSecurityOrigin representing the origin from which the
+ * @query was emitted.
+ *
+ * Since: 2.40
+ */
+WebKitSecurityOrigin *
+webkit_permission_state_query_get_security_origin(WebKitPermissionStateQuery* query)
+{
+    g_return_val_if_fail(query, nullptr);
+
+    return query->securityOrigin;
+}
+
+/**
+ * webkit_permission_state_query_finish:
+ * @query: a #WebKitPermissionStateQuery
+ * @state: a #WebKitPermissionState
+ *
+ * Notify the web-engine of the selected permission state for the given query. This function should
+ * only be called as a response to the `WebKitWebView::query-permission-state` signal.
+ *
+ * Since: 2.40
+ */
+void
+webkit_permission_state_query_finish(WebKitPermissionStateQuery* query, WebKitPermissionState state)
+{
+    g_return_if_fail(query);
+    g_return_if_fail(query->completionHandler);
+
+    switch (state) {
+    case WEBKIT_PERMISSION_STATE_GRANTED:
+        query->completionHandler(WebCore::PermissionState::Granted);
+        break;
+    case WEBKIT_PERMISSION_STATE_DENIED:
+        query->completionHandler(WebCore::PermissionState::Denied);
+        break;
+    case WEBKIT_PERMISSION_STATE_PROMPT:
+        query->completionHandler(WebCore::PermissionState::Prompt);
+        break;
+    }
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQuery.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQuery.h.in
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_CHECK@
+
+#ifndef WebKitPermissionStateQuery_h
+#define WebKitPermissionStateQuery_h
+
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+#include <@API_INCLUDE_PREFIX@/WebKitSecurityOrigin.h>
+
+G_BEGIN_DECLS
+
+#define WEBKIT_TYPE_PERMISSION_STATE_QUERY (webkit_permission_state_query_get_type())
+
+typedef struct _WebKitPermissionStateQuery WebKitPermissionStateQuery;
+
+/**
+ * WebKitPermissionState:
+ * @WEBKIT_PERMISSION_STATE_GRANTED: Access to the feature is granted.
+ * @WEBKIT_PERMISSION_STATE_DENIED: Access to the feature is denied.
+ * @WEBKIT_PERMISSION_STATE_PROMPT: Access to the feature has to be requested via user prompt.
+ *
+ * Enum values representing query permission results.
+ *
+ * Since: 2.40
+ */
+typedef enum {
+    WEBKIT_PERMISSION_STATE_GRANTED,
+    WEBKIT_PERMISSION_STATE_DENIED,
+    WEBKIT_PERMISSION_STATE_PROMPT,
+} WebKitPermissionState;
+
+WEBKIT_API GType
+webkit_permission_state_query_get_type    (void);
+
+WEBKIT_API WebKitPermissionStateQuery *
+webkit_permission_state_query_ref                 (WebKitPermissionStateQuery *query);
+
+WEBKIT_API void
+webkit_permission_state_query_unref               (WebKitPermissionStateQuery *query);
+
+WEBKIT_API const gchar *
+webkit_permission_state_query_get_name            (WebKitPermissionStateQuery *query);
+
+WEBKIT_API WebKitSecurityOrigin *
+webkit_permission_state_query_get_security_origin (WebKitPermissionStateQuery *query);
+
+WEBKIT_API void
+webkit_permission_state_query_finish              (WebKitPermissionStateQuery *query,
+                                                   WebKitPermissionState       state);
+
+G_END_DECLS
+
+#endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQueryPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQueryPrivate.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "APISecurityOrigin.h"
+#include "WebKitPermissionStateQuery.h"
+#include <WebCore/PermissionState.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/text/WTFString.h>
+
+WebKitPermissionStateQuery* webkitPermissionStateQueryCreate(const WTF::String& permissionName, API::SecurityOrigin&, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -29,6 +29,7 @@
 #include "WebKitMediaKeySystemPermissionRequestPrivate.h"
 #include "WebKitNavigationActionPrivate.h"
 #include "WebKitNotificationPermissionRequestPrivate.h"
+#include "WebKitPermissionStateQueryPrivate.h"
 #include "WebKitPointerLockPermissionRequestPrivate.h"
 #include "WebKitURIRequestPrivate.h"
 #include "WebKitUserMediaPermissionRequestPrivate.h"
@@ -377,6 +378,13 @@ private:
         webkitWebViewDidLosePointerLock(m_webView);
     }
 #endif
+
+    void queryPermission(const WTF::String& permissionName, API::SecurityOrigin& origin, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler) final
+    {
+        auto* query = webkitPermissionStateQueryCreate(permissionName, origin, WTFMove(completionHandler));
+        webkitWebViewPermissionStateQuery(m_webView, query);
+        webkit_permission_state_query_unref(query);
+    }
 
     WebKitWebView* m_webView;
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in
@@ -41,6 +41,7 @@
 #include <@API_INCLUDE_PREFIX@/WebKitNotification.h>
 #include <@API_INCLUDE_PREFIX@/WebKitOptionMenu.h>
 #include <@API_INCLUDE_PREFIX@/WebKitPermissionRequest.h>
+#include <@API_INCLUDE_PREFIX@/WebKitPermissionStateQuery.h>
 #include <@API_INCLUDE_PREFIX@/WebKitPolicyDecision.h>
 #include <@API_INCLUDE_PREFIX@/WebKitScriptDialog.h>
 #include <@API_INCLUDE_PREFIX@/WebKitSettings.h>
@@ -49,8 +50,8 @@
 #include <@API_INCLUDE_PREFIX@/WebKitUserMessage.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebContext.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebResource.h>
-#include <@API_INCLUDE_PREFIX@/WebKitWebsitePolicies.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWebViewSessionState.h>
+#include <@API_INCLUDE_PREFIX@/WebKitWebsitePolicies.h>
 #include <@API_INCLUDE_PREFIX@/WebKitWindowProperties.h>
 
 #if PLATFORM(GTK)
@@ -374,15 +375,16 @@ struct _WebKitWebViewClass {
                                                 WebKitRectangle             *rectangle);
 #endif
 
-    /*< private >*/
-    void (*_webkit_reserved0) (void);
+    gboolean   (* query_permission_state)      (WebKitWebView               *web_view,
+                                                WebKitPermissionStateQuery  *query);
 
 #if PLATFORM(WPE)
+    /*< private >*/
+    void (*_webkit_reserved0) (void);
     void (*_webkit_reserved1) (void);
     void (*_webkit_reserved2) (void);
     void (*_webkit_reserved3) (void);
     void (*_webkit_reserved4) (void);
-    void (*_webkit_reserved5) (void);
 #endif
 };
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -99,6 +99,7 @@ void webkitWebViewMediaCaptureStateDidChange(WebKitWebView*, WebCore::MediaProdu
 void webkitWebViewSelectionDidChange(WebKitWebView*);
 void webkitWebViewRequestInstallMissingMediaPlugins(WebKitWebView*, WebKit::InstallMissingMediaPluginsPermissionRequest&);
 WebKitWebsiteDataManager* webkitWebViewGetWebsiteDataManager(WebKitWebView*);
+void webkitWebViewPermissionStateQuery(WebKitWebView*, WebKitPermissionStateQuery*);
 
 #if PLATFORM(GTK)
 bool webkitWebViewEmitRunColorChooser(WebKitWebView*, WebKitColorChooserRequest*);

--- a/Source/WebKit/UIProcess/API/gtk/webkit.h
+++ b/Source/WebKit/UIProcess/API/gtk/webkit.h
@@ -66,6 +66,7 @@
 #include <webkit/WebKitOptionMenu.h>
 #include <webkit/WebKitOptionMenuItem.h>
 #include <webkit/WebKitPermissionRequest.h>
+#include <webkit/WebKitPermissionStateQuery.h>
 #include <webkit/WebKitPlugin.h>
 #include <webkit/WebKitPointerLockPermissionRequest.h>
 #include <webkit/WebKitPrintCustomWidget.h>

--- a/Source/WebKit/UIProcess/API/gtk/webkit2.h
+++ b/Source/WebKit/UIProcess/API/gtk/webkit2.h
@@ -66,6 +66,7 @@
 #include <webkit/WebKitOptionMenu.h>
 #include <webkit/WebKitOptionMenuItem.h>
 #include <webkit/WebKitPermissionRequest.h>
+#include <webkit/WebKitPermissionStateQuery.h>
 #include <webkit/WebKitPlugin.h>
 #include <webkit/WebKitPointerLockPermissionRequest.h>
 #include <webkit/WebKitPrintCustomWidget.h>

--- a/Source/WebKit/UIProcess/API/wpe/webkit.h
+++ b/Source/WebKit/UIProcess/API/wpe/webkit.h
@@ -64,6 +64,7 @@
 #include <wpe/WebKitOptionMenu.h>
 #include <wpe/WebKitOptionMenuItem.h>
 #include <wpe/WebKitPermissionRequest.h>
+#include <wpe/WebKitPermissionStateQuery.h>
 #include <wpe/WebKitPlugin.h>
 #include <wpe/WebKitResponsePolicyDecision.h>
 #include <wpe/WebKitScriptDialog.h>


### PR DESCRIPTION
#### 80fe491a82749b5b90733f08cae3f2eac7286f9b
<pre>
[WPE][GTK] Enable permissions request API
<a href="https://bugs.webkit.org/show_bug.cgi?id=247065">https://bugs.webkit.org/show_bug.cgi?id=247065</a>

Reviewed by Carlos Garcia Campos.

This is exposed in the GLib API as a WebKitPermissionStateQuery signalled by the WebView using the
`query-permission-state` GObject signal. When the application has a handler for this signal it has
to eventually call `webkit_permission_state_query_finish()` with a valid `WebKitPermissionState`. If
not handled, the default result is `WEBKIT_PERMISSION_STATE_PROMPT`, thus instructing the User-Agent
that it has to explicitely present a prompt asking for permission to the given feature.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/glib/WebKitAutocleanups.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQuery.cpp: Added.
(_WebKitPermissionStateQuery::_WebKitPermissionStateQuery):
(_WebKitPermissionStateQuery::~_WebKitPermissionStateQuery):
(webkitPermissionStateQueryCreate):
(webkit_permission_state_query_ref):
(webkit_permission_state_query_unref):
(webkit_permission_state_query_get_name):
(webkit_permission_state_query_get_security_origin):
(webkit_permission_state_query_finish):
* Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQuery.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitPermissionStateQueryPrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkit_web_view_class_init):
(webkitWebViewPermissionStateQuery):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.h.in:
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/gtk/webkit.h:
* Source/WebKit/UIProcess/API/gtk/webkit2.h:
* Source/WebKit/UIProcess/API/wpe/webkit.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestUIClient.cpp:
(testWebViewQueryPermissionRequests):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/257787@main">https://commits.webkit.org/257787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fc5ecd09f9e5d279987e9214bde2fec8c3c2ad5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/100018 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/9189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/33099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/109365 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/169599 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/104017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/10069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/86543 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/92465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/107264 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105786 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/7608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/34326 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/89515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/22286 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/90625 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2981 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/23801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/86561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/83/builds/388 "Built successfully and passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2940 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/46173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/29025 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/9074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/43282 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/89440 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5343 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/4790 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19997 "Passed tests") | 
| | | | | 
<!--EWS-Status-Bubble-End-->