### PR TITLE
Read remote images back into local images before sending them to other threads.

### DIFF
--- a/Source/WebCore/html/ImageBitmapBacking.cpp
+++ b/Source/WebCore/html/ImageBitmapBacking.cpp
@@ -45,6 +45,11 @@ RefPtr<ImageBuffer> ImageBitmapBacking::takeImageBuffer()
     return WTFMove(m_bitmapData);
 }
 
+RefPtr<ImageBuffer> ImageBitmapBacking::takeImageBufferForDifferentThread()
+{
+    return ImageBuffer::sinkIntoBufferForDifferentThread(WTFMove(m_bitmapData));
+}
+
 unsigned ImageBitmapBacking::width() const
 {
     // FIXME: Is this the right width?

--- a/Source/WebCore/html/ImageBitmapBacking.h
+++ b/Source/WebCore/html/ImageBitmapBacking.h
@@ -42,6 +42,7 @@ public:
 
     ImageBuffer* buffer() const;
     RefPtr<ImageBuffer> takeImageBuffer();
+    RefPtr<ImageBuffer> takeImageBufferForDifferentThread();
 
     unsigned width() const;
     unsigned height() const;

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -446,7 +446,7 @@ std::unique_ptr<DetachedOffscreenCanvas> OffscreenCanvas::detach()
 
     m_detached = true;
 
-    auto detached = makeUnique<DetachedOffscreenCanvas>(takeImageBuffer(), size(), originClean());
+    auto detached = makeUnique<DetachedOffscreenCanvas>(takeImageBufferForDifferentThread(), size(), originClean());
     detached->m_placeholderCanvas = std::exchange(m_placeholderData->canvas, nullptr);
 
     return detached;
@@ -492,7 +492,7 @@ void OffscreenCanvas::commitToPlaceholderCanvas()
 
     Locker locker { m_placeholderData->bufferLock };
     bool shouldPushBuffer = !m_placeholderData->pendingCommitBuffer;
-    m_placeholderData->pendingCommitBuffer = imageBuffer->clone();
+    m_placeholderData->pendingCommitBuffer = imageBuffer->cloneForDifferentThread();
     if (m_placeholderData->pendingCommitBuffer && shouldPushBuffer)
         pushBufferToPlaceholder();
 }
@@ -538,7 +538,7 @@ void OffscreenCanvas::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)
     didDraw(FloatRect(FloatPoint(), size()));
 }
 
-RefPtr<ImageBuffer> OffscreenCanvas::takeImageBuffer() const
+RefPtr<ImageBuffer> OffscreenCanvas::takeImageBufferForDifferentThread() const
 {
     ASSERT(m_detached);
 
@@ -546,7 +546,7 @@ RefPtr<ImageBuffer> OffscreenCanvas::takeImageBuffer() const
         return nullptr;
 
     clearCopiedImage();
-    return setImageBuffer(nullptr);
+    return ImageBuffer::sinkIntoBufferForDifferentThread(setImageBuffer(nullptr));
 }
 
 void OffscreenCanvas::reset()

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -178,7 +178,7 @@ private:
 #endif
 
     void createImageBuffer() const final;
-    RefPtr<ImageBuffer> takeImageBuffer() const;
+    RefPtr<ImageBuffer> takeImageBufferForDifferentThread() const;
 
     void reset();
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -185,6 +185,11 @@ RefPtr<ImageBuffer> ImageBuffer::clone() const
     return copyImageBuffer(const_cast<ImageBuffer&>(*this), PreserveResolution::Yes);
 }
 
+RefPtr<ImageBuffer> ImageBuffer::cloneForDifferentThread()
+{
+    return clone();
+}
+
 GraphicsContext& ImageBuffer::context() const
 {
     ASSERT(m_backend);
@@ -232,6 +237,20 @@ RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage()
         return backend->sinkIntoNativeImage();
     }
     return nullptr;
+}
+
+RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer> buffer)
+{
+    if (!buffer)
+        return nullptr;
+    ASSERT(buffer->hasOneRef());
+    return buffer->sinkIntoBufferForDifferentThread();
+}
+
+RefPtr<ImageBuffer> ImageBuffer::sinkIntoBufferForDifferentThread()
+{
+    ASSERT(hasOneRef());
+    return this;
 }
 
 RefPtr<Image> ImageBuffer::filteredImage(Filter& filter)

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -48,7 +48,7 @@ enum class ImageBufferOptions : uint8_t {
     UseDisplayList  = 1 << 1
 };
 
-class ImageBuffer : public ThreadSafeRefCounted<ImageBuffer, WTF::DestructionThread::Main>, public CanMakeWeakPtr<ImageBuffer> {
+class ImageBuffer : public ThreadSafeRefCounted<ImageBuffer>, public CanMakeWeakPtr<ImageBuffer> {
 public:
     struct CreationContext {
         // clang 13.1.6 throws errors if we use default initializers here.
@@ -135,6 +135,7 @@ public:
     static FloatRect clampedRect(const FloatRect&);
 
     RefPtr<ImageBuffer> clone() const;
+    WEBCORE_EXPORT virtual RefPtr<ImageBuffer> cloneForDifferentThread();
 
     WEBCORE_EXPORT virtual GraphicsContext& context() const;
     WEBCORE_EXPORT virtual void flushContext();
@@ -177,6 +178,8 @@ public:
     static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImageBuffer>);
     WEBCORE_EXPORT static RefPtr<Image> sinkIntoImage(RefPtr<ImageBuffer>, PreserveResolution = PreserveResolution::No);
 
+    static RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread(RefPtr<ImageBuffer>);
+
     WEBCORE_EXPORT virtual void draw(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const ImagePaintingOptions&);
     WEBCORE_EXPORT virtual void drawPattern(GraphicsContext& destContext, const FloatRect& destRect, const FloatRect& srcRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions&);
 
@@ -215,6 +218,7 @@ public:
 protected:
     WEBCORE_EXPORT ImageBuffer(const ImageBufferBackend::Parameters&, const ImageBufferBackend::Info&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
+    WEBCORE_EXPORT virtual RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread();
     ImageBufferBackend::Parameters m_parameters;
     ImageBufferBackend::Info m_backendInfo;
     std::unique_ptr<ImageBufferBackend> m_backend;

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-class NativeImage : public ThreadSafeRefCounted<NativeImage, WTF::DestructionThread::Main>, public CanMakeWeakPtr<NativeImage> {
+class NativeImage : public ThreadSafeRefCounted<NativeImage>, public CanMakeWeakPtr<NativeImage> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     class Observer {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -194,6 +194,23 @@ RefPtr<NativeImage> RemoteImageBufferProxy::sinkIntoNativeImage()
     return copyNativeImage();
 }
 
+RefPtr<ImageBuffer> RemoteImageBufferProxy::sinkIntoBufferForDifferentThread()
+{
+    ASSERT(hasOneRef());
+    // We can't use these on a different thread, so make a local clone instead.
+    return cloneForDifferentThread();
+}
+
+RefPtr<ImageBuffer> RemoteImageBufferProxy::cloneForDifferentThread()
+{
+    auto copyBuffer = ImageBuffer::create(logicalSize(), renderingPurpose(), resolutionScale(), colorSpace(), pixelFormat());
+    if (!copyBuffer)
+        return nullptr;
+
+    copyBuffer->context().drawImageBuffer(*this, FloatPoint { }, CompositeOperator::Copy);
+    return copyBuffer;
+}
+
 RefPtr<Image> RemoteImageBufferProxy::filteredImage(Filter& filter)
 {
     if (UNLIKELY(!m_remoteRenderingBackendProxy))

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -74,6 +74,9 @@ private:
     RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) const final;
     RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
 
+    RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread() final;
+    RefPtr<ImageBuffer> cloneForDifferentThread() final;
+
     RefPtr<WebCore::Image> filteredImage(WebCore::Filter&) final;
 
     void drawConsuming(WebCore::GraphicsContext& destContext, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&) final;


### PR DESCRIPTION
#### ab926d67967c8bd903746ff95aaeec64fcf43fbb
<pre>
Read remote images back into local images before sending them to other threads.
<a href="https://bugs.webkit.org/show_bug.cgi?id=248416">https://bugs.webkit.org/show_bug.cgi?id=248416</a>

Reviewed by Kimmo Kinnunen.

We currently can&apos;t use RemoteRenderingBackendProxy from other threads, so sending RemoteImageBufferProxys to other threads
leaves us in an invalid state. This reads them back into local images before transferring so that we can access the contents.

* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::detachBitmaps):
(WebCore::ImageBitmap::~ImageBitmap):
* Source/WebCore/html/ImageBitmapBacking.cpp:
(WebCore::ImageBitmapBacking::takeImageBufferForDifferentThread):
* Source/WebCore/html/ImageBitmapBacking.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::detach):
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
(WebCore::OffscreenCanvas::takeImageBufferForDifferentThread const):
(WebCore::OffscreenCanvas::takeImageBuffer const): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::cloneForDifferentThread):
(WebCore::ImageBuffer::sinkIntoBufferForDifferentThread):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::drawConsuming):
(WebKit::RemoteImageBufferProxy::sinkIntoNativeImage):
(WebKit::RemoteImageBufferProxy::sinkIntoBufferForDifferentThread):
(WebKit::RemoteImageBufferProxy::cloneForDifferentThread):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:

Canonical link: <a href="https://commits.webkit.org/257103@main">https://commits.webkit.org/257103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/552e45782770847ee25686497a6d64024ffd2654

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107404 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7618 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/35925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103583 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84543 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1134 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4881 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5950 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41668 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->