### PR TITLE
[web-animations] css/css-animations/event-order.tentative.html is a unique failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/event-order.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/event-order.tentative-expected.txt
@@ -2,7 +2,7 @@
 PASS Same events are ordered by elements
 PASS Same events on pseudo-elements follow the prescribed order
 PASS Same events on pseudo-elements follow the prescribed order (::marker)
-FAIL Start and iteration events are ordered by time assert_equals: Event #1 types should match (expected: animationiteration, animationstart, actual: animationstart, animationiteration) expected "animationiteration" but got "animationstart"
-FAIL Iteration and end events are ordered by time assert_equals: Event #1 types should match (expected: animationiteration, animationend, actual: animationend, animationiteration) expected "animationiteration" but got "animationend"
-FAIL Start and end events are sorted correctly when fired simultaneously assert_equals: Event #1 targets should match expected Element node <div style="animation: anim 100s 2"></div> but got Element node <div style="animation: anim 100s 100s"></div>
+PASS Start and iteration events are ordered by time
+PASS Iteration and end events are ordered by time
+PASS Start and end events are sorted correctly when fired simultaneously
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "CSSAnimation.h"
 
-#include "Animation.h"
 #include "AnimationEffect.h"
 #include "CSSAnimationEvent.h"
 #include "InspectorInstrumentation.h"
@@ -281,9 +280,9 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
         keyframeEffect.computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
 }
 
-Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, double elapsedTime, PseudoId pseudoId)
+Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
 {
-    return CSSAnimationEvent::create(eventType, this, std::nullopt, elapsedTime, pseudoId, m_animationName);
+    return CSSAnimationEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoId, m_animationName);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -54,7 +54,7 @@ private:
     CSSAnimation(const Styleable&, const Animation&);
 
     void syncPropertiesWithBackingAnimation() final;
-    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, PseudoId) final;
+    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
 
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -93,9 +93,9 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
     unsuspendEffectInvalidation();
 }
 
-Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, double elapsedTime, PseudoId pseudoId)
+Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
 {
-    return CSSTransitionEvent::create(eventType, this, std::nullopt, elapsedTime, pseudoId, nameString(m_property));
+    return CSSTransitionEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoId, nameString(m_property));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -56,7 +56,7 @@ public:
 private:
     CSSTransition(const Styleable&, CSSPropertyID, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
-    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, PseudoId) final;
+    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
     void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }

--- a/Source/WebCore/animation/DeclarativeAnimation.cpp
+++ b/Source/WebCore/animation/DeclarativeAnimation.cpp
@@ -234,6 +234,27 @@ AnimationEffectPhase DeclarativeAnimation::phaseWithoutEffect() const
     return *animationCurrentTime < 0_s ? AnimationEffectPhase::Before : AnimationEffectPhase::After;
 }
 
+Seconds DeclarativeAnimation::effectTimeAtStart() const
+{
+    if (auto* effect = this->effect())
+        return effect->delay();
+    return 0_s;
+}
+
+Seconds DeclarativeAnimation::effectTimeAtIteration(double iteration) const
+{
+    if (auto* effect = this->effect())
+        return effect->delay() + effect->iterationDuration() * iteration;
+    return 0_s;
+}
+
+Seconds DeclarativeAnimation::effectTimeAtEnd() const
+{
+    if (auto* effect = this->effect())
+        return effect->endTime();
+    return 0_s;
+}
+
 void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
 {
     if (!m_owningElement)
@@ -276,54 +297,55 @@ void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
     if (is<CSSAnimation>(this)) {
         // https://drafts.csswg.org/css-animations-2/#events
         if ((wasIdle || wasBefore) && isActive)
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart);
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
         else if ((wasIdle || wasBefore) && isAfter) {
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart);
-            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
         } else if (wasActive && isBefore)
-            enqueueDOMEvent(eventNames().animationendEvent, intervalStart);
+            enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
         else if (wasActive && isActive && m_previousIteration != iteration) {
             auto iterationBoundary = iteration;
             if (m_previousIteration > iteration)
                 iterationBoundary++;
             auto elapsedTime = animationEffect ? animationEffect->iterationDuration() * (iterationBoundary - animationEffect->iterationStart()) : 0_s;
-            enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime);
+            enqueueDOMEvent(eventNames().animationiterationEvent, elapsedTime, effectTimeAtIteration(iteration));
         } else if (wasActive && isAfter)
-            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().animationendEvent, intervalEnd, effectTimeAtEnd());
         else if (wasAfter && isActive)
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
         else if (wasAfter && isBefore) {
-            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd);
-            enqueueDOMEvent(eventNames().animationendEvent, intervalStart);
+            enqueueDOMEvent(eventNames().animationstartEvent, intervalEnd, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().animationendEvent, intervalStart, effectTimeAtEnd());
         } else if ((!wasIdle && !wasAfter) && isIdle)
-            enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime);
+            enqueueDOMEvent(eventNames().animationcancelEvent, elapsedTime, elapsedTime);
     } else if (is<CSSTransition>(this)) {
         // https://drafts.csswg.org/css-transitions-2/#transition-events
         if (wasIdle && (isPending || isBefore))
-            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart);
+            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
         else if (wasIdle && isActive) {
-            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart);
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart);
+            auto scheduledEffectTime = effectTimeAtStart();
+            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, scheduledEffectTime);
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, scheduledEffectTime);
         } else if (wasIdle && isAfter) {
-            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart);
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart);
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().transitionrunEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
         } else if ((m_wasPending || wasBefore) && isActive)
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart);
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
         else if ((m_wasPending || wasBefore) && isAfter) {
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart);
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalStart, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
         } else if (wasActive && isAfter)
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalEnd, effectTimeAtEnd());
         else if (wasActive && isBefore)
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart);
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
         else if (wasAfter && isActive)
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd);
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
         else if (wasAfter && isBefore) {
-            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd);
-            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart);
+            enqueueDOMEvent(eventNames().transitionstartEvent, intervalEnd, effectTimeAtStart());
+            enqueueDOMEvent(eventNames().transitionendEvent, intervalStart, effectTimeAtEnd());
         } else if ((!wasIdle && !wasAfter) && isIdle)
-            enqueueDOMEvent(eventNames().transitioncancelEvent, elapsedTime);
+            enqueueDOMEvent(eventNames().transitioncancelEvent, elapsedTime, elapsedTime);
     }
 
     m_wasPending = isPending;
@@ -331,13 +353,21 @@ void DeclarativeAnimation::invalidateDOMEvents(Seconds elapsedTime)
     m_previousIteration = iteration;
 }
 
-void DeclarativeAnimation::enqueueDOMEvent(const AtomString& eventType, Seconds elapsedTime)
+void DeclarativeAnimation::enqueueDOMEvent(const AtomString& eventType, Seconds elapsedTime, Seconds scheduledEffectTime)
 {
     if (!m_owningElement)
         return;
 
+    auto scheduledTimelineTime = [&]() -> std::optional<Seconds> {
+        if (auto* documentTimeline = dynamicDowncast<DocumentTimeline>(timeline())) {
+            if (auto scheduledAnimationTime = convertAnimationTimeToTimelineTime(scheduledEffectTime))
+                return documentTimeline->convertTimelineTimeToOriginRelativeTime(*scheduledAnimationTime);
+        }
+        return std::nullopt;
+    }();
+
     auto time = secondsToWebAnimationsAPITime(elapsedTime) / 1000;
-    auto event = createEvent(eventType, time, m_owningPseudoId);
+    auto event = createEvent(eventType, scheduledTimelineTime, time, m_owningPseudoId);
     event->setTarget(RefPtr { m_owningElement.get() });
     enqueueAnimationEvent(WTFMove(event));
 }

--- a/Source/WebCore/animation/DeclarativeAnimation.h
+++ b/Source/WebCore/animation/DeclarativeAnimation.h
@@ -76,13 +76,17 @@ protected:
 
     void initialize(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     virtual void syncPropertiesWithBackingAnimation();
-    virtual Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, double elapsedTime, PseudoId) = 0;
+    virtual Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) = 0;
     void invalidateDOMEvents(Seconds elapsedTime = 0_s);
 
 private:
     void disassociateFromOwningElement();
     AnimationEffectPhase phaseWithoutEffect() const;
-    void enqueueDOMEvent(const AtomString&, Seconds);
+    void enqueueDOMEvent(const AtomString&, Seconds elapsedTime, Seconds scheduledEffectTime);
+
+    Seconds effectTimeAtStart() const;
+    Seconds effectTimeAtIteration(double) const;
+    Seconds effectTimeAtEnd() const;
 
     bool m_wasPending { false };
     AnimationEffectPhase m_previousPhase { AnimationEffectPhase::Idle };


### PR DESCRIPTION
#### 9d465450dccf6dc4e9ac1ee113d8e465f9bc3bdc
<pre>
[web-animations] css/css-animations/event-order.tentative.html is a unique failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=235145">https://bugs.webkit.org/show_bug.cgi?id=235145</a>
rdar://87785713

Reviewed by Simon Fraser.

We need to sort animation and transition events based on the relative scheduled event
time. We compute those scheduled event times when we enqueue the events and let
compareAnimationEventsByCompositeOrder() first try to sort animation and transition
events among their respective event class by this scheduled event time.

If the scheduled event times are a match, we try to sort the events by the relative
position of the owning element in the tree, the owning element always matching the
target at the time the event was enqueued.

Finally, we preserve the relative order of events enqueued for the same animation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/event-order.tentative-expected.txt:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/DeclarativeAnimation.cpp:
(WebCore::DeclarativeAnimation::effectTimeAtStart const):
(WebCore::DeclarativeAnimation::effectTimeAtIteration const):
(WebCore::DeclarativeAnimation::effectTimeAtEnd const):
(WebCore::DeclarativeAnimation::invalidateDOMEvents):
(WebCore::DeclarativeAnimation::enqueueDOMEvent):
* Source/WebCore/animation/DeclarativeAnimation.h:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareDeclarativeAnimationEvents):
(WebCore::compareAnimationEventsByCompositeOrder):

Canonical link: <a href="https://commits.webkit.org/257080@main">https://commits.webkit.org/257080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf91ea00f7c13672b80545935aab0dd7b8d57fc6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107282 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167551 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7462 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35805 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103925 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5601 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84423 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32565 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1017 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22164 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5836 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2413 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2264 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41570 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->