### PR TITLE
Follow-Up Fix for 256844@main REGRESSION(256180@main): Enabling accelerated drawing caused some ImageOnly Failures

### DIFF
--- a/LayoutTests/compositing/geometry/css-clip-oversize.html
+++ b/LayoutTests/compositing/geometry/css-clip-oversize.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-14581" />
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-14581" />
     <style>
         .parent {
             position: absolute;

--- a/LayoutTests/fast/borders/border-painting-inset.html
+++ b/LayoutTests/fast/borders/border-painting-inset.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-490" />
+<meta name="fuzzy" content="maxDifference=0-49;totalPixels=0-698" />
 <title>This test that inset borders are painted.</title>
 <style>
   .borderBox {

--- a/LayoutTests/fast/borders/border-painting-outset.html
+++ b/LayoutTests/fast/borders/border-painting-outset.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+<!DOCTYPE ht698
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-38;totalPixels=0-490" />
+<meta name="fuzzy" content="maxDifference=0-49;totalPixels=0-698" />
 <title>This test that outset borders are painted.</title>
 <style>
   .borderBox {

--- a/LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html
+++ b/LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-461" />
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-464" />
 <title>This tests that parent clipping is applied properly when border-radius is present.</title>
 <style>
   .container {


### PR DESCRIPTION
#### 543c335f8661bdc00e9a818f8b08c273c0b92913
<pre>
Follow-Up Fix for 256844@main REGRESSION(256180@main): Enabling accelerated drawing caused some ImageOnly Failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=248018">https://bugs.webkit.org/show_bug.cgi?id=248018</a>
rdar://102449694

Reviewed by Simon Fraser.

Follow-up fix for several tests that did not get fixed with previous tolerance adjustment.

* LayoutTests/compositing/geometry/css-clip-oversize.html:
* LayoutTests/fast/borders/border-painting-inset.html:
* LayoutTests/fast/borders/border-painting-outset.html:
* LayoutTests/fast/layers/parent-clipping-overflow-is-overwritten-by-child-clipping.html:

Canonical link: <a href="https://commits.webkit.org/257168@main">https://commits.webkit.org/257168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d4da580d88534a8c447c37b392a85121d2002ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107341 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167616 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7527 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35927 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103978 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5660 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84478 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32723 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1072 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20710 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1061 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22217 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/cache-storage/cross-partition.https.tentative.html (failure)") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/74/builds/4933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44666 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2456 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2326 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41620 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->