### PR TITLE
Remove the unnecessary HDRMediaCapabilitiesEnabled feature flag

### DIFF
--- a/LayoutTests/fast/media/mq-highdynamicrange-live-update.html
+++ b/LayoutTests/fast/media/mq-highdynamicrange-live-update.html
@@ -18,7 +18,6 @@ window.addEventListener('load', event => {
     if (!window.internals)
         return;
 
-    window.internals.settings.setHDRMediaCapabilitiesEnabled(true);
     window.internals.settings.forcedSupportsHighDynamicRangeValue = "off";
     var element = document.getElementById("a");
     document.getElementById("before").textContent = window.getComputedStyle(element).color;

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr-expected.txt
@@ -1,6 +1,5 @@
 RUN(internals.enableMockMediaCapabilities())
 RUN(internals.settings.setMediaCapabilitiesExtensionsEnabled(true))
-RUN(internals.settings.setHDRMediaCapabilitiesEnabled(true))
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs="mock-with-hdr"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK

--- a/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr.html
+++ b/LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr.html
@@ -15,7 +15,6 @@
 
         run('internals.enableMockMediaCapabilities()');
         run('internals.settings.setMediaCapabilitiesExtensionsEnabled(true)');
-        run('internals.settings.setHDRMediaCapabilitiesEnabled(true)');
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'file', video: { contentType: 'video/mp4; codecs=\"mock-with-hdr\"', height: 720, bitrate: 1000, width: 1280, framerate: 24.5 }});");
         info = await shouldResolve(promise);

--- a/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr-expected.txt
+++ b/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr-expected.txt
@@ -1,5 +1,4 @@
 RUN(internals.settings.setMediaCapabilitiesExtensionsEnabled(true))
-RUN(internals.settings.setHDRMediaCapabilitiesEnabled(true))
 RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs="hvc1.2.4.H153.B0"', height: 720, bitrate: 800000, width: 1280, framerate: 24.5 }});)
 Promise resolved OK
 EXPECTED (info.supported == 'true') OK

--- a/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr.html
+++ b/LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr.html
@@ -14,7 +14,6 @@
         }
 
         run('internals.settings.setMediaCapabilitiesExtensionsEnabled(true)');
-        run('internals.settings.setHDRMediaCapabilitiesEnabled(true)');
 
         run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', video: { contentType: 'video/mp4; codecs=\"hvc1.2.4.H153.B0\"', height: 720, bitrate: 800000, width: 1280, framerate: 24.5 }});");
         info = await shouldResolve(promise);

--- a/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
+++ b/Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml
@@ -833,19 +833,6 @@ GoogleAntiFlickerOptimizationQuirkEnabled:
     WebCore:
       default: true
 
-# FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
-HDRMediaCapabilitiesEnabled:
-  type: bool
-  humanReadableName: "HDR Media Capabilities"
-  humanReadableDescription: "HDR Media Capabilities"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
-
 HasPseudoClassEnabled:
   type: bool
   humanReadableName: ":has() pseudo-class"

--- a/Source/WebCore/Modules/mediacapabilities/VideoConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/VideoConfiguration.idl
@@ -33,7 +33,7 @@
   required unsigned long long bitrate;
   required double framerate;
   [EnabledBySetting=MediaCapabilitiesExtensionsEnabled] boolean alphaChannel;
-  [EnabledBySetting=HDRMediaCapabilitiesEnabled] HdrMetadataType hdrMetadataType;
-  [EnabledBySetting=HDRMediaCapabilitiesEnabled] ColorGamut colorGamut;
-  [EnabledBySetting=HDRMediaCapabilitiesEnabled] TransferFunction transferFunction;
+  HdrMetadataType hdrMetadataType;
+  ColorGamut colorGamut;
+  TransferFunction transferFunction;
 };

--- a/Source/WebCore/css/LegacyMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/LegacyMediaQueryEvaluator.cpp
@@ -409,9 +409,6 @@ static bool dynamicRangeEvaluate(CSSValue* value, const CSSToLengthConversionDat
     if (!value)
         return false;
 
-    if (!frame.settings().hdrMediaCapabilitiesEnabled())
-        return false;
-
     bool supportsHighDynamicRange;
 
     if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::On)

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -334,8 +334,6 @@ const FeatureSchema& dynamicRange()
         [](auto& context) {
             bool supportsHighDynamicRange = [&] {
                 auto& frame = *context.document.frame();
-                if (!frame.settings().hdrMediaCapabilitiesEnabled())
-                    return false;
                 if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::On)
                     return true;
                 if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::Off)


### PR DESCRIPTION
#### 49dfaedfc2b5a1c6a16338964dbe162d1ed00f6f
<pre>
Remove the unnecessary HDRMediaCapabilitiesEnabled feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=248436">https://bugs.webkit.org/show_bug.cgi?id=248436</a>
&lt;rdar://problem/102738537&gt;

Reviewed by Eric Carlson.

Modern WebKit always enables HDRMediaCapabilitiesEnabled, and we no longer need
to toggle this option for A/B testing. We should remove it to reduce the cluttered
set of experimental features.

* LayoutTests/fast/media/mq-highdynamicrange-live-update.html: Remove call to set the
removed enablement flag. No change in behavior since the flag was always turned on,
and the feature is now always enabled.
* LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr-expected.txt: Ditto.
* LayoutTests/media/mediacapabilities/mock-decodingInfo-hdr.html: Ditto.
* LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr-expected.txt: Ditto.
* LayoutTests/platform/mac/media/mediacapabilities/hevc-decodingInfo-hdr.html: Ditto.
* Source/WTF/Scripts/Preferences/WebPreferencesExperimental.yaml:
* Source/WebCore/Modules/mediacapabilities/VideoConfiguration.idl:
* Source/WebCore/css/LegacyMediaQueryEvaluator.cpp:
(WebCore::dynamicRangeEvaluate):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::dynamicRange):

Canonical link: <a href="https://commits.webkit.org/257200@main">https://commits.webkit.org/257200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4ba1dcdc3e71f8c0b6ddc93d548f0ab65f03771

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107462 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167736 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7692 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35985 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90723 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104082 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5789 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84603 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33015 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89374 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88862 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1195 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84568 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1169 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22312 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28589 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6014 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44766 "Found 1 new test failure: fast/images/animated-heics-draw.html (failure)") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87404 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41714 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19607 "Passed tests") | 
<!--EWS-Status-Bubble-End-->