### PR TITLE
[Live Range Selection] fast/forms/input-maxlength-ime-completed.html fails

### DIFF
--- a/LayoutTests/fast/forms/input-maxlength-ime-completed-expected.txt
+++ b/LayoutTests/fast/forms/input-maxlength-ime-completed-expected.txt
@@ -3,7 +3,7 @@ There was a bug that users could input text longer than maxlength via IME. This 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.getSelection().toString() is "ab"
+PASS input.value.substring(input.selectionStart, input.selectionEnd) is "ab"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/input-maxlength-ime-completed.html
+++ b/LayoutTests/fast/forms/input-maxlength-ime-completed.html
@@ -18,7 +18,7 @@ textInputController.insertText('abcd');  // Debug WebKit crashed by this without
 // Check the current value without input.value.
 // In Release WebKit, input.value was 'ab' though the user-visible value was 'abcd'.
 document.execCommand('SelectAll');
-shouldBe('document.getSelection().toString()', '"ab"');
+shouldBeEqualToString('input.value.substring(input.selectionStart, input.selectionEnd)', 'ab');
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>


### PR DESCRIPTION
#### af5a3eece794411331039b263c7ecd9524ed82fe
<pre>
[Live Range Selection] fast/forms/input-maxlength-ime-completed.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248425">https://bugs.webkit.org/show_bug.cgi?id=248425</a>

Reviewed by Darin Adler.

Use input.selectionStart and input.selectionEnd to get the substring out of an input element
instead of relying on getSelection().toString() to include text within the input element.

* LayoutTests/fast/forms/input-maxlength-ime-completed-expected.txt:
* LayoutTests/fast/forms/input-maxlength-ime-completed.html:

Canonical link: <a href="https://commits.webkit.org/257127@main">https://commits.webkit.org/257127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43f420fc11c20490d12cdd083111da2beebcf23c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107357 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167635 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7556 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35881 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103994 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5681 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84498 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32740 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89288 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1090 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22224 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44675 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2435 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41627 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->