### PR TITLE
[web-animations] store pseudo-element as a PseudoId on DeclarativeAnimationEvent

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -281,7 +281,7 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
         keyframeEffect.computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
 }
 
-Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
+Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, PseudoId pseudoId)
 {
     return CSSAnimationEvent::create(eventType, this, std::nullopt, elapsedTime, pseudoId, m_animationName);
 }

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -54,7 +54,7 @@ private:
     CSSAnimation(const Styleable&, const Animation&);
 
     void syncPropertiesWithBackingAnimation() final;
-    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId) final;
+    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, PseudoId) final;
 
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -38,8 +38,8 @@ CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, const Init& initial
 {
 }
 
-CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& animationName)
-    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElement)
+CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String& animationName)
+    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
     , m_animationName(animationName)
 {
 }

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -32,9 +32,9 @@ namespace WebCore {
 class CSSAnimationEvent final : public DeclarativeAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSAnimationEvent);
 public:
-    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& animationName)
+    static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String& animationName)
     {
-        return adoptRef(*new CSSAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElement, animationName));
+        return adoptRef(*new CSSAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId, animationName));
     }
 
     struct Init : EventInit {
@@ -57,7 +57,7 @@ public:
     EventInterface eventInterface() const override { return CSSAnimationEventInterfaceType; }
 
 private:
-    CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& animationName);
+    CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId, const String& animationName);
     CSSAnimationEvent(const AtomString&, const Init&, IsTrusted);
 
     String m_animationName;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -93,7 +93,7 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
     unsuspendEffectInvalidation();
 }
 
-Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId)
+Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, PseudoId pseudoId)
 {
     return CSSTransitionEvent::create(eventType, this, std::nullopt, elapsedTime, pseudoId, nameString(m_property));
 }

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -56,7 +56,7 @@ public:
 private:
     CSSTransition(const Styleable&, CSSPropertyID, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
-    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId) final;
+    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, PseudoId) final;
     void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -33,8 +33,8 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransitionEvent);
 
-CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& propertyName)
-    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoElement)
+CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String& propertyName)
+    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
     , m_propertyName(propertyName)
 {
 }

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -33,9 +33,9 @@ namespace WebCore {
 class CSSTransitionEvent final : public DeclarativeAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSTransitionEvent);
 public:
-    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, const String& pseudoElement, const String& propertyName)
+    static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, PseudoId pseudoId, const String& propertyName)
     {
-        return adoptRef(*new CSSTransitionEvent(type, animation, scheduledTime, elapsedTime, pseudoElement, propertyName));
+        return adoptRef(*new CSSTransitionEvent(type, animation, scheduledTime, elapsedTime, pseudoId, propertyName));
     }
 
     struct Init : EventInit {
@@ -58,7 +58,7 @@ public:
     EventInterface eventInterface() const override { return CSSTransitionEventInterfaceType; }
 
 private:
-    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement, const String& propertyName);
+    CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId, const String& propertyName);
     CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
     String m_propertyName;

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -337,8 +337,7 @@ void DeclarativeAnimation::enqueueDOMEvent(const AtomString& eventType, Seconds 
         return;
 
     auto time = secondsToWebAnimationsAPITime(elapsedTime) / 1000;
-    auto pseudoId = pseudoIdAsString(m_owningPseudoId);
-    auto event = createEvent(eventType, time, pseudoId);
+    auto event = createEvent(eventType, time, m_owningPseudoId);
     event->setTarget(RefPtr { m_owningElement.get() });
     enqueueAnimationEvent(WTFMove(event));
 }

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -27,6 +27,7 @@
 
 #include "AnimationEffect.h"
 #include "AnimationEffectPhase.h"
+#include "RenderStyleConstants.h"
 #include "Styleable.h"
 #include "WebAnimation.h"
 #include <wtf/Ref.h>
@@ -75,7 +76,7 @@ protected:
 
     void initialize(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     virtual void syncPropertiesWithBackingAnimation();
-    virtual Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, const String& pseudoId) = 0;
+    virtual Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, PseudoId) = 0;
     void invalidateDOMEvents(Seconds elapsedTime = 0_s);
 
 private:

--- a/Source/WebCore/animation/DeclarativeAnimationEvent.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimationEvent.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "DeclarativeAnimationEvent.h"
+#include "WebAnimationUtilities.h"
 
 #include <wtf/IsoMallocInlines.h>
 
@@ -32,10 +33,10 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(DeclarativeAnimationEvent);
 
-DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, const String& pseudoElement)
+DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
     : AnimationEventBase(type, animation, scheduledTime)
     , m_elapsedTime(elapsedTime)
-    , m_pseudoElement(pseudoElement)
+    , m_pseudoId(pseudoId)
 {
 }
 
@@ -44,8 +45,18 @@ DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, con
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
 {
+    auto pseudoIdOrException = pseudoIdFromString(m_pseudoElement);
+    if (!pseudoIdOrException.hasException())
+        m_pseudoId = pseudoIdOrException.returnValue();
 }
 
 DeclarativeAnimationEvent::~DeclarativeAnimationEvent() = default;
+
+const String& DeclarativeAnimationEvent::pseudoElement()
+{
+    if (m_pseudoElement.isNull())
+        m_pseudoElement = pseudoIdAsString(m_pseudoId);
+    return m_pseudoElement;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/animation/DeclarativeAnimationEvent.h
+++ b/Source/WebCore/animation/DeclarativeAnimationEvent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AnimationEventBase.h"
+#include "RenderStyleConstants.h"
 
 namespace WebCore {
 
@@ -35,15 +36,17 @@ public:
     virtual ~DeclarativeAnimationEvent();
 
     double elapsedTime() const { return m_elapsedTime; }
-    const String& pseudoElement() const { return m_pseudoElement; }
+    const String& pseudoElement();
+    PseudoId pseudoId() const { return m_pseudoId; }
 
 protected:
-    DeclarativeAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, const String&);
+    DeclarativeAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, PseudoId);
     DeclarativeAnimationEvent(const AtomString&, const EventInit&, IsTrusted, double, const String&);
 
 private:
     double m_elapsedTime;
     String m_pseudoElement;
+    PseudoId m_pseudoId { PseudoId::None };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1202,25 +1202,10 @@ const String KeyframeEffect::pseudoElement() const
 ExceptionOr<void> KeyframeEffect::setPseudoElement(const String& pseudoElement)
 {
     // https://drafts.csswg.org/web-animations/#dom-keyframeeffect-pseudoelement
-
-    // On setting, sets the target pseudo-selector of the animation effect to the provided value after applying the following exceptions:
-    //
-    // - If the provided value is not null and is an invalid <pseudo-element-selector>, the user agent must throw a DOMException with error
-    // name SyntaxError and leave the target pseudo-selector of this animation effect unchanged. Note, that invalid in this context follows
-    // the definition of an invalid selector defined in [SELECTORS-4] such that syntactically invalid pseudo-elements as well as pseudo-elements
-    // for which the user agent has no usable level of support are both deemed invalid.
-    // - If one of the legacy Selectors Level 2 single-colon selectors (':before', ':after', ':first-letter', or ':first-line') is specified,
-    // the target pseudo-selector must be set to the equivalent two-colon selector (e.g. '::before').
-    auto pseudoId = PseudoId::None;
-    if (!pseudoElement.isNull()) {
-        auto isLegacy = pseudoElement == ":before"_s || pseudoElement == ":after"_s || pseudoElement == ":first-letter"_s || pseudoElement == ":first-line"_s;
-        if (!isLegacy && !pseudoElement.startsWith("::"_s))
-            return Exception { SyntaxError };
-        auto pseudoType = CSSSelector::parsePseudoElementType(StringView(pseudoElement).substring(isLegacy ? 1 : 2));
-        if (pseudoType == CSSSelector::PseudoElementUnknown || pseudoType == CSSSelector::PseudoElementWebKitCustom)
-            return Exception { SyntaxError };
-        pseudoId = CSSSelector::pseudoId(pseudoType);
-    }
+    auto pseudoIdOrException = pseudoIdFromString(pseudoElement);
+    if (pseudoIdOrException.hasException())
+        return pseudoIdOrException.releaseException();
+    auto pseudoId = pseudoIdOrException.returnValue();
 
     if (pseudoId == m_pseudoId)
         return { };

--- a/Source/WebCore/animation/WebAnimationUtilities.h
+++ b/Source/WebCore/animation/WebAnimationUtilities.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "ExceptionOr.h"
+#include "RenderStyleConstants.h"
 #include <wtf/Forward.h>
 #include <wtf/Markable.h>
 #include <wtf/Seconds.h>
@@ -56,6 +58,7 @@ const auto timeEpsilon = Seconds::fromMilliseconds(0.001);
 bool compareAnimationsByCompositeOrder(const WebAnimation&, const WebAnimation&);
 bool compareAnimationEventsByCompositeOrder(const AnimationEventBase&, const AnimationEventBase&);
 String pseudoIdAsString(PseudoId);
+ExceptionOr<PseudoId> pseudoIdFromString(const String&);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 7fd1368cc82ba69731b9e1cc244cbac8307426ad
<pre>
[web-animations] store pseudo-element as a PseudoId on DeclarativeAnimationEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=248389">https://bugs.webkit.org/show_bug.cgi?id=248389</a>

Reviewed by Antti Koivisto.

To fix bug 235145 we&apos;re going to need to sort animation events by composite order and account for the
relative position of the event targets, which means we&apos;ll need to get to the pseudo-element quite a bit.
This is currently stored as a string, but we should store it as a PseudoId to be efficient, and convert
to a string for API use as needed.

We do just that in this patch, moving the code from KeyframeEffect to convert a pseudo-element string to
a PseudoId to WebAnimationUtilities to be shared and used in DeclarativeAnimationEvent.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSAnimationEvent.cpp:
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::enqueueDOMEvent):
* Source/WebCore/animation/DeclarativeAnimation.h:
* Source/WebCore/animation/DeclarativeAnimationEvent.cpp:
(WebCore::DeclarativeAnimationEvent::DeclarativeAnimationEvent):
(WebCore::DeclarativeAnimationEvent::pseudoElement):
* Source/WebCore/animation/DeclarativeAnimationEvent.h:
(WebCore::DeclarativeAnimationEvent::pseudoId const):
(WebCore::DeclarativeAnimationEvent::pseudoElement const): Deleted.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setPseudoElement):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::pseudoIdFromString):
* Source/WebCore/animation/WebAnimationUtilities.h:

Canonical link: <a href="https://commits.webkit.org/257069@main">https://commits.webkit.org/257069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f040ff781aa9ee24d67d4e5e3923747254b20480

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107281 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7461 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35804 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90174 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103428 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84422 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/32563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1016 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5835 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2407 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2263 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->