### PR TITLE
Fix handling of calculated values in CSSStyleValue.parse()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt
@@ -164,35 +164,35 @@ PASS CSSMathSum interface: existence and properties of interface prototype objec
 PASS CSSMathSum interface: existence and properties of interface prototype object's "constructor" property
 PASS CSSMathSum interface: existence and properties of interface prototype object's @@unscopables property
 PASS CSSMathSum interface: attribute values
-FAIL CSSMathSum must be primary interface of mathSum assert_equals: mathSum's prototype is not CSSMathSum.prototype expected [stringifying object threw TypeError: Can only call CSSStyleValue.toString on instances of CSSStyleValue with type object] but got [stringifying object threw TypeError: Can only call CSSStyleValue.toString on instances of CSSStyleValue with type object]
-FAIL Stringification of mathSum assert_class_string: class string of mathSum expected "[object CSSMathSum]" but got "[object CSSStyleValue]"
-FAIL CSSMathSum interface: mathSum must inherit property "values" with the proper type assert_inherits: property "values" not found in prototype chain
-FAIL CSSMathValue interface: mathSum must inherit property "operator" with the proper type assert_inherits: property "operator" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "add(CSSNumberish...)" with the proper type assert_inherits: property "add" not found in prototype chain
-FAIL CSSNumericValue interface: calling add(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "add" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "sub(CSSNumberish...)" with the proper type assert_inherits: property "sub" not found in prototype chain
-FAIL CSSNumericValue interface: calling sub(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "sub" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "mul(CSSNumberish...)" with the proper type assert_inherits: property "mul" not found in prototype chain
-FAIL CSSNumericValue interface: calling mul(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "mul" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "div(CSSNumberish...)" with the proper type assert_inherits: property "div" not found in prototype chain
-FAIL CSSNumericValue interface: calling div(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "div" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "min(CSSNumberish...)" with the proper type assert_inherits: property "min" not found in prototype chain
-FAIL CSSNumericValue interface: calling min(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "min" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "max(CSSNumberish...)" with the proper type assert_inherits: property "max" not found in prototype chain
-FAIL CSSNumericValue interface: calling max(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "max" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "equals(CSSNumberish...)" with the proper type assert_inherits: property "equals" not found in prototype chain
-FAIL CSSNumericValue interface: calling equals(CSSNumberish...) on mathSum with too few arguments must throw TypeError assert_inherits: property "equals" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "to(USVString)" with the proper type assert_inherits: property "to" not found in prototype chain
-FAIL CSSNumericValue interface: calling to(USVString) on mathSum with too few arguments must throw TypeError assert_inherits: property "to" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "toSum(USVString...)" with the proper type assert_inherits: property "toSum" not found in prototype chain
-FAIL CSSNumericValue interface: calling toSum(USVString...) on mathSum with too few arguments must throw TypeError assert_inherits: property "toSum" not found in prototype chain
-FAIL CSSNumericValue interface: mathSum must inherit property "type()" with the proper type assert_inherits: property "type" not found in prototype chain
+PASS CSSMathSum must be primary interface of mathSum
+PASS Stringification of mathSum
+PASS CSSMathSum interface: mathSum must inherit property "values" with the proper type
+PASS CSSMathValue interface: mathSum must inherit property "operator" with the proper type
+PASS CSSNumericValue interface: mathSum must inherit property "add(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling add(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "sub(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling sub(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "mul(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling mul(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "div(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling div(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "min(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling min(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "max(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling max(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "equals(CSSNumberish...)" with the proper type
+PASS CSSNumericValue interface: calling equals(CSSNumberish...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "to(USVString)" with the proper type
+PASS CSSNumericValue interface: calling to(USVString) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "toSum(USVString...)" with the proper type
+PASS CSSNumericValue interface: calling toSum(USVString...) on mathSum with too few arguments must throw TypeError
+PASS CSSNumericValue interface: mathSum must inherit property "type()" with the proper type
 PASS CSSNumericValue interface: mathSum must inherit property "parse(USVString)" with the proper type
-PASS CSSNumericValue interface: calling parse(USVString) on mathSum with too few arguments must throw TypeError
+FAIL CSSNumericValue interface: calling parse(USVString) on mathSum with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "parse" missing
 PASS CSSStyleValue interface: mathSum must inherit property "parse(USVString, USVString)" with the proper type
-PASS CSSStyleValue interface: calling parse(USVString, USVString) on mathSum with too few arguments must throw TypeError
+FAIL CSSStyleValue interface: calling parse(USVString, USVString) on mathSum with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "parse" missing
 PASS CSSStyleValue interface: mathSum must inherit property "parseAll(USVString, USVString)" with the proper type
-PASS CSSStyleValue interface: calling parseAll(USVString, USVString) on mathSum with too few arguments must throw TypeError
+FAIL CSSStyleValue interface: calling parseAll(USVString, USVString) on mathSum with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "parseAll" missing
 PASS CSSMathProduct interface: existence and properties of interface object
 PASS CSSMathProduct interface object length
 PASS CSSMathProduct interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative-expected.txt
@@ -26,5 +26,5 @@ PASS Normalizing a skewY() returns a CSSSkewY
 PASS Normalizing a perspective() returns a CSSPerspective
 PASS Normalizing a perspective(none) returns a CSSPerspective
 PASS Normalizing a <transform-list> returns a CSSTransformValue containing all the transforms
-FAIL Normalizing transforms with calc values contains CSSMathValues assert_equals: expected "CSSMathSum" but got "CSSUnitValue"
+FAIL Normalizing transforms with calc values contains CSSMathValues assert_equals: expected "px" but got "em"
 

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -76,6 +76,8 @@ public:
 
     bool convertingToLengthRequiresNonNullStyle(int lengthConversion) const;
 
+    const CSSCalcExpressionNode& expressionNode() const { return m_expression; }
+
 private:
     CSSCalcValue(Ref<CSSCalcExpressionNode>&&, bool shouldClampToNonNegative);
 

--- a/Source/WebCore/css/typedom/CSSNumericValue.h
+++ b/Source/WebCore/css/typedom/CSSNumericValue.h
@@ -75,6 +75,8 @@ public:
 
     virtual RefPtr<CSSCalcExpressionNode> toCalcExpressionNode() const = 0;
 
+    static ExceptionOr<Ref<CSSNumericValue>> reifyMathExpression(const CSSCalcExpressionNode&);
+
 protected:
     ExceptionOr<Ref<CSSNumericValue>> addInternal(Vector<Ref<CSSNumericValue>>&&);
     ExceptionOr<Ref<CSSNumericValue>> multiplyInternal(Vector<Ref<CSSNumericValue>>&&);


### PR DESCRIPTION
#### ec3382a6412fca39ba4041e39c660f4c4c6355e5
<pre>
Fix handling of calculated values in CSSStyleValue.parse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=248414">https://bugs.webkit.org/show_bug.cgi?id=248414</a>

Reviewed by Geoffrey Garen.

Calling CSSStyleValue.parse() with a `calc()` would return a generic CSSStyleValue
instead of the correct CSSMathValue subclass (e.g. CSSMathSum). This was causing
the CSSMathSum tests to fail in idlharness.html.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/idlharness-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/stylevalue-normalization/transformvalue-normalization.tentative-expected.txt:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::reifyMathExpression):
(WebCore::reifyMathExpressions):
(WebCore::CSSNumericValue::reifyMathExpression):
* Source/WebCore/css/typedom/CSSNumericValue.h:
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
(WebCore::CSSStyleValue::parse):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):

Canonical link: <a href="https://commits.webkit.org/257215@main">https://commits.webkit.org/257215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dba7f075c5906ccff2e2c138acdb061ee79c6da6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107612 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167873 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7856 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36129 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104203 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5897 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84747 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33022 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89481 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1328 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1288 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4968 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6161 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41836 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->