### PR TITLE
Media fullscreen banner showing when gesture is disabled

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -137,8 +137,10 @@ private:
     RetainPtr<UILongPressGestureRecognizer> _touchGestureRecognizer;
     RetainPtr<UIView> _animatingView;
     RetainPtr<UIStackView> _stackView;
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     RetainPtr<UIStackView> _banner;
     RetainPtr<_WKInsetLabel> _bannerLabel;
+#endif
     RetainPtr<_WKExtrinsicButton> _cancelButton;
     RetainPtr<_WKExtrinsicButton> _pipButton;
     RetainPtr<UIButton> _locationButton;
@@ -189,7 +191,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _valid = NO;
 
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideUI) object:nil];
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
+#endif
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     _playbackClient.setParent(nullptr);
     _playbackClient.setInterface(nullptr);
@@ -271,6 +275,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)showBanner
 {
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     ASSERT(_valid);
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
 
@@ -280,10 +285,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }];
 
     [self performSelector:@selector(hideBanner) withObject:nil afterDelay:autoHideDelay];
+#endif
 }
 
 - (void)hideBanner
 {
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     ASSERT(_valid);
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideBanner) object:nil];
     [UIView animateWithDuration:showHideAnimationDuration animations:^{
@@ -294,6 +301,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         [_banner setHidden:YES];
     }];
+#endif
 }
 
 - (void)videoControlsManagerDidChange
@@ -410,7 +418,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     _location = location;
 
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     [_bannerLabel setText:[NSString stringWithFormat:WEB_UI_NSSTRING(@"”%@” is in full screen.\nSwipe down to exit.", "Full Screen Warning Banner Content Text"), (NSString *)self.location]];
+#endif
 }
 
 #pragma mark - UIViewController Overrides
@@ -494,6 +504,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_stackView setTranslatesAutoresizingMaskIntoConstraints:NO];
     [_animatingView addSubview:_stackView.get()];
 
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     _bannerLabel = adoptNS([[_WKInsetLabel alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     [_bannerLabel setEdgeInsets:UIEdgeInsetsMake(16, 16, 16, 16)];
     [_bannerLabel setBackgroundColor:[UIColor clearColor]];
@@ -508,6 +519,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_banner setTranslatesAutoresizingMaskIntoConstraints:NO];
 
     [_animatingView addSubview:_banner.get()];
+#endif
 
     UILayoutGuide *safeArea = self.view.safeAreaLayoutGuide;
     UILayoutGuide *margins = self.view.layoutMarginsGuide;
@@ -524,9 +536,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [NSLayoutConstraint activateConstraints:@[
         _topConstraint.get(),
         stackViewToTopGuideConstraint,
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
         [[_banner centerYAnchor] constraintEqualToAnchor:margins.centerYAnchor],
         [[_banner centerXAnchor] constraintEqualToAnchor:margins.centerXAnchor],
         [[_banner widthAnchor] constraintEqualToAnchor:margins.widthAnchor],
+#endif
         [[_stackView leadingAnchor] constraintEqualToAnchor:margins.leadingAnchor],
     ]];
 
@@ -534,8 +548,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_stackView setHidden:YES];
     [self videoControlsManagerDidChange];
 
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
     [_banner setAlpha:0];
     [_banner setHidden:YES];
+#endif
 
     _touchGestureRecognizer = adoptNS([[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(_touchDetected:)]);
     [_touchGestureRecognizer setCancelsTouchesInView:NO];


### PR DESCRIPTION
#### 8537f74a00cdbcc63ca53257f9924200e8214319
<pre>
Media fullscreen banner showing when gesture is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=248441">https://bugs.webkit.org/show_bug.cgi?id=248441</a>
rdar://101917160

Reviewed by Eric Carlson.

We currently show a banner explaining the gesture to get out of
fullscreen on iOS. However, certain build configurations do not
support that gesture, so make the banner conditional on that
compile flag.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController invalidate]):
(-[WKFullScreenViewController showBanner]):
(-[WKFullScreenViewController hideBanner]):
(-[WKFullScreenViewController setLocation:]):
(-[WKFullScreenViewController loadView]):

Canonical link: <a href="https://commits.webkit.org/257101@main">https://commits.webkit.org/257101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f5e2c0b4c65991b8f13c7f511366fcbf7f029c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107374 "Built successfully") | 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7577 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35898 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103545 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84515 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1107 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4877 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5923 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41646 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->