### PR TITLE
[Linux] Prevent encoding of DMABufObject lvalue references

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufObject.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufObject.h
@@ -51,7 +51,6 @@ struct DMABufObject {
     DMABufObject(DMABufObject&&) = default;
     DMABufObject& operator=(DMABufObject&&) = default;
 
-    template<class Encoder> void encode(Encoder&) const &;
     template<class Encoder> void encode(Encoder&) &&;
     template<class Decoder> static std::optional<DMABufObject> decode(Decoder&);
 
@@ -66,18 +65,6 @@ struct DMABufObject {
     std::array<uint32_t, DMABufFormat::c_maxPlanes> stride { 0, 0, 0, 0 };
     std::array<uint64_t, DMABufFormat::c_maxPlanes> modifier { 0, 0, 0, 0 };
 };
-
-template<class Encoder>
-void DMABufObject::encode(Encoder& encoder) const &
-{
-    encoder << handle << uint32_t(format.fourcc) << uint32_t(colorSpace) << width << height;
-    encoder << releaseFlag.fd.duplicate();
-
-    for (unsigned i = 0; i < DMABufFormat::c_maxPlanes; ++i) {
-        encoder << fd[i].duplicate();
-        encoder << offset[i] << stride[i] << modifier[i];
-    }
-}
 
 template<class Encoder>
 void DMABufObject::encode(Encoder& encoder) &&


### PR DESCRIPTION
#### 5d29c301be511e4ee1414e96c5c4dc0632c7bf31
<pre>
[Linux] Prevent encoding of DMABufObject lvalue references
<a href="https://bugs.webkit.org/show_bug.cgi?id=248395">https://bugs.webkit.org/show_bug.cgi?id=248395</a>

Reviewed by Michael Catanzaro.

Remove the lvaue-ref-qualified DMABufObject::encode() method, only leaving
the encoding possible for rvalues of this type. Currently this method is
not used, so everything continues to work. But in any future encoding of
such objects, rvalues will be demanded, avoiding accidentally duplicating
the underlying resources (specifically the different file descriptors).

* Source/WebCore/platform/graphics/gbm/DMABufObject.h:
(WebCore::DMABufObject::encode const): Deleted.

Canonical link: <a href="https://commits.webkit.org/257079@main">https://commits.webkit.org/257079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3086602bc07102e79343497743511276b16e9980

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/30972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107283 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167552 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7464 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35806 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103926 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5602 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84424 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32567 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75480 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1018 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22163 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4857 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5837 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41569 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->