### PR TITLE
Properly validate CSSMathValue unit for coords passed to CSSScale constructor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssScale.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssScale.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Constructing a CSSScale with an angle CSSUnitValue for the coordinates throws a TypeError
 PASS Constructing a CSSScale with a CSSMathValue that doesn't match <number> for the coordinates throws a TypeError
-FAIL Constructing a CSSScale with an invalid division by px/px for the coordinates throws a TypeError assert_throws_js: function "() => new CSSScale(coord, 0)" did not throw
+PASS Constructing a CSSScale with an invalid division by px/px for the coordinates throws a TypeError
 PASS Updating CSSScale.x to an angle CSSUnitValue throws a TypeError
 PASS Updating CSSScale.x to a CSSMathValue that doesn't match <number> throws a TypeError
 PASS Updating CSSScale.x to an invalid division by px/px throws a TypeError

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.h
@@ -73,3 +73,7 @@ public:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CSSMathValue)
+static bool isType(const WebCore::CSSStyleValue& styleValue) { return WebCore::isCSSMathValue(styleValue.getType()); }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### bfb893e2a4d4063809d0f9dc6075bb84833d68f6
<pre>
Properly validate CSSMathValue unit for coords passed to CSSScale constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=248408">https://bugs.webkit.org/show_bug.cgi?id=248408</a>

Reviewed by Antoine Quint.

Properly validate CSSMathValue unit for coords passed to CSSScale constructor:
- <a href="https://drafts.css-houdini.org/css-typed-om/#dom-cssscale-cssscale">https://drafts.css-houdini.org/css-typed-om/#dom-cssscale-cssscale</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-subclasses/cssScale.tentative-expected.txt:
* Source/WebCore/css/typedom/numeric/CSSMathValue.h:
(isType):
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::isValidScaleCoord):
(WebCore::CSSScale::create):

Canonical link: <a href="https://commits.webkit.org/257106@main">https://commits.webkit.org/257106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75ced26e05b9d65342a0e0324046b0aa7cdd3d3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107314 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167581 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7498 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35838 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103954 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5645 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84455 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32594 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89257 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75509 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1049 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22199 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5867 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44645 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2425 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41597 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->