### PR TITLE
Add experimental feature flag for CSS Typed OM Color support

### DIFF
--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -479,6 +479,19 @@ CSSTextJustifyEnabled:
     WebCore:
       default: false
 
+CSSTypedOMColorEnabled:
+  type: bool
+  humanReadableName: "CSS Typed OM: Color Support"
+  humanReadableDescription: "Enable the CSS Typed OM Color support"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      "ENABLE(EXPERIMENTAL_FEATURES)": true
+      default: false
+    WebCore:
+      default: false
+
 CSSTypedOMEnabled:
   type: bool
   humanReadableName: "CSS Typed OM"

--- a/Source/WebCore/css/typedom/color/CSSColor.idl
+++ b/Source/WebCore/css/typedom/color/CSSColor.idl
@@ -29,7 +29,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csscolor
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSColor : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSColorValue.idl
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.idl
@@ -27,7 +27,7 @@ typedef (DOMString or CSSKeywordValue) CSSKeywordish;
 
 // https://drafts.css-houdini.org/css-typed-om/#csscolorvalue
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSColorValue : CSSStyleValue {

--- a/Source/WebCore/css/typedom/color/CSSHSL.idl
+++ b/Source/WebCore/css/typedom/color/CSSHSL.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csshsl
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSHSL : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSHWB.idl
+++ b/Source/WebCore/css/typedom/color/CSSHWB.idl
@@ -27,7 +27,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#csshwb
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSHWB : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSLCH.idl
+++ b/Source/WebCore/css/typedom/color/CSSLCH.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csslch
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSLCH : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSLab.idl
+++ b/Source/WebCore/css/typedom/color/CSSLab.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csslab
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSLab : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSOKLCH.idl
+++ b/Source/WebCore/css/typedom/color/CSSOKLCH.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssoklch
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSOKLCH : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSOKLab.idl
+++ b/Source/WebCore/css/typedom/color/CSSOKLab.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssoklab
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSOKLab : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSRGB.idl
+++ b/Source/WebCore/css/typedom/color/CSSRGB.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssrgb
 [
-    EnabledBySetting=CSSTypedOMEnabled,
+    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSRGB : CSSColorValue {


### PR DESCRIPTION
#### dc6ec366afda0bfa1f44399f428677a5a1f970e3
<pre>
Add experimental feature flag for CSS Typed OM Color support
<a href="https://bugs.webkit.org/show_bug.cgi?id=248426">https://bugs.webkit.org/show_bug.cgi?id=248426</a>

Reviewed by Antoine Quint.

Add experimental feature flag for CSS Typed OM Color support. The color API in
CSS Typed OM is still changing a lot and Blink hasn&apos;t shipped this part yet.

Odds are we will want to enable CSS Typed OM while keeping the Color part of
the API disabled until the specification has stabilized.

* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/css/typedom/color/CSSColor.idl:
* Source/WebCore/css/typedom/color/CSSColorValue.idl:
* Source/WebCore/css/typedom/color/CSSHSL.idl:
* Source/WebCore/css/typedom/color/CSSHWB.idl:
* Source/WebCore/css/typedom/color/CSSLCH.idl:
* Source/WebCore/css/typedom/color/CSSLab.idl:
* Source/WebCore/css/typedom/color/CSSOKLCH.idl:
* Source/WebCore/css/typedom/color/CSSOKLab.idl:
* Source/WebCore/css/typedom/color/CSSRGB.idl:

Canonical link: <a href="https://commits.webkit.org/257172@main">https://commits.webkit.org/257172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1a5acdcf573f3addcc04c639da52fdbc0f481ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107359 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167637 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7558 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35883 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103996 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5683 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84500 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32772 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75691 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1092 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20721 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84457 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22229 "Passed tests") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28563 "Found 21 new JSC stress test failures: wasm.yaml/wasm/gc/arrays.js.default-wasm, wasm.yaml/wasm/gc/arrays.js.wasm-collect-continuously, wasm.yaml/wasm/gc/arrays.js.wasm-eager, wasm.yaml/wasm/gc/arrays.js.wasm-eager-jettison, wasm.yaml/wasm/gc/arrays.js.wasm-no-cjit-yes-tls-context, wasm.yaml/wasm/gc/arrays.js.wasm-no-tls-context, wasm.yaml/wasm/gc/arrays.js.wasm-slow-memory, wasm.yaml/wasm/gc/rec.js.default-wasm, wasm.yaml/wasm/gc/rec.js.wasm-collect-continuously, wasm.yaml/wasm/gc/rec.js.wasm-eager ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44679 "Passed tests") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87288 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2458 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41632 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19587 "Passed tests") | 
<!--EWS-Status-Bubble-End-->