### PR TITLE
Support ::backdrop renderer on all elements

### DIFF
--- a/Source/WebCore/css/dialog.css
+++ b/Source/WebCore/css/dialog.css
@@ -29,12 +29,3 @@ dialog:modal {
 dialog::backdrop {
     background: rgba(0, 0, 0, 0.1);
 }
-
-::backdrop {
-    display: block;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-}

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -112,6 +112,14 @@ abbr[title], acronym[title] {
     text-decoration: dotted underline;
 }
 
+/* ::backdrop */
+
+::backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+}
+
 /* media elements */
 
 body:-webkit-full-page-media {

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -175,8 +175,6 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
 
 void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& renderer)
 {
-    if (!renderer.canHaveGeneratedChildren())
-        return;
     // ::backdrop does not inherit style, hence using the view style as parent style
     auto style = renderer.getCachedPseudoStyle(PseudoId::Backdrop, &renderer.view().style());
 
@@ -194,7 +192,10 @@ void RenderTreeUpdater::GeneratedContent::updateBackdropRenderer(RenderElement& 
         auto newBackdropRenderer = WebCore::createRenderer<RenderBlockFlow>(renderer.document(), WTFMove(newStyle));
         newBackdropRenderer->initializeStyle();
         renderer.setBackdropRenderer(*newBackdropRenderer.get());
-        m_updater.m_builder.attach(renderer, WTFMove(newBackdropRenderer), renderer.firstChild());
+
+        // Use the renderer as parent when we can for hit-testing purposes.
+        RenderElement& parentRenderer = renderer.canHaveGeneratedChildren() ? renderer : renderer.view();
+        m_updater.m_builder.attach(parentRenderer, WTFMove(newBackdropRenderer), parentRenderer.lastChild());
     }
 }
 


### PR DESCRIPTION
#### c819410e71385d58040f24b7ea826966475529c0
<pre>
Support ::backdrop renderer on all elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=248456">https://bugs.webkit.org/show_bug.cgi?id=248456</a>
rdar://102748281

Reviewed by Cameron McCormack.

- Move UA styles for ::backdrop to html.css, since dialog.css is only injected when a dialog element is present.
- Support ::backdrop renderer on elements that can&apos;t have generated children, by appending them as the child of RenderView instead.

* Source/WebCore/css/dialog.css:
(dialog::backdrop):
(::backdrop): Deleted.
* Source/WebCore/css/html.css:
(::backdrop):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateBackdropRenderer):

Canonical link: <a href="https://commits.webkit.org/257194@main">https://commits.webkit.org/257194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dca1fcde81e048590d5ef409d91867882d58602

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/6/builds/98053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/77/builds/7271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/43/builds/31208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/8/builds/107516 "Built successfully") | [✅ 🛠 🧪 win](https://ews-build.webkit.org/#/builders/10/builds/167787 "Built successfully and passed tests") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/11/builds/101992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/76/builds/7757 "Built successfully") | [✅ 🛠 mac-debug](https://ews-build.webkit.org/#/builders/71/builds/36036 "Built successfully") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/36/builds/90649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/12/builds/104131 "Built successfully") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/19/builds/103705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/78/builds/5832 "Passed tests") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/84655 "Built successfully") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/35/builds/32963 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/9/builds/87701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/3/builds/89415 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/34/builds/75888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/81/builds/1247 "Built successfully") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/73/builds/20848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/82/builds/1212 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/70/builds/22353 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/80/builds/6071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/60/builds/44804 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/75/builds/2470 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/79/builds/2511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/62/builds/41758 "Passed tests") | | 
<!--EWS-Status-Bubble-End-->