### PR TITLE
[WebIDL] JSErrorHandler should restore window.event after it reports an exception

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-is-still-set-when-reporting-exception-onerror-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-is-still-set-when-reporting-exception-onerror-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: ReferenceError: Can't find variable: foo
+
+
+PASS window.onerror handler restores window.event after it reports an exception
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-is-still-set-when-reporting-exception-onerror.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-is-still-set-when-reporting-exception-onerror.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>window.onerror handler restores window.event after it reports an exception</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+<iframe src="resources/empty-document.html"></iframe>
+<iframe src="resources/empty-document.html"></iframe>
+
+<script>
+setup({ allow_uncaught_exception: true });
+
+async_test(t => {
+    window.onload = t.step_func_done(onLoadEvent => {
+        frames[0].onerror = new frames[1].Function(`
+            top.eventDuringSecondOnError = top.window.event;
+            top.frames[0].eventDuringSecondOnError = top.frames[0].event;
+            top.frames[1].eventDuringSecondOnError = top.frames[1].event;
+        `);
+
+        window.onerror = new frames[0].Function(`
+            top.eventDuringFirstOnError = top.window.event;
+            top.frames[0].eventDuringFirstOnError = top.frames[0].event;
+            top.frames[1].eventDuringFirstOnError = top.frames[1].event;
+
+            foo; // cause second onerror
+        `);
+
+        const myEvent = new ErrorEvent("error", { error: new Error("myError") });
+        window.dispatchEvent(myEvent);
+
+        assert_equals(top.eventDuringFirstOnError, onLoadEvent);
+        assert_equals(frames[0].eventDuringFirstOnError, myEvent);
+        assert_equals(frames[1].eventDuringFirstOnError, undefined);
+
+        assert_equals(top.eventDuringSecondOnError, onLoadEvent);
+        assert_equals(frames[0].eventDuringSecondOnError, myEvent);
+        assert_equals(frames[1].eventDuringSecondOnError.error.name, "ReferenceError");
+    });
+});
+</script>

--- a/Source/WebCore/bindings/js/JSErrorHandler.cpp
+++ b/Source/WebCore/bindings/js/JSErrorHandler.cpp
@@ -110,15 +110,15 @@ void JSErrorHandler::handleEvent(ScriptExecutionContext& scriptExecutionContext,
 
         InspectorInstrumentation::didCallFunction(&scriptExecutionContext);
 
-        if (jsFunctionWindow)
-            jsFunctionWindow->setCurrentEvent(savedEvent.get());
-
         if (exception)
             reportException(jsFunction->globalObject(), exception);
         else {
             if (returnValue.isTrue())
                 event.preventDefault();
         }
+
+        if (jsFunctionWindow)
+            jsFunctionWindow->setCurrentEvent(savedEvent.get());
     }
 }
 


### PR DESCRIPTION
#### a94e852bfc69edb31f494b31f0e3c9627e8b7386
<pre>
[WebIDL] JSErrorHandler should restore window.event after it reports an exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=248452">https://bugs.webkit.org/show_bug.cgi?id=248452</a>

Reviewed by Darin Adler.

The remark in r286873 that &quot;JSErrorHandler is correct regarding window.error&quot; was only valid
because reportException() was called on the wrong global object, which was fixed in r257086.

This change aligns WebKit with Blink by restoring window.error after exception is reported [1],
making JSErrorHandler consistent with JSEventListener.

[1] <a href="https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke">https://dom.spec.whatwg.org/#concept-event-listener-inner-invoke</a> (steps 10.2 - 12)

* LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-is-still-set-when-reporting-exception-onerror-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-is-still-set-when-reporting-exception-onerror.html: Added.
* Source/WebCore/bindings/js/JSErrorHandler.cpp:
(WebCore::JSErrorHandler::handleEvent):

Canonical link: <a href="https://commits.webkit.org/257149@main">https://commits.webkit.org/257149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5f60df30bc4729b61a36d8ee79fc19aa8e30ba7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107396 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167671 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7607 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35918 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104030 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5724 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84536 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32797 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89323 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1127 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22261 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44722 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2450 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41660 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->