### PR TITLE
Remove a float from an element's list even if its style suggests it can't contain floats

### DIFF
--- a/LayoutTests/fast/block/overhanging-float-crashes-when-sibling-becomes-formatting-context-expected.txt
+++ b/LayoutTests/fast/block/overhanging-float-crashes-when-sibling-becomes-formatting-context-expected.txt
@@ -1,0 +1,2 @@
+crbug.com/459533: Don't crash when changing an element to one that interacts with other floats to one that can't.
+

--- a/LayoutTests/fast/block/overhanging-float-crashes-when-sibling-becomes-formatting-context.html
+++ b/LayoutTests/fast/block/overhanging-float-crashes-when-sibling-becomes-formatting-context.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<body>
+crbug.com/459533: Don't crash when changing an element to one that interacts with other floats to one that can't.
+</body>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    iframe.style.cssFloat='right';
+    document.documentElement.style.padding='913917816% 300vmin 0vmax';
+    var div = document.createElement('div');
+    div.style.webkitWritingMode='horizontal-tb';
+    document.documentElement.appendChild(div);
+    window.setTimeout("updateStyle()",0);
+
+    function updateStyle() {
+        document.documentElement.style.webkitWritingMode='vertical-rl';
+        iframe.style.all='unset';
+        document.documentElement.clientWidth;
+        iframe.style.marginBlockEnd='22vmin';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2813,7 +2813,7 @@ void RenderBlockFlow::markSiblingsWithFloatsForLayout(RenderBox* floatToRemove)
     auto end = floatingObjectSet.end();
 
     for (RenderObject* next = nextSibling(); next; next = next->nextSibling()) {
-        if (!is<RenderBlockFlow>(*next) || next->isFloatingOrOutOfFlowPositioned())
+        if (!is<RenderBlockFlow>(*next) || (!floatToRemove && (next->isFloatingOrOutOfFlowPositioned() || downcast<RenderBlockFlow>(*next).avoidsFloats())))
             continue;
 
         RenderBlockFlow& nextBlock = downcast<RenderBlockFlow>(*next);


### PR DESCRIPTION
#### 6112c5929ca9012278c62ee3b2a0d82d424aad99
<pre>
Remove a float from an element&apos;s list even if its style suggests it can&apos;t contain floats

Remove a float from an element&apos;s list even if its style suggests it can&apos;t contain floats
<a href="https://bugs.webkit.org/show_bug.cgi?id=248487">https://bugs.webkit.org/show_bug.cgi?id=248487</a>

Reviewed by Alan Baradlay.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=190902

The reason we are failing to remove floats here is because we put an element in a
second element&apos;s float lists, then put a style on that second element that prevents
it from overlapping with floats in future, and then we assume that because it has
that style it can&apos;t contain the float we&apos;re destroying in its float lists.

* Source/WebCore/rendering/RenderBlockFlow.cpp:
(RenderBlockFlow::markSiblingsWithFloatsForLayout): Add logic to remove float from an element&apos;s list
* LayoutTests/fast/block/overhanging-float-crashes-when-sibling-becomes-formatting-context.html: Add Test Case
* LayoutTests/fast/block/overhanging-float-crashes-when-sibling-becomes-formatting-context-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/257370@main">https://commits.webkit.org/257370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce88acdf03e0aee8f888bec6a748ddb4a667d985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107578 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167845 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102058 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84713 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104183 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33008 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/20896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/75942 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1302 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22399 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44852 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5062 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41811 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->