### PR TITLE
Add support to return an adjusted URL when accessed from JavaScript bindings

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -722,7 +722,9 @@ public:
 
     const URL& url() const final { return m_url; }
     void setURL(const URL&);
-    const URL& urlForBindings() const { return m_url.url().isEmpty() ? aboutBlankURL() : m_url.url(); }
+    WEBCORE_EXPORT const URL& urlForBindings() const;
+
+    URL adjustedURL() const;
 
     const URL& creationURL() const { return m_creationURL; }
 
@@ -1879,6 +1881,7 @@ private:
     URL m_cookieURL; // The URL to use for cookie access.
     URL m_firstPartyForCookies; // The policy URL for third-party cookie blocking.
     URL m_siteForCookies; // The policy URL for Same-Site cookies.
+    URL m_adjustedURL; // The URL to return for bindings after a cross-site navigation when the "network connection integrity" setting is enabled.
 
     // Document.documentURI:
     // Although URL-like, Document.documentURI can actually be set to any

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -53,7 +53,7 @@ inline const URL& Location::url() const
     if (!frame())
         return aboutBlankURL();
 
-    const URL& url = frame()->document()->url();
+    const URL& url = frame()->document()->urlForBindings();
     if (!url.isValid())
         return aboutBlankURL(); // Use "about:blank" while the page is still loading (before we have a frame).
 


### PR DESCRIPTION
#### 31e1e52a0454daa2899f75aa1ec6af635a3828ed
<pre>
Add support to return an adjusted URL when accessed from JavaScript bindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=248490">https://bugs.webkit.org/show_bug.cgi?id=248490</a>
rdar://100472810

Reviewed by Wenson Hsieh.

This patch adds support to return an adjusted URL for JavaScript bindings
after a cross site top level navigation.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setURL):
(WebCore::Document::urlForBindings const):
(WebCore::Document::adjustedURL const):
* Source/WebCore/dom/Document.h:
(WebCore::Document::urlForBindings const): Deleted.
* Source/WebCore/page/Location.cpp:
(WebCore::Location::url const):

Canonical link: <a href="https://commits.webkit.org/257490@main">https://commits.webkit.org/257490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88c31a9ab615cce61edc8469ab557440c8d0c7ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107986 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/168250 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/102513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/8284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/85152 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/91098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/105971 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/104245 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/6280 "Found 2 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89835 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/33270 "Found 1 new test failure: css3/supports-dom-api.html (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/88098 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/73/builds/21194 "Found 4 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-simple.html, fast/text/text-edge-no-half-leading-with-line-height-simple.html, fast/text/text-edge-with-margin-padding-border-simple.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/34/builds/76209 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1707 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22723 "Found 3 new test failures: css3/supports-dom-api.html, fast/text/text-edge-no-half-leading-with-line-height-simple.html, fast/text/text-edge-with-margin-padding-border-simple.html (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1620 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/45222 "Found 4 new test failures: fast/text/text-edge-with-margin-padding-border-simple.html, http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html, imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-selection.html, media/video-inaccurate-duration-ended.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/74/builds/5150 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6558 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/42148 "Passed tests") | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/3007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->