### PR TITLE
notification.close() not working

### DIFF
--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -636,7 +636,9 @@ void ServiceWorkerContainer::getNotifications(const URL& serviceWorkerRegistrati
 
         auto data = result.releaseReturnValue();
         auto notifications = map(data, [context](auto&& data) {
-            return Notification::create(*context, WTFMove(data));
+            auto notification = Notification::create(*context, WTFMove(data));
+            notification->markAsShown();
+            return notification;
         });
         promise.resolve(WTFMove(notifications));
     });

--- a/Tools/TestWebKitAPI/TestNotificationProvider.h
+++ b/Tools/TestWebKitAPI/TestNotificationProvider.h
@@ -45,17 +45,20 @@ public:
 
     WKDictionaryRef notificationPermissions() const;
     void showWebNotification(WKPageRef, WKNotificationRef);
+    void closeWebNotification(WKNotificationRef);
     bool simulateNotificationClick();
 
-    bool hasReceivedNotification() const { return m_hasReceivedNotification; }
-    void resetHasReceivedNotification() { m_hasReceivedNotification = false; }
+    bool hasReceivedShowNotification() const { return m_hasReceivedShowNotification; }
+    bool hasReceivedCloseNotification() const { return m_hasReceivedCloseNotification; }
+    void resetHasReceivedNotification();
 
 private:
     Vector<WKNotificationManagerRef> m_managers;
     HashMap<String, bool> m_permissions;
     WKNotificationProviderV0 m_provider;
 
-    bool m_hasReceivedNotification { false };
+    bool m_hasReceivedShowNotification { false };
+    bool m_hasReceivedCloseNotification { false };
     std::pair<WKNotificationManagerRef, uint64_t> m_pendingNotification;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -707,7 +707,7 @@ TEST(PushAPI, fireNotificationClickEvent)
     expectedMessage = "Received: Sweet Potatoes"_s;
 
     [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
-        EXPECT_TRUE(providerRef.hasReceivedNotification());
+        EXPECT_TRUE(providerRef.hasReceivedShowNotification());
         pushMessageSuccessful = result;
         pushMessageProcessed = true;
     }];
@@ -727,6 +727,130 @@ TEST(PushAPI, fireNotificationClickEvent)
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
 
+static constexpr auto closeNotificationMainBytes = R"SWRESOURCE(
+<script>
+function log(msg)
+{
+    window.webkit.messageHandlers.sw.postMessage(msg);
+}
+
+const channel = new MessageChannel();
+channel.port1.onmessage = (event) => log(event.data);
+navigator.serviceWorker.onmessage = (event) => log(event.data);
+
+let swRegistration;
+navigator.serviceWorker.register('/sw.js').then((registration) => {
+    swRegistration = registration;
+    if (registration.active) {
+        registration.active.postMessage({port: channel.port2}, [channel.port2]);
+        return;
+    }
+    worker = registration.installing;
+    worker.addEventListener('statechange', function() {
+        if (worker.state == 'activated')
+            worker.postMessage({port: channel.port2}, [channel.port2]);
+    });
+}).catch(function(error) {
+    log("Registration failed with: " + error);
+});
+
+function closeNotification()
+{
+    const notifications = swRegistration.getNotifications().then(notifications => {
+        notifications[0].close();
+        log("PASS close notification");
+    });
+}
+</script>
+)SWRESOURCE"_s;
+
+static constexpr auto closeNotificationScriptBytes = R"SWRESOURCE(
+let port;
+self.addEventListener("message", (event) => {
+    if (port)
+        return;
+    port = event.data.port;
+    port.postMessage("Ready");
+});
+self.addEventListener("push", (event) => {
+    self.registration.showNotification("notification");
+    try {
+        if (!event.data) {
+            port.postMessage("Received: null data");
+            return;
+        }
+        const value = event.data.text();
+        port.postMessage("Received: " + value);
+    } catch (e) {
+        port.postMessage("Got exception " + e);
+    }
+});
+)SWRESOURCE"_s;
+
+TEST(PushAPI, fireNotificationCloseEvent)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { closeNotificationMainBytes } },
+        { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, closeNotificationScriptBytes } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    auto provider = TestWebKitAPI::TestNotificationProvider({ [[configuration processPool] _notificationManagerForTesting], WKNotificationManagerGetSharedServiceWorkerNotificationManager() });
+    provider.setPermission(server.origin(), true);
+
+    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    clearWebsiteDataStore([configuration websiteDataStore]);
+
+    expectedMessage = "Ready"_s;
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:server.request()];
+
+    TestWebKitAPI::Util::run(&done);
+
+    provider.resetHasReceivedNotification();
+    auto& providerRef = provider;
+
+    done = false;
+    pushMessageProcessed = false;
+    pushMessageSuccessful = false;
+    NSString *message = @"Sweet Potatoes";
+    expectedMessage = "Received: Sweet Potatoes"_s;
+
+    [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
+        EXPECT_TRUE(providerRef.hasReceivedShowNotification());
+        pushMessageSuccessful = result;
+        pushMessageProcessed = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    TestWebKitAPI::Util::run(&pushMessageProcessed);
+    EXPECT_TRUE(pushMessageSuccessful);
+
+    terminateNetworkProcessWhileRegistrationIsStored(configuration.get());
+
+    [webView evaluateJavaScript:@"closeNotification()" completionHandler:nil];
+
+    EXPECT_FALSE(providerRef.hasReceivedCloseNotification());
+
+    done = false;
+    expectedMessage = "PASS close notification"_s;
+    TestWebKitAPI::Util::run(&done);
+
+    int counter = 0;
+    while (!providerRef.hasReceivedCloseNotification() && ++counter < 10)
+        TestWebKitAPI::Util::spinRunLoop(10);
+
+    EXPECT_LT(counter, 10);
+
+    providerRef.resetHasReceivedNotification();
+
+    clearWebsiteDataStore([configuration websiteDataStore]);
+}
 #endif // WK_HAVE_C_SPI
 
 #endif // ENABLE(NOTIFICATIONS) && ENABLE(NOTIFICATION_EVENT)


### PR DESCRIPTION
#### d02120f1bc06da2453a9fa69884a4dd2b4733643
<pre>
notification.close() not working
<a href="https://bugs.webkit.org/show_bug.cgi?id=248309">https://bugs.webkit.org/show_bug.cgi?id=248309</a>
rdar://problem/102683841

Reviewed by Chris Dumez.

Make sure to mark the notifications as showing so that close actually does something.
Covered by API test.

* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::getNotifications):
* Tools/TestWebKitAPI/TestNotificationProvider.cpp:
(TestWebKitAPI::closeWebNotification):
(TestWebKitAPI::TestNotificationProvider::TestNotificationProvider):
(TestWebKitAPI::TestNotificationProvider::showWebNotification):
(TestWebKitAPI::TestNotificationProvider::closeWebNotification):
(TestWebKitAPI::TestNotificationProvider::resetHasReceivedNotification):
* Tools/TestWebKitAPI/TestNotificationProvider.h:
(TestWebKitAPI::TestNotificationProvider::hasReceivedShowNotification const):
(TestWebKitAPI::TestNotificationProvider::hasReceivedCloseNotification const):
(TestWebKitAPI::TestNotificationProvider::hasReceivedNotification const): Deleted.
(TestWebKitAPI::TestNotificationProvider::resetHasReceivedNotification): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:

Canonical link: <a href="https://commits.webkit.org/257108@main">https://commits.webkit.org/257108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7ec2b56350b3eaf0a743c467dfa0e2f7393ecea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97784 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107275 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167544 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7454 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35798 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90167 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103918 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5596 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84416 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32560 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1010 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20649 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22155 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4888 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44603 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41560 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->