### PR TITLE
Web Inspector: REGRESSION(r256223@main) Styles Panel: All CSS variables marked as unsupported

### DIFF
--- a/LayoutTests/inspector/css/css-property-expected.txt
+++ b/LayoutTests/inspector/css/css-property-expected.txt
@@ -37,6 +37,8 @@ Initially selected completion when ranked by `count % 3`: "Fake Property 200 See
 PASS: "background-repeat" is a valid property.
 PASS: "background-repeat-x" is an invalid property.
 PASS: "background-repeat-invalid" is an invalid property.
+PASS: "--foo" is a valid property.
+PASS: "--bar" is a valid property.
 
 -- Running test case: CSSProperty.prototype.get anonymous
 PASS: "background-repeat" is not an anonymous CSS property.

--- a/LayoutTests/inspector/css/css-property.html
+++ b/LayoutTests/inspector/css/css-property.html
@@ -66,6 +66,8 @@ function test() {
                 for (let property of rule.style.enabledProperties) {
                     switch (property.name) {
                     case "background-repeat":
+                    case "--foo":
+                    case "--bar":
                         InspectorTest.expectThat(property.valid, `"${property.name}" is a valid property.`);
                         break;
                     case "background-repeat-x":

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -807,6 +807,9 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
 
         CSSPropertyID propertyId = cssPropertyID(name);
 
+        if (isCustomPropertyName(name))
+            propertyId = CSSPropertyID::CSSPropertyCustom;
+
         // Default "parsedOk" == true.
         if (!propertyEntry.parsedOk || !isExposed(propertyId, m_style->settings()))
             property->setParsedOk(false);
@@ -838,7 +841,7 @@ Ref<Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() const
                 bool shouldInactivate = false;
 
                 // Canonicalize property names to treat non-prefixed and vendor-prefixed property names the same (opacity vs. -webkit-opacity).
-                String canonicalPropertyName = propertyId ? nameString(propertyId) : name;
+                String canonicalPropertyName = propertyId != CSSPropertyID::CSSPropertyInvalid && propertyId != CSSPropertyID::CSSPropertyCustom ? nameString(propertyId) : name;
                 HashMap<String, RefPtr<Protocol::CSS::CSSProperty>>::iterator activeIt = propertyNameToPreviousActiveProperty.find(canonicalPropertyName);
                 if (activeIt != propertyNameToPreviousActiveProperty.end()) {
                     if (propertyEntry.parsedOk) {


### PR DESCRIPTION
#### a6fb71355a3d3d21d04f662d6ed0e192752d4450
<pre>
Web Inspector: REGRESSION(r256223@main) Styles Panel: All CSS variables marked as unsupported
<a href="https://bugs.webkit.org/show_bug.cgi?id=248314">https://bugs.webkit.org/show_bug.cgi?id=248314</a>

Reviewed by Darin Adler.

Querying `WebCore::cssPropertyID()` defined in `CSSPropertyParser.cpp`
with a CSS custom property name (aka CSS variable) mistakenly returns
`CSSPropertyID::CSSPropertyInvalid` instead of `CSSPropertyID::CSSPropertyCustom`.

This was also the case before <a href="https://github.com/WebKit/WebKit/pull/5986">https://github.com/WebKit/WebKit/pull/5986</a> landed,
so this wasn&apos;t regressed by it.

What the refactoring in <a href="https://github.com/WebKit/WebKit/pull/5986">https://github.com/WebKit/WebKit/pull/5986</a> did was to
introduce stricter checks in `PropertySetCSSStyleDeclaration::isExposed()`
and in `WebCore::isExposed()` declared in the generated file `CSSPropertyNames.cpp`
to return `false` when encountering `CSSPropertyID::CSSPropertyInvalid`.

The specific `CSSPropertyID` wasn&apos;t of particular importance for Web Inspector so the
wrong id didn&apos;t cause issues previously.

But `InspectorStyle::styleWithProperties()` makes use of the `isExposed()` check to
mark a CSS custom property as `property-&gt;setParsedOk(false)` which ultimately marks it
as unsupported in the Web Inspector frontend.

Now that the check is more strict, compounded with the effect of the mistaken
`CSSPropertyID::CSSPropertyInvalid`, causes CSS custom properties to be incorrectly
marked as unsupported.

To mitigate this:

- explicitly check if the property is a custom property and assign it the correct id of
`CSSPropertyID::CSSPropertyCustom`.

- since `WebCore::nameString()` can&apos;t return an arbitrary CSS custom property name
even if it were provided the correct `CSSPropertyID`, we guard for this before calling the method.

There are many callers of `WebCore::cssPropertyID()` and only some of them
manually check for `WebCore::isCustomPropertyName()` to take special action.
Fixing the root issue so that it correctly returns `CSSPropertyID::CSSPropertyCustom`
will be done in another patch to account for any regressions it may introduce.

* LayoutTests/inspector/css/css-property-expected.txt:
* LayoutTests/inspector/css/css-property.html:

Added a check that CSS custom properties are valid.
`Protocol::CSS::CSSProperty::parsedOk` maps to `WI.CSSProperty.valid`.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyle::styleWithProperties const):

Canonical link: <a href="https://commits.webkit.org/257564@main">https://commits.webkit.org/257564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bddb5fb6a4f3ce7497d90dc514df8b186c72affa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/99314 "Failed to checkout and rebase branch from PR 6927") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/8512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/32431 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/108698 "Failed to checkout and rebase branch from PR 6927") | [❌ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168945 "Failed to checkout and rebase branch from PR 6927") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/103311 "Failed to checkout and rebase branch from PR 6927") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/9071 "Failed to checkout and rebase branch from PR 6927") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85830 "Built successfully") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91803 "Failed to checkout and rebase branch from PR 6927") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/106625 "Failed to checkout and rebase branch from PR 6927") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/105071 "Failed to checkout and rebase branch from PR 6927") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/76/builds/9071 "Failed to checkout and rebase branch from PR 6927") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/90397 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/36/builds/91803 "Failed to checkout and rebase branch from PR 6927") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/76/builds/9071 "Failed to checkout and rebase branch from PR 6927") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21743 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/36/builds/91803 "Failed to checkout and rebase branch from PR 6927") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/2389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/23260 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/2287 "Failed to checkout and rebase branch from PR 6927") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/60/builds/45665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5203 "Built successfully and passed tests") | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/8299 "Failed to checkout and rebase branch from PR 6927") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42739 "Failed to checkout and rebase branch from PR 6927") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->