### PR TITLE
[Live Range Selection] fast/events/no-scroll-on-input-text-selection.html fails

### DIFF
--- a/LayoutTests/fast/events/no-scroll-on-input-text-selection-expected.txt
+++ b/LayoutTests/fast/events/no-scroll-on-input-text-selection-expected.txt
@@ -3,7 +3,7 @@ Verify selecting text does not cause any scrolling.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.getSelection().toString().length > 1 is true
+PASS ta.selectionStart < ta.selectionEnd is true
 PASS pageXOffset is 0
 PASS pageYOffset is originalPageYOffset
 PASS document.scrollingElement.scrollLeft is 0

--- a/LayoutTests/fast/events/no-scroll-on-input-text-selection.html
+++ b/LayoutTests/fast/events/no-scroll-on-input-text-selection.html
@@ -37,7 +37,7 @@
                 if (window.eventSender)
                     eventSender.mouseUp();
 
-                shouldBeTrue('document.getSelection().toString().length > 1');
+                shouldBeTrue('ta.selectionStart < ta.selectionEnd');
                 shouldBe('pageXOffset', '0');
                 shouldBe('pageYOffset', 'originalPageYOffset');
                 shouldBe('document.scrollingElement.scrollLeft', '0');


### PR DESCRIPTION
#### 8aeaa9c5ab41bec574d64a2f2a6aa6c711602f8d
<pre>
[Live Range Selection] fast/events/no-scroll-on-input-text-selection.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248423">https://bugs.webkit.org/show_bug.cgi?id=248423</a>

Reviewed by Darin Adler.

Check input.selectionEnd &gt; input.selectionStart instead of checking
getSelection().toString().length &gt; 0 since enabling live range selection will
make getSelection().toString() to no longer return the string inside the input.

* LayoutTests/fast/events/no-scroll-on-input-text-selection-expected.txt:
* LayoutTests/fast/events/no-scroll-on-input-text-selection.html:

Canonical link: <a href="https://commits.webkit.org/257126@main">https://commits.webkit.org/257126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bb8611923e13bf99e5e627671bdce0d51b7e6ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107353 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167630 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7547 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35877 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103990 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5679 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84494 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32743 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87550 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1086 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1073 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44674 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2434 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41686 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->