### PR TITLE
imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html times out

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1198,7 +1198,7 @@ imported/w3c/web-platform-tests/fetch/metadata/style.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/redirect/redirect-http-upgrade.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/window-open.https.sub.html [ Skip ]
 imported/w3c/web-platform-tests/fetch/metadata/redirect/ [ Skip ]
-imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html [ Skip ]
+
 # These tests have unreliable ordering and are flakey
 
 # Not supported

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp-expected.txt
@@ -1,3 +1,4 @@
 
-FAIL Request revalidation aren't blocked by CSP promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: ReportingObserver"
+
+PASS Request revalidation aren't blocked by CSP
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html
@@ -54,12 +54,14 @@ promise_test(async t => {
   // Query the server again and again. At some point it must have received the
   // revalidation request. We poll, because we don't know when the revalidation
   // will occur.
+  let query = false;
   while(true) {
     await new Promise(r => step_timeout(r, 25));
-    let response = await fetch(image_src + "&query");
+    let response = await fetch(`${image_src}${query ? "&query" : ""}`);
     let count = response.headers.get("Count");
     if (count == "2")
       break;
+    query ^= true;
   }
 }, "Request revalidation aren't blocked by CSP");
 


### PR DESCRIPTION
#### ee768c0b2c5815e09934e3e4588e64a687878ba8
<pre>
imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=248424">https://bugs.webkit.org/show_bug.cgi?id=248424</a>
rdar://102734100

Reviewed by Brent Fulgham.

This test times out for all browsers because of a bug in how the Count header value is incremented.
The server backed by fetch/stale-while-revalidate/resources/stale-image.py will
only increment the count value it stores if the request URL does not contain a `query` URL
query parameter. The first time the server gets a request (when the image is first loaded) the URL
does not contain that parameter and so it increments count. However, when we poll the server in
the while loop we always call fetch with a URL that contains the `query` parameter. This caused the
server to never increment the counter and so we time out waiting for the fetch response headers to
contain Count: 2.

This fixes that bug by adding a boolean which causes us to poll the server with the `query` parameter
every other time around the loop.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html:

Canonical link: <a href="https://commits.webkit.org/257154@main">https://commits.webkit.org/257154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f3d3715357cd612d373ed0602ac18bdbba8c52b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107370 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167648 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7571 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35894 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104007 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5694 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84511 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32767 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89303 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1103 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20731 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4926 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44693 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41642 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->