### PR TITLE
Implement support for StylePropertyMap.append()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-properties-values-api/typedom-expected.txt
@@ -191,16 +191,8 @@ PASS CSSUnitValue rejected by set() for syntax <length>+ [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <length>+ [styleMap]
 PASS CSSUnitValue rejected by set() for syntax <length># [attributeStyleMap]
 PASS CSSUnitValue rejected by set() for syntax <length># [styleMap]
-FAIL Appending a string to * is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to * is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Appending a string to * is not allowed [attributeStyleMap]
+PASS Appending a string to * is not allowed [styleMap]
 FAIL Appending a string to foo+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to foo+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <angle>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -211,46 +203,14 @@ FAIL Appending a string to <custom-ident>+ is not allowed [attributeStyleMap] Th
 FAIL Appending a string to <custom-ident>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <image>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <image>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a string to <integer>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <integer>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <length-percentage>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <length-percentage>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <length>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <length>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <number>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <number>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Appending a string to <integer>+ is not allowed [attributeStyleMap]
+PASS Appending a string to <integer>+ is not allowed [styleMap]
+PASS Appending a string to <length-percentage>+ is not allowed [attributeStyleMap]
+PASS Appending a string to <length-percentage>+ is not allowed [styleMap]
+PASS Appending a string to <length>+ is not allowed [attributeStyleMap]
+PASS Appending a string to <length>+ is not allowed [styleMap]
+PASS Appending a string to <number>+ is not allowed [attributeStyleMap]
+PASS Appending a string to <number>+ is not allowed [styleMap]
 FAIL Appending a string to <percentage>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <percentage>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <resolution>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -263,26 +223,10 @@ FAIL Appending a string to <transform-list> is not allowed [attributeStyleMap] T
 FAIL Appending a string to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <url>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a string to <url>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a string to <length># is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a string to <length># is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSKeywordValue to * is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSKeywordValue to * is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Appending a string to <length># is not allowed [attributeStyleMap]
+PASS Appending a string to <length># is not allowed [styleMap]
+PASS Appending a CSSKeywordValue to * is not allowed [attributeStyleMap]
+PASS Appending a CSSKeywordValue to * is not allowed [styleMap]
 FAIL Appending a CSSKeywordValue to foo+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSKeywordValue to foo+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSUnitValue to <angle>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -291,46 +235,14 @@ FAIL Appending a CSSKeywordValue to <custom-ident>+ is not allowed [attributeSty
 FAIL Appending a CSSKeywordValue to <custom-ident>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSImageValue to <image>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSImageValue to <image>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a CSSUnitValue to <integer>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <integer>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <length-percentage>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <length-percentage>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <length>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <length>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <number>+ is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <number>+ is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Appending a CSSUnitValue to <integer>+ is not allowed [attributeStyleMap]
+PASS Appending a CSSUnitValue to <integer>+ is not allowed [styleMap]
+PASS Appending a CSSUnitValue to <length-percentage>+ is not allowed [attributeStyleMap]
+PASS Appending a CSSUnitValue to <length-percentage>+ is not allowed [styleMap]
+PASS Appending a CSSUnitValue to <length>+ is not allowed [attributeStyleMap]
+PASS Appending a CSSUnitValue to <length>+ is not allowed [styleMap]
+PASS Appending a CSSUnitValue to <number>+ is not allowed [attributeStyleMap]
+PASS Appending a CSSUnitValue to <number>+ is not allowed [styleMap]
 FAIL Appending a CSSUnitValue to <percentage>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSUnitValue to <percentage>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSUnitValue to <resolution>+ is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
@@ -339,16 +251,8 @@ FAIL Appending a CSSUnitValue to <time>+ is not allowed [attributeStyleMap] The 
 FAIL Appending a CSSUnitValue to <time>+ is not allowed [styleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [attributeStyleMap] The given initial value does not parse for the given syntax.
 FAIL Appending a CSSKeywordValue to <transform-list> is not allowed [styleMap] The given initial value does not parse for the given syntax.
-FAIL Appending a CSSUnitValue to <length># is not allowed [attributeStyleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a CSSUnitValue to <length># is not allowed [styleMap] assert_throws_js: function "() => {
-        map.append(name, value);
-    }" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS Appending a CSSUnitValue to <length># is not allowed [attributeStyleMap]
+PASS Appending a CSSUnitValue to <length># is not allowed [styleMap]
 PASS CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax *
 FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <angle> The given initial value does not parse for the given syntax.
 FAIL CSSStyleValue.parse[All] returns CSSUnparsedValue for syntax <color> The given initial value does not parse for the given syntax.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/append.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/append.tentative-expected.txt
@@ -1,32 +1,14 @@
 
-FAIL Calling StylePropertyMap.append with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with an null property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a property that is not list valued throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a shorthand property throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with an invalid String value throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a var ref throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a list-valued property with CSSStyleValue or String updates its values append() is not yet supported
-FAIL Appending a list-valued property with list-valued string updates its values append() is not yet supported
-FAIL StylePropertyMap.append is case-insensitive append() is not yet supported
+PASS Calling StylePropertyMap.append with an unsupported property name throws TypeError
+PASS Calling StylePropertyMap.append with an null property name throws TypeError
+PASS Calling StylePropertyMap.append with a property that is not list valued throws TypeError
+PASS Calling StylePropertyMap.append with a shorthand property throws TypeError
+PASS Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError
+PASS Calling StylePropertyMap.append with an invalid String value throws TypeError
+PASS Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError
+PASS Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError
+PASS Calling StylePropertyMap.append with a var ref throws TypeError
+PASS Appending a list-valued property with CSSStyleValue or String updates its values
+PASS Appending a list-valued property with list-valued string updates its values
+PASS StylePropertyMap.append is case-insensitive
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt
@@ -1,32 +1,14 @@
 
-FAIL Calling StylePropertyMap.append with an unsupported property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with an null property name throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a property that is not list valued throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a shorthand property throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with an invalid String value throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Calling StylePropertyMap.append with a var ref throws TypeError assert_throws_js: function "() => styleMap.append(property, ...values)" threw object "NotSupportedError: append() is not yet supported" ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL Appending a list-valued property with CSSStyleValue or String updates its values append() is not yet supported
-FAIL Appending a list-valued property with list-valued string updates its values append() is not yet supported
-FAIL StylePropertyMap.append is case-insensitive append() is not yet supported
+PASS Calling StylePropertyMap.append with an unsupported property name throws TypeError
+PASS Calling StylePropertyMap.append with an null property name throws TypeError
+PASS Calling StylePropertyMap.append with a property that is not list valued throws TypeError
+PASS Calling StylePropertyMap.append with a shorthand property throws TypeError
+PASS Calling StylePropertyMap.append with an invalid CSSStyleValue throws TypeError
+PASS Calling StylePropertyMap.append with an invalid String value throws TypeError
+PASS Calling StylePropertyMap.append with a mix of valid and invalid values throws TypeError
+PASS Calling StylePropertyMap.append with a CSSUnparsedValue throws TypeError
+PASS Calling StylePropertyMap.append with a var ref throws TypeError
+PASS Appending a list-valued property with CSSStyleValue or String updates its values
+PASS Appending a list-valued property with list-valued string updates its values
+PASS StylePropertyMap.append is case-insensitive
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.h
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.h
@@ -46,7 +46,7 @@ public:
     static ExceptionOr<Ref<CSSStyleValue>> reifyValue(Ref<CSSValue>, Document* = nullptr);
     static ExceptionOr<Vector<Ref<CSSStyleValue>>> parseStyleValue(const AtomString&, const String&, bool);
     static ExceptionOr<RefPtr<CSSStyleValue>> constructStyleValueForShorthandProperty(CSSPropertyID, const Function<RefPtr<CSSValue>(CSSPropertyID)>& propertyValue, Document* = nullptr);
-    static Vector<Ref<CSSStyleValue>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
+    static ExceptionOr<Vector<Ref<CSSStyleValue>>> vectorFromStyleValuesOrStrings(const AtomString& property, FixedVector<std::variant<RefPtr<CSSStyleValue>, String>>&& values);
 
 protected:
     CSSStyleValueFactory() = delete;


### PR DESCRIPTION
#### 30535abeb949cd7184975a689457ed372ed7a107
<pre>
Implement support for StylePropertyMap.append()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248400">https://bugs.webkit.org/show_bug.cgi?id=248400</a>

Reviewed by Alex Christensen.

Implement support for StylePropertyMap.append():
- <a href="https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-append">https://drafts.css-houdini.org/css-typed-om/#dom-stylepropertymap-append</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/declared/append.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/inline/append.tentative-expected.txt:
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::append):

Canonical link: <a href="https://commits.webkit.org/257123@main">https://commits.webkit.org/257123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97b08dcb1492b962fddd6743dc3364cad4269b75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107339 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167608 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7524 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35914 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103976 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5666 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84475 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32724 "") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87537 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89278 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1069 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20703 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1059 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22214 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44663 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2431 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2323 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41617 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->