### PR TITLE
[JSC] Add more resizable / growable ArrayBuffer tests

### DIFF
--- a/JSTests/stress/growable-arraybuffer-basic.js
+++ b/JSTests/stress/growable-arraybuffer-basic.js
@@ -1,0 +1,110 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test1(view) {
+    return view[1023];
+}
+noInline(test1);
+
+{
+    var arrayView1 = new Int8Array(new SharedArrayBuffer(1024));
+    arrayView1[1023] = 42;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test1(arrayView1), 42);
+    arrayView1[1023] = 41;
+    shouldBe(test1(arrayView1), 41);
+
+    var arrayView2 = new Int8Array(new SharedArrayBuffer(1024, { maxByteLength: 4096 }));
+    arrayView2[1023] = 42;
+    shouldBe(test1(arrayView2), 42);
+    arrayView2.buffer.grow(4096);
+    shouldBe(test1(arrayView2), 42);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test1(arrayView2), 42);
+    shouldBe(test1(arrayView1), 41);
+}
+
+function test2(view) {
+    return view[1023];
+}
+noInline(test2);
+
+{
+    var arrayView1 = new Int8Array(new SharedArrayBuffer(1024));
+    arrayView1[1023] = 42;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test2(arrayView1), 42);
+    arrayView1[1023] = 41;
+    shouldBe(test2(arrayView1), 41);
+
+    var arrayView2 = new Int8Array(new SharedArrayBuffer(1024, { maxByteLength: 4096 }), 0, 1024);
+    arrayView2[1023] = 42;
+    shouldBe(test2(arrayView2), 42);
+    shouldBe(arrayView2.length, 1024);
+    arrayView2.buffer.grow(4096);
+    shouldBe(arrayView2.length, 1024);
+    shouldBe(test2(arrayView2), 42);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test2(arrayView2), 42);
+    shouldBe(test2(arrayView1), 41);
+}
+
+function test3(view) {
+    return view.getInt8(1023);
+}
+noInline(test3);
+
+{
+    var arrayView1 = new DataView(new SharedArrayBuffer(1024));
+    arrayView1.setInt8(1023, 42);
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test3(arrayView1), 42);
+    arrayView1.setInt8(1023, 41);
+    shouldBe(test3(arrayView1), 41);
+
+    var arrayView2 = new DataView(new SharedArrayBuffer(1024, { maxByteLength: 4096 }), 0, 1024);
+    arrayView2.setInt8(1023, 42);
+    shouldBe(test3(arrayView2), 42);
+    shouldBe(arrayView2.byteLength, 1024);
+    arrayView2.buffer.grow(4096);
+    shouldBe(arrayView2.byteLength, 1024);
+    shouldBe(test3(arrayView2), 42);
+    shouldBe(arrayView2.byteLength, 1024);
+    shouldBe(test3(arrayView2), 42);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test3(arrayView2), 42);
+    shouldBe(test3(arrayView1), 41);
+}
+
+function test4(view) {
+    return view.getInt8(1023);
+}
+noInline(test4);
+
+{
+    var arrayView1 = new DataView(new SharedArrayBuffer(1024));
+    arrayView1.setInt8(1023, 42);
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test4(arrayView1), 42);
+    arrayView1.setInt8(1023, 41);
+    shouldBe(test4(arrayView1), 41);
+
+    var arrayView2 = new DataView(new SharedArrayBuffer(1024, { maxByteLength: 4096 }));
+    arrayView2.setInt8(1023, 42);
+    shouldBe(test4(arrayView2), 42);
+    shouldBe(arrayView2.byteLength, 1024);
+    arrayView2.buffer.grow(4096);
+    shouldBe(arrayView2.byteLength, 4096);
+    shouldBe(test4(arrayView2), 42);
+    shouldBe(arrayView2.byteLength, 4096);
+    shouldBe(test4(arrayView2), 42);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test4(arrayView2), 42);
+    shouldBe(test4(arrayView1), 41);
+}

--- a/JSTests/stress/resizable-arraybuffer-basic.js
+++ b/JSTests/stress/resizable-arraybuffer-basic.js
@@ -1,0 +1,138 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function test1(view) {
+    return view[1023];
+}
+noInline(test1);
+
+{
+    var arrayView1 = new Int8Array(1024);
+    arrayView1[1023] = 42;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test1(arrayView1), 42);
+    arrayView1[1023] = 41;
+    shouldBe(test1(arrayView1), 41);
+
+    var arrayView2 = new Int8Array(new ArrayBuffer(1024, { maxByteLength: 1024 }));
+    arrayView2[1023] = 42;
+    shouldBe(test1(arrayView2), 42);
+    arrayView2.buffer.resize(0);
+    shouldBe(test1(arrayView2), undefined);
+    arrayView2.buffer.resize(1024);
+    shouldBe(test1(arrayView2), 0);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test1(arrayView2), 0);
+    shouldBe(test1(arrayView1), 41);
+}
+
+function test2(view) {
+    return view[1023];
+}
+noInline(test2);
+
+{
+    var arrayView1 = new Int8Array(1024);
+    arrayView1[1023] = 42;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test2(arrayView1), 42);
+    arrayView1[1023] = 41;
+    shouldBe(test2(arrayView1), 41);
+
+    var arrayView2 = new Int8Array(new ArrayBuffer(1024, { maxByteLength: 1024 }), 0, 1024);
+    arrayView2[1023] = 42;
+    shouldBe(test2(arrayView2), 42);
+    shouldBe(arrayView2.length, 1024);
+    arrayView2.buffer.resize(0);
+    shouldBe(arrayView2.length, 0);
+    shouldBe(test2(arrayView2), undefined);
+    arrayView2.buffer.resize(1024);
+    shouldBe(arrayView2.length, 1024);
+    shouldBe(test2(arrayView2), 0);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test2(arrayView2), 0);
+    shouldBe(test2(arrayView1), 41);
+}
+
+function test3(view) {
+    return view.getInt8(1023);
+}
+noInline(test3);
+
+{
+    var arrayView1 = new DataView(new ArrayBuffer(1024));
+    arrayView1.setInt8(1023, 42);
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test3(arrayView1), 42);
+    arrayView1.setInt8(1023, 41);
+    shouldBe(test3(arrayView1), 41);
+
+    var arrayView2 = new DataView(new ArrayBuffer(1024, { maxByteLength: 1024 }), 0, 1024);
+    arrayView2.setInt8(1023, 42);
+    shouldBe(test3(arrayView2), 42);
+    shouldBe(arrayView2.byteLength, 1024);
+    arrayView2.buffer.resize(0);
+    shouldThrow(() => {
+        arrayView2.byteLength;
+    }, `TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds`);
+    shouldThrow(() => {
+        test3(arrayView2);
+    }, `TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds`);
+    arrayView2.buffer.resize(1024);
+    shouldBe(arrayView2.byteLength, 1024);
+    shouldBe(test3(arrayView2), 0);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test3(arrayView2), 0);
+    shouldBe(test3(arrayView1), 41);
+}
+
+function test4(view) {
+    return view.getInt8(1023);
+}
+noInline(test4);
+
+{
+    var arrayView1 = new DataView(new ArrayBuffer(1024));
+    arrayView1.setInt8(1023, 42);
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test4(arrayView1), 42);
+    arrayView1.setInt8(1023, 41);
+    shouldBe(test4(arrayView1), 41);
+
+    var arrayView2 = new DataView(new ArrayBuffer(1024, { maxByteLength: 1024 }));
+    arrayView2.setInt8(1023, 42);
+    shouldBe(test4(arrayView2), 42);
+    shouldBe(arrayView2.byteLength, 1024);
+    arrayView2.buffer.resize(0);
+    shouldBe(arrayView2.byteLength, 0);
+    shouldThrow(() => {
+        test4(arrayView2);
+    }, `RangeError: Out of bounds access`);
+    arrayView2.buffer.resize(1024);
+    shouldBe(arrayView2.byteLength, 1024);
+    shouldBe(test4(arrayView2), 0);
+
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(test4(arrayView2), 0);
+    shouldBe(test4(arrayView1), 41);
+}


### PR DESCRIPTION
#### 734267fa06bc8cd229afb1d2e304dfc5ea55a140
<pre>
[JSC] Add more resizable / growable ArrayBuffer tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=248420">https://bugs.webkit.org/show_bug.cgi?id=248420</a>
rdar://102731641

Reviewed by Justin Michaud.

Add more tests specialized for JSC&apos;s JIT tiers.

* JSTests/stress/growable-arraybuffer-basic.js: Added.
(shouldBe):
(test1):
(noInline):
(test2):
(test3):
(test4):
* JSTests/stress/resizable-arraybuffer-basic.js: Added.
(shouldBe):
(shouldThrow):
(noInline):
(test2):
(test3):
(test4):

Canonical link: <a href="https://commits.webkit.org/257089@main">https://commits.webkit.org/257089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b876c6a121b921b2024bfc6215045df49dae4c14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97859 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/7095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/31040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/107345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7532 "Built successfully") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/35869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/103982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103501 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/84483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/31040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88746 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/1078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/31040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84434 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/31040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/46/builds/28558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/5894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/84483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87265 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2420 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2331 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/31040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19579 "Passed tests") | 
<!--EWS-Status-Bubble-End-->