### PR TITLE
Support injected content in Web Extensions.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h
@@ -197,14 +197,6 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 /*! @abstract A Boolean value indicating whether the extension has background content that stays in memory as long as the extension is loaded. */
 @property (nonatomic, readonly) BOOL backgroundContentIsPersistent;
 
-/*!
- @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.
- @param url The webpage URL to check.
- @result Returns `YES` if the extension has content that can be injected by matching the `url` against the extension's requested match patterns.
- @discussion The extension will still need to be loaded and have granted website permissions for its content to actually be injected.
- */
-- (BOOL)hasInjectedContentForURL:(NSURL *)url;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -205,11 +205,11 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return _webExtension->backgroundContentUsesModules();
 }
 
-- (BOOL)hasInjectedContentForURL:(NSURL *)url
+- (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url
 {
     NSParameterAssert(url);
 
-    return _webExtension->hasInjectedContentForURL(url);
+    return _webExtension->hasStaticInjectedContentForURL(url);
 }
 
 #pragma mark WKObject protocol implementation
@@ -351,7 +351,7 @@ NSNotificationName const _WKWebExtensionErrorsWereUpdatedNotification = @"_WKWeb
     return NO;
 }
 
-- (BOOL)hasInjectedContentForURL:(NSURL *)url
+- (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -295,6 +295,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly) BOOL hasAccessToAllHosts;
 
 /*!
+ @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.
+ @param url The webpage URL to check.
+ @result Returns `YES` if the extension has content that can be injected by matching the `url` against the extension's requested match patterns.
+ @discussion The extension context will still need to be loaded and have granted website permissions for its content to actually be injected.
+ */
+- (BOOL)hasInjectedContentForURL:(NSURL *)url;
+
+/*!
  @abstract Checks the specified permission against the currently denied, granted, and requested permissions.
  @discussion Permissions can be granted on a per-tab basis. When the tab is known, access checks should always use the method that checks in a tab.
  @seealso permissionStateForPermission:inTab:

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -434,6 +434,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
     return _webExtensionContext->hasAccessToAllHosts();
 }
 
+- (BOOL)hasInjectedContentForURL:(NSURL *)url
+{
+    return _webExtensionContext->hasInjectedContentForURL(url);
+}
+
 - (void)userGesturePerformedInTab:(id<_WKWebExtensionTab>)tab
 {
     NSParameterAssert(tab);
@@ -657,6 +662,11 @@ static inline WebKit::WebExtensionContext::PermissionState toImpl(_WKWebExtensio
 }
 
 - (BOOL)hasAccessToAllHosts
+{
+    return NO;
+}
+
+- (BOOL)hasInjectedContentForURL:(NSURL *)url
 {
     return NO;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h
@@ -34,7 +34,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
+/*! @abstract A Boolean value indicating whether the extension use modules for the background content. */
 @property (readonly, nonatomic) BOOL _backgroundContentUsesModules;
+
+/*!
+ @abstract Checks if the extension has script or stylesheet content that can be injected into the specified URL.
+ @param url The webpage URL to check.
+ @result Returns `YES` if the extension has content that can be injected by matching the `url` against the extension's requested match patterns.
+ @discussion The extension will still need to be loaded and have granted website permissions for its content to actually be injected.
+ */
+- (BOOL)_hasStaticInjectedContentForURL:(NSURL *)url;
 
 @end
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -265,6 +265,36 @@ NSURL *WebExtension::resourceFileURLForPath(NSString *path)
     return resourceURL;
 }
 
+NSString *WebExtension::resourceStringForPath(NSString *path, CacheResult cacheResult)
+{
+    ASSERT(path);
+
+    // Remove leading slash to normalize the path for lookup/storage in the cache dictionary.
+    if ([path hasPrefix:@"/"])
+        path = [path substringFromIndex:1];
+
+    if (NSString *cachedString = objectForKey<NSString>(m_resources, path))
+        return cachedString;
+
+    if ([path isEqualToString:generatedBackgroundPageFilename])
+        return generatedBackgroundContent();
+
+    NSData *data = resourceDataForPath(path, CacheResult::No);
+
+    NSString *string;
+    [NSString stringEncodingForData:data encodingOptions:nil convertedString:&string usedLossyConversion:nil];
+    if (!string)
+        return nil;
+
+    if (cacheResult == CacheResult::Yes) {
+        if (!m_resources)
+            m_resources = [NSMutableDictionary dictionary];
+        [m_resources setObject:string forKey:path];
+    }
+
+    return string;
+}
+
 NSData *WebExtension::resourceDataForPath(NSString *path, CacheResult cacheResult)
 {
     ASSERT(path);
@@ -276,23 +306,15 @@ NSData *WebExtension::resourceDataForPath(NSString *path, CacheResult cacheResul
     if (NSData *cachedData = objectForKey<NSData>(m_resources, path))
         return cachedData;
 
-    if (NSString *cachedString = objectForKey<NSString>(m_resources, path)) {
-        NSData *cachedData = [cachedString dataUsingEncoding:NSUTF8StringEncoding];
-        ASSERT(cachedData);
-        [m_resources setObject:cachedData forKey:path];
-        return cachedData;
-    }
+    if (NSString *cachedString = objectForKey<NSString>(m_resources, path))
+        return [cachedString dataUsingEncoding:NSUTF8StringEncoding];
 
     if ([path isEqualToString:generatedBackgroundPageFilename])
         return [generatedBackgroundContent() dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURL *resourceURL = resourceFileURLForPath(path);
     if (!resourceURL) {
-        if (m_resources)
-            recordError(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find \"%@\" in the extension’s resources.", "WKWebExtensionErrorResourceNotFound description with file name", (__bridge CFStringRef)path)));
-        else
-            recordError(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find \"%@\" in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", (__bridge CFStringRef)path)));
-
+        recordError(createError(Error::ResourceNotFound, WEB_UI_FORMAT_CFSTRING("Unable to find \"%@\" in the extension’s resources. It is an invalid path.", "WKWebExtensionErrorResourceNotFound description with invalid file path", (__bridge CFStringRef)path)));
         return nil;
     }
 
@@ -499,8 +521,8 @@ void WebExtension::removeError(Error error, SuppressNotification suppressNotific
     if (suppressNotification == SuppressNotification::Yes)
         return;
 
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&, protectedThis = Ref { *this }]() {
-        [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionErrorsWereUpdatedNotification object:WebKit::wrapper(this) userInfo:nil];
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+        [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionErrorsWereUpdatedNotification object:wrapper() userInfo:nil];
     }).get());
 }
 
@@ -516,8 +538,8 @@ void WebExtension::recordError(NSError *error, SuppressNotification suppressNoti
     if (suppressNotification == SuppressNotification::Yes)
         return;
 
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&, protectedThis = Ref { *this }]() {
-        [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionErrorsWereUpdatedNotification object:WebKit::wrapper(this) userInfo:nil];
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }]() {
+        [NSNotificationCenter.defaultCenter postNotificationName:_WKWebExtensionErrorsWereUpdatedNotification object:wrapper() userInfo:nil];
     }).get());
 }
 
@@ -989,19 +1011,19 @@ void WebExtension::populateBackgroundPropertiesIfNeeded()
 #endif
 }
 
-const Vector<WebExtension::InjectedContentData>& WebExtension::injectedContents()
+const Vector<WebExtension::InjectedContentData>& WebExtension::staticInjectedContents()
 {
     populateContentScriptPropertiesIfNeeded();
-    return m_injectedContents;
+    return m_staticInjectedContents;
 }
 
-bool WebExtension::hasInjectedContentForURL(NSURL *url)
+bool WebExtension::hasStaticInjectedContentForURL(NSURL *url)
 {
     ASSERT(url);
 
     populateContentScriptPropertiesIfNeeded();
 
-    for (auto& injectedContent : m_injectedContents) {
+    for (auto& injectedContent : m_staticInjectedContents) {
         // FIXME: <https://webkit.org/b/246492> Add support for exclude globs.
         bool isExcluded = false;
         for (auto& excludeMatchPattern : injectedContent.excludeMatchPatterns) {
@@ -1145,7 +1167,7 @@ void WebExtension::populateContentScriptPropertiesIfNeeded()
         else
             recordError(createError(Error::InvalidContentScripts, WEB_UI_STRING("Manifest `content_scripts` entry has unknown `run_at` value.", "WKWebExtensionErrorInvalidContentScripts description for unknown 'run_at' value")));
 
-        m_injectedContents.append({ WTFMove(includeMatchPatterns), WTFMove(excludeMatchPatterns), injectionTime, matchesAboutBlank, injectsIntoAllFrames, scriptPaths, styleSheetPaths, includeGlobPatternStrings, excludeGlobPatternStrings });
+        m_staticInjectedContents.append({ WTFMove(includeMatchPatterns), WTFMove(excludeMatchPatterns), injectionTime, matchesAboutBlank, injectsIntoAllFrames, false, scriptPaths, styleSheetPaths, includeGlobPatternStrings, excludeGlobPatternStrings });
     };
 
     for (NSDictionary<NSString *, id> *contentScriptsManifestEntry in contentScriptsManifestArray)
@@ -1197,7 +1219,7 @@ WebExtension::MatchPatternSet WebExtension::allRequestedMatchPatterns()
 
     // FIXME: <https://webkit.org/b/246491> Add externally connectable match patterns.
 
-    for (auto& injectedContent : m_injectedContents) {
+    for (auto& injectedContent : m_staticInjectedContents) {
         for (auto& matchPattern : injectedContent.includeMatchPatterns)
             result.add(matchPattern);
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -32,6 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "InjectUserScriptImmediately.h"
 #import "WKNavigationActionPrivate.h"
 #import "WKNavigationDelegatePrivate.h"
 #import "WKPreferencesPrivate.h"
@@ -40,12 +41,15 @@
 #import "WKWebViewInternal.h"
 #import "WebExtensionURLSchemeHandler.h"
 #import "WebPageProxy.h"
+#import "WebUserContentControllerProxy.h"
 #import "_WKWebExtensionContextInternal.h"
 #import "_WKWebExtensionPermission.h"
 #import "_WKWebExtensionTab.h"
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/UserScript.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/URLParser.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 // This number was chosen arbitrarily based on testing with some popular extensions.
 static constexpr size_t maximumCachedPermissionResults = 256;
@@ -185,9 +189,13 @@ bool WebExtensionContext::load(WebExtensionController& controller, NSError **out
     m_extensionController = controller;
     m_contentScriptWorld = API::ContentWorld::sharedWorldWithName(makeString("WebExtension-", m_uniqueIdentifier));
 
+    // FIXME: <https://webkit.org/b/248430> Move local storage (if base URL changed).
+
     loadBackgroundWebViewDuringLoad();
 
-    // FIXME: <https://webkit.org/b/246486> Inject content, move local storage (if base URL changed), etc.
+    // FIXME: <https://webkit.org/b/248429> Support dynamic content scripts by loading them from storage here.
+
+    addInjectedContent();
 
     return true;
 }
@@ -203,12 +211,11 @@ bool WebExtensionContext::unload(NSError **outError)
         return false;
     }
 
+    unloadBackgroundWebView();
+    removeInjectedContent();
+
     m_extensionController = nil;
     m_contentScriptWorld = nullptr;
-
-    unloadBackgroundWebView();
-
-    // FIXME: <https://webkit.org/b/246486> Remove injected content, etc.
 
     return true;
 }
@@ -248,6 +255,39 @@ void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
         uniqueIdentifier = m_baseURL.host().toString();
 
     m_uniqueIdentifier = uniqueIdentifier;
+}
+
+const WebExtensionContext::InjectedContentVector& WebExtensionContext::injectedContents()
+{
+    // FIXME: <https://webkit.org/b/248429> Support dynamic content scripts by including them here.
+    return m_extension->staticInjectedContents();
+}
+
+bool WebExtensionContext::hasInjectedContentForURL(NSURL *url)
+{
+    ASSERT(url);
+
+    for (auto& injectedContent : injectedContents()) {
+        // FIXME: <https://webkit.org/b/246492> Add support for exclude globs.
+        bool isExcluded = false;
+        for (auto& excludeMatchPattern : injectedContent.excludeMatchPatterns) {
+            if (excludeMatchPattern->matchesURL(url)) {
+                isExcluded = true;
+                break;
+            }
+        }
+
+        if (isExcluded)
+            continue;
+
+        // FIXME: <https://webkit.org/b/246492> Add support for include globs.
+        for (auto& includeMatchPattern : injectedContent.includeMatchPatterns) {
+            if (includeMatchPattern->matchesURL(url))
+                return true;
+        }
+    }
+
+    return false;
 }
 
 const WebExtensionContext::PermissionsMap& WebExtensionContext::grantedPermissions()
@@ -385,8 +425,8 @@ void WebExtensionContext::postAsyncNotification(NSNotificationName notificationN
     if (permissions.isEmpty())
         return;
 
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&, protectedThis = Ref { *this }]() {
-        [NSNotificationCenter.defaultCenter postNotificationName:notificationName object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyPermissions: toAPI(permissions) }];
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, notificationName = retainPtr(notificationName), permissions]() {
+        [NSNotificationCenter.defaultCenter postNotificationName:notificationName.get() object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyPermissions: toAPI(permissions) }];
     }).get());
 }
 
@@ -395,8 +435,8 @@ void WebExtensionContext::postAsyncNotification(NSNotificationName notificationN
     if (matchPatterns.isEmpty())
         return;
 
-    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([&, protectedThis = Ref { *this }]() {
-        [NSNotificationCenter.defaultCenter postNotificationName:notificationName object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns: toAPI(matchPatterns) }];
+    dispatch_async(dispatch_get_main_queue(), makeBlockPtr([this, protectedThis = Ref { *this }, notificationName = retainPtr(notificationName), matchPatterns]() {
+        [NSNotificationCenter.defaultCenter postNotificationName:notificationName.get() object:wrapper() userInfo:@{ _WKWebExtensionContextNotificationUserInfoKeyMatchPatterns: toAPI(matchPatterns) }];
     }).get());
 }
 
@@ -437,6 +477,8 @@ void WebExtensionContext::grantPermissionMatchPatterns(MatchPatternSet&& permiss
     removeDeniedPermissionMatchPatterns(permissionMatchPatterns, EqualityOnly::Yes);
     clearCachedPermissionStates();
 
+    addInjectedContent(injectedContents(), permissionMatchPatterns);
+
     postAsyncNotification(_WKWebExtensionContextPermissionMatchPatternsWereGrantedNotification, permissionMatchPatterns);
 }
 
@@ -451,6 +493,8 @@ void WebExtensionContext::denyPermissionMatchPatterns(MatchPatternSet&& permissi
     removeGrantedPermissionMatchPatterns(permissionMatchPatterns, EqualityOnly::Yes);
     clearCachedPermissionStates();
 
+    updateInjectedContent();
+
     postAsyncNotification(_WKWebExtensionContextPermissionMatchPatternsWereDeniedNotification, permissionMatchPatterns);
 }
 
@@ -462,6 +506,8 @@ void WebExtensionContext::removeGrantedPermissions(PermissionsSet& permissionsTo
 void WebExtensionContext::removeGrantedPermissionMatchPatterns(MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly)
 {
     removePermissionMatchPatterns(m_grantedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, _WKWebExtensionContextGrantedPermissionMatchPatternsWereRemovedNotification);
+
+    removeInjectedContent(matchPatternsToRemove);
 }
 
 void WebExtensionContext::removeDeniedPermissions(PermissionsSet& permissionsToRemove)
@@ -472,6 +518,8 @@ void WebExtensionContext::removeDeniedPermissions(PermissionsSet& permissionsToR
 void WebExtensionContext::removeDeniedPermissionMatchPatterns(MatchPatternSet& matchPatternsToRemove, EqualityOnly equalityOnly)
 {
     removePermissionMatchPatterns(m_deniedPermissionMatchPatterns, matchPatternsToRemove, equalityOnly, _WKWebExtensionContextDeniedPermissionsWereRemovedNotification);
+
+    updateInjectedContent();
 }
 
 void WebExtensionContext::removePermissions(PermissionsMap& permissionMap, PermissionsSet& permissionsToRemove, NSNotificationName notificationName)
@@ -1059,7 +1107,7 @@ void WebExtensionContext::loadBackgroundWebView()
         return;
     }
 
-    [m_backgroundWebView _loadServiceWorker:backgroundContentURL() usingModules:extension().backgroundContentUsesModules() completionHandler:makeBlockPtr([&, protectedThis = Ref { *this }](BOOL success) {
+    [m_backgroundWebView _loadServiceWorker:backgroundContentURL() usingModules:extension().backgroundContentUsesModules() completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }](BOOL success) {
         if (!success) {
             extension().recordError(extension().createError(WebExtension::Error::BackgroundContentFailedToLoad), WebExtension::SuppressNotification::No);
             return;
@@ -1131,6 +1179,280 @@ void WebExtensionContext::webViewWebContentProcessDidTerminate(WKWebView *webVie
     // FIXME: <https://webkit.org/b/246485> Handle inspector background pages too.
 
     ASSERT_NOT_REACHED();
+}
+
+void WebExtensionContext::addInjectedContent(const InjectedContentVector& injectedContents)
+{
+    if (!isLoaded())
+        return;
+
+    // Only add content for one "all hosts" pattern if the extension has the permission.
+    // This avoids duplicate injected content if individual hosts are granted in addition to "all hosts".
+    if (hasAccessToAllHosts()) {
+        addInjectedContent(injectedContents, WebExtensionMatchPattern::allHostsAndSchemesMatchPattern());
+        return;
+    }
+
+    MatchPatternSet grantedMatchPatterns;
+    for (auto& pattern : currentPermissionMatchPatterns())
+        grantedMatchPatterns.add(pattern);
+
+    addInjectedContent(injectedContents, grantedMatchPatterns);
+}
+
+void WebExtensionContext::addInjectedContent(const InjectedContentVector& injectedContents, MatchPatternSet& grantedMatchPatterns)
+{
+    if (!isLoaded())
+        return;
+
+    if (hasAccessToAllHosts()) {
+        // If this is not currently granting "all hosts", then we can return early. This means
+        // the "all hosts" pattern injected content was added already, and no content needs added.
+        // Continuing here would add multiple copies of injected content, one for "all hosts" and
+        // another for individually granted hosts.
+        if (!WebExtensionMatchPattern::patternsMatchAllHosts(grantedMatchPatterns))
+            return;
+
+        // Since we are granting "all hosts" we want to remove any previously added content since
+        // "all hosts" will cover any hosts previously added, and we don't want duplicate scripts.
+        MatchPatternSet patternsToRemove;
+        for (auto& entry : m_injectedScriptsPerPatternMap)
+            patternsToRemove.add(entry.key);
+
+        for (auto& entry : m_injectedStyleSheetsPerPatternMap)
+            patternsToRemove.add(entry.key);
+
+        for (auto& pattern : patternsToRemove)
+            removeInjectedContent(pattern);
+    }
+
+    for (auto& pattern : grantedMatchPatterns)
+        addInjectedContent(injectedContents, pattern);
+}
+
+static WebCore::UserScriptInjectionTime toImpl(WebExtension::InjectionTime injectionTime)
+{
+    switch (injectionTime) {
+    case WebExtension::InjectionTime::DocumentStart:
+        return WebCore::UserScriptInjectionTime::DocumentStart;
+    case WebExtension::InjectionTime::DocumentIdle:
+        // FIXME: <rdar://problem/57613315> Implement idle injection time. For now, the end injection time is fine.
+    case WebExtension::InjectionTime::DocumentEnd:
+        return WebCore::UserScriptInjectionTime::DocumentEnd;
+    }
+}
+
+void WebExtensionContext::addInjectedContent(const InjectedContentVector& injectedContents, WebExtensionMatchPattern& pattern)
+{
+    if (!isLoaded())
+        return;
+
+    auto scriptAddResult = m_injectedScriptsPerPatternMap.ensure(pattern, [&] {
+        return UserScriptVector { };
+    });
+
+    auto styleSheetAddResult = m_injectedStyleSheetsPerPatternMap.ensure(pattern, [&] {
+        return UserStyleSheetVector { };
+    });
+
+    auto& originInjectedScripts = scriptAddResult.iterator->value;
+    auto& originInjectedStyleSheets = styleSheetAddResult.iterator->value;
+
+    NSMutableSet<NSString *> *baseExcludeMatchPatternsSet = [NSMutableSet set];
+
+    auto& deniedMatchPatterns = deniedPermissionMatchPatterns();
+    for (auto& deniedEntry : deniedMatchPatterns) {
+        // Granted host patterns always win over revoked host patterns. Skip any revoked "all hosts" patterns.
+        // This supports the case where "all hosts" is revoked and a handful of specific hosts are granted.
+        if (deniedEntry.key->matchesAllHosts())
+            continue;
+
+        // Only revoked patterns that match the granted pattern need to be included. This limits
+        // the size of the exclude match patterns list to speed up processing.
+        if (!pattern.matchesPattern(deniedEntry.key, { WebExtensionMatchPattern::Options::IgnorePaths, WebExtensionMatchPattern::Options::MatchBidirectionally }))
+            continue;
+
+        [baseExcludeMatchPatternsSet addObjectsFromArray:deniedEntry.key->expandedStrings()];
+    }
+
+    auto allUserContentControllers = extensionController()->allUserContentControllers();
+
+    for (auto& injectedContentData : injectedContents) {
+        NSMutableSet<NSString *> *includeMatchPatternsSet = [NSMutableSet set];
+
+        for (auto& includeMatchPattern : injectedContentData.includeMatchPatterns) {
+            // Paths are not matched here since all we need to match at this point is scheme and host.
+            // The path matching will happen in WebKit when deciding to inject content into a frame.
+
+            // When the include pattern matches all hosts, we can generate a restricted patten here and skip
+            // the more expensive calls to matchesPattern() below since we know they will match.
+            if (includeMatchPattern->matchesAllHosts()) {
+                auto restrictedPattern = WebExtensionMatchPattern::getOrCreate(includeMatchPattern->scheme(), pattern.host(), includeMatchPattern->path());
+                if (!restrictedPattern)
+                    continue;
+
+                [includeMatchPatternsSet addObjectsFromArray:restrictedPattern->expandedStrings()];
+                continue;
+            }
+
+            // When deciding if injected content patterns match, we need to check bidirectionally.
+            // This allows an extension that requests *.wikipedia.org, to still inject content when
+            // it is granted more specific access to *.en.wikipedia.org.
+            if (!includeMatchPattern->matchesPattern(pattern, { WebExtensionMatchPattern::Options::IgnorePaths, WebExtensionMatchPattern::Options::MatchBidirectionally }))
+                continue;
+
+            // Pick the most restrictive match pattern by comparing unidirectionally to the granted origin pattern.
+            // If the include pattern still matches the granted origin pattern, it is not restrictive enough.
+            // In that case we need to use the include pattern scheme and path, but with the granted pattern host.
+            RefPtr restrictedPattern = includeMatchPattern.ptr();
+            if (includeMatchPattern->matchesPattern(pattern, { WebExtensionMatchPattern::Options::IgnoreSchemes, WebExtensionMatchPattern::Options::IgnorePaths }))
+                restrictedPattern = WebExtensionMatchPattern::getOrCreate(includeMatchPattern->scheme(), pattern.host(), includeMatchPattern->path());
+            if (!restrictedPattern)
+                continue;
+
+            [includeMatchPatternsSet addObjectsFromArray:restrictedPattern->expandedStrings()];
+        }
+
+        if (!includeMatchPatternsSet.count)
+            continue;
+
+        // FIXME: <rdar://problem/57613243> Support injecting into about:blank, honoring self.contentMatchesAboutBlank. Appending @"about:blank" to the includeMatchPatterns does not work currently.
+        NSArray<NSString *> *includeMatchPatterns = includeMatchPatternsSet.allObjects;
+
+        NSMutableSet<NSString *> *excludeMatchPatternsSet = [NSMutableSet setWithArray:injectedContentData.expandedExcludeMatchPatternStrings()];
+        [excludeMatchPatternsSet unionSet:baseExcludeMatchPatternsSet];
+
+        NSArray<NSString *> *excludeMatchPatterns = excludeMatchPatternsSet.allObjects;
+
+        auto injectedFrames = injectedContentData.injectsIntoAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly;
+        auto injectionTime = toImpl(injectedContentData.injectionTime);
+        auto waitForNotification = WebCore::WaitForNotificationBeforeInjecting::No;
+        auto& executionWorld = injectedContentData.forMainWorld ? API::ContentWorld::pageContentWorld() : *m_contentScriptWorld;
+
+        for (NSString *scriptPath in injectedContentData.scriptPaths.get()) {
+            NSString *scriptString = m_extension->resourceStringForPath(scriptPath, WebExtension::CacheResult::Yes);
+            if (!scriptString)
+                continue;
+
+            auto userScript = API::UserScript::create(WebCore::UserScript { scriptString, URL { m_baseURL, scriptPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectionTime, injectedFrames, waitForNotification }, executionWorld);
+            originInjectedScripts.append(userScript);
+
+            for (auto& userContentController : allUserContentControllers)
+                userContentController.addUserScript(userScript, InjectUserScriptImmediately::Yes);
+        }
+
+        for (NSString *styleSheetPath in injectedContentData.styleSheetPaths.get()) {
+            NSString *styleSheetString = m_extension->resourceStringForPath(styleSheetPath, WebExtension::CacheResult::Yes);
+            if (!styleSheetString)
+                continue;
+
+            auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheetString, URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, WebCore::UserStyleUserLevel, std::nullopt }, executionWorld);
+            originInjectedStyleSheets.append(userStyleSheet);
+
+            for (auto& userContentController : allUserContentControllers)
+                userContentController.addUserStyleSheet(userStyleSheet);
+        }
+    }
+}
+
+void WebExtensionContext::addInjectedContent(WebUserContentControllerProxy& userContentController)
+{
+    for (auto& entry : m_injectedScriptsPerPatternMap) {
+        for (auto& userScript : entry.value)
+            userContentController.addUserScript(userScript, InjectUserScriptImmediately::Yes);
+    }
+
+    for (auto& entry : m_injectedStyleSheetsPerPatternMap) {
+        for (auto& userStyleSheet : entry.value)
+            userContentController.addUserStyleSheet(userStyleSheet);
+    }
+}
+
+void WebExtensionContext::removeInjectedContent()
+{
+    if (!isLoaded())
+        return;
+
+    auto allUserContentControllers = extensionController()->allUserContentControllers();
+    for (auto& userContentController : allUserContentControllers) {
+        for (auto& entry : m_injectedScriptsPerPatternMap) {
+            for (auto& userScript : entry.value)
+                userContentController.removeUserScript(userScript);
+        }
+
+        for (auto& entry : m_injectedStyleSheetsPerPatternMap) {
+            for (auto& userStyleSheet : entry.value)
+                userContentController.removeUserStyleSheet(userStyleSheet);
+        }
+    }
+
+    m_injectedScriptsPerPatternMap.clear();
+    m_injectedStyleSheetsPerPatternMap.clear();
+}
+
+void WebExtensionContext::removeInjectedContent(MatchPatternSet& removedMatchPatterns)
+{
+    if (!isLoaded())
+        return;
+
+    for (auto& removedPattern : removedMatchPatterns)
+        removeInjectedContent(removedPattern);
+
+    // If "all hosts" was removed, then we need to add back any individual granted hosts,
+    // now that the catch all pattern has been removed.
+    if (WebExtensionMatchPattern::patternsMatchAllHosts(removedMatchPatterns))
+        addInjectedContent();
+}
+
+void WebExtensionContext::removeInjectedContent(WebExtensionMatchPattern& pattern)
+{
+    if (!isLoaded())
+        return;
+
+    auto originInjectedScripts = m_injectedScriptsPerPatternMap.take(pattern);
+    auto originInjectedStyleSheets = m_injectedStyleSheetsPerPatternMap.take(pattern);
+
+    if (originInjectedScripts.isEmpty() && originInjectedStyleSheets.isEmpty())
+        return;
+
+    auto allUserContentControllers = extensionController()->allUserContentControllers();
+
+    for (auto& userContentController : allUserContentControllers) {
+        for (auto& userScript : originInjectedScripts)
+            userContentController.removeUserScript(userScript);
+
+        for (auto& userStyleSheet : originInjectedStyleSheets)
+            userContentController.removeUserStyleSheet(userStyleSheet);
+    }
+
+    auto *tabsToRemove = [NSMutableSet set];
+    for (id<_WKWebExtensionTab> tab in m_temporaryTabPermissionMatchPatterns.get().keyEnumerator) {
+        if (![tab respondsToSelector:@selector(urlForWebExtensionContext:)])
+            continue;
+
+        NSURL *currentURL = [tab urlForWebExtensionContext:wrapper()];
+        if (!currentURL)
+            continue;
+
+        if (pattern.matchesURL(currentURL))
+            [tabsToRemove addObject:tab];
+    }
+
+    for (id tab in tabsToRemove)
+        [m_temporaryTabPermissionMatchPatterns removeObjectForKey:tab];
+}
+
+void WebExtensionContext::removeInjectedContent(WebUserContentControllerProxy& userContentController)
+{
+    for (auto& entry : m_injectedScriptsPerPatternMap) {
+        for (auto& userScript : entry.value)
+            userContentController.removeUserScript(userScript);
+    }
+
+    for (auto& entry : m_injectedStyleSheetsPerPatternMap) {
+        for (auto& userStyleSheet : entry.value)
+            userContentController.removeUserStyleSheet(userStyleSheet);
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -76,9 +76,9 @@ RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(NSString 
 
 RefPtr<WebExtensionMatchPattern> WebExtensionMatchPattern::getOrCreate(NSString *scheme, NSString *host, NSString *path)
 {
-    ASSERT(scheme);
-    ASSERT(host);
-    ASSERT(path);
+    scheme = scheme.length ? scheme : @"*";
+    host = host.length ? host : @"*";
+    path = path.length ? path : @"/*";
 
     NSString *pattern = [NSString stringWithFormat:patternFormat, scheme, host, path];
 
@@ -95,6 +95,16 @@ Ref<WebExtensionMatchPattern> WebExtensionMatchPattern::allURLsMatchPattern()
 Ref<WebExtensionMatchPattern> WebExtensionMatchPattern::allHostsAndSchemesMatchPattern()
 {
     return getOrCreate(allHostsAndSchemesPattern).releaseNonNull();
+}
+
+bool WebExtensionMatchPattern::patternsMatchAllHosts(HashSet<Ref<WebExtensionMatchPattern>>& patterns)
+{
+    for (auto& pattern : patterns) {
+        if (pattern->matchesAllHosts())
+            return true;
+    }
+
+    return false;
 }
 
 WebExtensionMatchPattern::WebExtensionMatchPattern(NSString *pattern, NSError **outError)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
@@ -54,7 +54,7 @@ WebExtensionURLSchemeHandler::WebExtensionURLSchemeHandler(WebExtensionControlle
 
 void WebExtensionURLSchemeHandler::platformStartTask(WebPageProxy& page, WebURLSchemeTask& task)
 {
-    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([&, protectedThis = Ref { *this }]() {
+    NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:makeBlockPtr([this, &task, protectedThis = Ref { *this }, protectedTask = Ref { task }]() {
         // If a frame is loading, the frame request URL will be an empty string, since the request is actually the frame URL being loaded.
         // In this case, consider the firstPartyForCookies() to be the document including the frame. This fails for nested frames, since
         // it is always the main frame URL, not the immediate parent frame.

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -61,13 +61,11 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
 
     parameters.identifier = identifier();
 
-#if PLATFORM(COCOA)
     parameters.baseURL = baseURL();
     parameters.uniqueIdentifier = uniqueIdentifier();
     parameters.manifest = extension().manifest();
     parameters.manifestVersion = extension().manifestVersion();
     parameters.testingMode = inTestingMode();
-#endif
 
     return parameters;
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -57,9 +57,7 @@ WebExtensionController::WebExtensionController()
 
 WebExtensionController::~WebExtensionController()
 {
-#if PLATFORM(COCOA)
     unloadAll();
-#endif
 }
 
 WebExtensionControllerParameters WebExtensionController::parameters() const
@@ -68,7 +66,6 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
 
     parameters.identifier = identifier();
 
-#if PLATFORM(COCOA)
     Vector<WebExtensionContextParameters> contextParameters;
     contextParameters.reserveInitialCapacity(extensionContexts().size());
 
@@ -76,9 +73,16 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
         contextParameters.append(context->parameters());
 
     parameters.contextParameters = contextParameters;
-#endif
 
     return parameters;
+}
+
+WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses() const
+{
+    WebProcessProxySet processes;
+    for (auto& page : m_pages)
+        processes.add(page.process());
+    return processes;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -32,14 +32,12 @@
 #include <wtf/OptionSet.h>
 #include <wtf/RetainPtr.h>
 
-#if PLATFORM(COCOA)
 OBJC_CLASS NSArray;
 OBJC_CLASS NSError;
 OBJC_CLASS NSSet;
 OBJC_CLASS NSString;
 OBJC_CLASS NSURL;
 OBJC_CLASS _WKWebExtensionMatchPattern;
-#endif
 
 namespace WebKit {
 
@@ -54,17 +52,17 @@ public:
         return result && result->isValid() ? WTFMove(result) : nullptr;
     }
 
-#if PLATFORM(COCOA)
     static RefPtr<WebExtensionMatchPattern> getOrCreate(NSString *pattern);
     static RefPtr<WebExtensionMatchPattern> getOrCreate(NSString *scheme, NSString *host, NSString *path);
 
     static Ref<WebExtensionMatchPattern> allURLsMatchPattern();
     static Ref<WebExtensionMatchPattern> allHostsAndSchemesMatchPattern();
 
+    static bool patternsMatchAllHosts(HashSet<Ref<WebExtensionMatchPattern>>&);
+
     explicit WebExtensionMatchPattern() { }
     explicit WebExtensionMatchPattern(NSString *pattern, NSError **outError = nullptr);
     explicit WebExtensionMatchPattern(NSString *scheme, NSString *host, NSString *path, NSError **outError = nullptr);
-#endif
 
     ~WebExtensionMatchPattern() { }
 
@@ -76,7 +74,6 @@ public:
         MatchBidirectionally = 1 << 2, // Match two patterns in either direction (A matches B, or B matches A). Invalid for matching URLs.
     };
 
-#if PLATFORM(COCOA)
     static const URLSchemeSet& validSchemes();
     static const URLSchemeSet& supportedSchemes();
 
@@ -104,10 +101,8 @@ public:
 #ifdef __OBJC__
     _WKWebExtensionMatchPattern *wrapper() const { return (_WKWebExtensionMatchPattern *)API::ObjectImpl<API::Object::Type::WebExtensionMatchPattern>::wrapper(); }
 #endif
-#endif
 
 private:
-#if PLATFORM(COCOA)
     NSString *stringWithScheme(NSString *differentScheme) const;
 
     static bool isValidScheme(NSString *);
@@ -126,7 +121,6 @@ private:
     bool m_matchesAllURLs = false;
     bool m_valid = false;
     unsigned m_hash = 0;
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -66,7 +66,7 @@ struct WebPageCreationParameters;
 struct UserContentControllerParameters;
 enum class InjectUserScriptImmediately : bool;
 
-class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, private IPC::MessageReceiver {
+class WebUserContentControllerProxy : public API::ObjectImpl<API::Object::Type::UserContentController>, public IPC::MessageReceiver {
 public:
     static Ref<WebUserContentControllerProxy> create()
     { 
@@ -114,6 +114,9 @@ public:
     UserContentControllerIdentifier identifier() const { return m_identifier; }
 
     void contentWorldDestroyed(API::ContentWorld&);
+
+    bool operator==(const WebUserContentControllerProxy& other) const { return (this == &other); }
+    bool operator!=(const WebUserContentControllerProxy& other) const { return !(this == &other); }
 
 private:
     // IPC::MessageReceiver.

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -573,6 +573,8 @@ public:
 
     void loadServiceWorker(const URL&, bool usingModules, CompletionHandler<void(bool success)>&&);
 
+    WebUserContentControllerProxy& userContentController() { return m_userContentController.get(); }
+
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxy* fullScreenManager();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -191,22 +191,22 @@ TEST(WKWebExtension, ContentScriptsParsing)
     auto exampleURL = [NSURL URLWithString:@"https://example.com/"];
 
     EXPECT_NULL(testExtension.errors);
-    EXPECT_TRUE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_TRUE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*/" ], @"exclude_matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NULL(testExtension.errors);
-    EXPECT_TRUE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js", @1, @"" ], @"css": @[ @NO, @"test.css", @"" ], @"matches": @[ @"*://*.example.com/" ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NULL(testExtension.errors);
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_TRUE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     // Invalid cases
 
@@ -215,32 +215,32 @@ TEST(WKWebExtension, ContentScriptsParsing)
 
     EXPECT_NOT_NULL(testExtension.errors);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @{ @"invalid": @YES };
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NOT_NULL(testExtension.errors);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ ] } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NOT_NULL(testExtension.errors);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 
     testManifestDictionary[@"content_scripts"] = @[ @{ @"js": @[ @"test.js" ], @"matches": @[ @"*://*.example.com/" ], @"run_at": @"invalid" } ];
     testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
 
     EXPECT_NOT_NULL(testExtension.errors);
     EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
-    EXPECT_FALSE([testExtension hasInjectedContentForURL:webkitURL]);
-    EXPECT_TRUE([testExtension hasInjectedContentForURL:exampleURL]);
+    EXPECT_FALSE([testExtension _hasStaticInjectedContentForURL:webkitURL]);
+    EXPECT_TRUE([testExtension _hasStaticInjectedContentForURL:exampleURL]);
 }
 
 TEST(WKWebExtension, PermissionsParsing)


### PR DESCRIPTION
#### 5b5387abfac2be339ec93a67d9e8db023aa52b61
<pre>
Support injected content in Web Extensions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246486">https://bugs.webkit.org/show_bug.cgi?id=246486</a>

Reviewed by Brian Weinstein.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
(-[_WKWebExtension _hasStaticInjectedContentForURL:]): Renamed from hasInjectedContentForURL:.
(-[_WKWebExtension hasInjectedContentForURL:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext hasInjectedContentForURL:]): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionController.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::removeError): Fix lambda capture to capture only this.
(WebKit::WebExtension::recordError): Ditto.
(WebKit::WebExtension::resourceStringForPath): Added. Helper for string resources.
(WebKit::WebExtension::resourceDataForPath): Don&apos;t replace cached strings.
(WebKit::WebExtension::staticInjectedContents): Renamed from injectedContents().
(WebKit::WebExtension::hasStaticInjectedContentForURL): Renamed from hasInjectedContentForURL().
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded): Use m_staticInjectedContents.
(WebKit::WebExtension::allRequestedMatchPatterns): Ditto.
(WebKit::WebExtension::injectedContents): Deleted.
(WebKit::WebExtension::hasInjectedContentForURL): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load): Call addInjectedContent(). Adjust FIXMEs.
(WebKit::WebExtensionContext::unload): Call removeInjectedContent(). Move nil setting to end.
(WebKit::WebExtensionContext::injectedContents): Added with FIXME for dynamic scripts.
(WebKit::WebExtensionContext::hasInjectedContentForURL): Added. This is better here than WebExtension
since dynamic scripts will make the answer wrong on WebExtension but correct here.
(WebKit::WebExtensionContext::postAsyncNotification): Fix lambda capture to fix crashes.
(WebKit::WebExtensionContext::grantPermissionMatchPatterns): Call addInjectedContent().
(WebKit::WebExtensionContext::denyPermissionMatchPatterns): Call updateInjectedContent().
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns): Call removeInjectedContent().
(WebKit::WebExtensionContext::removeDeniedPermissionMatchPatterns): Call updateInjectedContent().
(WebKit::WebExtensionContext::loadBackgroundWebView): Fix lambda capture to capture only this.
(WebKit::WebExtensionContext::addInjectedContent): Added.
(WebKit::toImpl): Added.
(WebKit::WebExtensionContext::removeInjectedContent): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::load): Fix the loading order again to fix some ASSERTs.
(WebKit::WebExtensionController::addPage): Call new addProcessPool() and addUserContentController() helpers.
(WebKit::WebExtensionController::removePage): Call new removeProcessPool() and removeUserContentController() helpers.
(WebKit::WebExtensionController::addProcessPool): Added.
(WebKit::WebExtensionController::removeProcessPool): Added.
(WebKit::WebExtensionController::addUserContentController): Added.
(WebKit::WebExtensionController::removeUserContentController): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::patternsMatchAllHosts): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask): Fix lambda capture to capture only this and protect task.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const): Remove PLATFORM(COCOA) ifdefs after review comments from Darin made me reconsider them.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::addInjectedContent): Added.
(WebKit::WebExtensionContext::updateInjectedContent): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::~WebExtensionController): Remove PLATFORM(COCOA) ifdefs after review comments from Darin made me reconsider them.
(WebKit::WebExtensionController::parameters const): Ditto.
(WebKit::WebExtensionController::allProcesses const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::allPages const): Added.
(WebKit::WebExtensionController::allUserContentControllers const): Added.
(WebKit::WebExtensionController::allProcessPools const): Added.
(WebKit::WebExtensionController::sendToAllProcesses): Use new allProcesses() method.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
(WebKit::WebUserContentControllerProxy::operator== const): Added. Needed for WebExtensionController::removeUserContentController().
(WebKit::WebUserContentControllerProxy::operator!= const): Added.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST): Use renamed _hasStaticInjectedContentForURL: method.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST): Added WKWebExtensionController.ContentScriptLoading test.

Canonical link: <a href="https://commits.webkit.org/257122@main">https://commits.webkit.org/257122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f73fc6702ff5b9667cdb6481bba52d3be734cd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/6/builds/97989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/77/builds/7204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/43/builds/31150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/8/builds/107453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/11/builds/101928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/76/builds/7670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-debug~~](https://ews-build.webkit.org/#/builders/71/builds/35980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/19/builds/103630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/84592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/43/builds/31150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/81/builds/1181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/43/builds/31150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/43/builds/31150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/80/builds/5997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/84592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2430 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/79/builds/2449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/43/builds/31150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
<!--EWS-Status-Bubble-End-->