### PR TITLE
First subtest is failing in css/css-typed-om/the-stylepropertymap/computed/computed.tentative.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -279,7 +279,6 @@ PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside
 PASS shape-rendering
-PASS size
 PASS speak-as
 PASS stop-color
 PASS stop-opacity

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/computed.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/computed.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Computed StylePropertyMap contains every CSS property assert_not_equals: got disallowed value null
+PASS Computed StylePropertyMap contains every CSS property
 PASS Computed StylePropertyMap contains CSS property declarations in style rules
 PASS Computed StylePropertyMap contains custom property declarations in style rules
 PASS Computed StylePropertyMap contains CSS property declarations in inline styles

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-all-longhands-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-all-longhands-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Specified style
-FAIL Computed style assert_array_equals: lengths differ, expected array [] length 0, got ["size"] length 1
+PASS Computed style
 

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -279,7 +279,6 @@ PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside
 PASS shape-rendering
-PASS size
 PASS speak-as
 PASS stop-color
 PASS stop-opacity

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -278,7 +278,6 @@ PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside
 PASS shape-rendering
-PASS size
 PASS speak-as
 PASS stop-color
 PASS stop-opacity

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4859,6 +4859,7 @@
         },
         "size": {
             "codegen-properties": {
+                "computable": false,
                 "custom": "All",
                 "custom-parser": true,
                 "parser-requires-context-mode": true

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -275,13 +275,8 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Ref<CSSValue> c
             return Ref<CSSStyleValue> { CSSNumericFactory::cqmax(primitiveValue->doubleValue()) };
         
         case CSSUnitType::CSS_IDENT:
-        case CSSUnitType::CSS_STRING: {
-            auto value = CSSKeywordValue::create(primitiveValue->stringValue());
-            if (value.hasException())
-                return value.releaseException();
-            
-            return Ref<CSSStyleValue> { value.releaseReturnValue() };
-        }
+        case CSSUnitType::CSS_STRING:
+            return static_reference_cast<CSSStyleValue>(CSSKeywordValue::rectifyKeywordish(primitiveValue->stringValue()));
         default:
             break;
         }


### PR DESCRIPTION
#### 310730c00382d5f24c21414a5e852891ff232ad2
<pre>
First subtest is failing in css/css-typed-om/the-stylepropertymap/computed/computed.tentative.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=248471">https://bugs.webkit.org/show_bug.cgi?id=248471</a>

Reviewed by Antoine Quint.

The first subtest was failing in WebKit. What it did is check that the computed
StylePropertyMap contains every CSS property in it. It did so by getting all
CSS property names via window.getComputedStyle() and then looking up those
properties in the Element.computedStyleMap() StylePropertyMap, and checking
that they are not null.

Two CSS properties were causing us to fail this subtest:
- &quot;alt&quot;. This is a non-standard property of string type. It&apos;s value is the
  empty String by default. CSSStyleValueFactory::reifyValue() would attempt to
  construct a CSSKeywordValue for this string. However, CSSKeywordValue::create()
  would throw when the string is empty (because that&apos;s what the JS-exposed
  constructor is supposed to do per the specification). To avoid the issue, we
  now construct the CSSKeywordValue by calling CSSKeywordValue::rectifyKeywordish()
  which doesn&apos;t do any string validation.
- &quot;size&quot;. This is a standard property which was exposed via window.getComputedStyle()
  but looking it up in the StylePropertyMap would return null. The reason for
  this is since we don&apos;t support this property in
  ComputedStyleExtractor::valueForPropertyInStyle() (with a comment stating so) and
  we just return null. To address this issue, I am now hiding the @page &quot;size&quot;
  property from computed properties.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/computed/computed.tentative-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):

Canonical link: <a href="https://commits.webkit.org/257245@main">https://commits.webkit.org/257245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc8a2d3fb6fa1656cf27189a87dc8670f1795666

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107747 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168015 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8009 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36266 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90872 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/12/builds/104342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103950 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/6039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84888 "Built successfully") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/35/builds/33112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87902 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/76056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1463 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/21010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1407 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4988 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41952 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->