### PR TITLE
Fix some edge cases in inline style cssText serialization

### DIFF
--- a/LayoutTests/fast/css/cssText-shorthand-expected.txt
+++ b/LayoutTests/fast/css/cssText-shorthand-expected.txt
@@ -1,29 +1,22 @@
-This test ensures WebKit uses shorthand notations for cssText
-
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
-PASS normalizeCssText(element.style.cssText) is "border: 1px"
-PASS normalizeCssText(element.style.cssText) is "border: 1px solid red"
-PASS normalizeCssText(element.style.cssText) is "border: 1px red"
-PASS normalizeCssText(element.style.cssText) is "border: red"
-PASS normalizeCssText(element.style.cssText) is "border: 1px"
-PASS normalizeCssText(element.style.cssText) is "border-width: 1px 2px 3px 4px"
-PASS normalizeCssText(element.style.cssText) is "border-width: 2px 1px 1px"
-PASS normalizeCssText(element.style.cssText) is "border-bottom-width: 1px; border-left-width: 1px; border-right-width: 1px; border-top-width: 1px !important"
-PASS normalizeCssText(element.style.cssText) is "border-top-color: red; border-width: 1px"
-PASS normalizeCssText(element.style.cssText) is "border: dotted"
-PASS normalizeCssText(element.style.cssText) is "border-width: 1px"
-PASS normalizeCssText(element.style.cssText) is "border-spacing: 1px 2px"
-PASS normalizeCssText(element.style.cssText) is "font-family: sans-serif; font-size: 3em; font-style: italic; font-weight: bold; line-height: 2em"
-PASS normalizeCssText(element.style.cssText) is "list-style: inside circle"
-PASS normalizeCssText(element.style.cssText) is "margin: 1px 2px 3px 4px"
-PASS normalizeCssText(element.style.cssText) is "outline: blue dotted 2px"
-PASS normalizeCssText(element.style.cssText) is "overflow: scroll hidden"
-PASS normalizeCssText(element.style.cssText) is "overflow: scroll"
-PASS normalizeCssText(element.style.cssText) is "padding: 1px 2px 3px 4px"
-PASS normalizeCssText(element.style.cssText) is "list-style-type: lower-alpha"
-PASS successfullyParsed is true
-
-TEST COMPLETE
+PASS cssText set to "border: 1px; border-top: 1px;" is read back as "border: 1px;"
+PASS cssText set to "border: 1px solid red;" is read back as "border: 1px solid red;"
+PASS cssText set to "border: 1px red;" is read back as "border: 1px red;"
+PASS cssText set to "border: red;" is read back as "border: red;"
+PASS cssText set to "border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px;" is read back as "border: 1px;"
+PASS cssText set to "border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px;" is read back as "border-color: initial; border-style: initial; border-width: 1px 2px 3px 4px;"
+PASS cssText set to "border: 1px; border-top: 2px;" is read back as "border-color: initial; border-style: initial; border-width: 2px 1px 1px;"
+PASS cssText set to "border: 1px; border-top: 1px !important;" is read back as "border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-top-width: 1px !important;"
+PASS cssText set to "border: 1px; border-top-color: red;" is read back as "border-style: initial; border-top-color: red; border-width: 1px;"
+PASS cssText set to "border: solid; border-style: dotted" is read back as "border: dotted;"
+PASS cssText set to "border-width: 1px;" is read back as "border-width: 1px;"
+PASS cssText set to "-webkit-border-horizontal-spacing: 1px; -webkit-border-vertical-spacing: 2px;" is read back as "border-spacing: 1px 2px;"
+PASS cssText set to "font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold;" is read back as "font-family: sans-serif; line-height: 2em; font-size: 3em; font-style: italic; font-weight: bold;"
+PASS cssText set to "list-style-type: circle; list-style-position: inside; list-style-image: initial;" is read back as "list-style: circle inside;"
+PASS cssText set to "margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;" is read back as "margin: 1px 2px 3px 4px;"
+PASS cssText set to "outline-width: 2px; outline-style: dotted; outline-color: blue;" is read back as "outline: blue dotted 2px;"
+PASS cssText set to "overflow-x: scroll; overflow-y: hidden;" is read back as "overflow-x: scroll; overflow-y: hidden;"
+PASS cssText set to "overflow-x: scroll; overflow-y: scroll;" is read back as "overflow: scroll;"
+PASS cssText set to "padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;" is read back as "padding: 1px 2px 3px 4px;"
+PASS cssText set to "padding: initial; padding-top: initial !important" is read back as "padding-top: initial !important; padding-right: initial; padding-bottom: initial; padding-left: initial;"
+PASS cssText set to "list-style-type: lower-alpha;" is read back as "list-style-type: lower-alpha;"
 

--- a/LayoutTests/fast/css/cssText-shorthand.html
+++ b/LayoutTests/fast/css/cssText-shorthand.html
@@ -1,24 +1,19 @@
 <!DOCTYPE html>
-<html>
-<body>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
 <script>
-
-description("This test ensures WebKit uses shorthand notations for cssText");
-
 var tests = [
-    // FIXME: This exhibits a bug. We shouldn't be outputing border-image here.
     ['border: 1px; border-top: 1px;', 'border: 1px;'],
     ['border: 1px solid red;', 'border: 1px solid red;'],
     ['border: 1px red;', 'border: 1px red;'],
     ['border: red;', 'border: red;'],
     ['border-top: 1px; border-right: 1px; border-bottom: 1px; border-left: 1px;', 'border: 1px;'],
-    ['border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px;', 'border-width: 1px 2px 3px 4px;'],
-    ['border: 1px; border-top: 2px;', 'border-width: 2px 1px 1px;'],
+    ['border-top: 1px; border-right: 2px; border-bottom: 3px; border-left: 4px;', 'border-color: initial; border-style: initial; border-width: 1px 2px 3px 4px;'],
+    ['border: 1px; border-top: 2px;', 'border-color: initial; border-style: initial; border-width: 2px 1px 1px;'],
     ['border: 1px; border-top: 1px !important;',
     'border-right-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-top-width: 1px !important;'],
 
-    ['border: 1px; border-top-color: red;', 'border-width: 1px; border-top-color: red;'],
+    ['border: 1px; border-top-color: red;', 'border-style: initial; border-top-color: red; border-width: 1px;'],
     ['border: solid; border-style: dotted', 'border: dotted;'],
     ['border-width: 1px;', 'border-width: 1px;'],
 
@@ -31,9 +26,10 @@ var tests = [
     ['list-style-type: circle; list-style-position: inside; list-style-image: initial;', 'list-style: inside circle;'],
     ['margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;', 'margin: 1px 2px 3px 4px;'],
     ['outline-width: 2px; outline-style: dotted; outline-color: blue;', 'outline: blue dotted 2px;'],
-    ['overflow-x: scroll; overflow-y: hidden;', 'overflow: scroll hidden;'],
+    ['overflow-x: scroll; overflow-y: hidden;', 'overflow-x: scroll; overflow-y: hidden;'],
     ['overflow-x: scroll; overflow-y: scroll;', 'overflow: scroll;'],
     ['padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;', 'padding: 1px 2px 3px 4px;'],
+    ['padding: initial; padding-top: initial !important', 'padding-top: initial !important; padding-right: initial; padding-bottom: initial; padding-left: initial;'],
 
 	['list-style-type: lower-alpha;', 'list-style-type: lower-alpha;']
 ];
@@ -41,17 +37,14 @@ var tests = [
 function normalizeCssText(text) { return text.trim().split(/;\s*/).sort().slice(1).join("; "); }
 
 var element;
-tests.forEach(function (test) {
-    var styleAttribute = test[0];
-    var expectedCssText = test[1];
+tests.forEach(function (values) {
+    var styleAttribute = values[0];
+    var expectedCssText = values[1];
+    test(function() {
+        element = document.createElement('div');
+        element.setAttribute('style', styleAttribute);
 
-    element = document.createElement('div');
-    element.setAttribute('style', styleAttribute);
-
-    shouldBe('normalizeCssText(element.style.cssText)', '"' + normalizeCssText(expectedCssText) + '"');
+        assert_equals(normalizeCssText(element.style.cssText), normalizeCssText(expectedCssText));
+    }, "cssText set to " + JSON.stringify(styleAttribute) + " is read back as " + JSON.stringify(expectedCssText));
 });
-
 </script>
-<script src="../../resources/js-test-post.js"></script>
-</body>
-</html>

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -705,16 +705,17 @@ String StyleProperties::get4Values(const StylePropertyShorthand& shorthand) cons
     if (!top.value() || !right.value() || !bottom.value() || !left.value())
         return String();
 
+    if (top.isImportant() != right.isImportant() || right.isImportant() != bottom.isImportant() || bottom.isImportant() != left.isImportant())
+        return String();
+
     if (top.isInherited() && right.isInherited() && bottom.isInherited() && left.isInherited())
         return nameString(CSSValueInherit);
 
-    if (top.value()->isInitialValue() || right.value()->isInitialValue() || bottom.value()->isInitialValue() || left.value()->isInitialValue()) {
-        if (top.value()->isInitialValue() && right.value()->isInitialValue() && bottom.value()->isInitialValue() && left.value()->isInitialValue() && !top.isImplicit()) {
-            // All components are "initial" and "top" is not implicit.
+    unsigned numInitial = top.value()->isInitialValue() + right.value()->isInitialValue() + bottom.value()->isInitialValue() + left.value()->isInitialValue();
+        if (numInitial == 4)
             return nameString(CSSValueInitial);
-        }
-        return String();
-    }
+        if (numInitial > 0)
+            return String();
 
     bool showLeft = !right.value()->equals(*left.value());
     bool showBottom = !top.value()->equals(*bottom.value()) || showLeft;


### PR DESCRIPTION
<pre>
Fix some edge cases in inline style cssText serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=248442">https://bugs.webkit.org/show_bug.cgi?id=248442</a>

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit behavior with Blink / Chromium and Gecko / Firefox.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/1b84d2a68d373efab9a6e571274ffefdeefe6c58">https://chromium.googlesource.com/chromium/blink/+/1b84d2a68d373efab9a6e571274ffefdeefe6c58</a>

This patch fixes a couple of edge cases in serializing inline styles for four-value
properties (padding, border-width, etc.).
[1] "padding: initial; padding-top: initial
!important;" no longer uses a shorthand with !important qualifier (since left/top/bottom
are not !important here)
[2] Shorthands which are all initial are no longer dropped when they are all implicitly
specified (e.g. "border: 1px; border-top: 2px" will now serialize border-color and border
style to initial instead of leaving them out)

* Source/WebCore/css/StyleProperties.cpp:
(StyleProperties::get4Values): Update to address edge cases
* LayoutTests/fast/css/cssText-shorthand.html: Rebaselined
* LayoutTests/fast/css/cssText-shorthand-expected.txt: Rebaselined
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc7915ce1f3120ec39b22f8fbc93e92f021941d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107384 "Built successfully") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167661 "Found 1 new test failure: fast/css/cssText-shorthand.html (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7591 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35907 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104020 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103559 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5712 "Found 1 new test failure: fast/css/cssText-shorthand.html (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84525 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32781 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89316 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1117 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1103 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22256 "Found 1 new test failure: fast/css/cssText-shorthand.html (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41655 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->