### PR TITLE
[Live Range Selection] fast/repaint/selected-replaced.html fails

### DIFF
--- a/LayoutTests/fast/repaint/selected-replaced.html
+++ b/LayoutTests/fast/repaint/selected-replaced.html
@@ -18,7 +18,10 @@
     {
       var selection = window.getSelection();
       var image = document.getElementById('test');
-      selection.setBaseAndExtent(image, 0, image, 1);
+      const range = new Range;
+      range.selectNode(image);
+      selection.removeAllRanges();
+      selection.addRange(range);
       runRepaintTest();
     }
     function repaintTest()


### PR DESCRIPTION
#### f470f8000bbe138d4024e2b5025dbee9af741d42
<pre>
[Live Range Selection] fast/repaint/selected-replaced.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248440">https://bugs.webkit.org/show_bug.cgi?id=248440</a>

Reviewed by Darin Adler.

Use Range&apos;s selectNode function to select the image element instead of
relying on legacy editing offset - (img, 1) to mean the position after img -
since that will break once live range selection is enabled.

* LayoutTests/fast/repaint/selected-replaced.html:

Canonical link: <a href="https://commits.webkit.org/257132@main">https://commits.webkit.org/257132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe9709f6dade5acd06ba779c31f9121e5da13321

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107375 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167653 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7579 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35899 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104012 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5701 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84516 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32775 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89308 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1108 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22244 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5924 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2439 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41647 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->