### PR TITLE
[JSC] Align Function#name behavior with spec

### DIFF
--- a/JSTests/stress/function-name-property.js
+++ b/JSTests/stress/function-name-property.js
@@ -1,0 +1,24 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+shouldBe(({ f: () => {} }).f.name, 'f');
+shouldBe(({ f: function () {} }).f.name, 'f');
+shouldBe(({ ['f']: () => {} }).f.name, 'f');
+shouldBe(({ ['f']: function () {} }).f.name, 'f');
+shouldBe(({ async f() {} }).f.name, 'f');
+shouldBe(({ async ['f']() {} }).f.name, 'f');
+shouldBe((class { f() {} }).prototype.f.name, 'f');
+shouldBe((class { ['f']() {} }).prototype.f.name, 'f');
+shouldBe((class { async f() {} }).prototype.f.name, 'f');
+shouldBe((class { async ['f']() {} }).prototype.f.name, 'f');
+
+shouldBe([() => {}][0].name, '');
+shouldBe([function () {}][0].name, '');
+shouldBe(({ 0: () => {} })[0].name, '0');
+shouldBe(({ 0: function () {} })[0].name, '0');
+shouldBe(({ [0]: () => {} })[0].name, '0');
+shouldBe(({ [0]: function () {} })[0].name, '0');
+shouldBe((class { 0() {} }).prototype[0].name, '0');
+shouldBe((class { [0]() {} }).prototype[0].name, '0');

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -3067,11 +3067,12 @@ parseMethod:
         case IDENT:
             if (UNLIKELY(*m_token.m_data.ident == m_vm.propertyNames->async && !m_token.m_data.escaped)) {
                 if (!isGeneratorMethodParseMode(parseMode) && !isAsyncMethodParseMode(parseMode)) {
-                    ident = m_token.m_data.ident;
                     next();
                     // We match SEMICOLON as a special case for a field called 'async' without initializer.
-                    if (match(OPENPAREN) || match(COLON) || match(SEMICOLON) || match(EQUAL) || m_lexer->hasLineTerminatorBeforeToken())
+                    if (match(OPENPAREN) || match(COLON) || match(SEMICOLON) || match(EQUAL) || m_lexer->hasLineTerminatorBeforeToken()) {
+                        ident = &m_vm.propertyNames->async;
                         break;
+                    }
                     if (UNLIKELY(consume(TIMES)))
                         parseMode = SourceParseMode::AsyncGeneratorWrapperMethodMode;
                     else
@@ -4598,12 +4599,11 @@ namedProperty:
     }
     case DOUBLE:
     case INTEGER: {
-        double propertyName = m_token.m_data.doubleValue;
+        const Identifier& ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
         next();
 
         if (match(OPENPAREN)) {
             SetForScope innerParseMode(m_parseMode, parseMode);
-            const Identifier& ident = m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), propertyName);
             auto method = parsePropertyMethod(context, &ident);
             propagateError();
             return context.createProperty(&ident, method, PropertyNode::Constant, SuperBinding::Needed, InferName::Allowed, ClassElementTag::No);
@@ -4614,7 +4614,7 @@ namedProperty:
         TreeExpression node = parseAssignmentExpression(context);
         failIfFalse(node, "Cannot parse expression for property declaration");
         context.setEndOffset(node, m_lexer->currentOffset());
-        return context.createProperty(const_cast<VM&>(m_vm), m_parserArena, propertyName, node, PropertyNode::Constant, SuperBinding::NotNeeded, ClassElementTag::No);
+        return context.createProperty(&ident, node, PropertyNode::Constant, SuperBinding::NotNeeded, InferName::Allowed, ClassElementTag::No);
     }
     case BIGINT: {
         const Identifier* ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);


### PR DESCRIPTION
#### c99e9b77dcb663545aed3758bacae744a6b3ecd9
<pre>
[JSC] Align Function#name behavior with spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=247725">https://bugs.webkit.org/show_bug.cgi?id=247725</a>

Reviewed by Yusuke Suzuki.

This patch fixes two bugs in our Function#name implementation, which were reported in the same BZ issue
(each is due to misalignment between object literals and class bodies -- one issue in each direction):

1. `class C { async [&apos;f&apos;]() {} }`
   Async class methods with computed names were given the function name &quot;async&quot;,
   because we were storing the async identifier *anytime* we encountered it.

2. `{ 0: () =&gt; {} }`
   Object literal function properties with Number literal names were given an empty function name (as would
   be correct behavior for Array). Incidentally, BigInt literal names were already behaving properly here.

* JSTests/stress/function-name-property.js: Added.
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseProperty):

Canonical link: <a href="https://commits.webkit.org/257114@main">https://commits.webkit.org/257114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a1d6d5f58b7a1274f52fe71adf867ce1724c4bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31122 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107428 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167701 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7643 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35952 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103608 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84567 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/1/builds/88833 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1158 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/38/builds/84539 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1140 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/46/builds/28584 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4891 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5974 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/37/builds/87375 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41693 "Passed tests") | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/45/builds/19603 "Passed tests") | 
<!--EWS-Status-Bubble-End-->