### PR TITLE
[reporelaypy] Improve logging in broken repositories

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py
@@ -44,7 +44,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 7, 5)
+version = Version(0, 7, 6)
 
 import webkitflaskpy
 

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/hooks.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/hooks.py
@@ -84,8 +84,10 @@ class HookProcessor(object):
             try:
                 if branch.startswith(self.BRANCH_PREFIX):
                     branch = branch[len(self.BRANCH_PREFIX):]
-                    self.checkout.update_for(branch, track=True, remote=remote)
-                    self.checkout.forward_update(branch=branch, remote=remote, track=True)
+                    if self.checkout.update_for(branch, track=True, remote=remote):
+                        self.checkout.forward_update(branch=branch, remote=remote, track=True)
+                    else:
+                        sys.stderr.write("Failed to update '{}' from '{}'\n".format(branch, remote or self.checkout.repository.default_remote))
 
                 if branch.startswith(self.TAG_PREFIX):
                     tag = branch[len(self.TAG_PREFIX):]

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/hooks_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/hooks_unittest.py
@@ -109,7 +109,7 @@ class HooksUnittest(testing.PathTestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json(), [])
 
-        self.assertEqual(captured.stderr.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), "Failed to update 'branch-a' from 'origin'\n")
 
     @mock_app
     def test_hmac(self, app=None, client=None):

--- a/Tools/Scripts/libraries/reporelaypy/setup.py
+++ b/Tools/Scripts/libraries/reporelaypy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='reporelaypy',
-    version='0.7.5',
+    version='0.7.6',
     description='Library for visualizing, processing and storing test results.',
     long_description=readme(),
     classifiers=[


### PR DESCRIPTION
#### 13674c4b6e05f061bf83b689d388e9008ca91729
<pre>
[reporelaypy] Improve logging in broken repositories
<a href="https://bugs.webkit.org/show_bug.cgi?id=248428">https://bugs.webkit.org/show_bug.cgi?id=248428</a>
rdar://102735925

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/__init__.py: Bump version.
* Tools/Scripts/libraries/reporelaypy/setup.py: Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/checkout.py:
(Checkout.update_for): Check returncode of self.repository.pull.
(Checkout.update_all): Print error message if self.repository.pull fails.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/hooks.py:
(HookProcessor.process_worker_hook): Only forward update if branch update succeeds.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/hooks_unittest.py:
(HooksUnittest.test_process_branch):

Canonical link: <a href="https://commits.webkit.org/257118@main">https://commits.webkit.org/257118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23f7d330dbe6af548339be8c10339db597806d8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107440 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7655 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35965 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/103620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84580 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101527 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/1170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1152 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5986 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2428 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2438 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/62/builds/41704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->