### PR TITLE
[WebAuthn] Incorrect RP ID hash when using U2F keys

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.cpp
@@ -50,18 +50,19 @@ std::optional<AuthenticationExtensionsClientInputs> AuthenticationExtensionsClie
     it = decodedMap.find(cbor::CBORValue("credProps"));
     if (it != decodedMap.end() && it->second.isBool())
         clientInputs.credProps = it->second.getBool();
+
     return clientInputs;
 }
 
 Vector<uint8_t> AuthenticationExtensionsClientInputs::toCBOR() const
 {
     cbor::CBORValue::MapValue clientInputsMap;
-    if (!appid.isEmpty())
-        clientInputsMap[cbor::CBORValue("appid")] = cbor::CBORValue(appid);
+    if (appid)
+        clientInputsMap[cbor::CBORValue("appid")] = cbor::CBORValue(*appid);
     if (googleLegacyAppidSupport)
-        clientInputsMap[cbor::CBORValue("googleLegacyAppidSupport")] = cbor::CBORValue(googleLegacyAppidSupport);
+        clientInputsMap[cbor::CBORValue("googleLegacyAppidSupport")] = cbor::CBORValue(*googleLegacyAppidSupport);
     if (credProps)
-        clientInputsMap[cbor::CBORValue("credProps")] = cbor::CBORValue(credProps);
+        clientInputsMap[cbor::CBORValue("credProps")] = cbor::CBORValue(*credProps);
 
     auto clientInputs = cbor::CBORWriter::write(cbor::CBORValue(WTFMove(clientInputsMap)));
     ASSERT(clientInputs);

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.h
@@ -32,9 +32,9 @@
 namespace WebCore {
 
 struct AuthenticationExtensionsClientInputs {
-    String appid;
-    bool googleLegacyAppidSupport;
-    bool credProps; // Not serialized but probably should be. Don't re-introduce rdar://101057340 though.
+    std::optional<String> appid;
+    std::optional<bool> googleLegacyAppidSupport;
+    std::optional<bool> credProps;
 
     WEBCORE_EXPORT Vector<uint8_t> toCBOR() const;
     WEBCORE_EXPORT static std::optional<AuthenticationExtensionsClientInputs> fromCBOR(Span<const uint8_t>);

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
@@ -44,6 +44,8 @@ std::optional<AuthenticationExtensionsClientOutputs> AuthenticationExtensionsCli
     auto it = decodedMap.find(cbor::CBORValue("appid"));
     if (it != decodedMap.end() && it->second.isBool())
         clientOutputs.appid = it->second.getBool();
+    else
+        clientOutputs.appid = std::nullopt;
     it = decodedMap.find(cbor::CBORValue("credProps"));
     if (it != decodedMap.end() && it->second.isMap()) {
         CredentialPropertiesOutput credProps;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -91,8 +91,8 @@ static bool processGoogleLegacyAppIdSupportExtension(const std::optional<Authent
     if (rpId != "google.com"_s)
         return false;
     if (!extensions)
-        return true;
-    return extensions->googleLegacyAppidSupport;
+        return false;
+    return extensions->googleLegacyAppidSupport && *extensions->googleLegacyAppidSupport;
 }
 
 } // namespace AuthenticatorCoordinatorInternal
@@ -229,9 +229,9 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
 
     // Step 8-9.
     // Only FIDO AppID Extension is supported.
-    if (options.extensions && !options.extensions->appid.isNull()) {
+    if (options.extensions && options.extensions->appid) {
         // The following implements https://www.w3.org/TR/webauthn/#sctn-appid-extension as of 4 March 2019.
-        auto appid = processAppIdExtension(callerOrigin, options.extensions->appid);
+        auto appid = processAppIdExtension(callerOrigin, *options.extensions->appid);
         if (!appid) {
             promise.reject(Exception { SecurityError, "The origin of the document is not authorized for the provided App ID."_s });
             return;

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -123,8 +123,8 @@ std::optional<Vector<uint8_t>> convertToU2fSignCommand(const Vector<uint8_t>& cl
 
     if (!isAppId)
         return constructU2fSignCommand(produceRpIdHash(request.rpId), clientDataHash, keyHandle, false);
-    ASSERT(request.extensions && !request.extensions->appid.isNull());
-    return constructU2fSignCommand(produceRpIdHash(request.extensions->appid), clientDataHash, keyHandle, false);
+    ASSERT(request.extensions && request.extensions->appid);
+    return constructU2fSignCommand(produceRpIdHash(*request.extensions->appid), clientDataHash, keyHandle, false);
 }
 
 Vector<uint8_t> constructBogusU2fRegistrationCommand()
@@ -140,7 +140,7 @@ String processGoogleLegacyAppIdSupportExtension(const std::optional<Authenticati
         return String();
     }
 
-    if (!extensions->googleLegacyAppidSupport)
+    if (!extensions->googleLegacyAppidSupport || !*extensions->googleLegacyAppidSupport)
         return String();
     return "https://www.gstatic.com/securitykey/origins.json"_s;
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -914,9 +914,10 @@ struct WebCore::WebLockManagerSnapshot {
 };
 
 #if ENABLE(WEB_AUTHN)
-[LegacyPopulateFrom=EmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
-    String appid;
-    bool googleLegacyAppidSupport;
+struct WebCore::AuthenticationExtensionsClientInputs {
+    std::optional<String> appid;
+    std::optional<bool> googleLegacyAppidSupport;
+    std::optional<bool> credProps;
 }
 
 [Nested] struct WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput {

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -579,6 +579,8 @@ UIProcess/Notifications/WebNotificationProvider.cpp
 UIProcess/UserContent/WebScriptMessageHandler.cpp
 UIProcess/UserContent/WebUserContentControllerProxy.cpp
 
+UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+UIProcess/WebAuthentication/fido/CtapHidDriver.cpp
 UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
 UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
 UIProcess/WebAuthentication/fido/FidoService.cpp
@@ -588,6 +590,7 @@ UIProcess/WebAuthentication/Mock/MockAuthenticatorManager.cpp
 UIProcess/WebAuthentication/Mock/MockHidConnection.cpp
 UIProcess/WebAuthentication/Mock/MockHidService.cpp
 
+UIProcess/WebAuthentication/AuthenticatorManager.cpp
 UIProcess/WebAuthentication/AuthenticatorTransportService.cpp
 UIProcess/WebAuthentication/Authenticator.cpp
 UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -576,6 +576,8 @@ UIProcess/WebAuthentication/Cocoa/AuthenticationServicesCoreSoftLink.mm @no-unif
 UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
 UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
 UIProcess/WebAuthentication/Cocoa/CcidService.mm
+UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+UIProcess/WebAuthentication/Cocoa/HidService.mm
 UIProcess/WebAuthentication/Cocoa/LocalAuthenticationSoftLink.mm @no-unify
 UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
 UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -586,6 +588,7 @@ UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebAuthentication/Cocoa/WKASCAuthorizationPresenterDelegate.mm
 UIProcess/WebAuthentication/Cocoa/WKNFReaderSessionDelegate.mm
 UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
 
 UIProcess/WebAuthentication/Mock/MockLocalConnection.mm
 UIProcess/WebAuthentication/Mock/MockLocalService.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticationExtensionsClientInputs.h
@@ -36,6 +36,7 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 
 @property (nullable, nonatomic, copy) NSString *appid;
 @property (nonatomic) BOOL googleLegacyAppidSupport;
+@property (nonatomic) BOOL credProps;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -891,6 +891,7 @@ static WebCore::AuthenticationExtensionsClientInputs authenticationExtensionsCli
     WebCore::AuthenticationExtensionsClientInputs result;
     result.appid = extensions.appid;
     result.googleLegacyAppidSupport = extensions.googleLegacyAppidSupport;
+    result.credProps = extensions.credProps;
 
     return result;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -158,7 +158,7 @@ static void processGoogleLegacyAppIdSupportExtension(const std::optional<Authent
         ASSERT_NOT_REACHED();
         return;
     }
-    if (!extensions->googleLegacyAppidSupport)
+    if (!extensions->googleLegacyAppidSupport || !*extensions->googleLegacyAppidSupport)
         return;
     transports.remove(AuthenticatorTransport::Internal);
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -177,7 +177,7 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
 static inline RetainPtr<ASCWebAuthenticationExtensionsClientInputs> toASCExtensions(const AuthenticationExtensionsClientInputs& extensions)
 {
     if ([allocASCWebAuthenticationExtensionsClientInputsInstance() respondsToSelector:@selector(initWithAppID:isGoogleLegacyAppIDSupport:)])
-        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:extensions.appid isGoogleLegacyAppIDSupport:extensions.googleLegacyAppidSupport]);
+        return adoptNS([allocASCWebAuthenticationExtensionsClientInputsInstance() initWithAppID:(extensions.appid ? nsStringNilIfEmpty(*extensions.appid) : nil) isGoogleLegacyAppIDSupport:extensions.googleLegacyAppidSupport && *extensions.googleLegacyAppidSupport]);
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -399,9 +399,11 @@ bool CtapAuthenticator::processGoogleLegacyAppIdSupportExtension()
         ASSERT_NOT_REACHED();
         return false;
     }
-    if (extensions->googleLegacyAppidSupport)
+    if (!extensions->googleLegacyAppidSupport)
+        return false;
+    if (*extensions->googleLegacyAppidSupport)
         tryDowngrade();
-    return extensions->googleLegacyAppidSupport;
+    return *extensions->googleLegacyAppidSupport;
 }
 
 Vector<AuthenticatorTransport> CtapAuthenticator::transports() const

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -227,8 +227,8 @@ void U2fAuthenticator::continueSignCommandAfterResponseReceived(ApduResponse&& a
     case ApduResponse::Status::SW_NO_ERROR: {
         RefPtr<AuthenticatorAssertionResponse> response;
         if (m_isAppId) {
-            ASSERT(requestOptions.extensions && !requestOptions.extensions->appid.isNull());
-            response = readU2fSignResponse(requestOptions.extensions->appid, requestOptions.allowCredentials[m_nextListIndex - 1].id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform);
+            ASSERT(requestOptions.extensions && requestOptions.extensions->appid);
+            response = readU2fSignResponse(*requestOptions.extensions->appid, requestOptions.allowCredentials[m_nextListIndex - 1].id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform);
         } else
             response = readU2fSignResponse(requestOptions.rpId, requestOptions.allowCredentials[m_nextListIndex - 1].id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform);
         if (!response) {
@@ -246,7 +246,7 @@ void U2fAuthenticator::continueSignCommandAfterResponseReceived(ApduResponse&& a
         m_retryTimer.startOneShot(Seconds::fromMilliseconds(retryTimeOutValueMs));
         return;
     case ApduResponse::Status::SW_WRONG_DATA:
-        if (requestOptions.extensions && !requestOptions.extensions->appid.isNull()) {
+        if (requestOptions.extensions && requestOptions.extensions->appid) {
             if (!m_isAppId) {
                 m_isAppId = true;
                 issueSignCommand(m_nextListIndex - 1);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1142,10 +1142,6 @@
 		51FAEC3A1B0657630009C4E7 /* AuxiliaryProcessMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FAEC371B0657310009C4E7 /* AuxiliaryProcessMessages.h */; };
 		51FAEC3B1B0657680009C4E7 /* AuxiliaryProcessMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51FAEC361B0657310009C4E7 /* AuxiliaryProcessMessageReceiver.cpp */; };
 		51FD18B61651FBAD00DBE1CE /* NetworkResourceLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 51FD18B41651FBAD00DBE1CE /* NetworkResourceLoader.h */; };
-		522F792928D50EBB0069B45B /* HidService.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5772F205217DBD6A0056BF2C /* HidService.mm */; settings = {COMPILER_FLAGS = "-O0 -DRELEASE_WITHOUT_OPTIMIZATIONS"; }; };
-		522F792A28D50EC60069B45B /* HidConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57AC8F4F217FEED90055438C /* HidConnection.mm */; settings = {COMPILER_FLAGS = "-O0 -DRELEASE_WITHOUT_OPTIMIZATIONS"; }; };
-		522F792B28D5318A0069B45B /* CtapHidDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57597EC021818BE20037F924 /* CtapHidDriver.cpp */; settings = {COMPILER_FLAGS = "-O0 -DRELEASE_WITHOUT_OPTIMIZATIONS"; }; };
-		522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57597EBC2181848F0037F924 /* CtapAuthenticator.cpp */; settings = {COMPILER_FLAGS = "-O0 -DRELEASE_WITHOUT_OPTIMIZATIONS"; }; };
 		5252A51927E048740094BEB9 /* VirtualHidConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 5252A51727E048740094BEB9 /* VirtualHidConnection.h */; };
 		5252A51A27E048740094BEB9 /* VirtualHidConnection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5252A51827E048740094BEB9 /* VirtualHidConnection.cpp */; };
 		52688AB427D7CE40003577A2 /* _WKResidentKeyRequirement.h in Headers */ = {isa = PBXBuildFile; fileRef = 52688AB327D7CE40003577A2 /* _WKResidentKeyRequirement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1163,8 +1159,6 @@
 		52CDC5C92731DA0D00A3E3EB /* VirtualLocalConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52CDC5C22731DA0C00A3E3EB /* VirtualLocalConnection.mm */; };
 		52CDC5CA2731DA0D00A3E3EB /* VirtualAuthenticatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 52CDC5C32731DA0C00A3E3EB /* VirtualAuthenticatorManager.h */; };
 		52D5A1B01C57495A00DE34A3 /* VideoFullscreenManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 52D5A1AA1C57494E00DE34A3 /* VideoFullscreenManagerProxy.h */; };
-		52EDB40328C2B8DD002DCF33 /* AuthenticatorManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 57DCED852147363A0016B847 /* AuthenticatorManager.cpp */; settings = {COMPILER_FLAGS = "-DRELEASE_WITHOUT_OPTIMIZATIONS -O0"; }; };
-		52EDB40428C2B8FD002DCF33 /* WebAuthenticatorCoordinatorProxy.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DCBF4D926E2ED3200EA0E07 /* WebAuthenticatorCoordinatorProxy.mm */; settings = {COMPILER_FLAGS = "-DRELEASE_WITHOUT_OPTIMIZATIONS -O0"; }; };
 		52F060E11654318500F3281B /* NetworkContentRuleListManagerMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F060DD1654317500F3281B /* NetworkContentRuleListManagerMessageReceiver.cpp */; };
 		52F4B46927E1197700FFD129 /* VirtualAuthenticatorUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F4B46727E1197700FFD129 /* VirtualAuthenticatorUtils.h */; };
 		52F4B46A27E1197700FFD129 /* VirtualAuthenticatorUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52F4B46827E1197700FFD129 /* VirtualAuthenticatorUtils.mm */; };
@@ -17860,7 +17854,6 @@
 				CD4570D3244113B500A3DCEB /* AudioSessionRoutingArbitratorProxyMessageReceiver.cpp in Sources */,
 				512F58A212A883AD00629530 /* AuthenticationManagerMessageReceiver.cpp in Sources */,
 				57FABB132581827C0059DC95 /* AuthenticationServicesCoreSoftLink.mm in Sources */,
-				52EDB40328C2B8DD002DCF33 /* AuthenticatorManager.cpp in Sources */,
 				9955A6F41C7986DC00EB6A93 /* AutomationBackendDispatchers.cpp in Sources */,
 				99249AD51F1F1E5600B62FBB /* AutomationFrontendDispatchers.cpp in Sources */,
 				9955A6F61C7986E300EB6A93 /* AutomationProtocolObjects.cpp in Sources */,
@@ -17869,9 +17862,7 @@
 				517CF0E3163A486C00C2950F /* CacheStorageEngineConnectionMessageReceiver.cpp in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
-				522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */,
 				526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */,
-				522F792B28D5318A0069B45B /* CtapHidDriver.cpp in Sources */,
 				2D0C56FE229F1DEA00BD33E7 /* DeviceManagementSoftLink.mm in Sources */,
 				1AB7D6191288B9D900CFD08C /* DownloadProxyMessageReceiver.cpp in Sources */,
 				1A64229912DD029200CAAE2C /* DrawingAreaMessageReceiver.cpp in Sources */,
@@ -17881,8 +17872,6 @@
 				CDA93DB122F8BCF400490A69 /* FullscreenTouchSecheuristicParameters.cpp in Sources */,
 				86760A6B28DB30DE00D07D06 /* GeneratedSerializers.mm in Sources */,
 				C1A152D724E5A29A00978C8B /* HandleXPCEndpointMessages.mm in Sources */,
-				522F792A28D50EC60069B45B /* HidConnection.mm in Sources */,
-				522F792928D50EBB0069B45B /* HidService.mm in Sources */,
 				51E9049727BCB3D900929E7E /* ICAppBundle.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
@@ -18197,7 +18186,6 @@
 				52CDC5C52731DA0D00A3E3EB /* VirtualService.mm in Sources */,
 				1A60224C18C16B9F00C3E8C9 /* VisitedLinkStoreMessageReceiver.cpp in Sources */,
 				1A8E7D3C18C15149005A702A /* VisitedLinkTableControllerMessageReceiver.cpp in Sources */,
-				52EDB40428C2B8FD002DCF33 /* WebAuthenticatorCoordinatorProxy.mm in Sources */,
 				57DCED702142EE680016B847 /* WebAuthenticatorCoordinatorProxyMessageReceiver.cpp in Sources */,
 				575B1BBA23CE9C130020639A /* WebAutomationSession.cpp in Sources */,
 				1C0A19571C90068F00FE0EBB /* WebAutomationSessionMessageReceiver.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -33,6 +33,8 @@
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <LocalAuthentication/LocalAuthentication.h>
+#import <WebCore/AuthenticationExtensionsClientInputs.h>
+#import <WebCore/AuthenticationExtensionsClientOutputs.h>
 #import <WebCore/AuthenticatorAttachment.h>
 #import <WebCore/ExceptionCode.h>
 #import <WebCore/PublicKeyCredentialCreationOptions.h>
@@ -1511,8 +1513,48 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
     EXPECT_EQ(result.excludeCredentials.size(), 0lu);
     EXPECT_EQ(result.authenticatorSelection, std::nullopt);
     EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
-    EXPECT_TRUE(result.extensions->appid.isNull());
-    EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
+    EXPECT_FALSE(result.extensions->appid.has_value());
+    EXPECT_FALSE(result.extensions->googleLegacyAppidSupport.has_value());
+}
+
+TEST(WebAuthenticationPanel, TestClientInputsCBORMinimum)
+{
+    WebCore::AuthenticationExtensionsClientInputs clientInputs = { ""_s /* appId */, false /* googleLegacyAppidSupport */, false /* credProps */ };
+    auto serializedInputs = clientInputs.toCBOR();
+    auto deserializedInputs = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(WTFMove(serializedInputs));
+    EXPECT_WK_STREQ(*clientInputs.appid, *deserializedInputs->appid);
+    EXPECT_EQ(clientInputs.googleLegacyAppidSupport, deserializedInputs->googleLegacyAppidSupport);
+    EXPECT_EQ(clientInputs.credProps, deserializedInputs->credProps);
+}
+
+TEST(WebAuthenticationPanel, TestClientInputsCBORMaximum)
+{
+    WebCore::AuthenticationExtensionsClientInputs clientInputs = { "testappid"_s /* appid */, true /* googleLegacyAppidSupport */, true /* credProps */ };
+    auto serializedInputs = clientInputs.toCBOR();
+    auto deserializedInputs = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(WTFMove(serializedInputs));
+    EXPECT_WK_STREQ(*clientInputs.appid, *deserializedInputs->appid);
+    EXPECT_EQ(clientInputs.googleLegacyAppidSupport, deserializedInputs->googleLegacyAppidSupport);
+    EXPECT_EQ(clientInputs.credProps, deserializedInputs->credProps);
+}
+
+TEST(WebAuthenticationPanel, TestClientOutputsCBORMinimum)
+{
+    WebCore::AuthenticationExtensionsClientOutputs clientOutputs = { std::nullopt /* appid */, std::nullopt /* credProps */ };
+    auto serializedOutputs = clientOutputs.toCBOR();
+    auto deserializedOutputs = WebCore::AuthenticationExtensionsClientOutputs::fromCBOR(WTFMove(serializedOutputs));
+    EXPECT_EQ(clientOutputs.appid, deserializedOutputs->appid);
+    EXPECT_TRUE(!clientOutputs.credProps);
+    EXPECT_TRUE(!deserializedOutputs->credProps);
+}
+
+
+TEST(WebAuthenticationPanel, TestClientOutputsCBORMaximum)
+{
+    WebCore::AuthenticationExtensionsClientOutputs clientOutputs = { true /* appid */, WebCore::AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput { true /* rk */} /* credProps */ };
+    auto serializedOutputs = clientOutputs.toCBOR();
+    auto deserializedOutputs = WebCore::AuthenticationExtensionsClientOutputs::fromCBOR(WTFMove(serializedOutputs));
+    EXPECT_EQ(clientOutputs.appid, deserializedOutputs->appid);
+    EXPECT_EQ(clientOutputs.credProps->rk, deserializedOutputs->credProps->rk);
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
@@ -1565,7 +1607,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
     EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Preferred);
 
     EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
-    EXPECT_TRUE(result.extensions->appid.isNull());
+    EXPECT_TRUE(result.extensions->appid.has_value());
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
@@ -1856,7 +1898,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
     EXPECT_TRUE(result.rpId.isNull());
     EXPECT_EQ(result.allowCredentials.size(), 0lu);
     EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
-    EXPECT_TRUE(result.extensions->appid.isNull());
+    EXPECT_FALSE(result.extensions->appid.has_value());
     EXPECT_EQ(result.extensions->googleLegacyAppidSupport, false);
 }
 
@@ -1882,7 +1924,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
     EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
 
     EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
-    EXPECT_TRUE(result.extensions->appid.isNull());
+    EXPECT_FALSE(result.extensions->appid.has_value());
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
@@ -1920,7 +1962,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     EXPECT_EQ(result.allowCredentials[0].transports[2], AuthenticatorTransport::Internal);
 
     EXPECT_EQ(result.userVerification, UserVerificationRequirement::Required);
-    EXPECT_WK_STREQ(result.extensions->appid, "https//www.example.com/fido");
+    EXPECT_WK_STREQ(*result.extensions->appid, "https//www.example.com/fido");
 }
 
 TEST(WebAuthenticationPanel, GetAssertionSPITimeout)


### PR DESCRIPTION
#### 4f64ea6024b734e00060649f55992bf561ecfd06
<pre>
[WebAuthn] Incorrect RP ID hash when using U2F keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=247344">https://bugs.webkit.org/show_bug.cgi?id=247344</a>
rdar://100466116

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.cpp:
(WebCore::AuthenticationExtensionsClientInputs::fromCBOR):
(WebCore::AuthenticationExtensionsClientInputs::toCBOR const):
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp:
(WebCore::AuthenticationExtensionsClientOutputs::fromCBOR):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Some CBOR encoding issues caused the incorrect RP ID hash to be used
when signing with U2F keys in certain circumstances. This patch fixes that.

Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
New unit tests for CBOR conversion.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f64ea6024b734e00060649f55992bf561ecfd06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/101225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/10378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/34289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/110510 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/170794 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/105212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/11315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/85/builds/1245 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/93630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/108343 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/107008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/8610 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/91854 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialCreationOptionsMinimum, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialRequestOptionsMaximumDefault, TestWebKitAPI.WebAuthenticationPanel.PublicKeyCredentialRequestOptionsMinimun (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/35148 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/90512 "2 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/23260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/78144 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/4019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/24774 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/4068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/84/builds/1200 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/10173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/44251 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/5822 "Built successfully") | | | 
| | | | | 
<!--EWS-Status-Bubble-End-->