### PR TITLE
[Live Range Selection] fast/forms/input-value-sanitization.html fails

### DIFF
--- a/LayoutTests/fast/forms/input-value-sanitization-expected.txt
+++ b/LayoutTests/fast/forms/input-value-sanitization-expected.txt
@@ -16,7 +16,9 @@ PASS input.value is "50"
 
 Text:
 PASS input.value is " foo bar "
-PASS document.getSelection().toString() is " foo bar "
+PASS input.selectionStart is 0
+PASS input.selectionEnd is 9
+PASS input.value.substring(input.selectionStart, input.selectionEnd) is " foo bar "
 PASS input.value is "foo\u0000bar"
 PASS input.value is "foo\bbar"
 PASS input.value is "foo\tbar"

--- a/LayoutTests/fast/forms/input-value-sanitization.html
+++ b/LayoutTests/fast/forms/input-value-sanitization.html
@@ -50,7 +50,9 @@ input = document.getElementById('text');
 shouldBe('input.value', '" foo bar "');
 input.focus();
 document.execCommand('SelectAll');
-shouldBe('document.getSelection().toString()', '" foo bar "');
+shouldBe('input.selectionStart', '0');
+shouldBe('input.selectionEnd', '9');
+shouldBeEqualToString('input.value.substring(input.selectionStart, input.selectionEnd)', ' foo bar ');
 
 input.value = 'foo\0bar';
 shouldBeEqualToString('input.value', 'foo\0bar');


### PR DESCRIPTION
#### fed33dd0ef232da0e4cf7759ba34c92a09525f3f
<pre>
[Live Range Selection] fast/forms/input-value-sanitization.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248431">https://bugs.webkit.org/show_bug.cgi?id=248431</a>

Reviewed by Darin Adler.

Use input.selectionStart and input.selectionEnd to get the substring out of an input element
instead of relying on getSelection().toString() to include text within the input element.

* LayoutTests/fast/forms/input-value-sanitization-expected.txt:
* LayoutTests/fast/forms/input-value-sanitization.html:

Canonical link: <a href="https://commits.webkit.org/257129@main">https://commits.webkit.org/257129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a62e4a15df055cd5d14f694e21d3707fc187ff63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107365 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167643 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7564 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35889 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90405 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104002 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5685 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84506 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32756 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89296 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1098 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22232 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44689 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2437 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41635 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->