### PR TITLE
REGRESSION (256320@main?): [iOS] 2 TestWebKitAPI.FullscreenVideoTextRecognition tests are flaky failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -236,7 +236,12 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 
 namespace TestWebKitAPI {
 
+// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
+#if PLATFORM(IOS)
+TEST(FullscreenVideoTextRecognition, DISABLED_TogglePlaybackInElementFullscreen)
+#else
 TEST(FullscreenVideoTextRecognition, TogglePlaybackInElementFullscreen)
+#endif
 {
     auto webView = [FullscreenVideoTextRecognitionWebView create];
     [webView loadVideoSource:@"test.mp4"];
@@ -263,7 +268,12 @@ TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
     [webView waitForImageAnalysisToBegin];
 }
 
+// FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
+#if PLATFORM(IOS)
+TEST(FullscreenVideoTextRecognition, DISABLED_DoNotAnalyzeVideoAfterExitingFullscreen)
+#else
 TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)
+#endif
 {
     auto webView = [FullscreenVideoTextRecognitionWebView create];
     [webView loadVideoSource:@"test.mp4"];


### PR DESCRIPTION
#### bd4a6843ce32c41e84afa8fef7774ea6de19912c
<pre>
REGRESSION (256320@main?): [iOS] 2 TestWebKitAPI.FullscreenVideoTextRecognition tests are flaky failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248094">https://bugs.webkit.org/show_bug.cgi?id=248094</a>
rdar://102522560

Unreviewed test gardening.

Disable the tests on iOS until the issue can be resolved.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/257121@main">https://commits.webkit.org/257121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35fdcdd5aacad17e47ab07c9732fc118b93095bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107336 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167615 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7521 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35855 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103973 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5659 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84472 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32730 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89272 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1066 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20697 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1056 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22208 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5884 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44656 "Found 1 new test failure: fast/images/animated-heics-verify.html (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2429 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41610 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->