### PR TITLE
Expand new CoreIPC serialization format to cover more of WebCoreArgumentCoders

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationResources.h
+++ b/Source/WebCore/Modules/notifications/NotificationResources.h
@@ -36,11 +36,23 @@ public:
     {
         return adoptRef(*new NotificationResources());
     }
+    
+    static Ref<NotificationResources> create(RefPtr<Image>&& image)
+    {
+        return adoptRef(*new NotificationResources(WTFMove(image)));
+    }
 
     void setIcon(RefPtr<Image>&& icon) { m_icon = WTFMove(icon); }
     const RefPtr<Image>& icon() const { return m_icon; }
 
 private:
+    NotificationResources(RefPtr<Image>&& image)
+        : m_icon(WTFMove(image))
+    {
+    }
+
+    NotificationResources() = default;
+
     RefPtr<Image> m_icon;
 };
 

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -30,6 +30,12 @@
 
 namespace WebCore {
 
+AbsolutePositionConstraints::AbsolutePositionConstraints(const FloatSize& alignmentOffset, const FloatPoint& layerPositionAtLastLayout)
+    : m_alignmentOffset(alignmentOffset)
+    , m_layerPositionAtLastLayout(layerPositionAtLastLayout)
+{
+}
+
 FloatPoint FixedPositionViewportConstraints::layerPositionForViewportRect(const FloatRect& viewportRect) const
 {
     FloatSize offset;

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -34,6 +34,7 @@ class AbsolutePositionConstraints {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     AbsolutePositionConstraints() = default;
+    WEBCORE_EXPORT AbsolutePositionConstraints(const FloatSize&, const FloatPoint&);
 
     bool operator==(const AbsolutePositionConstraints& other) const
     {

--- a/Source/WebCore/platform/DragData.cpp
+++ b/Source/WebCore/platform/DragData.cpp
@@ -44,7 +44,7 @@ DragData::DragData(DragDataRef data, const IntPoint& clientPosition, const IntPo
 {  
 }
 
-DragData::DragData(const String&, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> sourceOperationMask, OptionSet<DragApplicationFlags> flags, OptionSet<DragDestinationAction> destinationActionMask, std::optional<PageIdentifier> pageID)
+DragData::DragData(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation> sourceOperationMask, OptionSet<DragApplicationFlags> flags, OptionSet<DragDestinationAction> destinationActionMask, std::optional<PageIdentifier> pageID)
     : m_clientPosition(clientPosition)
     , m_globalPosition(globalPosition)
     , m_platformDragData(0)

--- a/Source/WebCore/platform/DragData.h
+++ b/Source/WebCore/platform/DragData.h
@@ -79,7 +79,16 @@ public:
 
     // clientPosition is taken to be the position of the drag event within the target window, with (0,0) at the top left
     WEBCORE_EXPORT DragData(DragDataRef, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
-    WEBCORE_EXPORT DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
+
+    WEBCORE_EXPORT DragData(
+#if PLATFORM(COCOA)
+        const String& dragStorageName,
+#endif
+        const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
+
+#if PLATFORM(COCOA)
+    WEBCORE_EXPORT DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, const Vector<String>&, OptionSet<DragOperation>, OptionSet<DragApplicationFlags> = { }, OptionSet<DragDestinationAction> = anyDragDestinationAction(), std::optional<PageIdentifier> pageID = std::nullopt);
+#endif
     // This constructor should used only by WebKit2 IPC because DragData
     // is initialized by the decoder and not in the constructor.
     DragData() = default;
@@ -122,7 +131,7 @@ public:
 private:
     IntPoint m_clientPosition;
     IntPoint m_globalPosition;
-    DragDataRef m_platformDragData;
+    DragDataRef m_platformDragData { NULL };
     OptionSet<DragOperation> m_draggingSourceOperationMask;
     OptionSet<DragApplicationFlags> m_applicationFlags;
     Vector<String> m_fileNames;

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -387,25 +387,6 @@ template<> struct EnumTraits<WebCore::ScrollIsAnimated> {
     >;
 };
 
-template<> struct EnumTraits<WebCore::ScrollbarMode> {
-    using values = EnumValues<
-        WebCore::ScrollbarMode,
-        WebCore::ScrollbarMode::Auto,
-        WebCore::ScrollbarMode::AlwaysOff,
-        WebCore::ScrollbarMode::AlwaysOn
-    >;
-};
-
-template<> struct EnumTraits<WebCore::ScrollElasticity> {
-    using values = EnumValues<
-        WebCore::ScrollElasticity,
-        WebCore::ScrollElasticity::Automatic,
-        WebCore::ScrollElasticity::None,
-        WebCore::ScrollElasticity::Allowed
-    >;
-};
-
-
 template<> struct EnumTraits<WebCore::ScrollPinningBehavior> {
     using values = EnumValues<
         WebCore::ScrollPinningBehavior,

--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -159,6 +159,18 @@ DragData::DragData(const String& dragStorageName, const IntPoint& clientPosition
 {
 }
 
+DragData::DragData(const String& dragStorageName, const IntPoint& clientPosition, const IntPoint& globalPosition, const Vector<String>& fileNames, OptionSet<DragOperation> sourceOperationMask, OptionSet<DragApplicationFlags> flags, OptionSet<DragDestinationAction> destinationActionMask, std::optional<PageIdentifier> pageID)
+    : m_clientPosition(clientPosition)
+    , m_globalPosition(globalPosition)
+    , m_draggingSourceOperationMask(sourceOperationMask)
+    , m_applicationFlags(flags)
+    , m_fileNames(fileNames)
+    , m_dragDestinationActionMask(destinationActionMask)
+    , m_pageID(pageID)
+    , m_pasteboardName(dragStorageName)
+{
+}
+
 bool DragData::containsURLTypeIdentifier() const
 {
     Vector<String> types;

--- a/Source/WebCore/platform/network/soup/AuthenticationChallenge.h
+++ b/Source/WebCore/platform/network/soup/AuthenticationChallenge.h
@@ -46,6 +46,12 @@ public:
     {
     }
 
+    AuthenticationChallenge(const ProtectionSpace& protectionSpace, const Credential& proposedCredential, unsigned previousFailureCount, const ResourceResponse& response, const ResourceError& error, uint32_t tlsPasswordFlags)
+        : AuthenticationChallengeBase(protectionSpace, proposedCredential, previousFailureCount, response, error)
+        , m_tlsPasswordFlags(tlsPasswordFlags)
+    {
+    }
+
     AuthenticationChallenge(SoupMessage*, SoupAuth*, bool retrying);
     AuthenticationChallenge(SoupMessage*, GTlsClientConnection*);
     AuthenticationChallenge(SoupMessage*, GTlsPassword*);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -251,21 +251,6 @@ template<> struct ArgumentCoder<WebCore::Length> {
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::Length&);
 };
 
-template<> struct ArgumentCoder<WebCore::VelocityData> {
-    static void encode(Encoder&, const WebCore::VelocityData&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::VelocityData&);
-};
-
-template<> struct ArgumentCoder<WebCore::MimeClassInfo> {
-    static void encode(Encoder&, const WebCore::MimeClassInfo&);
-    static std::optional<WebCore::MimeClassInfo> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::AuthenticationChallenge> {
-    static void encode(Encoder&, const WebCore::AuthenticationChallenge&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::AuthenticationChallenge&);
-};
-
 template<> struct ArgumentCoder<WebCore::ProtectionSpace> {
     static void encode(Encoder&, const WebCore::ProtectionSpace&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ProtectionSpace&);
@@ -309,13 +294,6 @@ template<> struct ArgumentCoder<WebCore::ResourceError> {
     static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::ResourceError&);
 };
 
-#if ENABLE(DRAG_SUPPORT)
-template<> struct ArgumentCoder<WebCore::DragData> {
-    static void encode(Encoder&, const WebCore::DragData&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::DragData&);
-};
-#endif
-
 #if PLATFORM(COCOA)
 
 template<> struct ArgumentCoder<WebCore::KeypressCommand> {
@@ -357,20 +335,6 @@ template<> struct ArgumentCoder<WebCore::CurlProxySettings> {
 };
 #endif
 
-template<> struct ArgumentCoder<WebCore::DictationAlternative> {
-    static void encode(Encoder&, const WebCore::DictationAlternative&);
-    static std::optional<WebCore::DictationAlternative> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::UserStyleSheet> {
-    static void encode(Encoder&, const WebCore::UserStyleSheet&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::UserStyleSheet&);
-};
-
-template<> struct ArgumentCoder<WebCore::ScrollableAreaParameters> {
-    static void encode(Encoder&, const WebCore::ScrollableAreaParameters&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ScrollableAreaParameters&);
-};
 
 template<> struct ArgumentCoder<WebCore::FixedPositionViewportConstraints> {
     static void encode(Encoder&, const WebCore::FixedPositionViewportConstraints&);
@@ -380,11 +344,6 @@ template<> struct ArgumentCoder<WebCore::FixedPositionViewportConstraints> {
 template<> struct ArgumentCoder<WebCore::StickyPositionViewportConstraints> {
     static void encode(Encoder&, const WebCore::StickyPositionViewportConstraints&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::StickyPositionViewportConstraints&);
-};
-
-template<> struct ArgumentCoder<WebCore::AbsolutePositionConstraints> {
-    static void encode(Encoder&, const WebCore::AbsolutePositionConstraints&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::AbsolutePositionConstraints&);
 };
 
 #if !USE(COORDINATED_GRAPHICS)
@@ -539,11 +498,6 @@ template<> struct ArgumentCoder<WebCore::SystemImage> {
     template<typename Encoder>
     static void encode(Encoder&, const WebCore::SystemImage&);
     static std::optional<Ref<WebCore::SystemImage>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::NotificationResources> {
-    static void encode(Encoder&, const WebCore::NotificationResources&);
-    static std::optional<RefPtr<WebCore::NotificationResources>> decode(Decoder&);
 };
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1680,3 +1680,100 @@ header: <WebCore/TextManipulationToken.h>
     URL documentURL;
     bool isVisible;
 };
+
+struct WebCore::VelocityData {
+    float horizontalVelocity;
+    float verticalVelocity;
+    float scaleChangeRate;
+    MonotonicTime lastUpdateTime;
+};
+
+header: <WebCore/PluginData.h>
+[CustomHeader] struct WebCore::MimeClassInfo {
+    AtomString type;
+    String desc;
+    Vector<String> extensions;
+};
+
+class WebCore::AuthenticationChallenge {
+    WebCore::ProtectionSpace protectionSpace();
+    WebCore::Credential proposedCredential();
+    unsigned previousFailureCount();
+    WebCore::ResourceResponse failureResponse();
+    WebCore::ResourceError error();
+    
+#if USE(SOUP)
+    uint32_t tlsPasswordFlags();
+#endif
+};
+
+#if ENABLE(DRAG_SUPPORT)
+class WebCore::DragData {
+#if PLATFORM(COCOA)
+    String pasteboardName();
+#endif
+    WebCore::IntPoint clientPosition();
+    WebCore::IntPoint globalPosition();
+#if PLATFORM(COCOA)
+    Vector<String> fileNames();
+#endif
+    OptionSet<WebCore::DragOperation> draggingSourceOperationMask();
+    OptionSet<WebCore::DragApplicationFlags> flags();
+    OptionSet<WebCore::DragDestinationAction> dragDestinationActionMask();
+    std::optional<WebCore::PageIdentifier> pageID();
+};
+#endif
+
+struct WebCore::DictationAlternative {
+    WebCore::CharacterRange range;
+    WebCore::DictationContext context;
+};
+
+class WebCore::UserStyleSheet {
+    String source();
+    URL url();
+    Vector<String> allowlist();
+    Vector<String> blocklist();
+    WebCore::UserContentInjectedFrames injectedFrames();
+    WebCore::UserStyleLevel level();
+    std::optional<WebCore::PageIdentifier> pageID();
+};
+
+header: <WebCore/ScrollTypes.h>
+[CustomHeader] enum class WebCore::ScrollElasticity : uint8_t {
+    Automatic,
+    None,
+    Allowed
+};
+
+header: <WebCore/ScrollTypes.h>
+[CustomHeader] enum class WebCore::ScrollbarMode : uint8_t {
+    Auto,
+    AlwaysOff,
+    AlwaysOn
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[CustomHeader] struct WebCore::ScrollableAreaParameters {
+    WebCore::ScrollElasticity horizontalScrollElasticity;
+    WebCore::ScrollElasticity verticalScrollElasticity;
+    WebCore::ScrollbarMode horizontalScrollbarMode;
+    WebCore::ScrollbarMode verticalScrollbarMode;
+    WebCore::OverscrollBehavior horizontalOverscrollBehavior;
+    WebCore::OverscrollBehavior verticalOverscrollBehavior;
+    bool allowsHorizontalScrolling;
+    bool allowsVerticalScrolling;
+    bool horizontalScrollbarHiddenByStyle;
+    bool verticalScrollbarHiddenByStyle;
+    bool useDarkAppearanceForScrollbars;
+};
+
+header: <WebCore/ScrollingConstraints.h>
+[CustomHeader] class WebCore::AbsolutePositionConstraints {
+    WebCore::FloatSize alignmentOffset();
+    WebCore::FloatPoint layerPositionAtLastLayout();
+};
+
+[Return=Ref] class WebCore::NotificationResources {
+    RefPtr<WebCore::Image> icon();
+};


### PR DESCRIPTION
#### 629347e3f7c53d8792152bbb9a08033e3a9a0eba
<pre>
Expand new CoreIPC serialization format to cover more of WebCoreArgumentCoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=248397">https://bugs.webkit.org/show_bug.cgi?id=248397</a>
rdar://102717379

Reviewed by Alex Christensen.

Expand CoreIPC serialization to cover more of WebCoreArgumentCoders.
This includes:
 - VelocityData
 - MimeClassInfo
 - AuthenticationChallenge
 - DragData
 - DictationAlternative
 - UserStyleSheet
 - ScrollElasticity
 - ScrollbarMode
 - ScrollableAreaParameters
 - AbsolutePositionConstraints
 - NotificationResources

* Source/WebCore/Modules/notifications/NotificationResources.h:
(WebCore::NotificationResources::NotificationResources):
(WebCore::NotificationResources::create):
* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
(WebCore::AbsolutePositionConstraints::AbsolutePositionConstraints):
* Source/WebCore/page/scrolling/ScrollingConstraints.h:
* Source/WebCore/platform/DragData.h:
(WebCore::DragData::DragData):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::DragData::DragData):
* Source/WebCore/platform/network/soup/AuthenticationChallenge.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;VelocityData&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;VelocityData&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;MimeClassInfo&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;MimeClassInfo&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;AuthenticationChallenge&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;AuthenticationChallenge&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;DragData&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;DragData&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;DictationAlternative&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;DictationAlternative&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;UserStyleSheet&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;UserStyleSheet&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;ScrollableAreaParameters&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ScrollableAreaParameters&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;AbsolutePositionConstraints&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;AbsolutePositionConstraints&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::NotificationResources&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::NotificationResources&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/257452@main">https://commits.webkit.org/257452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cdd171ba5546f78bedbfa29ea7606d2a6b504cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108352 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168607 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8702 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/85579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106321 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33619 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76468 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2054 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23035 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1960 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/85579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5132 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6920 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42509 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->