### PR TITLE
Add exports to link a shared WebCore with WebKit for WinCairo

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.h
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.h
@@ -44,7 +44,7 @@ class DeflateResultHolder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit DeflateResultHolder(WebSocketDeflateFramer&);
-    ~DeflateResultHolder();
+    WEBCORE_EXPORT ~DeflateResultHolder();
 
     bool succeeded() const { return m_succeeded; }
     String failureReason() const { return m_failureReason; }
@@ -61,7 +61,7 @@ class InflateResultHolder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit InflateResultHolder(WebSocketDeflateFramer&);
-    ~InflateResultHolder();
+    WEBCORE_EXPORT ~InflateResultHolder();
 
     bool succeeded() const { return m_succeeded; }
     String failureReason() const { return m_failureReason; }
@@ -76,16 +76,16 @@ private:
 
 class WebSocketDeflateFramer {
 public:
-    std::unique_ptr<WebSocketExtensionProcessor> createExtensionProcessor();
+    WEBCORE_EXPORT std::unique_ptr<WebSocketExtensionProcessor> createExtensionProcessor();
 
     bool enabled() const { return m_enabled; }
 
-    std::unique_ptr<DeflateResultHolder> deflate(WebSocketFrame&);
+    WEBCORE_EXPORT std::unique_ptr<DeflateResultHolder> deflate(WebSocketFrame&);
     void resetDeflateContext();
-    std::unique_ptr<InflateResultHolder> inflate(WebSocketFrame&);
+    WEBCORE_EXPORT std::unique_ptr<InflateResultHolder> inflate(WebSocketFrame&);
     void resetInflateContext();
 
-    void didFail();
+    WEBCORE_EXPORT void didFail();
 
     void enableDeflate(int windowBits, WebSocketDeflater::ContextTakeOverMode);
 

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.h
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.h
@@ -46,7 +46,7 @@ public:
     };
 
     explicit WebSocketDeflater(int windowBits, ContextTakeOverMode = TakeOverContext);
-    ~WebSocketDeflater();
+    WEBCORE_EXPORT ~WebSocketDeflater();
 
     bool initialize();
     bool addBytes(const uint8_t*, size_t);
@@ -66,7 +66,7 @@ class WebSocketInflater {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WebSocketInflater(int windowBits = 15);
-    ~WebSocketInflater();
+    WEBCORE_EXPORT ~WebSocketInflater();
 
     bool initialize();
     bool addBytes(const uint8_t*, size_t);

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.h
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.h
@@ -55,11 +55,11 @@ struct WebSocketFrame {
     static bool isNonControlOpCode(OpCode opCode) { return opCode == OpCodeContinuation || opCode == OpCodeText || opCode == OpCodeBinary; }
     static bool isControlOpCode(OpCode opCode) { return opCode == OpCodeClose || opCode == OpCodePing || opCode == OpCodePong; }
     static bool isReservedOpCode(OpCode opCode) { return !isNonControlOpCode(opCode) && !isControlOpCode(opCode); }
-    static bool needsExtendedLengthField(size_t payloadLength);
-    static ParseFrameResult parseFrame(uint8_t* data, size_t dataLength, WebSocketFrame&, const uint8_t*& frameEnd, String& errorString); // May modify part of data to unmask the frame.
+    WEBCORE_EXPORT static bool needsExtendedLengthField(size_t payloadLength);
+    WEBCORE_EXPORT static ParseFrameResult parseFrame(uint8_t* data, size_t dataLength, WebSocketFrame&, const uint8_t*& frameEnd, String& errorString); // May modify part of data to unmask the frame.
 
     WEBCORE_EXPORT WebSocketFrame(OpCode = OpCodeInvalid, bool final = false, bool compress = false, bool masked = false, const uint8_t* payload = nullptr, size_t payloadLength = 0);
-    void makeFrameData(Vector<uint8_t>& frameData);
+    WEBCORE_EXPORT void makeFrameData(Vector<uint8_t>& frameData);
 
     OpCode opCode;
     bool final;

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -49,8 +49,8 @@ public:
     enum Mode {
         Incomplete, Normal, Failed, Connected
     };
-    WebSocketHandshake(const URL&, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated);
-    ~WebSocketHandshake();
+    WEBCORE_EXPORT WebSocketHandshake(const URL&, const String& protocol, const String& userAgent, const String& clientOrigin, bool allowCookies, bool isAppInitiated);
+    WEBCORE_EXPORT ~WebSocketHandshake();
 
     const URL& url() const;
     void setURL(const URL&);
@@ -64,25 +64,25 @@ public:
 
     String clientLocation() const;
 
-    CString clientHandshakeMessage() const;
+    WEBCORE_EXPORT CString clientHandshakeMessage() const;
     ResourceRequest clientHandshakeRequest(const Function<String(const URL&)>& cookieRequestHeaderFieldValue) const;
 
-    void reset();
+    WEBCORE_EXPORT void reset();
 
-    int readServerHandshake(const uint8_t* header, size_t len);
-    Mode mode() const;
-    String failureReason() const; // Returns a string indicating the reason of failure if mode() == Failed.
+    WEBCORE_EXPORT int readServerHandshake(const uint8_t* header, size_t len);
+    WEBCORE_EXPORT Mode mode() const;
+    WEBCORE_EXPORT String failureReason() const; // Returns a string indicating the reason of failure if mode() == Failed.
 
-    String serverWebSocketProtocol() const;
-    String serverSetCookie() const;
+    WEBCORE_EXPORT String serverWebSocketProtocol() const;
+    WEBCORE_EXPORT String serverSetCookie() const;
     String serverUpgrade() const;
     String serverConnection() const;
     String serverWebSocketAccept() const;
-    String acceptedExtensions() const;
+    WEBCORE_EXPORT String acceptedExtensions() const;
 
-    const ResourceResponse& serverHandshakeResponse() const;
+    WEBCORE_EXPORT const ResourceResponse& serverHandshakeResponse() const;
 
-    void addExtensionProcessor(std::unique_ptr<WebSocketExtensionProcessor>);
+    WEBCORE_EXPORT void addExtensionProcessor(std::unique_ptr<WebSocketExtensionProcessor>);
 
     static String getExpectedWebSocketAccept(const String& secWebSocketKey);
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -91,7 +91,7 @@ public:
 
     static uint32_t wireFormatVersion();
 
-    String toString() const;
+    WEBCORE_EXPORT String toString() const;
 
     // API implementation helpers. These don't expose special behavior for ArrayBuffers or MessagePorts.
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSContextRef, JSValueRef, JSValueRef* exception);

--- a/Source/WebCore/fileapi/File.h
+++ b/Source/WebCore/fileapi/File.h
@@ -85,7 +85,7 @@ public:
     const std::optional<int64_t>& lastModifiedOverride() const { return m_lastModifiedDateOverride; } // Number of milliseconds since Epoch.
     const std::optional<FileSystem::PlatformFileID> fileID() const { return m_fileID; }
 
-    static String contentTypeForFile(const String& path);
+    WEBCORE_EXPORT static String contentTypeForFile(const String& path);
 
 #if ENABLE(FILE_REPLACEMENT)
     static bool shouldReplaceFile(const String& path);

--- a/Source/WebCore/inspector/InspectorController.h
+++ b/Source/WebCore/inspector/InspectorController.h
@@ -71,7 +71,7 @@ public:
 
     void inspectedPageDestroyed();
 
-    bool enabled() const;
+    WEBCORE_EXPORT bool enabled() const;
     Page& inspectedPage() const;
 
     WEBCORE_EXPORT void show();

--- a/Source/WebCore/platform/Length.h
+++ b/Source/WebCore/platform/Length.h
@@ -126,7 +126,7 @@ public:
     bool isSpecified() const;
     bool isSpecifiedOrIntrinsic() const;
 
-    float nonNanCalculatedValue(float maxValue) const;
+    WEBCORE_EXPORT float nonNanCalculatedValue(float maxValue) const;
 
     bool isLegacyIntrinsic() const;
 

--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -81,7 +81,7 @@ const double ForceAtForceClick = 2;
 #endif
 
 #if PLATFORM(WIN)
-        PlatformMouseEvent(HWND, UINT, WPARAM, LPARAM, bool didActivateWebView = false);
+        WEBCORE_EXPORT PlatformMouseEvent(HWND, UINT, WPARAM, LPARAM, bool didActivateWebView = false);
         void setClickCount(int count) { m_clickCount = count; }
         bool didActivateWebView() const { return m_didActivateWebView; }
 #endif

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -77,7 +77,7 @@ public:
     WEBCORE_EXPORT void scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
 
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
-    void scrollToOffsetWithoutAnimation(ScrollbarOrientation, float offset);
+    WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(ScrollbarOrientation, float offset);
 
     // Should be called when the scroll position changes externally, for example if the scroll layer position
     // is updated on the scrolling thread and we need to notify the main thread.
@@ -248,8 +248,8 @@ public:
     bool scrollOriginChanged() const { return m_scrollOriginChanged; }
 
     virtual ScrollPosition scrollPosition() const = 0;
-    virtual ScrollPosition minimumScrollPosition() const;
-    virtual ScrollPosition maximumScrollPosition() const;
+    WEBCORE_EXPORT virtual ScrollPosition minimumScrollPosition() const;
+    WEBCORE_EXPORT virtual ScrollPosition maximumScrollPosition() const;
 
     ScrollPosition constrainedScrollPosition(const ScrollPosition& position) const
     {

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -110,7 +110,7 @@ public:
     // This constructor is only used if the platform wants to start with a native font.
     WEBCORE_EXPORT FontCascade(const FontPlatformData&, FontSmoothingMode = FontSmoothingMode::AutoSmoothing);
 
-    FontCascade(const FontCascade&);
+    WEBCORE_EXPORT FontCascade(const FontCascade&);
     WEBCORE_EXPORT FontCascade& operator=(const FontCascade&);
 
     WEBCORE_EXPORT bool operator==(const FontCascade& other) const;

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -111,7 +111,7 @@ public:
 #endif
 
 #if PLATFORM(WIN)
-    FontPlatformData(GDIObject<HFONT>, float size, bool syntheticBold, bool syntheticOblique, bool useGDI, const CreationData* = nullptr);
+    WEBCORE_EXPORT FontPlatformData(GDIObject<HFONT>, float size, bool syntheticBold, bool syntheticOblique, bool useGDI, const CreationData* = nullptr);
 #if USE(CORE_TEXT)
     FontPlatformData(GDIObject<HFONT>, CTFontRef, CGFontRef, float size, bool syntheticBold, bool syntheticOblique, bool useGDI);
 #endif

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -374,8 +374,8 @@ private:
     virtual bool supportsTransparencyLayers() const { return true; }
 
 protected:
-    void fillEllipseAsPath(const FloatRect&);
-    void strokeEllipseAsPath(const FloatRect&);
+    WEBCORE_EXPORT void fillEllipseAsPath(const FloatRect&);
+    WEBCORE_EXPORT void strokeEllipseAsPath(const FloatRect&);
 
     FloatRect computeLineBoundsAndAntialiasingModeForText(const FloatRect&, bool printing, Color&);
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -282,7 +282,7 @@ public:
     // Layer name. Only used to identify layers in debug output
     const String& name() const { return m_name; }
     virtual void setName(const String& name) { m_name = name; }
-    virtual String debugName() const;
+    WEBCORE_EXPORT virtual String debugName() const;
 
     GraphicsLayer* parent() const { return m_parent; };
     void setParent(GraphicsLayer*); // Internal use only.
@@ -308,7 +308,7 @@ public:
 
     // The parent() of a maskLayer is set to the layer being masked.
     GraphicsLayer* maskLayer() const { return m_maskLayer.get(); }
-    virtual void setMaskLayer(RefPtr<GraphicsLayer>&&);
+    WEBCORE_EXPORT virtual void setMaskLayer(RefPtr<GraphicsLayer>&&);
 
     void setIsMaskLayer(bool isMask) { m_isMaskLayer = isMask; }
     bool isMaskLayer() const { return m_isMaskLayer; }
@@ -368,22 +368,22 @@ public:
     // For platforms that move underlying platform layers on a different thread for scrolling; just update the GraphicsLayer state.
     virtual void syncBoundsOrigin(const FloatPoint& origin) { m_boundsOrigin = origin; }
 
-    const TransformationMatrix& transform() const;
-    virtual void setTransform(const TransformationMatrix&);
+    WEBCORE_EXPORT const TransformationMatrix& transform() const;
+    WEBCORE_EXPORT virtual void setTransform(const TransformationMatrix&);
     bool hasNonIdentityTransform() const { return m_transform && !m_transform->isIdentity(); }
 
-    const TransformationMatrix& childrenTransform() const;
-    virtual void setChildrenTransform(const TransformationMatrix&);
+    WEBCORE_EXPORT const TransformationMatrix& childrenTransform() const;
+    WEBCORE_EXPORT virtual void setChildrenTransform(const TransformationMatrix&);
     bool hasNonIdentityChildrenTransform() const { return m_childrenTransform && !m_childrenTransform->isIdentity(); }
 
     bool preserves3D() const { return m_preserves3D; }
-    virtual void setPreserves3D(bool);
+    WEBCORE_EXPORT virtual void setPreserves3D(bool);
     
     bool masksToBounds() const { return m_masksToBounds; }
-    virtual void setMasksToBounds(bool);
+    WEBCORE_EXPORT virtual void setMasksToBounds(bool);
     
     bool drawsContent() const { return m_drawsContent; }
-    virtual void setDrawsContent(bool);
+    WEBCORE_EXPORT virtual void setDrawsContent(bool);
 
     bool contentsAreVisible() const { return m_contentsVisible; }
     virtual void setContentsVisible(bool b) { m_contentsVisible = b; }
@@ -427,7 +427,7 @@ public:
 
     const FilterOperations& filters() const { return m_filters; }
     // Returns true if filter can be rendered by the compositor.
-    virtual bool setFilters(const FilterOperations&);
+    WEBCORE_EXPORT virtual bool setFilters(const FilterOperations&);
 
     const FilterOperations& backdropFilters() const { return m_backdropFilters; }
     virtual bool setBackdropFilters(const FilterOperations& filters) { m_backdropFilters = filters; return true; }
@@ -476,13 +476,13 @@ public:
     virtual void setContentsRectClipsDescendants(bool b) { m_contentsRectClipsDescendants = b; }
 
     Path shapeLayerPath() const;
-    virtual void setShapeLayerPath(const Path&);
+    WEBCORE_EXPORT virtual void setShapeLayerPath(const Path&);
 
     WindRule shapeLayerWindRule() const;
-    virtual void setShapeLayerWindRule(WindRule);
+    WEBCORE_EXPORT virtual void setShapeLayerWindRule(WindRule);
 
     const EventRegion& eventRegion() const { return m_eventRegion; }
-    virtual void setEventRegion(EventRegion&&);
+    WEBCORE_EXPORT virtual void setEventRegion(EventRegion&&);
 
     // Transitions are identified by a special animation name that cannot clash with a keyframe identifier.
     static String animationNameForTransition(AnimatedPropertyID);
@@ -526,7 +526,7 @@ public:
     virtual bool usesContentsLayer() const { return false; }
 
     // Callback from the underlying graphics system to draw layer contents.
-    void paintGraphicsLayerContents(GraphicsContext&, const FloatRect& clip, GraphicsLayerPaintBehavior = GraphicsLayerPaintNormal);
+    WEBCORE_EXPORT void paintGraphicsLayerContents(GraphicsContext&, const FloatRect& clip, GraphicsLayerPaintBehavior = GraphicsLayerPaintNormal);
 
     // For hosting this GraphicsLayer in a native layer hierarchy.
     virtual PlatformLayer* platformLayer() const { return nullptr; }
@@ -629,12 +629,12 @@ public:
     virtual TiledBacking* tiledBacking() const { return 0; }
 
     void resetTrackedRepaints();
-    void addRepaintRect(const FloatRect&);
+    WEBCORE_EXPORT void addRepaintRect(const FloatRect&);
 
     static bool supportsLayerType(Type);
     static bool supportsContentsTiling();
 
-    void updateDebugIndicators();
+    WEBCORE_EXPORT void updateDebugIndicators();
 
     virtual bool isGraphicsLayerCA() const { return false; }
     virtual bool isGraphicsLayerCARemote() const { return false; }

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -172,7 +172,7 @@ public:
     WEBCORE_EXPORT RefPtr<Image> copyImage(BackingStoreCopy = CopyBackingStore, PreserveResolution = PreserveResolution::No) const;
     WEBCORE_EXPORT virtual RefPtr<Image> filteredImage(Filter&);
 #if USE(CAIRO)
-    RefPtr<cairo_surface_t> createCairoSurface();
+    WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
 #endif
 
     static RefPtr<NativeImage> sinkIntoNativeImage(RefPtr<ImageBuffer>);

--- a/Source/WebCore/platform/graphics/IntPoint.h
+++ b/Source/WebCore/platform/graphics/IntPoint.h
@@ -131,9 +131,9 @@ public:
 #endif // !PLATFORM(IOS_FAMILY)
 
 #if PLATFORM(WIN)
-    IntPoint(const POINT&);
-    operator POINT() const;
-    IntPoint(const POINTS&);
+    WEBCORE_EXPORT IntPoint(const POINT&);
+    WEBCORE_EXPORT operator POINT() const;
+    WEBCORE_EXPORT IntPoint(const POINTS&);
     operator POINTS() const;
 #endif
 

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -191,8 +191,8 @@ public:
     bool isValid() const;
 
 #if PLATFORM(WIN)
-    IntRect(const RECT&);
-    operator RECT() const;
+    WEBCORE_EXPORT IntRect(const RECT&);
+    WEBCORE_EXPORT operator RECT() const;
 #endif
 
 #if USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/BackingStoreBackendCairoImpl.h
+++ b/Source/WebCore/platform/graphics/cairo/BackingStoreBackendCairoImpl.h
@@ -27,7 +27,7 @@ namespace WebCore {
 class BackingStoreBackendCairoImpl final : public BackingStoreBackendCairo {
 public:
     WEBCORE_EXPORT BackingStoreBackendCairoImpl(const IntSize&, float deviceScaleFactor);
-    virtual ~BackingStoreBackendCairoImpl();
+    WEBCORE_EXPORT virtual ~BackingStoreBackendCairoImpl();
 
 private:
     void scroll(const IntRect&, const IntSize&) override;

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h
@@ -37,9 +37,9 @@ namespace WebCore {
 
 class ImageBufferCairoBackend : public ImageBufferBackend {
 public:
-    void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
+    WEBCORE_EXPORT void clipToMask(GraphicsContext&, const FloatRect& destRect) override;
 
-    void transformToColorSpace(const DestinationColorSpace&) override;
+    WEBCORE_EXPORT void transformToColorSpace(const DestinationColorSpace&) override;
 
 protected:
     using ImageBufferBackend::ImageBufferBackend;

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
@@ -54,7 +54,7 @@ struct DefaultRefDerefTraits<cairo_font_face_t> {
 template<>
 struct DefaultRefDerefTraits<cairo_scaled_font_t> {
     static void refIfNotNull(cairo_scaled_font_t* ptr);
-    static void derefIfNotNull(cairo_scaled_font_t* ptr);
+    WEBCORE_EXPORT static void derefIfNotNull(cairo_scaled_font_t* ptr);
 };
 
 template<>

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class FilterOperations {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    bool operator==(const FilterOperations&) const;
+    WEBCORE_EXPORT bool operator==(const FilterOperations&) const;
     bool operator!=(const FilterOperations& other) const { return !(*this == other); }
 
     void clear() { m_operations.clear(); }

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h
@@ -89,7 +89,7 @@ public:
     void flushCompositingState(const FloatRect&) override;
     void flushCompositingStateForThisLayerOnly() override;
 
-    void updateBackingStoreIncludingSubLayers(TextureMapper&);
+    WEBCORE_EXPORT void updateBackingStoreIncludingSubLayers(TextureMapper&);
 
     TextureMapperLayer& layer() { return m_layer; }
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperSparseBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperSparseBackingStore.h
@@ -41,12 +41,12 @@ class TextureMapperSparseBackingStore final : public TextureMapperBackingStore {
 public:
     using TileIndex = WebCore::IntPoint;
 
-    void setSize(const IntSize&);
-    void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
-    void drawBorder(TextureMapper&, const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;
-    void drawRepaintCounter(TextureMapper&, int repaintCount, const Color&, const FloatRect&, const TransformationMatrix&) override;
-    void updateContents(TextureMapper&, const TileIndex&, Image&, const IntRect& dirtyRect);
-    void removeTile(const TileIndex&);
+    WEBCORE_EXPORT void setSize(const IntSize&);
+    WEBCORE_EXPORT void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix&, float) override;
+    WEBCORE_EXPORT void drawBorder(TextureMapper&, const Color&, float borderWidth, const FloatRect&, const TransformationMatrix&) override;
+    WEBCORE_EXPORT void drawRepaintCounter(TextureMapper&, int repaintCount, const Color&, const FloatRect&, const TransformationMatrix&) override;
+    WEBCORE_EXPORT void updateContents(TextureMapper&, const TileIndex&, Image&, const IntRect& dirtyRect);
+    WEBCORE_EXPORT void removeTile(const TileIndex&);
 
 private:
     TransformationMatrix adjustedTransformForRect(const FloatRect&);

--- a/Source/WebCore/platform/graphics/transforms/TransformState.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.h
@@ -74,7 +74,7 @@ public:
     
     TransformState(const TransformState& other) { *this = other; }
 
-    TransformState& operator=(const TransformState&);
+    WEBCORE_EXPORT TransformState& operator=(const TransformState&);
 
     void setQuad(const FloatQuad& quad)
     {
@@ -102,8 +102,8 @@ public:
 
     void move(const LayoutSize&, TransformAccumulation = FlattenTransform);
     void applyTransform(const AffineTransform& transformFromContainer, TransformAccumulation = FlattenTransform, bool* wasClamped = nullptr);
-    void applyTransform(const TransformationMatrix& transformFromContainer, TransformAccumulation = FlattenTransform, bool* wasClamped = nullptr);
-    void flatten(bool* wasClamped = nullptr);
+    WEBCORE_EXPORT void applyTransform(const TransformationMatrix& transformFromContainer, TransformAccumulation = FlattenTransform, bool* wasClamped = nullptr);
+    WEBCORE_EXPORT void flatten(bool* wasClamped = nullptr);
 
     // Return the coords of the point or quad in the last flattened layer
     FloatPoint lastPlanarPoint() const { return m_lastPlanarPoint; }
@@ -113,8 +113,8 @@ public:
 
     // Return the point or quad mapped through the current transform
     FloatPoint mappedPoint(bool* wasClamped = nullptr) const;
-    FloatQuad mappedQuad(bool* wasClamped = nullptr) const;
-    std::optional<FloatQuad> mappedSecondaryQuad(bool* wasClamped = nullptr) const;
+    WEBCORE_EXPORT FloatQuad mappedQuad(bool* wasClamped = nullptr) const;
+    WEBCORE_EXPORT std::optional<FloatQuad> mappedSecondaryQuad(bool* wasClamped = nullptr) const;
 
     TransformationMatrix* accumulatedTransform() const { return m_accumulatedTransform.get(); }
     std::unique_ptr<TransformationMatrix> releaseTrackedTransform() { return WTFMove(m_trackedTransform); }

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -265,11 +265,11 @@ public:
     TransformationMatrix& rotate3d(double x, double y, double z, double angle);
     
     WEBCORE_EXPORT TransformationMatrix& translate(double tx, double ty);
-    TransformationMatrix& translate3d(double tx, double ty, double tz);
+    WEBCORE_EXPORT TransformationMatrix& translate3d(double tx, double ty, double tz);
 
     // translation added with a post-multiply
     TransformationMatrix& translateRight(double tx, double ty);
-    TransformationMatrix& translateRight3d(double tx, double ty, double tz);
+    WEBCORE_EXPORT TransformationMatrix& translateRight3d(double tx, double ty, double tz);
     
     WEBCORE_EXPORT TransformationMatrix& flipX();
     WEBCORE_EXPORT TransformationMatrix& flipY();

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformData.h
@@ -52,7 +52,7 @@ struct FontCustomPlatformData {
     WTF_MAKE_NONCOPYABLE(FontCustomPlatformData);
 public:
     FontCustomPlatformData(const String& name, FontPlatformData::CreationData&&);
-    ~FontCustomPlatformData();
+    WEBCORE_EXPORT ~FontCustomPlatformData();
 
     FontPlatformData fontPlatformData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
@@ -65,7 +65,7 @@ public:
     FontPlatformData::CreationData creationData;
 };
 
-std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer&, const String&);
+WEBCORE_EXPORT std::unique_ptr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer&, const String&);
 
 }
 

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -142,7 +142,7 @@ public:
     void saveCredentialToPersistentStorage(const ProtectionSpace&, const Credential&);
 #elif USE(CURL)
     WEBCORE_EXPORT NetworkStorageSession(PAL::SessionID);
-    ~NetworkStorageSession();
+    WEBCORE_EXPORT ~NetworkStorageSession();
 
     CookieJarDB& cookieDatabase() const;
     WEBCORE_EXPORT void setCookieDatabase(UniqueRef<CookieJarDB>&&);

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -104,7 +104,7 @@ public:
     const CurlShareHandle& shareHandle() { return m_shareHandle; }
 
     CurlRequestScheduler& scheduler() { return *m_scheduler; }
-    CurlStreamScheduler& streamScheduler();
+    WEBCORE_EXPORT CurlStreamScheduler& streamScheduler();
 
     // Proxy
     const CurlProxySettings& proxySettings() const { return m_proxySettings; }

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -71,14 +71,14 @@ public:
 
     virtual ~CurlRequest();
 
-    void invalidateClient();
+    WEBCORE_EXPORT void invalidateClient();
     WEBCORE_EXPORT void setAuthenticationScheme(ProtectionSpace::AuthenticationScheme);
     WEBCORE_EXPORT void setUserPass(const String&, const String&);
     bool isServerTrustEvaluationDisabled() { return m_shouldDisableServerTrustEvaluation; }
     void disableServerTrustEvaluation() { m_shouldDisableServerTrustEvaluation = true; }
 
-    void start();
-    void cancel();
+    WEBCORE_EXPORT void start();
+    WEBCORE_EXPORT void cancel();
     WEBCORE_EXPORT void suspend();
     WEBCORE_EXPORT void resume();
 
@@ -105,7 +105,7 @@ private:
         FinishTransfer
     };
 
-    CurlRequest(const ResourceRequest&, CurlRequestClient*, ShouldSuspend, EnableMultipart, CaptureNetworkLoadMetrics, RefPtr<SynchronousLoaderMessageQueue>&&);
+    WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, ShouldSuspend, EnableMultipart, CaptureNetworkLoadMetrics, RefPtr<SynchronousLoaderMessageQueue>&&);
 
     void retain() override { ref(); }
     void release() override { deref(); }

--- a/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
+++ b/Source/WebCore/platform/network/curl/CurlStreamScheduler.h
@@ -38,9 +38,9 @@ public:
     CurlStreamScheduler();
     virtual ~CurlStreamScheduler();
 
-    CurlStreamID createStream(const URL&, CurlStream::Client&);
-    void destroyStream(CurlStreamID);
-    void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
+    WEBCORE_EXPORT CurlStreamID createStream(const URL&, CurlStream::Client&);
+    WEBCORE_EXPORT void destroyStream(CurlStreamID);
+    WEBCORE_EXPORT void send(CurlStreamID, UniqueArray<uint8_t>&&, size_t);
 
     void callOnWorkerThread(Function<void()>&&);
     void callClientOnMainThread(CurlStreamID, Function<void(CurlStream::Client&)>&&);

--- a/Source/WebCore/platform/win/BitmapInfo.h
+++ b/Source/WebCore/platform/win/BitmapInfo.h
@@ -46,7 +46,7 @@ struct BitmapInfo : public BITMAPINFO {
 
     BitmapInfo();
     WEBCORE_EXPORT static BitmapInfo create(const IntSize&, BitCount bitCount = BitCount32);
-    static BitmapInfo createBottomUp(const IntSize&, BitCount bitCount = BitCount32);
+    WEBCORE_EXPORT static BitmapInfo createBottomUp(const IntSize&, BitCount bitCount = BitCount32);
 
     bool is16bit() const { return bmiHeader.biBitCount == 16; }
     bool is32bit() const { return bmiHeader.biBitCount == 32; }

--- a/Source/WebCore/platform/win/WebCoreBundleWin.h
+++ b/Source/WebCore/platform/win/WebCoreBundleWin.h
@@ -38,9 +38,9 @@ namespace WebCore {
 CFBundleRef webKitBundle();
 #endif
 
-String webKitBundlePath();
-String webKitBundlePath(StringView path);
-String webKitBundlePath(StringView name, StringView type, StringView directory);
-String webKitBundlePath(const Vector<StringView>& components);
+WEBCORE_EXPORT String webKitBundlePath();
+WEBCORE_EXPORT String webKitBundlePath(StringView path);
+WEBCORE_EXPORT String webKitBundlePath(StringView name, StringView type, StringView directory);
+WEBCORE_EXPORT String webKitBundlePath(const Vector<StringView>& components);
 
 }

--- a/Source/WebCore/platform/win/WindowMessageBroadcaster.h
+++ b/Source/WebCore/platform/win/WindowMessageBroadcaster.h
@@ -40,8 +40,8 @@ namespace WebCore {
     class WindowMessageBroadcaster {
         WTF_MAKE_NONCOPYABLE(WindowMessageBroadcaster);
     public:
-        static void addListener(HWND, WindowMessageListener*);
-        static void removeListener(HWND, WindowMessageListener*);
+        WEBCORE_EXPORT static void addListener(HWND, WindowMessageListener*);
+        WEBCORE_EXPORT static void removeListener(HWND, WindowMessageListener*);
 
     private:
         typedef HashSet<WindowMessageListener*> ListenerSet;

--- a/Source/WebCore/platform/win/WindowsKeyNames.h
+++ b/Source/WebCore/platform/win/WindowsKeyNames.h
@@ -38,11 +38,11 @@ namespace WebCore {
 
 class WindowsKeyNames {
 public:
-    WindowsKeyNames();
+    WEBCORE_EXPORT WindowsKeyNames();
 
-    String domKeyFromParams(WPARAM, LPARAM);
-    String domKeyFromChar(UChar);
-    String domCodeFromLParam(LPARAM);
+    WEBCORE_EXPORT String domKeyFromParams(WPARAM, LPARAM);
+    WEBCORE_EXPORT String domKeyFromChar(UChar);
+    WEBCORE_EXPORT String domCodeFromLParam(LPARAM);
 
     enum class KeyModifier : uint8_t;
     using KeyModifierSet = OptionSet<KeyModifier>;

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -156,8 +156,8 @@ public:
     Color inactiveSelectionForegroundColor(OptionSet<StyleColorOptions>) const;
 
     // List box selection colors
-    Color activeListBoxSelectionBackgroundColor(OptionSet<StyleColorOptions>) const;
-    Color activeListBoxSelectionForegroundColor(OptionSet<StyleColorOptions>) const;
+    WEBCORE_EXPORT Color activeListBoxSelectionBackgroundColor(OptionSet<StyleColorOptions>) const;
+    WEBCORE_EXPORT Color activeListBoxSelectionForegroundColor(OptionSet<StyleColorOptions>) const;
     Color inactiveListBoxSelectionBackgroundColor(OptionSet<StyleColorOptions>) const;
     Color inactiveListBoxSelectionForegroundColor(OptionSet<StyleColorOptions>) const;
 


### PR DESCRIPTION
#### 6e266388a02754e1e9ff0655feefaa5c536b37c0
<pre>
Add exports to link a shared WebCore with WebKit for WinCairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=248468">https://bugs.webkit.org/show_bug.cgi?id=248468</a>

Reviewed by Michael Catanzaro.

Adds all `WEBCORE_EXPORT`s required to get WebKit to link with a
`SHARED` WebCore.

* Source/WebCore/Modules/websockets/WebSocketDeflateFramer.h:
* Source/WebCore/Modules/websockets/WebSocketDeflater.h:
* Source/WebCore/Modules/websockets/WebSocketFrame.h:
* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/fileapi/File.h:
* Source/WebCore/inspector/InspectorController.h:
* Source/WebCore/platform/Length.h:
* Source/WebCore/platform/PlatformMouseEvent.h:
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/IntPoint.h:
* Source/WebCore/platform/graphics/IntRect.h:
* Source/WebCore/platform/graphics/cairo/BackingStoreBackendCairoImpl.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.h:
* Source/WebCore/platform/graphics/cairo/RefPtrCairo.h:
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperSparseBackingStore.h:
* Source/WebCore/platform/graphics/transforms/TransformState.h:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/platform/graphics/win/FontCustomPlatformData.h:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlRequest.h:
* Source/WebCore/platform/network/curl/CurlStreamScheduler.h:
* Source/WebCore/platform/win/BitmapInfo.h:
* Source/WebCore/platform/win/WebCoreBundleWin.h:
* Source/WebCore/platform/win/WindowMessageBroadcaster.h:
* Source/WebCore/platform/win/WindowsKeyNames.h:
* Source/WebCore/rendering/RenderTheme.h:

Canonical link: <a href="https://commits.webkit.org/257147@main">https://commits.webkit.org/257147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5a06a06aa6cd1a3e2e1d5bbb059e61c32fa103d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98039 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107505 "Built successfully") | [  ~~🛠 🧪 win~~](https://ews-build.webkit.org/#/builders/10/builds/167781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7736 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36027 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103691 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84646 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/90568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/9/builds/87692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1236 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/82/builds/1207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4916 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41752 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->