### PR TITLE
[CSS] Fix shadow of text-decoration/box with currentcolor

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5961,7 +5961,6 @@ imported/w3c/web-platform-tests/clipboard-apis/feature-policy/clipboard-write/cl
 imported/w3c/web-platform-tests/html/infrastructure/urls/terminology-0/document-base-url-initiated-grand-parent.https.window.html [ DumpJSConsoleLogInStdErr ]
 
 # text-shadow
-imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/currentcolor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/decorations-multiple-zorder.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/quirks-decor-noblur.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/standards-decor-noblur.html [ ImageOnlyFailure ]
@@ -6342,7 +6341,6 @@ webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/border-r
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-near-zero-gradient.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-near-zero-png.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-near-zero-svg.html [ ImageOnlyFailure ]
-webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-currentcolor.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-radius-000.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow-radius-001.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-block-fragmentation-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -915,9 +915,9 @@ Ref<CSSValue> ComputedStyleExtractor::valueForShadow(const ShadowData* shadow, C
         auto y = adjustLengthForZoom(currShadowData->y(), style, adjust);
         auto blur = adjustLengthForZoom(currShadowData->radius(), style, adjust);
         auto spread = propertyID == CSSPropertyTextShadow ? RefPtr<CSSPrimitiveValue>() : adjustLengthForZoom(currShadowData->spread(), style, adjust);
-        auto style = propertyID == CSSPropertyTextShadow || currShadowData->style() == ShadowStyle::Normal ? RefPtr<CSSPrimitiveValue>() : CSSPrimitiveValue::create(CSSValueInset);
-        auto color = cssValuePool.createColorValue(currShadowData->color());
-        list.append(CSSShadowValue::create(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(style), WTFMove(color)));
+        auto shadowStyle = propertyID == CSSPropertyTextShadow || currShadowData->style() == ShadowStyle::Normal ? RefPtr<CSSPrimitiveValue>() : CSSPrimitiveValue::create(CSSValueInset);
+        auto color = cssValuePool.createColorValue(style.colorResolvingCurrentColor(currShadowData->color()));
+        list.append(CSSShadowValue::create(WTFMove(x), WTFMove(y), WTFMove(blur), WTFMove(spread), WTFMove(shadowStyle), WTFMove(color)));
     }
     list.reverse();
     return CSSValueList::createCommaSeparated(WTFMove(list));

--- a/Source/WebCore/display/css/DisplayStyle.cpp
+++ b/Source/WebCore/display/css/DisplayStyle.cpp
@@ -62,7 +62,7 @@ static std::unique_ptr<ShadowData> deepCopy(const ShadowData* shadow, const Rend
 
     for (auto* currShadow = shadow; currShadow; currShadow = currShadow->next()) {
         auto shadowCopy = makeUnique<ShadowData>(*currShadow);
-        shadowCopy->setColor(style.colorByApplyingColorFilter(shadowCopy->color()));
+        shadowCopy->setColor(style.colorWithColorFilter(shadowCopy->color()));
         
         if (!firstShadow) {
             currCopiedShadow = shadowCopy.get();
@@ -93,6 +93,8 @@ Style::Style(const RenderStyle& style, const RenderStyle* styleForBackground)
     if (styleForBackground)
         setupBackground(*styleForBackground);
 
+    // FIXME: m_boxShadow should use a custom data structure with a resolved color (aka Color).
+    // https://bugs.webkit.org/show_bug.cgi?id=248467
     m_boxShadow = deepCopy(style.boxShadow(), style);
 
     if (!style.hasAutoUsedZIndex())

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4167,7 +4167,7 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
         attributes.foregroundColor = foregroundColor;
 
     if (auto* shadowData = style->textShadow())
-        attributes.fontShadow = { shadowData->color(), { shadowData->x().value(), shadowData->y().value() }, shadowData->radius().value() };
+        attributes.fontShadow = { style->colorWithColorFilter(shadowData->color()), { shadowData->x().value(), shadowData->y().value() }, shadowData->radius().value() };
 
     switch (style->verticalAlign()) {
     case VerticalAlign::Baseline:

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -159,7 +159,7 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const RenderSt
         boxShadow = boxShadow->next();
 
     FloatSize shadowOffset(boxShadow->x().value(), boxShadow->y().value());
-    context.setShadow(shadowOffset, boxShadow->radius().value(), style.colorByApplyingColorFilter(boxShadow->color()), boxShadow->isWebkitBoxShadow() ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default);
+    context.setShadow(shadowOffset, boxShadow->radius().value(), style.colorWithColorFilter(boxShadow->color()), boxShadow->isWebkitBoxShadow() ? ShadowRadiusMode::Legacy : ShadowRadiusMode::Default);
 }
 
 void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLayer, const LayoutRect& rect,
@@ -817,7 +817,7 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
         if (shadowOffset.isZero() && !shadowRadius && !shadowSpread)
             continue;
 
-        Color shadowColor = style.colorByApplyingColorFilter(shadow->color());
+        Color shadowColor = style.colorWithColorFilter(shadow->color());
 
         if (shadow->style() == ShadowStyle::Normal) {
             auto fillRect = borderRect;

--- a/Source/WebCore/rendering/EllipsisBoxPainter.cpp
+++ b/Source/WebCore/rendering/EllipsisBoxPainter.cpp
@@ -63,7 +63,7 @@ void EllipsisBoxPainter::paint()
 
     auto setShadow = false;
     if (style.textShadow()) {
-        auto shadowColor = style.colorByApplyingColorFilter(style.textShadow()->color());
+        auto shadowColor = style.colorWithColorFilter(style.textShadow()->color());
         context.setShadow(LayoutSize(style.textShadow()->x().value(), style.textShadow()->y().value()), style.textShadow()->radius().value(), shadowColor);
         setShadow = true;
     }

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -465,7 +465,7 @@ void TextBoxPainter<TextBoxPath>::paintForeground(const StyledMarkedText& marked
     if (!emphasisMark.isEmpty())
         emphasisMarkOffset = *m_emphasisMarkExistsAndIsAbove ? -font.metricsOfPrimaryFont().ascent() - font.emphasisMarkDescent(emphasisMark) : font.metricsOfPrimaryFont().descent() + font.emphasisMarkAscent(emphasisMark);
 
-    TextPainter textPainter { context, font };
+    TextPainter textPainter { context, font, m_style };
     textPainter.setStyle(markedText.style.textStyles);
     textPainter.setIsHorizontal(textBox().isHorizontal());
     if (markedText.style.textShadow) {
@@ -637,7 +637,7 @@ void TextBoxPainter<TextBoxPath>::paintBackgroundDecorations(TextDecorationPaint
             };
         };
 
-        decorationPainter.paintBackgroundDecorations(textRun, computedBackgroundDecorationGeometry(), computedTextDecorationType, decoratingBox.textDecorationStyles);
+        decorationPainter.paintBackgroundDecorations(m_style, textRun, computedBackgroundDecorationGeometry(), computedTextDecorationType, decoratingBox.textDecorationStyles);
     }
 
     if (m_isCombinedText)

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -200,7 +200,7 @@ TextDecorationPainter::TextDecorationPainter(GraphicsContext& context, const Fon
 }
 
 // Paint text-shadow, underline, overline
-void TextDecorationPainter::paintBackgroundDecorations(const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, OptionSet<TextDecorationLine> decorationType, const Styles& decorationStyle)
+void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style, const TextRun& textRun, const BackgroundDecorationGeometry& decorationGeometry, OptionSet<TextDecorationLine> decorationType, const Styles& decorationStyle)
 {
     auto paintDecoration = [&] (auto decoration, auto style, auto& color, auto& rect) {
         m_context.setStrokeColor(color);
@@ -270,7 +270,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const TextRun& textRun, c
                 boxOrigin.move(0, -extraOffset);
                 extraOffset = 0;
             }
-            auto shadowColor = shadow->color();
+            auto shadowColor = style.colorResolvingCurrentColor(shadow->color());
             if (m_shadowColorFilter)
                 m_shadowColorFilter->transformColor(shadowColor);
 

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -66,7 +66,7 @@ public:
         float clippingOffset { 0.f };
         WavyStrokeParameters wavyStrokeParameters;
     };
-    void paintBackgroundDecorations(const TextRun&, const BackgroundDecorationGeometry&, OptionSet<TextDecorationLine>, const Styles&);
+    void paintBackgroundDecorations(const RenderStyle&, const TextRun&, const BackgroundDecorationGeometry&, OptionSet<TextDecorationLine>, const Styles&);
 
     struct ForegroundDecorationGeometry {
         FloatPoint boxOrigin;

--- a/Source/WebCore/rendering/TextPainter.h
+++ b/Source/WebCore/rendering/TextPainter.h
@@ -50,7 +50,7 @@ static inline AffineTransform rotation(const FloatRect& boxRect, RotationDirecti
 
 class TextPainter {
 public:
-    TextPainter(GraphicsContext&, const FontCascade&);
+    TextPainter(GraphicsContext&, const FontCascade&, const RenderStyle&);
 
     void setStyle(const TextPaintStyle& textPaintStyle) { m_style = textPaintStyle; }
     void setShadow(const ShadowData* shadow) { m_shadow = shadow; }
@@ -96,6 +96,7 @@ private:
 
     GraphicsContext& m_context;
     const FontCascade& m_font;
+    const RenderStyle& m_renderStyle;
     TextPaintStyle m_style;
     AtomString m_emphasisMark;
     const ShadowData* m_shadow { nullptr };
@@ -115,7 +116,7 @@ inline void TextPainter::setEmphasisMark(const AtomString& mark, float offset, c
 
 class ShadowApplier {
 public:
-    ShadowApplier(GraphicsContext&, const ShadowData*, const FilterOperations* colorFilter, const FloatRect& textRect, bool lastShadowIterationShouldDrawText = true, bool opaque = false, FontOrientation = FontOrientation::Horizontal);
+    ShadowApplier(const RenderStyle&, GraphicsContext&, const ShadowData*, const FilterOperations* colorFilter, const FloatRect& textRect, bool lastShadowIterationShouldDrawText = true, bool opaque = false, FontOrientation = FontOrientation::Horizontal);
     FloatSize extraOffset() const { return m_extraOffset; }
     bool nothingToDraw() const { return m_nothingToDraw; }
     bool didSaveContext() const { return m_didSaveContext; }

--- a/Source/WebCore/rendering/style/ShadowData.h
+++ b/Source/WebCore/rendering/style/ShadowData.h
@@ -24,11 +24,11 @@
 
 #pragma once
 
-#include "Color.h"
 #include "FloatRect.h"
 #include "LayoutRect.h"
 #include "Length.h"
 #include "LengthPoint.h"
+#include "StyleColor.h"
 
 namespace WebCore {
 
@@ -41,7 +41,7 @@ class ShadowData {
 public:
     ShadowData() = default;
 
-    ShadowData(const LengthPoint& location, Length radius, Length spread, ShadowStyle style, bool isWebkitBoxShadow, const Color& color)
+    ShadowData(const LengthPoint& location, Length radius, Length spread, ShadowStyle style, bool isWebkitBoxShadow, const StyleColor& color)
         : m_location(location.x(), location.y())
         , m_spread(spread)
         , m_radius(radius)
@@ -75,8 +75,8 @@ public:
     const Length& spread() const { return m_spread; }
     ShadowStyle style() const { return m_style; }
 
-    void setColor(const Color& color) { m_color = color; }
-    const Color& color() const { return m_color; }
+    void setColor(const StyleColor& color) { m_color = color; }
+    const StyleColor& color() const { return m_color; }
 
     bool isWebkitBoxShadow() const { return m_isWebkitBoxShadow; }
 
@@ -92,7 +92,7 @@ private:
     LengthPoint m_location;
     Length m_spread;
     Length m_radius; // This is the "blur radius", or twice the standard deviation of the Gaussian blur.
-    Color m_color;
+    StyleColor m_color;
     ShadowStyle m_style { ShadowStyle::Normal };
     bool m_isWebkitBoxShadow { false };
     std::unique_ptr<ShadowData> m_next;

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -555,7 +555,7 @@ void SVGInlineTextBox::paintTextWithShadows(GraphicsContext& context, const Rend
             break;
 
         {
-            ShadowApplier shadowApplier(*usedContext, shadow, nullptr, shadowRect);
+            ShadowApplier shadowApplier(style, *usedContext, shadow, nullptr, shadowRect);
 
             if (!shadowApplier.didSaveContext())
                 usedContext->save();

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -922,13 +922,12 @@ inline void BuilderCustom::applyTextOrBoxShadowValue(BuilderState& builderState,
         auto blur = shadowValue.blur ? shadowValue.blur->computeLength<Length>(conversionData) : Length(0, LengthType::Fixed);
         auto spread = shadowValue.spread ? shadowValue.spread->computeLength<Length>(conversionData) : Length(0, LengthType::Fixed);
         ShadowStyle shadowStyle = shadowValue.style && shadowValue.style->valueID() == CSSValueInset ? ShadowStyle::Inset : ShadowStyle::Normal;
-        Color color;
+        // If no color value is specified, the color is currentColor
+        auto color = StyleColor::currentColor();
         if (shadowValue.color)
-            color = builderState.colorFromPrimitiveValueWithResolvedCurrentColor(*shadowValue.color);
-        else
-            color = builderState.style().color();
+            color = builderState.colorFromPrimitiveValue(*shadowValue.color);
 
-        auto shadowData = makeUnique<ShadowData>(LengthPoint(x, y), blur, spread, shadowStyle, property == CSSPropertyWebkitBoxShadow, color.isValid() ? color : Color::transparentBlack);
+        auto shadowData = makeUnique<ShadowData>(LengthPoint(x, y), blur, spread, shadowStyle, property == CSSPropertyWebkitBoxShadow, color);
         if (property == CSSPropertyTextShadow)
             builderState.style().setTextShadow(WTFMove(shadowData), !isFirstEntry); // add to the list if this is not the first entry
         else


### PR DESCRIPTION
#### c71ce85eb4568e261e01fb6b73cff7cce4dce787
<pre>
[CSS] Fix shadow of text-decoration/box with currentcolor
<a href="https://bugs.webkit.org/show_bug.cgi?id=248126">https://bugs.webkit.org/show_bug.cgi?id=248126</a>
rdar://102542182

Reviewed by Antti Koivisto.

&apos;currentcolor&apos; for shadow (text and box) should be resolved at use time to
inherit the cascade properly and not at specified time.

* LayoutTests/TestExpectations:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForShadow):
* Source/WebCore/display/css/DisplayBoxDecorationPainter.cpp:
(WebCore::Display::BoxDecorationPainter::paintBoxShadow const):
* Source/WebCore/display/css/DisplayStyle.cpp:
(WebCore::Display::deepCopy):
(WebCore::Display::Style::Style):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::fontAttributesAtSelectionStart):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::applyBoxShadowForBackground):
(WebCore::BackgroundPainter::paintBoxShadow):
* Source/WebCore/rendering/EllipsisBoxPainter.cpp:
(WebCore::EllipsisBoxPainter::paint):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForeground):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintBackgroundDecorations):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
* Source/WebCore/rendering/TextDecorationPainter.h:
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::ShadowApplier::ShadowApplier):
(WebCore::TextPainter::TextPainter):
(WebCore::TextPainter::paintTextWithShadows):
* Source/WebCore/rendering/TextPainter.h:
* Source/WebCore/rendering/style/ShadowData.h:
(WebCore::ShadowData::ShadowData):
(WebCore::ShadowData::setColor):
(WebCore::ShadowData::color const):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::paintTextWithShadows):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyTextOrBoxShadowValue):

Canonical link: <a href="https://commits.webkit.org/264120@main">https://commits.webkit.org/264120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30dbc67c8f1842df7ae0f23b8d24a37c696499e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9907 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8438 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13930 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5473 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6065 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1598 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->