### PR TITLE
Fix constant timeouts in transition tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1915,7 +1915,7 @@ imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.ht
 
 transitions/svg-text-shadow-transition.html [ Failure ]
 webkit.org/b/137883 transitions/background-transitions.html [ Failure Pass ]
-webkit.org/b/137883 transitions/border-radius-transition.html [ Failure Pass Timeout ]
+webkit.org/b/137883 transitions/border-radius-transition.html [ Failure Pass ]
 webkit.org/b/137883 transitions/change-values-during-transition.html [ Failure Pass ]
 webkit.org/b/137883 transitions/clip-transition.html [ Failure Pass ]
 webkit.org/b/137883 transitions/color-transition-all.html [ Failure Pass ]
@@ -1950,7 +1950,7 @@ webkit.org/b/137883 transitions/repeated-firing-background-color.html [ Pass Fai
 webkit.org/b/137883 transitions/retargetted-transition.html [ Pass Failure ]
 webkit.org/b/137883 transitions/rounded-rect-becomes-non-renderable-while-transitioning.html [ Pass Failure ]
 webkit.org/b/137883 transitions/shorthand-border-transitions.html [ Pass Failure ]
-webkit.org/b/137883 transitions/shorthand-transitions.html [ Pass Failure Timeout ]
+webkit.org/b/137883 transitions/shorthand-transitions.html [ Pass Failure ]
 webkit.org/b/137883 transitions/started-while-suspended.html [ Pass Failure ]
 webkit.org/b/137883 transitions/transition-shorthand-delay.html
 webkit.org/b/137883 transitions/transition-timing-function.html [ Pass Failure ]


### PR DESCRIPTION
#### 4ee897dd423cb67f2715cd1211ddc5b25174369b
<pre>
Fix constant timeouts in transition tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=248449">https://bugs.webkit.org/show_bug.cgi?id=248449</a>

Reviewed by Darin Adler.

In 257041@main I changed the computed getPropertyCSSValue() for the
border-radius longhands. Previously it was either a CSSPrimitiveValue
holding a length, or a CSSValueList with 2 CSSPrimitiveValue lengths.
To make it consistent with the parser, I made it always return a
CSSPrimitiveValue holding a Pair of CSSPrimitiveValue lengths.

This affected transition-test-helpers.js, which didn&apos;t have logic for
the border-radius longhands, so it was falling back to getFloatValue().
This would have already failed in the CSSValueList case, but it went
undetected until I used the CSSPrimitiveValue pair.

Then getFloatValue() started throwing an exception, which would prevent
the tests from completing. Hence a timeout.

This patch adds custom logic for the border-radius longhands, and adds
a try...catch so that exceptions don&apos;t cause a timeout.

* LayoutTests/TestExpectations:
* LayoutTests/transitions/resources/transition-test-helpers.js:

Canonical link: <a href="https://commits.webkit.org/257208@main">https://commits.webkit.org/257208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a312df69bb81c73147c0728c13a82775754e6ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/97965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107427 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167700 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7642 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/35951 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90618 "Built successfully") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104056 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5760 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84566 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32934 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89351 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1157 "Built successfully") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20778 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1139 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4965 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/5973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44744 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41691 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->