### PR TITLE
[Live Range Selection] fast/forms/number/number-validity-badinput.html fails

### DIFF
--- a/LayoutTests/fast/forms/number/number-validity-badinput-expected.txt
+++ b/LayoutTests/fast/forms/number/number-validity-badinput-expected.txt
@@ -22,7 +22,7 @@ PASS number.value is ""
 The element losts focus. The element state should not be changed.
 PASS colorOf(number) is invalidStyleColor
 PASS number.validity.badInput is true
-PASS document.getSelection().toString() is "-1a"
+PASS visibleValue(number) is "-1a"
 PASS number.value is ""
 The element losts a renderer. The element state should not be changed.
 PASS number.style.display = "none"; number.validity.badInput is true

--- a/LayoutTests/fast/forms/number/number-validity-badinput.html
+++ b/LayoutTests/fast/forms/number/number-validity-badinput.html
@@ -53,7 +53,13 @@ shouldBeTrue('number.validity.badInput');
 // Visible value is '-1a'.
 number.focus();
 document.execCommand('SelectAll');
-shouldBeEqualToString('document.getSelection().toString()', '-1a');
+function visibleValue(input) {
+    const shadowRoot = internals.shadowRoot(input);
+    const range = new Range;
+    range.selectNodeContents(shadowRoot.querySelector('[contenteditable]'));
+    return internals.rangeAsText(range);
+}
+shouldBeEqualToString('visibleValue(number)', '-1a');
 shouldBeEqualToString('number.value', '');
 
 debug("The element losts a renderer. The element state should not be changed.");


### PR DESCRIPTION
#### 025bc03a4da8db230297be2c5fc58a6529a6b9f1
<pre>
[Live Range Selection] fast/forms/number/number-validity-badinput.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248438">https://bugs.webkit.org/show_bug.cgi?id=248438</a>

Reviewed by Darin Adler.

Use internals functions to get the visible text out of an input element
instead of relying on getSelection().toString() to include the text within.

* LayoutTests/fast/forms/number/number-validity-badinput-expected.txt:
* LayoutTests/fast/forms/number/number-validity-badinput.html:

Canonical link: <a href="https://commits.webkit.org/257131@main">https://commits.webkit.org/257131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86d13312009db276724a553534f6db9846716b2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107372 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167650 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7575 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35896 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104009 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5700 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84513 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32765 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89304 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1105 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22240 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5921 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2438 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41643 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->