### PR TITLE
[Live Range Selection] fast/replaced/selection-rect-transform.html fails

### DIFF
--- a/LayoutTests/fast/replaced/selection-rect-transform.html
+++ b/LayoutTests/fast/replaced/selection-rect-transform.html
@@ -13,7 +13,11 @@
         }
     </style>
 </head>
-<body onload="getSelection().setBaseAndExtent(q, 0, q, 1)">
+<body onload="
+range = new Range;
+range.selectNode(q);
+getSelection().removeAllRanges();
+getSelection().addRange(range);">
     <p>Tests selection painting on a transformed, replaced element<br>
       <a href="https://bugs.webkit.org/show_bug.cgi?id=15739">https://bugs.webkit.org/show_bug.cgi?id=15739</a>
     </p>


### PR DESCRIPTION
#### 17971479361d6acc55463e7ed8a18a3ceaf84667
<pre>
[Live Range Selection] fast/replaced/selection-rect-transform.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248443">https://bugs.webkit.org/show_bug.cgi?id=248443</a>

Reviewed by Darin Adler.

Use Range&apos;s selectNode function to select the image element instead of
relying on legacy editing offset - (img, 1) to mean the position after img -
since that will break once live range selection is enabled.

* LayoutTests/fast/replaced/selection-rect-transform.html:

Canonical link: <a href="https://commits.webkit.org/257137@main">https://commits.webkit.org/257137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43025973acea159b3176b753894eaf818dea1845

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107378 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167655 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7582 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35901 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104014 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5704 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84519 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32771 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89310 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1111 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1097 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22246 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44701 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2444 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41649 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->