### PR TITLE
[Filters] Add a new test for SVG filter overriding geometry

### DIFF
--- a/LayoutTests/svg/filters/filter-geometry-override-expected.svg
+++ b/LayoutTests/svg/filters/filter-geometry-override-expected.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500px" height="500px">
+    <defs>
+        <clipPath id="clip-path-1">
+            <rect x="0" y="0" width="100" height="100"></rect>
+        </clipPath>
+        <clipPath id="clip-path-2">
+            <rect x="150" y="0" width="100" height="100"></rect>
+        </clipPath>
+        <clipPath id="clip-path-3">
+            <rect x="0" y="150" width="100" height="100"></rect>
+        </clipPath>
+        <clipPath id="clip-path-4">
+            <rect x="150" y="150" width="100" height="100"></rect>
+        </clipPath>
+        <symbol id="rect-with-shadow"   >
+            <rect x="0" y="0" width="250" height="250" fill="cyan"/>
+            <rect x="50" y="50" width="150" height="150" fill="green"/>
+        </symbol>
+    </defs>
+    <use href="#rect-with-shadow" clip-path="url(#clip-path-1)" x="0" y="0" width="250" hright="250" />
+    <use href="#rect-with-shadow" clip-path="url(#clip-path-2)" x="0" y="0" width="250" hright="250" />
+    <use href="#rect-with-shadow" clip-path="url(#clip-path-3)" x="0" y="0" width="250" hright="250" />
+    <use href="#rect-with-shadow" clip-path="url(#clip-path-4)" x="0" y="0" width="250" hright="250" />
+</svg>

--- a/LayoutTests/svg/filters/filter-geometry-override.svg
+++ b/LayoutTests/svg/filters/filter-geometry-override.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500px" height="500px">
+    <defs>
+        <filter id="shadow-1" filterUnits="userSpaceOnUse">
+            <feDropShadow dx="-50" dy="-50" stdDeviation="0" flood-color="cyan" x="0" y="0" width="100" height="100"/>
+        </filter>
+        <filter id="shadow-2" filterUnits="userSpaceOnUse">
+            <feDropShadow dx="50" dy="-50" stdDeviation="0" flood-color="cyan" x="150" y="0" width="100" height="100"/>
+        </filter>
+        <filter id="shadow-3" filterUnits="userSpaceOnUse">
+            <feDropShadow dx="-50" dy="50" stdDeviation="0" flood-color="cyan" x="0" y="150" width="100" height="100"/>
+        </filter>
+        <filter id="shadow-4" filterUnits="userSpaceOnUse">
+            <feDropShadow dx="50" dy="50" stdDeviation="0" flood-color="cyan" x="150" y="150" width="100" height="100"/>
+        </filter>
+    </defs>
+    <rect x="50" y="50" width="150" height="150" style="fill:green; filter:url(#shadow-1);"/>
+    <rect x="50" y="50" width="150" height="150" style="fill:green; filter:url(#shadow-2);"/>
+    <rect x="50" y="50" width="150" height="150" style="fill:green; filter:url(#shadow-3);"/>
+    <rect x="50" y="50" width="150" height="150" style="fill:green; filter:url(#shadow-4);"/>
+</svg>


### PR DESCRIPTION
#### 68a960c3744522c563e5e1c81407666386ccf132
<pre>
[Filters] Add a new test for SVG filter overriding geometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=248483">https://bugs.webkit.org/show_bug.cgi?id=248483</a>
rdar://102775394

Reviewed by Simon Fraser.

Ensure the primitive subregion is clipped to the effect geometry. The Filter/
FilterEffect is set up to work this way for long time. This new test was used to
verify the geometry of the GraphicsContext filters are working correctly.

* LayoutTests/svg/filters/filter-geometry-override-expected.svg: Added.
* LayoutTests/svg/filters/filter-geometry-override.svg: Added.

Canonical link: <a href="https://commits.webkit.org/257158@main">https://commits.webkit.org/257158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59a707e05c9563423e840be2175e7ac9795685ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107483 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167762 "Built successfully and passed tests") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7713 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36005 "Built successfully") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/36/builds/90644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104107 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103670 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/78/builds/5803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84626 "Built successfully") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32897 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87672 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/3/builds/89389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1215 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1189 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/70/builds/22327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/4923 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6035 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/44781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41730 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->