### PR TITLE
[ iOS16 ] 5 css3/filters/effect-hw tests are constant failures

### DIFF
--- a/LayoutTests/css3/filters/effect-contrast-hw.html
+++ b/LayoutTests/css3/filters/effect-contrast-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-200; totalPixels=0-35500">
+    <meta name="fuzzy" content="maxDifference=0-230; totalPixels=0-36000">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-grayscale-hw.html
+++ b/LayoutTests/css3/filters/effect-grayscale-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-32500">
+    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-32600">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-opacity-hw.html
+++ b/LayoutTests/css3/filters/effect-opacity-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-11800">
+    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-11950">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-saturate-hw.html
+++ b/LayoutTests/css3/filters/effect-saturate-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-256; totalPixels=0-18500">
+    <meta name="fuzzy" content="maxDifference=0-256; totalPixels=0-18900">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/css3/filters/effect-sepia-hw.html
+++ b/LayoutTests/css3/filters/effect-sepia-hw.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-36600">
+    <meta name="fuzzy" content="maxDifference=0-54; totalPixels=0-36800">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <style>
         img {

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2345,13 +2345,6 @@ webkit.org/b/245091 http/wpt/shared-workers/connect-event-ordering.html [ Pass F
 
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-032.html [ Failure ]
 
-# webkit.org/b/245543 New Test(254408@main): [ iOS16 ] 5X css3/filters/effect-(Layout tests) are constant image failures
-css3/filters/effect-contrast-hw.html [ ImageOnlyFailure ]
-css3/filters/effect-grayscale-hw.html [ ImageOnlyFailure ]
-css3/filters/effect-opacity-hw.html [ ImageOnlyFailure ]
-css3/filters/effect-saturate-hw.html [ ImageOnlyFailure ]
-css3/filters/effect-sepia-hw.html [ ImageOnlyFailure ]
-
 # webkit.org/b/245586 [ iOS16 ] 3X imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/(Layout tests) are constant failures
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-video-resize.html [ Failure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html [ Failure ]


### PR DESCRIPTION
#### 048739819f556a86e5ae7a14afc88d8aa232d61a
<pre>
[ iOS16 ] 5 css3/filters/effect-hw tests are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=245543">https://bugs.webkit.org/show_bug.cgi?id=245543</a>
rdar://100297846

Unreviewed test gardening.

These tests need a bit more tolerance on iOS.

* LayoutTests/css3/filters/effect-contrast-hw.html:
* LayoutTests/css3/filters/effect-grayscale-hw.html:
* LayoutTests/css3/filters/effect-opacity-hw.html:
* LayoutTests/css3/filters/effect-saturate-hw.html:
* LayoutTests/css3/filters/effect-sepia-hw.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/257134@main">https://commits.webkit.org/257134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89482d443b24b73feabc01d5629dac1b6429d667

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107390 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167667 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7599 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35913 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90439 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104026 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5719 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84531 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32792 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89325 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1123 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1109 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4899 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5939 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2390 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41662 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->