### PR TITLE
Share collectDescendantLayersAtPoint() code

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
@@ -25,6 +25,11 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+#ifdef __cplusplus
+#import "FloatPoint.h"
+#import <wtf/Vector.h>
+#endif
+
 @interface CALayer (WebCoreCALayerExtras)
 
 + (CALayer *)_web_renderLayerWithContextID:(uint32_t)contextID;
@@ -36,3 +41,14 @@
 - (BOOL)_web_maskMayIntersectRect:(CGRect)rect;
 
 @end
+
+#ifdef __cplusplus
+
+namespace WebCore {
+
+using LayerAndPoint = std::pair<CALayer *, FloatPoint>;
+WEBCORE_EXPORT void collectDescendantLayersAtPoint(Vector<LayerAndPoint, 16>& layersAtPoint, CALayer *parent, CGPoint, const std::function<bool(CALayer *, CGPoint localPoint)>& pointInLayerFunction);
+
+} // namespace WebCore
+
+#endif // __cplusplus


### PR DESCRIPTION
#### 2d88fb59358717a051df4d9593f929f1e9ae989b
<pre>
Share collectDescendantLayersAtPoint() code
<a href="https://bugs.webkit.org/show_bug.cgi?id=248446">https://bugs.webkit.org/show_bug.cgi?id=248446</a>
rdar://102741971

Reviewed by Wenson Hsieh.

Scrolling in the UI process needs to share `collectDescendantLayersAtPoint()` code, so
make it re-usable, and factor out the implementation specific parts by passing in
a function.

* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(layerEventRegionContainsPoint):
(ScrollingTreeMac::scrollingNodeForPoint):
(ScrollingTreeMac::eventListenerRegionTypesForPoint const):
(collectDescendantLayersAtPoint): Deleted.
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(WebCore::collectDescendantLayersAtPoint):

Canonical link: <a href="https://commits.webkit.org/257135@main">https://commits.webkit.org/257135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/095dd2d07b8629216874cb2e846f023d44a82936

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107385 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167662 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7592 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35908 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104021 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5715 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84526 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32790 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89317 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1118 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22257 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4900 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5934 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41656 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->