### PR TITLE
[Live Range Selection] fast/forms/input-maxlength-ime-preedit.html fails

### DIFF
--- a/LayoutTests/fast/forms/input-maxlength-ime-preedit-expected.txt
+++ b/LayoutTests/fast/forms/input-maxlength-ime-preedit-expected.txt
@@ -3,7 +3,9 @@ This test checks users can input pre-edit text longer than maxlength.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.getSelection().toString() is "abcd"
+PASS input.selectionStart is 0
+PASS input.selectionEnd is 4
+PASS input.value.substring(input.selectionStart, input.selectionEnd) is "abcd"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/input-maxlength-ime-preedit.html
+++ b/LayoutTests/fast/forms/input-maxlength-ime-preedit.html
@@ -15,7 +15,9 @@ input.maxLength = 2;
 input.focus();
 textInputController.setMarkedText('abcd', 0, 4);
 // The selection should have 4 characters though maxLength is 2.
-shouldBe('document.getSelection().toString()', '"abcd"');
+shouldBe('input.selectionStart', '0');
+shouldBe('input.selectionEnd', '4');
+shouldBeEqualToString('input.value.substring(input.selectionStart, input.selectionEnd)', 'abcd');
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>


### PR DESCRIPTION
#### 98f73ea0a4f5e641f61c8ec1cb1f7bdb8b3035ca
<pre>
[Live Range Selection] fast/forms/input-maxlength-ime-preedit.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248427">https://bugs.webkit.org/show_bug.cgi?id=248427</a>

Reviewed by Darin Adler.

Use input.selectionStart and input.selectionEnd to get the substring out of an input element
instead of relying on getSelection().toString() to include text within the input element.

* LayoutTests/fast/forms/input-maxlength-ime-preedit-expected.txt:
* LayoutTests/fast/forms/input-maxlength-ime-preedit.html:

Canonical link: <a href="https://commits.webkit.org/257128@main">https://commits.webkit.org/257128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b19d74a7318493319c7a65367bf01b950fb780a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107360 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167638 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7559 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35884 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/103997 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5684 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84501 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32745 "") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87555 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89292 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1093 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1080 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22228 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5909 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2436 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41631 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->