### PR TITLE
[webkitbugspy] Add default version to issue trackers

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py
@@ -335,6 +335,54 @@ class TestBugzilla(unittest.TestCase):
 
             self.assertEqual(created.project, 'WebKit')
             self.assertEqual(created.component, 'SVG')
+            self.assertEqual(created.version, 'Safari 15')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '''What project should the bug be associated with?:
+    1) CFNetwork
+    2) WebKit
+: 
+What component in 'WebKit' should the bug be associated with?:
+    1) SVG
+    2) Scrolling
+    3) Tables
+    4) Text
+: 
+What version of 'WebKit' should the bug be associated with?:
+    1) Other
+    2) Safari 15
+    3) Safari Technology Preview
+    4) WebKit Local Build
+: 
+''',
+        )
+
+    def test_create_prompt_default_version(self):
+        with mocks.Bugzilla(self.URL.split('://')[1], environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        ), projects=mocks.PROJECTS, issues=mocks.ISSUES), wkmocks.Terminal.input('2', '1',
+                                                                                     '2'), OutputCapture() as captured:
+            created = bugzilla.Tracker(self.URL, default_version='Other').create('New bug', 'Creating new bug')
+            self.assertEqual(created.id, 4)
+            self.assertEqual(created.title, 'New bug')
+            self.assertEqual(created.description, 'Creating new bug')
+            self.assertTrue(created.opened)
+            self.assertEqual(
+                User.Encoder().default(created.creator),
+                dict(name='Tim Contributor', username='tcontributor@example.com',
+                     emails=['tcontributor@example.com']),
+            )
+            self.assertEqual(
+                User.Encoder().default(created.assignee),
+                dict(name='Tim Contributor', username='tcontributor@example.com',
+                     emails=['tcontributor@example.com']),
+            )
+
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'SVG')
+            self.assertEqual(created.version, 'Other')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -349,7 +397,7 @@ What component in 'WebKit' should the bug be associated with?:
     4) Text
 : 
 ''',
-        )
+            )
 
     def test_get_component(self):
         with mocks.Bugzilla(self.URL.split('://')[1], issues=mocks.ISSUES, projects=mocks.PROJECTS):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -321,6 +321,43 @@ What version of 'WebKit Text' should the bug be associated with?:
 ''',
         )
 
+    def test_create_prompt(self):
+        with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS), \
+            wkmocks.Terminal.input('2', '4', '4'), OutputCapture() as captured:
+
+            created = radar.Tracker(projects=['CFNetwork', 'WebKit'], default_version='Other').create('New bug', 'Creating new bug')
+            self.assertEqual(created.id, 4)
+            self.assertEqual(created.title, 'New bug')
+            self.assertEqual(created.description, 'Creating new bug')
+            self.assertTrue(created.opened)
+            self.assertEqual(
+                User.Encoder().default(created.creator),
+                dict(name='Tim Contributor', username=504, emails=['tcontributor@example.com']),
+            )
+            self.assertEqual(
+                User.Encoder().default(created.assignee),
+                dict(name='Tim Contributor', username=504, emails=['tcontributor@example.com']),
+            )
+
+            self.assertEqual(created.project, 'WebKit')
+            self.assertEqual(created.component, 'Text')
+            self.assertEqual(created.version, 'Other')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            '''What project should the bug be associated with?:
+    1) CFNetwork
+    2) WebKit
+: 
+What component in 'WebKit' should the bug be associated with?:
+    1) SVG
+    2) Scrolling
+    3) Tables
+    4) Text
+: 
+''',
+            )
+
     def test_get_component(self):
         with wkmocks.Environment(RADAR_USERNAME='tcontributor'), mocks.Radar(issues=mocks.ISSUES, projects=mocks.PROJECTS):
             issue = radar.Tracker(project='WebKit').issue(1)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py
@@ -120,8 +120,9 @@ class Tracker(object):
             return cls._trackers[0]
         return None
 
-    def __init__(self, users=None, redact=None):
+    def __init__(self, users=None, redact=None, default_version=None):
         self.users = users or User.Mapping()
+        self.default_version = default_version
         if redact is None:
             self._redact = {re.compile('.*'): False}
         elif isinstance(redact, dict):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -251,6 +251,7 @@ class TestBranch(testing.PathTestCase):
             self.assertEqual(issue.description, 'Issue created via command line prompts.')
             self.assertEqual(issue.project, 'WebKit')
             self.assertEqual(issue.component, 'SVG')
+            self.assertEqual(issue.version, 'Safari 15')
 
         self.assertEqual(
             captured.stdout.getvalue(),
@@ -265,6 +266,12 @@ What component in 'WebKit' should the bug be associated with?:
     2) Scrolling
     3) Tables
     4) Text
+: 
+What version of 'WebKit' should the bug be associated with?:
+    1) Other
+    2) Safari 15
+    3) Safari Technology Preview
+    4) WebKit Local Build
 : 
 Created 'https://bugs.example.com/show_bug.cgi?id=4 [Area] New Issue'
 Created the local development branch 'eng/Area-New-Issue'

--- a/metadata/trackers.json
+++ b/metadata/trackers.json
@@ -14,7 +14,7 @@
             "name": "Radar WebKit Bug Importer",
             "emails": ["webkit-bug-importer@group.apple.com"],
             "username": "webkit-bug-importer@group.apple.com"
-        }
+        }, "default_version" : "WebKit Nightly Build"
     },
     {
         "type" : "radar",


### PR DESCRIPTION
#### 217dc0de1c162ce4fda00faabfba08ba0fd4eade
<pre>
[webkitbugspy] Add default version to issue trackers
<a href="https://bugs.webkit.org/show_bug.cgi?id=248163">https://bugs.webkit.org/show_bug.cgi?id=248163</a>
rdar://102571648

Reviewed by NOBODY (OOPS!).

Instead of stripping the idea of version from our issue trackers, we should
define a default version which will avoid prompting users for

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.Encoder.default): Encode default_version.
(Tracker.__init__): Pass default_version to base class.
(Tracker.create): Use default_version as the version of a created bug.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py:
(Tracker.Encoder.default): Encode default_version.
(Tracker.__init__): Pass default_version to base class.
(Tracker.create): Use default_version as the version of a created bug.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.Encoder.default): Encode default_version.
(Tracker.__init__): Pass default_version to base class.
(Tracker.create): Use default_version as the version of a created bug.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_unittest.py:
(TestBugzilla.test_create_prompt):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/github_unittest.py:
(TestGitHub.test_create_prompt):
(TestGitHub.test_create_projects): Renamed test_create_prompt.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tracker.py:
(Tracker.__init__):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_create_bug):
* metadata/trackers.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/217dc0de1c162ce4fda00faabfba08ba0fd4eade

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97996 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107463 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167746 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7696 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36165 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90699 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104083 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5793 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84605 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33001 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/5/builds/101544 "webkitpy-tests (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89375 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75941 "252 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1196 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20804 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/20/builds/96922 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1170 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22313 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44767 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2461 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41715 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->